### PR TITLE
feat(config): carry context publication outcomes (#1061)

### DIFF
--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -13,6 +13,69 @@ const CONTEXT_TEMPLATE_CHANGED: &str =
 const CONTEXT_TEMPLATE_DEFAULT_CHANGED: &str =
     "Context template default changed; reload the project before overwriting.";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ContextPublication {
+    pub(crate) published_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextTemplateSkipReason {
+    CreationDisabled,
+    MissingAfterCreate,
+    AmbiguousWithoutState,
+    IgnoredByUser,
+    WorkspaceUnavailable,
+    TargetMissing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TemplatePublication {
+    Published(ContextPublication),
+    AlreadyCurrent,
+    ChangedUnderUs,
+    Observed,
+    Skipped(ContextTemplateSkipReason),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ContextTemplateExecution<T> {
+    pub(crate) completion: Result<T, String>,
+    pub(crate) published: Option<ContextPublication>,
+}
+
+impl<T> ContextTemplateExecution<T> {
+    pub(crate) fn from_parts(
+        completion: Result<T, String>,
+        published: Option<ContextPublication>,
+    ) -> Self {
+        Self {
+            completion,
+            published,
+        }
+    }
+
+    pub(crate) fn completed(value: T) -> Self {
+        Self::from_parts(Ok(value), None)
+    }
+
+    pub(crate) fn failed(error: String) -> Self {
+        Self::from_parts(Err(error), None)
+    }
+
+    pub(crate) fn with_publication(
+        completion: Result<T, String>,
+        publication: ContextPublication,
+    ) -> Self {
+        Self::from_parts(completion, Some(publication))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TemplateSyncOutcome {
+    pub(crate) pending_update: Option<ContextTemplateUpdate>,
+    pub(crate) target_outcome: TemplatePublication,
+}
+
 const OLD_COORDINATOR_CONTEXT_TEMPLATE_BEFORE_RAISE_HAND: &str = "You are the coordinator for your team. You must:\n\
      - Keep your base role; coordination is an additional assignment, not a replacement.\n\
      - Receive team work requests.\n\
@@ -745,38 +808,88 @@ fn make_update(
     }
 }
 
-fn create_missing_template(path: &Path, content: &str) -> Result<(), String> {
-    crate::config::session_context::write_template_if_missing(path, content)?;
-    validate_existing_file(path, "Context template")
+fn create_missing_template(
+    path: &Path,
+    content: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> ContextTemplateExecution<crate::config::session_context::CreateOnlyPublication> {
+    let outcome = match crate::config::session_context::write_template_if_missing_with_clock(
+        path, content, clock,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => return ContextTemplateExecution::failed(error),
+    };
+    let published = match outcome {
+        crate::config::session_context::CreateOnlyPublication::Published { published_at } => {
+            Some(ContextPublication { published_at })
+        }
+        crate::config::session_context::CreateOnlyPublication::AlreadyPresent => None,
+    };
+    ContextTemplateExecution::from_parts(
+        validate_existing_file(path, "Context template").map(|()| outcome),
+        published,
+    )
 }
 
 fn auto_update_generated_template(
     path: &Path,
     spec: SeededContextTemplateSpec,
     expected_file_sha256: &str,
-) -> Result<bool, String> {
-    let Some(snapshot) = read_validated_snapshot(path, "Context template")? else {
-        return Ok(false);
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> ContextTemplateExecution<TemplatePublication> {
+    auto_update_generated_template_with(
+        path,
+        spec,
+        expected_file_sha256,
+        clock,
+        crate::config::session_context::atomically_replace_context_template,
+    )
+}
+
+fn auto_update_generated_template_with<R>(
+    path: &Path,
+    spec: SeededContextTemplateSpec,
+    expected_file_sha256: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    replace: R,
+) -> ContextTemplateExecution<TemplatePublication>
+where
+    R: FnOnce(
+        &Path,
+        &str,
+        &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    ) -> Result<chrono::DateTime<chrono::Utc>, String>,
+{
+    let snapshot = match read_validated_snapshot(path, "Context template") {
+        Ok(Some(snapshot)) => snapshot,
+        Ok(None) => {
+            return ContextTemplateExecution::completed(TemplatePublication::ChangedUnderUs)
+        }
+        Err(error) => return ContextTemplateExecution::failed(error),
     };
     if snapshot.sha256 != expected_file_sha256 {
         log::warn!(
             "[context-templates] {} changed before generated update; preserving current content",
             path.display()
         );
-        return Ok(false);
+        return ContextTemplateExecution::completed(TemplatePublication::ChangedUnderUs);
     }
     if !(spec.is_known_generated)(&snapshot.content) {
         log::warn!(
             "[context-templates] {} no longer matches a known generated default; preserving current content",
             path.display()
         );
-        return Ok(false);
+        return ContextTemplateExecution::completed(TemplatePublication::ChangedUnderUs);
     }
-    crate::config::session_context::atomically_replace_context_template(
-        path,
-        (spec.current_content)(),
-    )?;
-    Ok(true)
+    let published_at = match replace(path, (spec.current_content)(), clock) {
+        Ok(published_at) => published_at,
+        Err(error) => return ContextTemplateExecution::failed(error),
+    };
+    let publication = ContextPublication { published_at };
+    ContextTemplateExecution::with_publication(
+        Ok(TemplatePublication::Published(publication)),
+        publication,
+    )
 }
 
 fn sync_one_template(
@@ -786,33 +899,81 @@ fn sync_one_template(
     loaded: &mut LoadedState,
     allow_create_missing: bool,
     return_pending: bool,
-) -> Result<Option<ContextTemplateUpdate>, String> {
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> ContextTemplateExecution<TemplateSyncOutcome> {
     let path = workspace_dir.join(spec.filename);
     let current_default = (spec.current_content)();
     let current_default_sha256 = sha256_hex(current_default.as_bytes());
-    let mut snapshot = read_validated_snapshot(&path, "Context template")?;
+    let mut snapshot = match read_validated_snapshot(&path, "Context template") {
+        Ok(snapshot) => snapshot,
+        Err(error) => return ContextTemplateExecution::failed(error),
+    };
+    let mut carried_publication = None;
 
     if snapshot.is_none() {
         if !allow_create_missing {
-            return Ok(None);
+            return ContextTemplateExecution::completed(TemplateSyncOutcome {
+                pending_update: None,
+                target_outcome: TemplatePublication::Skipped(
+                    ContextTemplateSkipReason::CreationDisabled,
+                ),
+            });
         }
-        create_missing_template(&path, current_default)?;
-        snapshot = read_validated_snapshot(&path, "Context template")?;
+        let creation = create_missing_template(&path, current_default, clock);
+        carried_publication = creation.published;
+        if let Err(error) = creation.completion {
+            return ContextTemplateExecution::from_parts(Err(error), carried_publication);
+        }
+        snapshot = match read_validated_snapshot(&path, "Context template") {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                return ContextTemplateExecution::from_parts(Err(error), carried_publication)
+            }
+        };
         if let Some(snapshot) = &snapshot {
             if snapshot.sha256 == current_default_sha256 {
                 loaded.mark_seeded(spec, &current_default_sha256);
-                return Ok(None);
+                let target_outcome = carried_publication
+                    .map(TemplatePublication::Published)
+                    .unwrap_or(TemplatePublication::AlreadyCurrent);
+                return ContextTemplateExecution::from_parts(
+                    Ok(TemplateSyncOutcome {
+                        pending_update: None,
+                        target_outcome,
+                    }),
+                    carried_publication,
+                );
             }
         }
     }
 
     let Some(snapshot) = snapshot else {
-        return Ok(None);
+        let target_outcome = carried_publication
+            .map(TemplatePublication::Published)
+            .unwrap_or(TemplatePublication::Skipped(
+                ContextTemplateSkipReason::MissingAfterCreate,
+            ));
+        return ContextTemplateExecution::from_parts(
+            Ok(TemplateSyncOutcome {
+                pending_update: None,
+                target_outcome,
+            }),
+            carried_publication,
+        );
     };
 
     if snapshot.sha256 == current_default_sha256 {
         loaded.mark_seeded(spec, &current_default_sha256);
-        return Ok(None);
+        let target_outcome = carried_publication
+            .map(TemplatePublication::Published)
+            .unwrap_or(TemplatePublication::AlreadyCurrent);
+        return ContextTemplateExecution::from_parts(
+            Ok(TemplateSyncOutcome {
+                pending_update: None,
+                target_outcome,
+            }),
+            carried_publication,
+        );
     }
 
     let trusted_entry = loaded.trusted_entry(spec).cloned();
@@ -821,19 +982,45 @@ fn sync_one_template(
             && entry.last_seeded_sha256.as_deref() != Some(current_default_sha256.as_str())
             && (spec.is_known_generated)(&snapshot.content)
         {
-            if auto_update_generated_template(&path, spec, &snapshot.sha256)? {
-                loaded.mark_seeded(spec, &current_default_sha256);
-            }
-            return Ok(None);
+            let execution = auto_update_generated_template(&path, spec, &snapshot.sha256, clock);
+            let published = execution.published;
+            return match execution.completion {
+                Ok(target_outcome) => {
+                    if matches!(target_outcome, TemplatePublication::Published(_)) {
+                        loaded.mark_seeded(spec, &current_default_sha256);
+                    }
+                    ContextTemplateExecution::from_parts(
+                        Ok(TemplateSyncOutcome {
+                            pending_update: None,
+                            target_outcome,
+                        }),
+                        published,
+                    )
+                }
+                Err(error) => ContextTemplateExecution::from_parts(Err(error), published),
+            };
         }
     }
 
     let has_valid_entry = trusted_entry.is_some();
     if !has_valid_entry && (spec.is_known_generated)(&snapshot.content) {
-        if auto_update_generated_template(&path, spec, &snapshot.sha256)? {
-            loaded.mark_seeded(spec, &current_default_sha256);
-        }
-        return Ok(None);
+        let execution = auto_update_generated_template(&path, spec, &snapshot.sha256, clock);
+        let published = execution.published;
+        return match execution.completion {
+            Ok(target_outcome) => {
+                if matches!(target_outcome, TemplatePublication::Published(_)) {
+                    loaded.mark_seeded(spec, &current_default_sha256);
+                }
+                ContextTemplateExecution::from_parts(
+                    Ok(TemplateSyncOutcome {
+                        pending_update: None,
+                        target_outcome,
+                    }),
+                    published,
+                )
+            }
+            Err(error) => ContextTemplateExecution::from_parts(Err(error), published),
+        };
     }
 
     if spec.suppress_unknown_without_state && !has_valid_entry {
@@ -841,40 +1028,78 @@ fn sync_one_template(
             "[context-templates] preserving ambiguous global context template {} without prompting",
             path.display()
         );
-        return Ok(None);
+        let target_outcome = carried_publication
+            .map(TemplatePublication::Published)
+            .unwrap_or(TemplatePublication::Skipped(
+                ContextTemplateSkipReason::AmbiguousWithoutState,
+            ));
+        return ContextTemplateExecution::from_parts(
+            Ok(TemplateSyncOutcome {
+                pending_update: None,
+                target_outcome,
+            }),
+            carried_publication,
+        );
     }
 
     if let Some(entry) = trusted_entry.as_ref() {
         if entry.ignored_observed_sha256.as_deref() == Some(snapshot.sha256.as_str())
             && entry.ignored_default_sha256.as_deref() == Some(current_default_sha256.as_str())
         {
-            return Ok(None);
+            let target_outcome = carried_publication
+                .map(TemplatePublication::Published)
+                .unwrap_or(TemplatePublication::Skipped(
+                    ContextTemplateSkipReason::IgnoredByUser,
+                ));
+            return ContextTemplateExecution::from_parts(
+                Ok(TemplateSyncOutcome {
+                    pending_update: None,
+                    target_outcome,
+                }),
+                carried_publication,
+            );
         }
     }
 
     loaded.mark_observed(spec, &snapshot.sha256);
-    if return_pending {
-        let project_dir = project_dir.ok_or_else(|| {
-            format!(
-                "Cannot create context template update for {} without a project path",
-                path.display()
-            )
-        })?;
-        Ok(Some(make_update(
+    let pending_update = if return_pending {
+        let project_dir = match project_dir {
+            Some(project_dir) => project_dir,
+            None => {
+                return ContextTemplateExecution::from_parts(
+                    Err(format!(
+                        "Cannot create context template update for {} without a project path",
+                        path.display()
+                    )),
+                    carried_publication,
+                )
+            }
+        };
+        Some(make_update(
             project_dir,
             workspace_dir,
             &path,
             spec,
             snapshot.sha256,
             current_default_sha256,
-        )))
+        ))
     } else {
         log::warn!(
             "[context-templates] preserving customized context template {}; a newer default is available",
             path.display()
         );
-        Ok(None)
-    }
+        None
+    };
+    let target_outcome = carried_publication
+        .map(TemplatePublication::Published)
+        .unwrap_or(TemplatePublication::Observed);
+    ContextTemplateExecution::from_parts(
+        Ok(TemplateSyncOutcome {
+            pending_update,
+            target_outcome,
+        }),
+        carried_publication,
+    )
 }
 
 fn compute_pending_update(
@@ -950,7 +1175,42 @@ fn validate_project_workspace_for_scan(
     Ok(())
 }
 
+fn consume_template_execution(
+    spec: SeededContextTemplateSpec,
+    execution: ContextTemplateExecution<TemplateSyncOutcome>,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<TemplateSyncOutcome, String> {
+    if let Some(publication) = execution.published {
+        on_publication(spec.filename, publication);
+    }
+    if let Ok(outcome) = &execution.completion {
+        log::debug!(
+            "[context-templates] {} target outcome: {:?}",
+            spec.filename,
+            outcome.target_outcome
+        );
+    }
+    execution.completion
+}
+
 pub fn ensure_project_context_templates(workspace_dir: &Path) -> Result<(), String> {
+    let mut on_publication = |_: &'static str, _: ContextPublication| {};
+    ensure_project_context_templates_with_publications(workspace_dir, &mut on_publication)
+}
+
+pub(crate) fn ensure_project_context_templates_with_publications(
+    workspace_dir: &Path,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<(), String> {
+    let mut clock = chrono::Utc::now;
+    ensure_project_context_templates_with_clock(workspace_dir, &mut clock, on_publication)
+}
+
+fn ensure_project_context_templates_with_clock(
+    workspace_dir: &Path,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<(), String> {
     std::fs::create_dir_all(workspace_dir).map_err(|e| {
         format!(
             "failed to create context templates directory {}: {}",
@@ -961,7 +1221,9 @@ pub fn ensure_project_context_templates(workspace_dir: &Path) -> Result<(), Stri
     validate_existing_dir(workspace_dir, "Context template directory")?;
     let mut loaded = load_state(workspace_dir, false)?;
     for spec in project_specs() {
-        sync_one_template(None, workspace_dir, spec, &mut loaded, true, false)?;
+        let execution =
+            sync_one_template(None, workspace_dir, spec, &mut loaded, true, false, clock);
+        let _ = consume_template_execution(spec, execution, on_publication)?;
     }
     persist_state_best_effort(workspace_dir, &loaded);
     Ok(())
@@ -971,18 +1233,50 @@ pub fn scan_project_context_template_updates(
     project_dir: &Path,
     workspace_dir: &Path,
 ) -> Result<Vec<ContextTemplateUpdate>, String> {
+    let mut on_publication = |_: &'static str, _: ContextPublication| {};
+    scan_project_context_template_updates_with_publications(
+        project_dir,
+        workspace_dir,
+        &mut on_publication,
+    )
+}
+
+pub(crate) fn scan_project_context_template_updates_with_publications(
+    project_dir: &Path,
+    workspace_dir: &Path,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<Vec<ContextTemplateUpdate>, String> {
+    let mut clock = chrono::Utc::now;
+    scan_project_context_template_updates_with_clock(
+        project_dir,
+        workspace_dir,
+        &mut clock,
+        on_publication,
+    )
+}
+
+fn scan_project_context_template_updates_with_clock(
+    project_dir: &Path,
+    workspace_dir: &Path,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<Vec<ContextTemplateUpdate>, String> {
     validate_project_workspace_for_scan(project_dir, workspace_dir)?;
     let mut loaded = load_state(workspace_dir, false)?;
     let mut updates = Vec::new();
     for spec in project_specs() {
-        if let Some(update) = sync_one_template(
+        let execution = sync_one_template(
             Some(project_dir),
             workspace_dir,
             spec,
             &mut loaded,
             false,
             true,
-        )? {
+            clock,
+        );
+        if let Some(update) =
+            consume_template_execution(spec, execution, on_publication)?.pending_update
+        {
             updates.push(update);
         }
     }
@@ -995,14 +1289,43 @@ pub fn sync_project_context_template_for_read(
     context_dir: &Path,
     filename: &str,
 ) -> Result<(), String> {
+    let mut on_publication = |_: &'static str, _: ContextPublication| {};
+    sync_project_context_template_for_read_with_publications(
+        context_dir,
+        filename,
+        &mut on_publication,
+    )
+}
+
+pub(crate) fn sync_project_context_template_for_read_with_publications(
+    context_dir: &Path,
+    filename: &str,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<(), String> {
+    let mut clock = chrono::Utc::now;
+    sync_project_context_template_for_read_with_clock(
+        context_dir,
+        filename,
+        &mut clock,
+        on_publication,
+    )
+}
+
+fn sync_project_context_template_for_read_with_clock(
+    context_dir: &Path,
+    filename: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> Result<(), String> {
     let Some(spec) = project_spec_by_filename(filename) else {
         return Ok(());
     };
     validate_existing_dir(context_dir, "Context template directory")?;
     let mut loaded = load_state(context_dir, false)?;
-    let result = sync_one_template(None, context_dir, spec, &mut loaded, true, false);
+    let execution = sync_one_template(None, context_dir, spec, &mut loaded, true, false, clock);
+    let result = consume_template_execution(spec, execution, on_publication).map(|_| ());
     persist_state_best_effort(context_dir, &loaded);
-    result.map(|_| ())
+    result
 }
 
 pub fn ensure_root_context_template(config_dir: &Path) -> Result<(), String> {
@@ -1015,7 +1338,17 @@ pub fn ensure_root_context_template(config_dir: &Path) -> Result<(), String> {
     })?;
     validate_existing_dir(config_dir, "Root agent config directory")?;
     let mut loaded = load_state(config_dir, false)?;
-    sync_one_template(None, config_dir, root_spec(), &mut loaded, true, false)?;
+    let mut clock = chrono::Utc::now;
+    let execution = sync_one_template(
+        None,
+        config_dir,
+        root_spec(),
+        &mut loaded,
+        true,
+        false,
+        &mut clock,
+    );
+    execution.completion?;
     persist_state_best_effort(config_dir, &loaded);
     Ok(())
 }
@@ -1343,9 +1676,52 @@ pub fn overwrite_context_template_with_default(
     expected_file_sha256: &str,
     expected_default_sha256: &str,
 ) -> Result<ContextTemplateOverwriteResult, String> {
+    let mut on_publication = |_: &'static str, _: ContextPublication| {};
+    let execution = overwrite_context_template_with_default_with_publications(
+        workspace_dir,
+        filename,
+        expected_file_sha256,
+        expected_default_sha256,
+        &mut on_publication,
+    );
+    if let Some(publication) = execution.published {
+        log::debug!(
+            "[context-templates] {} overwrite published at {}",
+            filename,
+            publication.published_at
+        );
+    }
+    execution.completion
+}
+
+pub(crate) fn overwrite_context_template_with_default_with_publications(
+    workspace_dir: &Path,
+    filename: &str,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+) -> ContextTemplateExecution<ContextTemplateOverwriteResult> {
+    let mut clock = chrono::Utc::now;
+    overwrite_context_template_with_default_with(
+        workspace_dir,
+        filename,
+        expected_file_sha256,
+        expected_default_sha256,
+        &mut clock,
+        on_publication,
+        persist_state_strict,
+    )
+}
+
+fn prepare_context_template_overwrite(
+    workspace_dir: &Path,
+    filename: &str,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+) -> Result<(SeededContextTemplateSpec, LoadedState, PathBuf, PathBuf), String> {
     let spec = actionable_project_spec_by_filename(filename)?;
     let project_dir = validate_project_workspace_dir(workspace_dir)?;
-    let mut loaded = load_state(workspace_dir, true)?;
+    let loaded = load_state(workspace_dir, true)?;
     validate_expected_hashes(
         &project_dir,
         workspace_dir,
@@ -1374,25 +1750,59 @@ pub fn overwrite_context_template_with_default(
         return Err(CONTEXT_TEMPLATE_CHANGED.to_string());
     }
 
-    if let Err(e) = crate::config::session_context::atomically_replace_context_template(
+    Ok((spec, loaded, path, backup_path))
+}
+
+fn overwrite_context_template_with_default_with<P>(
+    workspace_dir: &Path,
+    filename: &str,
+    expected_file_sha256: &str,
+    expected_default_sha256: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    on_publication: &mut dyn FnMut(&'static str, ContextPublication),
+    persist: P,
+) -> ContextTemplateExecution<ContextTemplateOverwriteResult>
+where
+    P: FnOnce(&Path, &LoadedState) -> Result<(), String>,
+{
+    let (spec, mut loaded, path, backup_path) = match prepare_context_template_overwrite(
+        workspace_dir,
+        filename,
+        expected_file_sha256,
+        expected_default_sha256,
+    ) {
+        Ok(prepared) => prepared,
+        Err(error) => return ContextTemplateExecution::failed(error),
+    };
+
+    let published_at = match crate::config::session_context::atomically_replace_context_template(
         &path,
         (spec.current_content)(),
+        clock,
     ) {
-        log::warn!(
-            "[context-templates] replacement failed after backup {} was created: {}",
-            backup_path.display(),
-            e
-        );
-        return Err(e);
-    }
+        Ok(published_at) => published_at,
+        Err(error) => {
+            log::warn!(
+                "[context-templates] replacement failed after backup {} was created: {}",
+                backup_path.display(),
+                error
+            );
+            return ContextTemplateExecution::failed(error);
+        }
+    };
+    let publication = ContextPublication { published_at };
+    on_publication(spec.filename, publication);
 
     loaded.mark_seeded(spec, expected_default_sha256);
-    persist_state_strict(workspace_dir, &loaded)?;
-    Ok(ContextTemplateOverwriteResult {
+    let result = ContextTemplateOverwriteResult {
         file_path: display_path(&path),
         backup_path: display_path(&backup_path),
         current_default_sha256: expected_default_sha256.to_string(),
-    })
+    };
+    ContextTemplateExecution::with_publication(
+        persist(workspace_dir, &loaded).map(|()| result),
+        publication,
+    )
 }
 
 fn create_backup(path: &Path, bytes: &[u8]) -> Result<PathBuf, String> {
@@ -1494,6 +1904,40 @@ mod tests {
         sha256_hex(content.as_bytes())
     }
 
+    fn fixed_publication_time() -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339("2026-07-20T10:30:45.123Z")
+            .expect("parse fixed publication time")
+            .with_timezone(&chrono::Utc)
+    }
+
+    fn sync_for_read_at(
+        workspace: &Path,
+        filename: &str,
+        published_at: chrono::DateTime<chrono::Utc>,
+    ) -> Vec<(&'static str, ContextPublication)> {
+        let mut clock = || published_at;
+        let mut publications = Vec::new();
+        sync_project_context_template_for_read_with_clock(
+            workspace,
+            filename,
+            &mut clock,
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect("sync for read");
+        publications
+    }
+
+    fn assert_one_publication(
+        publications: &[(&'static str, ContextPublication)],
+        filename: &'static str,
+        published_at: chrono::DateTime<chrono::Utc>,
+    ) {
+        assert_eq!(
+            publications,
+            &[(filename, ContextPublication { published_at })]
+        );
+    }
+
     #[test]
     fn old_coordinator_default_is_known_generated_without_raise_hand() {
         assert!(
@@ -1567,8 +2011,17 @@ mod tests {
         )
         .expect("write pristine v2 coordinator");
 
-        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_one_publication(
+            &publications,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content =
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1626,8 +2079,14 @@ mod tests {
         )
         .expect("write pristine v1 global");
 
-        sync_project_context_template_for_read(&workspace, GLOBAL_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications =
+            sync_for_read_at(&workspace, GLOBAL_CONTEXT_TEMPLATE_FILENAME, published_at);
+        assert_one_publication(
+            &publications,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content = std::fs::read_to_string(workspace.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
             .expect("read global");
@@ -1662,13 +2121,205 @@ mod tests {
     }
 
     #[test]
+    fn equal_default_observation_has_no_publication() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::write(
+            workspace.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            crate::config::session_context::get_default_agent_template(),
+        )
+        .expect("write current global default");
+
+        let publications = sync_for_read_at(
+            &workspace,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            fixed_publication_time(),
+        );
+
+        assert!(
+            publications.is_empty(),
+            "observing equal default bytes must not manufacture a publication"
+        );
+    }
+
+    #[test]
+    fn generated_update_lost_race_has_no_publication_or_clock_sample() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let path = workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(
+            &path,
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION,
+        )
+        .expect("write generated coordinator");
+        let spec = project_spec_by_filename(COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .expect("coordinator spec");
+        let mut clock_calls = 0_u32;
+        let mut clock = || {
+            clock_calls += 1;
+            fixed_publication_time()
+        };
+
+        let execution =
+            auto_update_generated_template(&path, spec, "different-observed-hash", &mut clock);
+
+        assert_eq!(execution.published, None);
+        assert_eq!(
+            execution.completion.expect("lost race outcome"),
+            TemplatePublication::ChangedUnderUs
+        );
+        assert_eq!(clock_calls, 0);
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read preserved target"),
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
+        );
+    }
+
+    #[test]
+    fn generated_update_publish_failure_has_no_publication() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(
+            &path,
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION,
+        )
+        .expect("write generated coordinator");
+        let expected_hash = hash_text(COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION);
+        let spec = project_spec_by_filename(COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .expect("coordinator spec");
+        let mut clock = || fixed_publication_time();
+
+        let execution = auto_update_generated_template_with(
+            &path,
+            spec,
+            &expected_hash,
+            &mut clock,
+            |_, _, _| Err("injected atomic publication failure".to_string()),
+        );
+
+        assert_eq!(execution.published, None);
+        assert_eq!(
+            execution
+                .completion
+                .expect_err("publication failure must remain an error"),
+            "injected atomic publication failure"
+        );
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read preserved target"),
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn readonly_generated_update_has_no_publication_or_clock_sample() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(
+            &path,
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION,
+        )
+        .expect("write generated coordinator");
+        let expected_hash = hash_text(COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION);
+        let original_permissions = std::fs::metadata(&path)
+            .expect("read target metadata")
+            .permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&path, permissions).expect("make target read-only");
+        let spec = project_spec_by_filename(COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
+            .expect("coordinator spec");
+        let mut clock_calls = 0_u32;
+        let mut clock = || {
+            clock_calls += 1;
+            fixed_publication_time()
+        };
+
+        let execution = auto_update_generated_template(&path, spec, &expected_hash, &mut clock);
+
+        std::fs::set_permissions(&path, original_permissions).expect("restore target permissions");
+        assert_eq!(execution.published, None);
+        assert!(execution.completion.is_err());
+        assert_eq!(clock_calls, 0);
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read preserved target"),
+            COORDINATOR_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
+        );
+    }
+
+    #[test]
+    fn create_publication_survives_post_commit_validation_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let published_at = fixed_publication_time();
+        let mut clock = || {
+            std::fs::remove_file(&path).expect("remove published target at validation seam");
+            std::fs::create_dir(&path).expect("replace published target with directory");
+            published_at
+        };
+
+        let execution = create_missing_template(&path, "published bytes", &mut clock);
+
+        assert_eq!(
+            execution.published,
+            Some(ContextPublication { published_at })
+        );
+        assert!(execution
+            .completion
+            .expect_err("post-commit validation must fail")
+            .contains("not a regular file"));
+    }
+
+    #[test]
+    fn ensure_consumes_first_publication_before_the_next_target_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        std::fs::create_dir(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("block coordinator target with directory");
+        let published_at = fixed_publication_time();
+        let mut clock = || published_at;
+        let mut publications = Vec::new();
+
+        let error = ensure_project_context_templates_with_clock(
+            &workspace,
+            &mut clock,
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect_err("second target must fail");
+
+        assert!(error.contains("not a regular file"), "{error}");
+        assert_one_publication(
+            &publications,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_eq!(
+            std::fs::read_to_string(workspace.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read first published target"),
+            crate::config::session_context::get_default_agent_template()
+        );
+    }
+
+    #[test]
     fn read_sync_creates_missing_coordinator_template() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join(".ac");
         std::fs::create_dir(&workspace).expect("create workspace");
 
-        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_one_publication(
+            &publications,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content =
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1687,8 +2338,17 @@ mod tests {
         )
         .expect("write old coordinator");
 
-        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_one_publication(
+            &publications,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content =
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1724,8 +2384,17 @@ mod tests {
         )
         .expect("write pristine v3 coordinator");
 
-        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_one_publication(
+            &publications,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content =
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1794,8 +2463,17 @@ mod tests {
             "row 3 requires the pristine v3 body to be recognized as generated"
         );
 
-        sync_project_context_template_for_read(&workspace, COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .expect("sync for read");
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(
+            &workspace,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+        assert_one_publication(
+            &publications,
+            COORDINATOR_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
 
         let content =
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1834,10 +2512,21 @@ mod tests {
         )
         .expect("write custom coordinator");
 
-        let updates =
-            scan_project_context_template_updates(temp.path(), &workspace).expect("scan updates");
+        let mut clock = || fixed_publication_time();
+        let mut publications = Vec::new();
+        let updates = scan_project_context_template_updates_with_clock(
+            temp.path(),
+            &workspace,
+            &mut clock,
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect("scan updates");
 
         assert_eq!(updates.len(), 1);
+        assert!(
+            publications.is_empty(),
+            "observing custom content must not produce publication evidence"
+        );
         assert_eq!(updates[0].filename, COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
         assert_eq!(
             std::fs::read_to_string(workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
@@ -1923,9 +2612,20 @@ mod tests {
         )
         .expect("dismiss");
 
-        let updates =
-            scan_project_context_template_updates(temp.path(), &workspace).expect("scan again");
+        let mut clock = || fixed_publication_time();
+        let mut publications = Vec::new();
+        let updates = scan_project_context_template_updates_with_clock(
+            temp.path(),
+            &workspace,
+            &mut clock,
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect("scan again");
         assert!(updates.is_empty());
+        assert!(
+            publications.is_empty(),
+            "a dismissed observation must not manufacture publication evidence"
+        );
     }
 
     #[test]
@@ -1993,6 +2693,63 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(result.backup_path).expect("read backup"),
             custom
+        );
+    }
+
+    #[test]
+    fn overwrite_publication_survives_later_strict_state_save_error() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join(".ac");
+        std::fs::create_dir(&workspace).expect("create workspace");
+        let path = workspace.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+        let custom = "custom coordinator guidance";
+        std::fs::write(&path, custom).expect("write custom coordinator");
+        let update = scan_project_context_template_updates(temp.path(), &workspace)
+            .expect("scan updates")
+            .pop()
+            .expect("pending update");
+        let published_at = fixed_publication_time();
+        let mut clock = || published_at;
+        let handled_publication = std::cell::Cell::new(None);
+
+        let execution = overwrite_context_template_with_default_with(
+            &workspace,
+            &update.filename,
+            &update.current_file_sha256,
+            &update.current_default_sha256,
+            &mut clock,
+            &mut |filename, publication| {
+                assert_eq!(filename, COORDINATOR_CONTEXT_TEMPLATE_FILENAME);
+                handled_publication.set(Some(publication));
+            },
+            |_, _| {
+                assert_eq!(
+                    std::fs::read_to_string(&path).expect("read target before state save"),
+                    get_default_coordinator_template(),
+                    "the physical replacement must precede specialized state persistence"
+                );
+                assert_eq!(
+                    handled_publication.get(),
+                    Some(ContextPublication { published_at }),
+                    "the publication must be consumed before specialized state persistence"
+                );
+                Err("injected strict state persistence failure".to_string())
+            },
+        );
+
+        assert_eq!(
+            execution.published,
+            Some(ContextPublication { published_at })
+        );
+        assert_eq!(
+            execution
+                .completion
+                .expect_err("strict state save failure remains an outer error"),
+            "injected strict state persistence failure"
+        );
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read surviving published target"),
+            get_default_coordinator_template()
         );
     }
 

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -11,6 +11,14 @@ pub const COORDINATOR_CONTEXT_TEMPLATE_FILENAME: &str = "Context.coordinator.md"
 pub const ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.root-agent.md";
 static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CreateOnlyPublication {
+    Published {
+        published_at: chrono::DateTime<chrono::Utc>,
+    },
+    AlreadyPresent,
+}
+
 /// Writes a per-agent copy of AgentsCommanderContext.md with the agent's own
 /// root path interpolated into the GOLDEN RULE. For WG replicas, also exposes
 /// the canonical Agent Matrix scope derived from config.json "identity". Uses a
@@ -865,29 +873,62 @@ fn find_workspace_root(path: &std::path::Path) -> Option<std::path::PathBuf> {
 }
 
 pub fn create_default_context_templates(workspace_dir: &Path) -> Result<(), String> {
-    crate::config::seeded_context_templates::ensure_project_context_templates(workspace_dir)
+    let mut on_publication =
+        |_: &'static str, _: crate::config::seeded_context_templates::ContextPublication| {};
+    create_default_context_templates_with_publications(workspace_dir, &mut on_publication)
 }
 
-pub(crate) fn write_template_if_missing(path: &Path, content: &str) -> Result<(), String> {
-    write_template_if_missing_with(path, content, |path| {
-        std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(path)
-    })
+pub(crate) fn create_default_context_templates_with_publications(
+    workspace_dir: &Path,
+    on_publication: &mut dyn FnMut(
+        &'static str,
+        crate::config::seeded_context_templates::ContextPublication,
+    ),
+) -> Result<(), String> {
+    crate::config::seeded_context_templates::ensure_project_context_templates_with_publications(
+        workspace_dir,
+        on_publication,
+    )
+}
+
+pub(crate) fn write_template_if_missing(
+    path: &Path,
+    content: &str,
+) -> Result<CreateOnlyPublication, String> {
+    let mut clock = chrono::Utc::now;
+    write_template_if_missing_with_clock(path, content, &mut clock)
+}
+
+pub(crate) fn write_template_if_missing_with_clock(
+    path: &Path,
+    content: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> Result<CreateOnlyPublication, String> {
+    write_template_if_missing_with(
+        path,
+        content,
+        |path| {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+        },
+        clock,
+    )
 }
 
 fn write_template_if_missing_with<W, F>(
     path: &Path,
     content: &str,
     open_new: F,
-) -> Result<(), String>
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> Result<CreateOnlyPublication, String>
 where
     W: ContextTemplateWriter,
     F: FnOnce(&Path) -> std::io::Result<W>,
 {
     match std::fs::symlink_metadata(path) {
-        Ok(_) => return Ok(()),
+        Ok(_) => return Ok(CreateOnlyPublication::AlreadyPresent),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {
             return Err(format!(
@@ -938,12 +979,13 @@ where
 
     match std::fs::hard_link(&temp_path, path) {
         Ok(()) => {
+            let published_at = clock();
             cleanup_failed_context_template(&temp_path);
-            Ok(())
+            Ok(CreateOnlyPublication::Published { published_at })
         }
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
             cleanup_failed_context_template(&temp_path);
-            Ok(())
+            Ok(CreateOnlyPublication::AlreadyPresent)
         }
         Err(e) => {
             cleanup_failed_context_template(&temp_path);
@@ -1039,24 +1081,82 @@ fn read_or_create_context_template(
     filename: &str,
     default_content: &str,
 ) -> Result<Option<String>, String> {
+    let mut on_publication =
+        |_: &'static str, _: crate::config::seeded_context_templates::ContextPublication| {};
+    read_or_create_context_template_with_publications(
+        agent_root,
+        filename,
+        default_content,
+        &mut on_publication,
+    )
+}
+
+fn read_or_create_context_template_with_publications(
+    agent_root: &str,
+    filename: &str,
+    default_content: &str,
+    on_publication: &mut dyn FnMut(
+        &'static str,
+        crate::config::seeded_context_templates::ContextPublication,
+    ),
+) -> Result<Option<String>, String> {
+    read_or_create_context_template_with_sync(
+        agent_root,
+        filename,
+        default_content,
+        on_publication,
+        |context_dir, filename, on_publication| {
+            crate::config::seeded_context_templates::
+                sync_project_context_template_for_read_with_publications(
+                    context_dir,
+                    filename,
+                    on_publication,
+                )
+        },
+    )
+}
+
+fn read_or_create_context_template_with_sync<F>(
+    agent_root: &str,
+    filename: &str,
+    default_content: &str,
+    on_publication: &mut dyn FnMut(
+        &'static str,
+        crate::config::seeded_context_templates::ContextPublication,
+    ),
+    synchronize: F,
+) -> Result<Option<String>, String>
+where
+    F: FnOnce(
+        &Path,
+        &str,
+        &mut dyn FnMut(&'static str, crate::config::seeded_context_templates::ContextPublication),
+    ) -> Result<(), String>,
+{
     let Some(context_dir) = resolve_workspace_context_dir(Path::new(agent_root)) else {
         return Ok(None);
     };
     if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME {
         migrate_legacy_agent_context_template(&context_dir)?;
     }
-    if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME
-        || filename == COORDINATOR_CONTEXT_TEMPLATE_FILENAME
-    {
-        crate::config::seeded_context_templates::sync_project_context_template_for_read(
-            &context_dir,
-            filename,
-        )?;
+    let is_managed_project_template = filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME
+        || filename == COORDINATOR_CONTEXT_TEMPLATE_FILENAME;
+    if is_managed_project_template {
+        if let Err(e) = synchronize(&context_dir, filename, on_publication) {
+            log::warn!(
+                "[context-templates] failed to synchronize {} before reading: {}",
+                context_dir.join(filename).display(),
+                e
+            );
+        }
     }
     if let Some(content) = read_context_template(agent_root, filename)? {
         return Ok(Some(content));
     }
-    write_template_if_missing(&context_dir.join(filename), default_content)?;
+    if is_managed_project_template {
+        return Ok(None);
+    }
+    let _ = write_template_if_missing(&context_dir.join(filename), default_content)?;
     read_context_template(agent_root, filename)
 }
 
@@ -1888,10 +1988,11 @@ pub fn materialize_agent_context_file_with_filename(
     auto_self_clear: bool,
     repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
 ) -> Result<Option<String>, String> {
-    let content = match resolve_session_context_content(cwd, is_coordinator, auto_self_clear, repo_mounts)? {
-        Some(content) => content,
-        None => return Ok(None),
-    };
+    let content =
+        match resolve_session_context_content(cwd, is_coordinator, auto_self_clear, repo_mounts)? {
+            Some(content) => content,
+            None => return Ok(None),
+        };
 
     // String-level guard (path escape): never write outside the root, even if a
     // direct `pub` caller bypassed settings validation. The on-disk link checks
@@ -2016,7 +2117,14 @@ pub fn materialize_agent_context_file(
     // materialize_agent_context_file_with_filename in session.rs, which resolves
     // and passes the real auto_self_clear flag. Pass false here so no production
     // path loses the gated directive.
-    materialize_agent_context_file_with_filename(cwd, target.filename(), &[], is_coordinator, false, None)
+    materialize_agent_context_file_with_filename(
+        cwd,
+        target.filename(),
+        &[],
+        is_coordinator,
+        false,
+        None,
+    )
 }
 
 // ── Context-cache GC (#621) ───────────────────────────────────────────────
@@ -2329,7 +2437,18 @@ fn resolve_agent_context(
     ) {
         LegacyRenderedDefaultContext::Current => Ok(template),
         LegacyRenderedDefaultContext::StaleGenerated => {
-            heal_stale_global_context_template(agent_root, matrix_root, skills_section);
+            let execution =
+                heal_stale_global_context_template(agent_root, matrix_root, skills_section);
+            if let Some(publication) = execution.published {
+                log::debug!(
+                    "#664 self-heal: {} published at {}",
+                    GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+                    publication.published_at
+                );
+            }
+            if let Err(error) = &execution.completion {
+                log::warn!("#664 self-heal: {}", error);
+            }
             Ok(render_default_agent_context(
                 agent_root,
                 matrix_root,
@@ -2380,9 +2499,35 @@ fn heal_stale_global_context_template(
     agent_root: &str,
     matrix_root: Option<&str>,
     skills_section: &str,
-) {
+) -> crate::config::seeded_context_templates::ContextTemplateExecution<
+    crate::config::seeded_context_templates::TemplatePublication,
+> {
+    let mut clock = chrono::Utc::now;
+    heal_stale_global_context_template_with_clock(
+        agent_root,
+        matrix_root,
+        skills_section,
+        &mut clock,
+    )
+}
+
+fn heal_stale_global_context_template_with_clock(
+    agent_root: &str,
+    matrix_root: Option<&str>,
+    skills_section: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> crate::config::seeded_context_templates::ContextTemplateExecution<
+    crate::config::seeded_context_templates::TemplatePublication,
+> {
+    use crate::config::seeded_context_templates::{
+        ContextPublication, ContextTemplateExecution, ContextTemplateSkipReason,
+        TemplatePublication,
+    };
+
     let Some(context_dir) = resolve_workspace_context_dir(Path::new(agent_root)) else {
-        return;
+        return ContextTemplateExecution::completed(TemplatePublication::Skipped(
+            ContextTemplateSkipReason::WorkspaceUnavailable,
+        ));
     };
     let path = context_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
 
@@ -2390,10 +2535,17 @@ fn heal_stale_global_context_template(
     // create-if-missing side effects) and re-classify under the exact contract.
     let current = match read_context_template(agent_root, GLOBAL_CONTEXT_TEMPLATE_FILENAME) {
         Ok(Some(content)) => content,
-        Ok(None) => return, // vanished under us; nothing to heal
+        Ok(None) => {
+            return ContextTemplateExecution::completed(TemplatePublication::Skipped(
+                ContextTemplateSkipReason::TargetMissing,
+            ))
+        }
         Err(e) => {
-            log::warn!("#664 self-heal: cannot re-read {}: {}", path.display(), e);
-            return;
+            return ContextTemplateExecution::failed(format!(
+                "cannot re-read {}: {}",
+                path.display(),
+                e
+            ));
         }
     };
     if !matches!(
@@ -2402,21 +2554,29 @@ fn heal_stale_global_context_template(
     ) {
         // Changed under us, or no longer recognized as a generated legacy
         // default: preserve whatever is there, do nothing.
-        return;
+        return ContextTemplateExecution::completed(TemplatePublication::ChangedUnderUs);
     }
 
-    if let Err(e) = atomically_replace_context_template(&path, get_default_agent_template()) {
-        log::warn!(
-            "#664 self-heal: failed to regenerate stale global context template {}: {}",
-            path.display(),
-            e
-        );
-        return;
-    }
+    let published_at =
+        match atomically_replace_context_template(&path, get_default_agent_template(), clock) {
+            Ok(published_at) => published_at,
+            Err(error) => {
+                return ContextTemplateExecution::failed(format!(
+                    "failed to regenerate stale global context template {}: {}",
+                    path.display(),
+                    error
+                ))
+            }
+        };
     log::info!(
         "#664 self-heal: regenerated stale global context template {} to the current default",
         path.display()
     );
+    let publication = ContextPublication { published_at };
+    ContextTemplateExecution::with_publication(
+        Ok(TemplatePublication::Published(publication)),
+        publication,
+    )
 }
 
 /// Atomically replace `path` with `content`: write a unique temp file in the
@@ -2427,7 +2587,20 @@ fn heal_stale_global_context_template(
 pub(crate) fn atomically_replace_context_template(
     path: &Path,
     content: &str,
-) -> Result<(), String> {
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+) -> Result<chrono::DateTime<chrono::Utc>, String> {
+    atomically_replace_context_template_with(path, content, clock, sync_context_template_parent)
+}
+
+fn atomically_replace_context_template_with<S>(
+    path: &Path,
+    content: &str,
+    clock: &mut dyn FnMut() -> chrono::DateTime<chrono::Utc>,
+    sync_parent: S,
+) -> Result<chrono::DateTime<chrono::Utc>, String>
+where
+    S: FnOnce(&Path),
+{
     let temp = unique_context_template_temp_path(path);
     let mut file = std::fs::OpenOptions::new()
         .write(true)
@@ -2480,20 +2653,25 @@ pub(crate) fn atomically_replace_context_template(
         cleanup_failed_context_template(&temp);
         return Err(e);
     }
+    let published_at = clock();
 
     if let Some(parent) = path.parent() {
-        if let Ok(dir) = std::fs::File::open(parent) {
-            if let Err(e) = dir.sync_all() {
-                log::warn!(
-                    "#664 self-heal: failed to sync context template directory {}: {}",
-                    parent.display(),
-                    e
-                );
-            }
-        }
+        sync_parent(parent);
     }
 
-    Ok(())
+    Ok(published_at)
+}
+
+fn sync_context_template_parent(parent: &Path) {
+    if let Ok(dir) = std::fs::File::open(parent) {
+        if let Err(e) = dir.sync_all() {
+            log::warn!(
+                "#664 self-heal: failed to sync context template directory {}: {}",
+                parent.display(),
+                e
+            );
+        }
+    }
 }
 
 const MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS: &[&str] = &[
@@ -3598,8 +3776,9 @@ fn is_provably_generated_legacy_skills_section(
     section: &str,
     skill_owner_root: Option<&str>,
 ) -> bool {
-    let expected =
-        normalize_context_for_compat(&render_skills_section(&discover_skill_index(skill_owner_root)));
+    let expected = normalize_context_for_compat(&render_skills_section(&discover_skill_index(
+        skill_owner_root,
+    )));
     let normalized = normalize_context_for_compat(section);
     if normalized == expected {
         return true;
@@ -3692,6 +3871,12 @@ mod tests {
 
     fn path_string(path: &Path) -> String {
         path.to_string_lossy().to_string()
+    }
+
+    fn fixed_publication_time() -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::parse_from_rfc3339("2026-07-20T10:30:45.123Z")
+            .expect("parse fixed publication time")
+            .with_timezone(&chrono::Utc)
     }
 
     fn canonical_display_path(path: &Path) -> String {
@@ -3941,7 +4126,9 @@ For peer discovery, the sections below (`## Inter-Agent Messaging` and `### List
         );
         assert!(out.contains("**You answer to the user, and to no one else.**"));
         // Project-scope write grant (ROOT_PROJECT_SCOPE_ENTRY; #1005 S3 removed the Allowed bullet).
-        assert!(out.contains("you may create, modify, and delete files anywhere under ANY project folder registered"));
+        assert!(out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder registered"
+        ));
         // The Golden Rule is intentionally duplicated on the stale-Root path
         // (inline stale copy + appended current copy carrying the root sections).
         assert_eq!(count_section_headings(&out, "## GOLDEN RULE"), 2, "{out}");
@@ -4507,9 +4694,11 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     fn root_read_scope_grants_settings_json_and_agency_cache() {
         let out = default_context_as_root("C:/fake/ac-root-agent", None, &no_skill_section());
         assert!(out.contains("- **FORBIDDEN**: Any read operation outside"));
-        assert!(out.contains("You may ALWAYS read the app config `settings.json` to enumerate that set"));
+        assert!(out
+            .contains("You may ALWAYS read the app config `settings.json` to enumerate that set"));
         assert!(out.contains("`agency-templates status` and `agency-templates list` report on"));
-        assert!(out.contains("those two reads are grants, while direct writes to them stay CLI-managed"));
+        assert!(out
+            .contains("those two reads are grants, while direct writes to them stay CLI-managed"));
     }
 
     fn read_forbidden_bullet(out: &str) -> &str {
@@ -4586,7 +4775,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(out.contains(
             "Listing the workspace root that contains them, to discover which `repo-*` folders exist, is allowed"
         ));
-        assert!(out.contains("that grants folder names only, not the contents of anything else inside it"));
+        assert!(out.contains(
+            "that grants folder names only, not the contents of anything else inside it"
+        ));
     }
 
     #[test]
@@ -4600,7 +4791,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(out.contains("`_agent_*` matrices and `__agent_*` replicas"));
         // The repo-* naming restriction must be explicitly waived for the root.
         assert!(out.contains("`repo-*` naming restriction in entry #1 does NOT apply to you"));
-        assert!(out.contains("you may create, modify, and delete files anywhere under ANY project folder registered"));
+        assert!(out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder registered"
+        ));
     }
 
     #[test]
@@ -4674,7 +4867,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         );
         assert!(!out.contains("Every registered AgentsCommander project folder"));
         // #1005 S3: the Allowed bullet is extinct everywhere; pair on the live grant anchor.
-        assert!(!out.contains("you may create, modify, and delete files anywhere under ANY project folder"));
+        assert!(!out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder"
+        ));
         assert!(!out.contains("Root Agent Authority and Chain of Command"));
     }
 
@@ -4687,7 +4882,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let out = default_context("C:/fake/ac-root-agent", None, &no_skill_section());
         assert!(!out.contains("Every registered AgentsCommander project folder"));
         // #1005 S3: the Allowed bullet is extinct everywhere; pair on the live grant anchor.
-        assert!(!out.contains("you may create, modify, and delete files anywhere under ANY project folder"));
+        assert!(!out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder"
+        ));
         assert!(!out.contains("Root Agent Authority and Chain of Command"));
         // ...but the name-based root messaging text is still present (gate unchanged).
         assert!(out.contains("Narrow exception — Root Agent messaging directory"));
@@ -4732,7 +4929,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         );
         assert!(!out.contains("Every registered AgentsCommander project folder"));
         // #1005 S3: the Allowed bullet is extinct everywhere; pair on the live grant anchor.
-        assert!(!out.contains("you may create, modify, and delete files anywhere under ANY project folder"));
+        assert!(!out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder"
+        ));
         assert!(!out.contains("## Root Agent Authority and Chain of Command"));
         // ...but the name-based Root messaging text is still present (gate unchanged).
         assert!(out.contains("Narrow exception — Root Agent messaging directory"));
@@ -4781,7 +4980,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
 
         // Root project scope and authority, and the Team/Workgroup definitions.
         assert!(out.contains("Every registered AgentsCommander project folder"));
-        assert!(out.contains("you may create, modify, and delete files anywhere under ANY project folder registered"));
+        assert!(out.contains(
+            "you may create, modify, and delete files anywhere under ANY project folder registered"
+        ));
         assert!(out.contains("## Root Agent Authority and Chain of Command"));
         assert!(out.contains("**Team**: the logical capability and organization."));
         assert!(out.contains("**Workgroup**: a runtime replica of a team"));
@@ -5353,6 +5554,22 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let legacy_path = workspace_dir.join(LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME);
         let new_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
         std::fs::write(&legacy_path, "LEGACY_BODY {{AGENT_ROOT}}").expect("write legacy template");
+        let mut publications = Vec::new();
+
+        let migrated = read_or_create_context_template_with_publications(
+            &path_string(&matrix_root),
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            get_default_agent_template(),
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect("migrate legacy template")
+        .expect("migrated content");
+
+        assert_eq!(migrated, "LEGACY_BODY {{AGENT_ROOT}}");
+        assert!(
+            publications.is_empty(),
+            "the legacy hard-link migration must remain unrecorded"
+        );
 
         let materialized = materialize_agent_context_file(
             &path_string(&matrix_root),
@@ -5925,6 +6142,57 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
+    fn stale_global_self_heal_returns_commit_point_publication() {
+        use crate::config::seeded_context_templates::{ContextPublication, TemplatePublication};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let old_matrix_root = workspace_dir.join("_agent_dev-rust");
+        let new_matrix_root = workspace_dir.join("_agent_tech-lead");
+        let old_replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        let new_replica_root = workspace_dir
+            .join("wg-19-dev-team")
+            .join("__agent_tech-lead");
+        std::fs::create_dir_all(&old_matrix_root).expect("create old matrix root");
+        std::fs::create_dir_all(&new_matrix_root).expect("create new matrix root");
+        std::fs::create_dir_all(&old_replica_root).expect("create old replica root");
+        std::fs::create_dir_all(&new_replica_root).expect("create new replica root");
+        let old_skills_section =
+            render_skills_section(&discover_skill_index(Some(&path_string(&old_matrix_root))));
+        let legacy = legacy_rendered_default_context_for_compat(
+            &path_string(&old_replica_root),
+            Some(&path_string(&old_matrix_root)),
+            &old_skills_section,
+        );
+        let template_path = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(&template_path, legacy).expect("write stale generated default");
+        let expected = fixed_publication_time();
+        let mut clock = || expected;
+
+        let execution = heal_stale_global_context_template_with_clock(
+            &path_string(&new_replica_root),
+            Some(&path_string(&new_matrix_root)),
+            &no_skill_section(),
+            &mut clock,
+        );
+
+        let publication = ContextPublication {
+            published_at: expected,
+        };
+        assert_eq!(execution.published, Some(publication));
+        assert_eq!(
+            execution.completion.expect("self-heal completion"),
+            TemplatePublication::Published(publication)
+        );
+        assert_eq!(
+            std::fs::read_to_string(template_path).expect("read healed target"),
+            get_default_agent_template()
+        );
+    }
+
+    #[test]
     fn current_tokenized_default_on_disk_is_not_rewritten() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace_dir = temp.path().join(".ac");
@@ -6265,12 +6533,48 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
+    fn atomic_context_publication_captures_clock_after_replace() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        std::fs::write(&path, "old contents").expect("write old target");
+        let expected = fixed_publication_time();
+        let later = expected + chrono::Duration::seconds(30);
+        let observed_time = std::cell::Cell::new(expected);
+        let clock_sampled = std::cell::Cell::new(false);
+        let mut clock = || {
+            assert_eq!(
+                std::fs::read_to_string(&path).expect("read target at commit clock"),
+                "new contents",
+                "the target replacement must commit before the clock sample"
+            );
+            clock_sampled.set(true);
+            observed_time.get()
+        };
+
+        let published_at =
+            atomically_replace_context_template_with(&path, "new contents", &mut clock, |parent| {
+                assert_eq!(parent, temp.path());
+                assert!(
+                    clock_sampled.get(),
+                    "the commit-point clock must be sampled before parent sync"
+                );
+                observed_time.set(later);
+            })
+            .expect("replace target");
+
+        assert_eq!(published_at, expected);
+        assert_eq!(observed_time.get(), later);
+        assert_no_context_template_temp_leftover(temp.path());
+    }
+
+    #[test]
     fn atomically_replace_context_template_writes_absent_and_existing_dest() {
         let temp = tempfile::tempdir().expect("tempdir");
         let path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let mut clock = chrono::Utc::now;
 
         // Absent destination: plain create + rename publish.
-        atomically_replace_context_template(&path, "first contents")
+        atomically_replace_context_template(&path, "first contents", &mut clock)
             .expect("replace over absent dest");
         assert_eq!(
             std::fs::read_to_string(&path).expect("read first"),
@@ -6278,7 +6582,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         );
 
         // Existing destination: exercises the Windows ReplaceFileW branch.
-        atomically_replace_context_template(&path, "second contents")
+        atomically_replace_context_template(&path, "second contents", &mut clock)
             .expect("replace over existing dest");
         assert_eq!(
             std::fs::read_to_string(&path).expect("read second"),
@@ -6295,7 +6599,9 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         // helper returns Err and never creates the directory or a temp file.
         let missing_dir = temp.path().join("does-not-exist");
         let path = missing_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
-        let result = atomically_replace_context_template(&path, get_default_agent_template());
+        let mut clock = chrono::Utc::now;
+        let result =
+            atomically_replace_context_template(&path, get_default_agent_template(), &mut clock);
         assert!(
             result.is_err(),
             "expected Err when the parent dir is missing"
@@ -6683,19 +6989,26 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         let cwd = path_string(&matrix_root);
 
-        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, true, None)
-            .expect("materialize ON")
-            .expect("context path");
+        let on =
+            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, true, None)
+                .expect("materialize ON")
+                .expect("context path");
         let on_content = std::fs::read_to_string(&on).expect("read ON context");
         assert!(on_content.contains("## Self-Maintenance (auto self-handoff-and-clear)"));
         assert!(on_content.contains("reaches 3 such lines"));
         assert!(on_content.contains("max 240 char forgotten summary"));
         assert!(on_content.contains("closed background"));
 
-        let off =
-            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], false, false, None)
-                .expect("materialize OFF")
-                .expect("context path");
+        let off = materialize_agent_context_file_with_filename(
+            &cwd,
+            "CLAUDE.md",
+            &[],
+            false,
+            false,
+            None,
+        )
+        .expect("materialize OFF")
+        .expect("context path");
         let off_content = std::fs::read_to_string(&off).expect("read OFF context");
         assert!(!off_content.contains("## Self-Maintenance"));
         assert!(!off_content.contains("max 240 char forgotten summary"));
@@ -6719,9 +7032,10 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         .expect("write legacy coordinator template");
         let cwd = path_string(&matrix_root);
 
-        let on = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, true, None)
-            .expect("materialize ON")
-            .expect("context path");
+        let on =
+            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, true, None)
+                .expect("materialize ON")
+                .expect("context path");
         let on_content = std::fs::read_to_string(&on).expect("read ON context");
         assert_eq!(
             on_content.matches("## Self-Maintenance").count(),
@@ -6741,9 +7055,10 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             "coordinator body preserved"
         );
 
-        let off = materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, false, None)
-            .expect("materialize OFF")
-            .expect("context path");
+        let off =
+            materialize_agent_context_file_with_filename(&cwd, "CLAUDE.md", &[], true, false, None)
+                .expect("materialize OFF")
+                .expect("context path");
         let off_content = std::fs::read_to_string(&off).expect("read OFF context");
         assert_eq!(
             off_content.matches("## Self-Maintenance").count(),
@@ -6839,6 +7154,116 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
+    fn create_only_publication_captures_clock_before_temp_cleanup() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let expected = fixed_publication_time();
+        let mut clock_called = false;
+        let mut clock = || {
+            clock_called = true;
+            assert!(
+                path.is_file(),
+                "the final target must exist before publication time is captured"
+            );
+            let temp_still_present = std::fs::read_dir(temp.path())
+                .expect("read template directory")
+                .filter_map(Result::ok)
+                .any(|entry| {
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    name.starts_with(".Context.AgentsCommander.md") && name.ends_with(".tmp")
+                });
+            assert!(
+                temp_still_present,
+                "the winning temp must remain linked until after the clock sample"
+            );
+            expected
+        };
+
+        let outcome = write_template_if_missing_with_clock(&path, "complete", &mut clock)
+            .expect("publish missing template");
+
+        assert_eq!(
+            outcome,
+            CreateOnlyPublication::Published {
+                published_at: expected
+            }
+        );
+        assert!(clock_called);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read target"),
+            "complete"
+        );
+        assert_no_context_template_temp_leftover(temp.path());
+    }
+
+    #[test]
+    fn create_only_lost_race_is_already_present_without_a_clock_sample() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        let mut clock_calls = 0_u32;
+        let mut clock = || {
+            clock_calls += 1;
+            fixed_publication_time()
+        };
+
+        let outcome = write_template_if_missing_with::<std::fs::File, _>(
+            &path,
+            "losing contents",
+            |temp_path| {
+                let file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(temp_path)?;
+                std::fs::write(&path, "winning contents")?;
+                Ok(file)
+            },
+            &mut clock,
+        )
+        .expect("lost create race is not an error");
+
+        assert_eq!(outcome, CreateOnlyPublication::AlreadyPresent);
+        assert_eq!(
+            clock_calls, 0,
+            "a lost race must not sample publication time"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read winning target"),
+            "winning contents"
+        );
+        assert_no_context_template_temp_leftover(temp.path());
+    }
+
+    #[test]
+    fn managed_read_never_falls_back_to_an_ungated_direct_create() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = temp.path().join(".ac");
+        let matrix_root = workspace_dir.join("_agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        let target = workspace_dir.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+
+        for synchronization in [Err("injected synchronization failure".to_string()), Ok(())] {
+            let mut on_publication =
+                |_: &'static str,
+                 _: crate::config::seeded_context_templates::ContextPublication| {};
+            let result = read_or_create_context_template_with_sync(
+                &path_string(&matrix_root),
+                GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+                get_default_agent_template(),
+                &mut on_publication,
+                |_, _, _| synchronization,
+            )
+            .expect("managed fallback remains fail-soft");
+
+            assert_eq!(result, None);
+            assert!(
+                !target.exists(),
+                "managed sync failure or skip must use the in-memory default"
+            );
+        }
+    }
+
+    #[test]
     fn missing_templates_are_created_and_used_during_regeneration() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace_dir = temp.path().join(".ac");
@@ -6891,6 +7316,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             ),
         ] {
             let path = workspace_dir.join(filename);
+            let mut clock = chrono::Utc::now;
             let err = write_template_if_missing_with::<PartialFailWriter, _>(
                 &path,
                 default_content,
@@ -6905,6 +7331,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
                         fail_after_bytes: 8,
                     })
                 },
+                &mut clock,
             )
             .expect_err("injected partial write must fail");
 
@@ -6964,6 +7391,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let writer_release_barrier = Arc::clone(&release_barrier);
         let writer_path = path.clone();
         let writer = std::thread::spawn(move || {
+            let mut clock = chrono::Utc::now;
             write_template_if_missing_with::<BlockingPartialWriter, _>(
                 &writer_path,
                 get_default_agent_template(),
@@ -6980,6 +7408,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
                         release_barrier: writer_release_barrier,
                     })
                 },
+                &mut clock,
             )
         });
 
@@ -8379,7 +8808,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let skill_dir = root.join(SKILLS_DIR_NAME).join("agency-agents-roles");
         std::fs::create_dir_all(&skill_dir).expect("create skill dir");
 
-        let broken = crate::config::root_agent::agency_pre_yaml_fix_snapshot().replace('\n', "\r\n");
+        let broken =
+            crate::config::root_agent::agency_pre_yaml_fix_snapshot().replace('\n', "\r\n");
         std::fs::write(skill_dir.join("SKILL.md"), &broken).expect("seed the broken skill");
 
         crate::config::root_agent::ensure_default_root_agent_skills_at(&root)
@@ -8458,8 +8888,11 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         .expect("write valid skill");
         let broken_skill = old_matrix.join(SKILLS_DIR_NAME).join("delta-skill");
         std::fs::create_dir_all(&broken_skill).expect("create broken skill");
-        std::fs::write(broken_skill.join(SKILL_MD_FILENAME), "---\nname: [unclosed\n---\n\nbody\n")
-            .expect("write broken skill");
+        std::fs::write(
+            broken_skill.join(SKILL_MD_FILENAME),
+            "---\nname: [unclosed\n---\n\nbody\n",
+        )
+        .expect("write broken skill");
 
         // The old-generation embedded section: frozen OLD intro + current tail.
         let current_render =
@@ -8561,9 +8994,11 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         .expect("resolve context");
         assert!(!rendered.is_empty());
         let on_disk = std::fs::read_to_string(&template_path).expect("read template");
-        assert_eq!(on_disk, legacy, "edited legacy file must be preserved, never healed");
+        assert_eq!(
+            on_disk, legacy,
+            "edited legacy file must be preserved, never healed"
+        );
     }
-
 }
 
 /// #1005 token-accounting harness (plan section 7). Renders the three boot
@@ -8626,7 +9061,9 @@ mod token_accounting {
     /// replaced by a fixed fake path before counting.
     fn root_skills_section_fixed() -> String {
         let temp = tempfile::tempdir().expect("tempdir");
-        let root = temp.path().join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
+        let root = temp
+            .path()
+            .join(crate::config::root_agent::ROOT_AGENT_DIR_NAME);
         for (dir, content) in [
             (
                 "role-skill-boundary-audit",
@@ -8652,8 +9089,12 @@ mod token_accounting {
         let skills = synthetic_replica_skills_section();
 
         // Per-block rows (replica-shaped inputs).
-        let values =
-            super::default_context_dynamic_values(FAKE_REPLICA_ROOT, Some(FAKE_MATRIX_ROOT), &skills, false);
+        let values = super::default_context_dynamic_values(
+            FAKE_REPLICA_ROOT,
+            Some(FAKE_MATRIX_ROOT),
+            &skills,
+            false,
+        );
         let write_restrictions = super::render_write_restrictions_block(FAKE_REPLICA_ROOT, &values);
         let messaging = super::render_inter_agent_messaging_block(&values);
         let workspace_repos =
@@ -8664,10 +9105,19 @@ mod token_accounting {
         println!();
         println!("| item | chars | ~tokens |");
         println!("|---|---|---|");
-        print_row("block: write restrictions (A2, replica)", write_restrictions.len());
-        print_row("block: inter-agent messaging (A3, replica)", messaging.len());
+        print_row(
+            "block: write restrictions (A2, replica)",
+            write_restrictions.len(),
+        );
+        print_row(
+            "block: inter-agent messaging (A3, replica)",
+            messaging.len(),
+        );
         print_row("block: CLI context (A4a)", super::DEFAULT_CLI_CONTEXT.len());
-        print_row("block: session credentials (A4b)", super::DEFAULT_SESSION_CREDENTIALS.len());
+        print_row(
+            "block: session credentials (A4b)",
+            super::DEFAULT_SESSION_CREDENTIALS.len(),
+        );
         print_row(
             "block: delegated task reporting (A4c)",
             super::DEFAULT_DELEGATED_TASK_REPORTING.len(),
@@ -8680,7 +9130,10 @@ mod token_accounting {
             "block: workspace repos header (A6, root variant)",
             super::workspace_repos_header(true).len(),
         );
-        print_row("block: skills section (A5, synthetic 2 skills)", skills.len());
+        print_row(
+            "block: skills section (A5, synthetic 2 skills)",
+            skills.len(),
+        );
         print_row("block: workspace repos (A6, empty)", workspace_repos.len());
         print_row(
             "block: self-maintenance (A8)",
@@ -8713,9 +9166,15 @@ mod token_accounting {
 
         print_row("profile: WG replica", replica.len());
         print_row("profile: coordinator", coordinator.len());
-        print_row("profile: coordinator + auto_self_clear", coordinator_auto_clear.len());
+        print_row(
+            "profile: coordinator + auto_self_clear",
+            coordinator_auto_clear.len(),
+        );
         print_row("profile: Root Agent", root.len());
-        print_row("profile: Root Agent + auto_self_clear", root_auto_clear.len());
+        print_row(
+            "profile: Root Agent + auto_self_clear",
+            root_auto_clear.len(),
+        );
 
         // Supplement rows (G4): boot-invisible durables.
         let b1 = crate::config::root_agent::default_root_context_template();


### PR DESCRIPTION
## Summary

- Add the dormant Stage B two-channel carrier for context-template completion and committed publication outcomes.
- Preserve create-only, recognized-update, explicit-overwrite, managed-read, and legacy self-heal publication truth across later validation or persistence failures.
- Keep public IPC, schema, frontend, PTY, dependency, and production activation behavior unchanged.

## Authority

- Parent delivery: #1038 (remains open for Stages C-F).
- Certified plan: `plans/1038-project-seed-manifest.md`.
- Plan SHA-256: `B0BDADDCB579B2A28826A2B527665A684E75AC4835224ABB6E8B2A4C97A83325`.
- Reviewed head: `c11f4e527d6e0cf2b22c2c34e029588a33d9c78c`.
- Reviewed tree: `81e5b99a08a425be645d0f4f9c9e1daa45ab38e7`.
- Current base: `7e06b08c5889a63047863555e16600bb59cdd750`.
- Final adversarial verdict: `PASS_STAGE_B_STEP_9`; `NON_VISUAL_CHANGE`; no unresolved findings.

## Verification

- Exact Stage B file matrix rustfmt: PASS.
- Rust focused suites: 44 seeded-context tests; 144 session-context tests with 1 allowlisted ignored; 26 profile tests; 178 Pi tests; both named cross-provider tests PASS.
- Full local evidence: npm install/debt/typecheck, 138-file / 1,281-test frontend suite, frontend builds, Cargo check/clippy, full Rust workspace (2,676 primary-library tests passed, 9 allowlisted ignored), production build, and Windows CLI smoke 4/4 PASS.
- Exact-head CI: validation run https://github.com/mblua/AgentsCommander/actions/runs/29746728488 and regression run https://github.com/mblua/AgentsCommander/actions/runs/29746728681 completed successfully.
- Coordinator Step 9.5: remote branch equals reviewed head, current `main` is an ancestor, and worktree/index are clean.

## Release / UX

- N/A — non-visual change.
- No version bump; no release is being cut.
- Production seed-manifest emission remains impossible and dormant in this stage.

Closes #1061