### PR TITLE
fix(#1078): mark repository badges red until local work reaches origin

### DIFF
--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -390,10 +390,12 @@ struct DiscoveryBranchPayload {
     /// to the previous repo list. A positional merge would then paint repo A's branch
     /// onto repo B, silently. Matching on the path cannot.
     repo_paths: Vec<String>,
-    /// #1028 - per-repo worktree-dirty, positionally parallel to `repo_paths` exactly as
-    /// `repo_branches` is, and keyed by path by the consumer for the same reason.
-    /// `Some(true)` paints the badge letters red; `None` = never successfully detected
-    /// for that path (rendered violet, like clean).
+    /// #1028/#1078 - per-repo local-work state, positionally parallel to `repo_paths`
+    /// exactly as `repo_branches` is, and keyed by path by the consumer for the same
+    /// reason. `Some(true)` means Git emitted a non-ignored worktree/index entry or the
+    /// checked-out `HEAD` was not confirmed reachable from the configured cached
+    /// `origin/*` upstream. `None` means never successfully detected for that path
+    /// (rendered violet, like clean).
     ///
     /// This rides the feed `repo_branches` already established, which is what covers
     /// DORMANT coordinator rows: Gate A runs for every replica whether or not a session

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -29,14 +29,14 @@ fn note_timeout(path: &str) -> u64 {
     *count
 }
 
-/// #1028 - one worktree status detection: the branch from the `## ` header plus
-/// whether the worktree holds any uncommitted work.
+/// #1028/#1078 - one local repository status detection: the branch from the
+/// `## ` header plus whether local work is confirmed by cached origin tracking.
 ///
-/// `dirty` is strictly the WORKTREE definition #1028 names: untracked, unstaged,
-/// or staged-but-uncommitted. It is deliberately NARROWER than
-/// `check_workgroup_repos_dirty` (`commands/entity_creation.rs`), which also counts
-/// unpushed commits and a missing upstream. A clean-but-unpushed repo is dirty
-/// there and clean here, on purpose. Reuse that pattern, never that function.
+/// `dirty` is true when Git emits a non-ignored worktree/index entry, or when the
+/// checked-out `HEAD` is not confirmed reachable from the current branch's configured,
+/// locally cached `origin/*` upstream. This detector never performs a remote operation.
+/// It remains deliberately separate from the blocking deletion-safety checks in
+/// `commands/entity_creation.rs`.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct GitStatus {
     /// `None` for a detached HEAD or a mid-rebase, matching what
@@ -98,36 +98,68 @@ pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool>
     }
 }
 
-/// #1028 - parse `git status --porcelain --branch` output.
+/// Return whether a successful porcelain header confirms that `HEAD` is reachable
+/// from the current branch's configured, locally cached `origin/*` upstream.
+///
+/// Only a synchronized header or an exact positive behind-only marker confirms that
+/// relation. Every missing, detached, unborn, non-origin, gone, ahead, diverged, or
+/// malformed shape fails closed.
+fn cached_origin_contains_head(header: &str) -> bool {
+    if header == "HEAD (no branch)" || header.starts_with("No commits yet on ") {
+        return false;
+    }
+
+    let Some((branch, upstream_and_tracking)) = header.split_once("...") else {
+        return false;
+    };
+    let branch = branch.trim();
+    if branch.is_empty() || branch == "HEAD" {
+        return false;
+    }
+
+    // Split only at the tracking marker boundary. Spaces and `[` are forbidden in
+    // refnames, so this cannot truncate a valid upstream name.
+    let (upstream, tracking) = match upstream_and_tracking.split_once(" [") {
+        Some((upstream, tracking)) => (upstream, Some(tracking)),
+        None => (upstream_and_tracking, None),
+    };
+    let Some(target) = upstream.strip_prefix("origin/") else {
+        return false;
+    };
+    if target.is_empty() {
+        return false;
+    }
+
+    match tracking {
+        None => true,
+        Some(tracking) => {
+            let Some(count) = tracking
+                .strip_prefix("behind ")
+                .and_then(|value| value.strip_suffix(']'))
+            else {
+                return false;
+            };
+            !count.is_empty()
+                && count.bytes().all(|byte| byte.is_ascii_digit())
+                && count.parse::<u64>().is_ok_and(|value| value > 0)
+        }
+    }
+}
+
+/// #1028/#1078 - parse
+/// `git status --porcelain --branch --untracked-files=normal --ahead-behind` output.
 ///
 /// Git builds the header as `## ` + (`No commits yet on ` if unborn) + branch +
-/// (`...` + upstream + optional ` [...]` if an upstream is configured), so unborn and
-/// upstream are orthogonal and the shape matrix is closed, not merely "what we found":
-///
-/// | State                     | Header                                          |
-/// |---------------------------|-------------------------------------------------|
-/// | born, no upstream         | `## master`                                      |
-/// | born, upstream in sync    | `## master...origin/master`                      |
-/// | born, upstream diverged   | `## master...origin/master [ahead 1, behind 2]`  |
-/// | detached / mid-rebase     | `## HEAD (no branch)`                            |
-/// | unborn, no upstream       | `## No commits yet on master`                    |
-/// | unborn, with upstream     | `## No commits yet on master...origin/master [gone]` |
-///
-/// An unborn branch prints `[gone]` even against a real, fetched upstream, because it
-/// has no commit and so ahead/behind cannot be computed. There is therefore no
-/// "unborn + upstream + no bracket" shape.
-///
-/// Splitting on `...` and trimming ` [...]` are both safe because git's refname rules
-/// reject `feat..bad` and `feat[x]`, so neither sequence can occur inside a real branch
-/// name. Single dots and slashes (`feat/a.b-c`) survive.
+/// (`...` + upstream + optional ` [...]` if an upstream is configured). Splitting on
+/// `...` and ` [` is safe because Git's refname rules reject those sequences inside a
+/// real branch name. Single dots and slashes (`feat/a.b-c`) survive branch extraction.
 pub(crate) fn parse_status_porcelain_branch(stdout: &str) -> Option<GitStatus> {
     let mut lines = stdout.lines();
     // Output we do not understand: do not guess.
     let header = lines.next()?.strip_prefix("## ")?;
 
-    // Any entry after the header is a dirty entry: ` M tracked`, `A  staged`,
-    // `?? untracked`. Ahead/behind live inside the header, so they cost nothing here.
-    let dirty = lines.any(|l| !l.trim().is_empty());
+    let has_porcelain_entries = lines.any(|line| !line.trim().is_empty());
+    let dirty = has_porcelain_entries || !cached_origin_contains_head(header);
 
     // (a) detached / mid-rebase. Must short-circuit before (b).
     let branch = if header == "HEAD (no branch)" {
@@ -155,8 +187,9 @@ pub(crate) fn parse_status_porcelain_branch(stdout: &str) -> Option<GitStatus> {
     Some(GitStatus { branch, dirty })
 }
 
-/// #1028 - detect branch AND worktree-dirty for `working_dir` in ONE git call. Shared
-/// by both badge writers (`GitWatcher` and `DiscoveryBranchWatcher`), which previously
+/// #1028/#1078 - detect branch and local work not confirmed by cached origin tracking
+/// for `working_dir` in one local Git call. Shared by both badge writers (`GitWatcher`
+/// and `DiscoveryBranchWatcher`), which previously
 /// kept near-identical `detect_branch` copies that had already diverged: one set the
 /// ceiling env, the other did not. Both writers must compute `dirty` identically or the
 /// badge flickers, and duplicating the parse is how that guarantee gets lost.
@@ -213,9 +246,16 @@ pub(crate) async fn detect_git_status(working_dir: &str) -> Option<GitStatus> {
 
     let mut cmd = tokio::process::Command::new("git");
     crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
-    cmd.args(["--no-optional-locks", "status", "--porcelain", "--branch"])
-        .current_dir(working_dir)
-        .kill_on_drop(true);
+    cmd.args([
+        "--no-optional-locks",
+        "status",
+        "--porcelain",
+        "--branch",
+        "--untracked-files=normal",
+        "--ahead-behind",
+    ])
+    .current_dir(working_dir)
+    .kill_on_drop(true);
 
     // Gate 2: no ancestor ascent. `join_paths` emits the platform separator, matching
     // the existing ceiling code. With no parent (a filesystem root), skip the env
@@ -524,102 +564,116 @@ mod tests {
         assert_eq!(note_timeout(p1), 4);
     }
 
-    // --- #1028: parse_status_porcelain_branch, one test per header shape ---
+    // --- #1078: cached-origin parser semantics ---
 
     fn parse(stdout: &str) -> GitStatus {
         parse_status_porcelain_branch(stdout).expect("header should parse")
     }
 
-    /// Shape 1: born, no upstream.
     #[test]
-    fn parse_born_no_upstream() {
-        let s = parse("## master\n");
-        assert_eq!(s.branch.as_deref(), Some("master"));
-        assert!(!s.dirty);
+    fn parse_synced_and_positive_behind_only_origin_headers_are_clean() {
+        for stdout in [
+            "## main...origin/main\n",
+            "## main...origin/main",
+            "## main...origin/main [behind 1]\n",
+            "## main...origin/main [behind 42]\n",
+        ] {
+            let status = parse(stdout);
+            assert_eq!(status.branch.as_deref(), Some("main"), "{stdout:?}");
+            assert!(!status.dirty, "{stdout:?}");
+        }
     }
 
-    /// Shape 2: born, upstream in sync. The upstream must not leak into the branch.
     #[test]
-    fn parse_born_upstream_in_sync() {
-        assert_eq!(
-            parse("## master...origin/master\n").branch.as_deref(),
-            Some("master")
-        );
+    fn parse_ahead_diverged_gone_and_malformed_tracking_are_red() {
+        for header in [
+            "main...origin/main [ahead 1]",
+            "main...origin/main [ahead 1, behind 2]",
+            "main...origin/main [gone]",
+            "main...origin/main [unknown 1]",
+            "main...origin/main [behind 0]",
+            "main...origin/main [behind -1]",
+            "main...origin/main [behind 1, ahead 2]",
+            "main...origin/main [behind 18446744073709551616]",
+            "main...origin/main [behind 1",
+        ] {
+            let stdout = format!("## {header}\n");
+            assert!(parse(&stdout).dirty, "{header:?} must fail closed");
+        }
     }
 
-    /// Shape 3: born, upstream diverged. Ahead/behind live in the header, so they must
-    /// not be read as dirty entries either.
     #[test]
-    fn parse_born_upstream_diverged() {
-        let s = parse("## master...origin/master [ahead 1, behind 2]\n");
-        assert_eq!(s.branch.as_deref(), Some("master"));
-        assert!(!s.dirty, "ahead/behind is not worktree dirt");
+    fn parse_missing_and_non_origin_upstreams_are_red() {
+        for header in [
+            "main",
+            "main...backup/main",
+            "main...backup/main [behind 1]",
+            "main...origin/",
+        ] {
+            let stdout = format!("## {header}\n");
+            let status = parse(&stdout);
+            assert_eq!(status.branch.as_deref(), Some("main"), "{header:?}");
+            assert!(status.dirty, "{header:?}");
+        }
     }
 
-    /// Shape 4: detached HEAD or mid-rebase. Parses fine; the BRANCH is what is unknown.
     #[test]
-    fn parse_detached_head() {
-        let s = parse("## HEAD (no branch)\n");
-        assert_eq!(s.branch, None);
-        assert!(!s.dirty);
+    fn parse_detached_empty_head_and_unborn_headers_are_red() {
+        let detached = parse("## HEAD (no branch)\n");
+        assert_eq!(detached.branch, None);
+        assert!(detached.dirty);
+
+        let empty = parse("## \n");
+        assert_eq!(empty.branch, None);
+        assert!(empty.dirty);
+
+        let head = parse("## HEAD\n");
+        assert_eq!(head.branch, None);
+        assert!(head.dirty);
+
+        let unborn = parse("## No commits yet on main\n");
+        assert_eq!(unborn.branch.as_deref(), Some("main"));
+        assert!(unborn.dirty);
+
+        let unborn_with_upstream = parse("## No commits yet on main...origin/main [gone]\n");
+        assert_eq!(unborn_with_upstream.branch.as_deref(), Some("main"));
+        assert!(unborn_with_upstream.dirty);
     }
 
-    /// Shape 5: unborn, no upstream.
     #[test]
-    fn parse_unborn_no_upstream() {
-        assert_eq!(
-            parse("## No commits yet on master\n").branch.as_deref(),
-            Some("master")
-        );
+    fn parse_preserves_legal_dots_and_slashes_in_branch_names() {
+        let synced = parse("## feat/a.b-c...origin/feat/a.b-c\n");
+        assert_eq!(synced.branch.as_deref(), Some("feat/a.b-c"));
+        assert!(!synced.dirty);
+
+        let ahead = parse("## feat/a.b-c...origin/feat/a.b-c [ahead 1]\n");
+        assert_eq!(ahead.branch.as_deref(), Some("feat/a.b-c"));
+        assert!(ahead.dirty);
     }
 
-    /// Shape 5b: unborn WITH an upstream. Regression guard for the shape both round-1
-    /// reports missed: step (b) must strip `No commits yet on ` and then CONTINUE into
-    /// the `...` split rather than returning. An unborn branch prints `[gone]` even
-    /// against a real fetched upstream, so this is the only unborn-with-upstream form.
     #[test]
-    fn parse_unborn_with_upstream() {
-        assert_eq!(
-            parse("## No commits yet on master...origin/master [gone]\n")
-                .branch
-                .as_deref(),
-            Some("master")
-        );
+    fn parse_every_nonblank_porcelain_entry_as_red() {
+        for (kind, row) in [
+            ("unstaged", " M tracked.txt"),
+            ("staged", "M  tracked.txt"),
+            ("untracked", "?? untracked.txt"),
+            ("deleted", " D deleted.txt"),
+            ("renamed", "R  old.txt -> new.txt"),
+            ("conflicted", "UU conflicted.txt"),
+            ("other", "T  type-changed.txt"),
+        ] {
+            let stdout = format!("## main...origin/main\n{row}\n");
+            assert!(parse(&stdout).dirty, "{kind}: {row:?}");
+        }
     }
 
-    /// A detached HEAD is checked before the unborn prefix strip, and a branch may not
-    /// be named `HEAD`, so nothing here can resolve to a `HEAD` branch.
     #[test]
-    fn parse_detached_head_beats_unborn_prefix() {
-        assert_eq!(parse("## HEAD (no branch)\n").branch, None);
-        assert_eq!(parse("## HEAD\n").branch, None);
+    fn parse_blank_lines_after_synced_header_are_clean() {
+        assert!(!parse("## main...origin/main\n\n  \n\t\n").dirty);
     }
 
-    /// All three dirty kinds #1028 names, each alone and then together.
     #[test]
-    fn parse_dirty_kinds() {
-        assert!(parse("## main\n M tracked.txt\n").dirty, "unstaged");
-        assert!(parse("## main\nA  staged.txt\n").dirty, "staged");
-        assert!(parse("## main\n?? untracked.txt\n").dirty, "untracked");
-
-        let all = parse("## main\n M tracked.txt\nA  staged.txt\n?? untracked.txt\n");
-        assert!(all.dirty);
-        assert_eq!(all.branch.as_deref(), Some("main"));
-    }
-
-    /// Clean: header only. The trailing newline must not read as a dirty entry.
-    #[test]
-    fn parse_clean_is_not_dirty() {
-        assert!(!parse("## main\n").dirty);
-        assert!(!parse("## main").dirty, "no trailing newline");
-        assert!(!parse("## main\n\n").dirty, "blank lines are not entries");
-    }
-
-    /// Output we do not understand: return None rather than guess. Only a first line
-    /// that is not a `## ` header does this; a header we CAN read but whose branch is
-    /// unknowable still answers, with `branch: None` (see the detached-HEAD shape).
-    #[test]
-    fn parse_garbage_returns_none() {
+    fn parse_missing_or_garbage_first_header_returns_none() {
         assert_eq!(parse_status_porcelain_branch(""), None, "no first line");
         assert_eq!(
             parse_status_porcelain_branch("fatal: not a git repository\n"),
@@ -638,41 +692,242 @@ mod tests {
         );
     }
 
-    /// A `## ` header with an empty branch is a HEADER, not garbage: it answers
-    /// `branch: None` like a detached HEAD rather than discarding the dirty scan. Git
-    /// does not emit this today; pinned so the two "unknown" paths stay distinct.
-    #[test]
-    fn parse_empty_branch_answers_with_none_branch() {
-        assert_eq!(
-            parse_status_porcelain_branch("## \n"),
-            Some(GitStatus {
-                branch: None,
-                dirty: false
-            })
+    // --- #1078: real temporary repositories ---
+
+    struct TestRepository {
+        repo: std::path::PathBuf,
+        origin: std::path::PathBuf,
+    }
+
+    fn git_path(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
+    }
+
+    fn git(cwd: &std::path::Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to execute git {args:?}: {error}"));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "git {args:?} failed in {} with {}\nstdout:\n{}\nstderr:\n{}",
+            cwd.display(),
+            output.status,
+            stdout,
+            stderr
         );
-        assert_eq!(
-            parse_status_porcelain_branch("## \n?? untracked.txt\n"),
-            Some(GitStatus {
-                branch: None,
-                dirty: true
-            }),
-            "dirty is still observable without a branch"
+        stdout.trim().to_string()
+    }
+
+    fn configure_test_repo(repo: &std::path::Path, hooks: &std::path::Path) {
+        let hooks = git_path(hooks);
+        git(
+            repo,
+            &["config", "--local", "user.name", "AgentsCommander Test"],
+        );
+        git(
+            repo,
+            &[
+                "config",
+                "--local",
+                "user.email",
+                "agentscommander@example.invalid",
+            ],
+        );
+        git(repo, &["config", "--local", "commit.gpgSign", "false"]);
+        git(repo, &["config", "--local", "tag.gpgSign", "false"]);
+        git(repo, &["config", "--local", "core.autocrlf", "false"]);
+        git(repo, &["config", "--local", "core.hooksPath", &hooks]);
+    }
+
+    fn init_synced_test_repo(root: &std::path::Path) -> TestRepository {
+        let origin = root.join("origin.git");
+        let repo = root.join("watched");
+        let hooks = root.join("empty-hooks");
+        std::fs::create_dir_all(&origin).expect("create bare origin directory");
+        std::fs::create_dir_all(&repo).expect("create watched repository directory");
+        std::fs::create_dir_all(&hooks).expect("create empty hooks directory");
+
+        let origin_arg = git_path(&origin);
+        git(
+            root,
+            &["init", "--bare", "--initial-branch=main", &origin_arg],
+        );
+        git(&repo, &["init", "--initial-branch=main", "."]);
+        configure_test_repo(&repo, &hooks);
+
+        std::fs::write(repo.join(".gitignore"), "ignored/\n").expect("write .gitignore");
+        std::fs::write(repo.join("tracked.txt"), "initial\n").expect("write tracked file");
+        git(&repo, &["add", ".gitignore", "tracked.txt"]);
+        git(&repo, &["commit", "--no-gpg-sign", "-m", "initial"]);
+        git(&repo, &["remote", "add", "origin", &origin_arg]);
+        git(&repo, &["push", "--set-upstream", "origin", "main"]);
+
+        TestRepository { repo, origin }
+    }
+
+    fn status_header(repo: &std::path::Path) -> String {
+        git(
+            repo,
+            &[
+                "--no-optional-locks",
+                "status",
+                "--porcelain",
+                "--branch",
+                "--untracked-files=normal",
+                "--ahead-behind",
+            ],
+        )
+        .lines()
+        .next()
+        .expect("status header")
+        .to_string()
+    }
+
+    async fn detect(repo: &std::path::Path) -> GitStatus {
+        detect_git_status(&repo.to_string_lossy())
+            .await
+            .unwrap_or_else(|| panic!("status detection failed for {}", repo.display()))
+    }
+
+    #[tokio::test]
+    async fn detect_git_status_forces_untracked_and_keeps_ignored_out_of_scope() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let test = init_synced_test_repo(temp.path());
+        git(
+            &test.repo,
+            &["config", "--local", "status.showUntrackedFiles", "no"],
+        );
+        assert!(!detect(&test.repo).await.dirty, "synchronized baseline");
+
+        let untracked = test.repo.join("visible-untracked.txt");
+        std::fs::write(&untracked, "visible\n").expect("write untracked file");
+        assert!(
+            detect(&test.repo).await.dirty,
+            "command-line untracked reporting must override repository config"
+        );
+
+        std::fs::remove_file(untracked).expect("remove untracked file");
+        let ignored_dir = test.repo.join("ignored");
+        std::fs::create_dir_all(&ignored_dir).expect("create ignored directory");
+        std::fs::write(ignored_dir.join("only.txt"), "ignored\n").expect("write ignored file");
+        assert!(
+            !detect(&test.repo).await.dirty,
+            "ignored-only content stays normal"
         );
     }
 
-    /// Single dots and slashes are legal in refnames and must survive: only `...` splits.
-    #[test]
-    fn parse_branch_with_dots_and_slashes() {
+    #[tokio::test]
+    async fn detect_git_status_stays_red_from_modify_through_commit_until_push() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let test = init_synced_test_repo(temp.path());
+        assert!(!detect(&test.repo).await.dirty, "synchronized baseline");
+
+        std::fs::write(test.repo.join("tracked.txt"), "initial\nmodified\n")
+            .expect("modify tracked file");
+        assert!(detect(&test.repo).await.dirty, "unstaged modification");
+
+        git(&test.repo, &["add", "tracked.txt"]);
+        assert!(detect(&test.repo).await.dirty, "staged modification");
+
+        git(
+            &test.repo,
+            &["commit", "--no-gpg-sign", "-m", "local commit"],
+        );
+        assert!(
+            detect(&test.repo).await.dirty,
+            "clean local-ahead commit remains red"
+        );
+
+        git(&test.repo, &["push", "origin", "main"]);
         assert_eq!(
-            parse("## feat/a.b-c\n").branch.as_deref(),
-            Some("feat/a.b-c")
+            git(&test.repo, &["rev-parse", "HEAD"]),
+            git(&test.repo, &["rev-parse", "refs/remotes/origin/main"]),
+            "push must update the cached origin tracking ref"
+        );
+        assert!(!detect(&test.repo).await.dirty, "push returns to normal");
+        assert!(
+            !detect(&test.repo).await.dirty,
+            "normal state is stable across detections"
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_git_status_handles_cached_history_matrix() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let test = init_synced_test_repo(temp.path());
+        let peer = temp.path().join("peer");
+        let peer_arg = git_path(&peer);
+        let origin_arg = git_path(&test.origin);
+        git(
+            temp.path(),
+            &["clone", "--branch", "main", &origin_arg, &peer_arg],
+        );
+        configure_test_repo(&peer, &temp.path().join("empty-hooks"));
+
+        std::fs::write(peer.join("tracked.txt"), "initial\npeer\n").expect("advance peer file");
+        git(&peer, &["add", "tracked.txt"]);
+        git(&peer, &["commit", "--no-gpg-sign", "-m", "peer commit"]);
+        git(&peer, &["push", "origin", "main"]);
+
+        assert_ne!(
+            git(&test.repo, &["rev-parse", "refs/remotes/origin/main"]),
+            git(&test.origin, &["rev-parse", "refs/heads/main"]),
+            "peer push must not mutate the watched repository's cached ref"
+        );
+        assert!(
+            !detect(&test.repo).await.dirty,
+            "without fetch, unchanged cached tracking deliberately stays normal"
+        );
+
+        git(&test.repo, &["fetch", "origin"]);
+        assert!(status_header(&test.repo).contains("[behind 1]"));
+        assert!(!detect(&test.repo).await.dirty, "behind-only is normal");
+
+        std::fs::write(test.repo.join("local-only.txt"), "local\n").expect("write local-only file");
+        git(&test.repo, &["add", "local-only.txt"]);
+        git(
+            &test.repo,
+            &["commit", "--no-gpg-sign", "-m", "diverging commit"],
+        );
+        assert!(status_header(&test.repo).contains("[ahead 1, behind 1]"));
+        assert!(detect(&test.repo).await.dirty, "diverged with ahead is red");
+
+        git(&test.repo, &["reset", "--hard", "origin/main"]);
+        assert!(!detect(&test.repo).await.dirty, "restored sync is normal");
+
+        git(&test.repo, &["branch", "--unset-upstream"]);
+        assert!(detect(&test.repo).await.dirty, "missing upstream is red");
+        git(
+            &test.repo,
+            &["branch", "--set-upstream-to=origin/main", "main"],
+        );
+        assert!(
+            !detect(&test.repo).await.dirty,
+            "restored upstream is normal"
+        );
+
+        git(
+            &test.repo,
+            &["update-ref", "-d", "refs/remotes/origin/main"],
         );
         assert_eq!(
-            parse("## feat/a.b-c...origin/feat/a.b-c [ahead 1]\n")
-                .branch
-                .as_deref(),
-            Some("feat/a.b-c")
+            git(&test.repo, &["config", "--get", "branch.main.remote"]),
+            "origin",
+            "branch configuration remains after deleting the cached target"
         );
+        assert!(status_header(&test.repo).contains("[gone]"));
+        assert!(detect(&test.repo).await.dirty, "gone cached target is red");
+
+        git(&test.repo, &["fetch", "origin"]);
+        assert!(!detect(&test.repo).await.dirty, "fetch restores normal");
+        git(&test.repo, &["checkout", "--detach", "HEAD"]);
+        let detached = detect(&test.repo).await;
+        assert_eq!(detached.branch, None);
+        assert!(detached.dirty, "detached HEAD is red");
     }
 
     // --- #1028: remember_dirty ---

--- a/src-tauri/src/session/session.rs
+++ b/src-tauri/src/session/session.rs
@@ -36,14 +36,16 @@ pub const TEMP_SESSION_PREFIX: &str = "[temp]";
 pub struct SessionRepo {
     /// Repo dir name with leading "repo-" stripped (e.g. "AgentsCommander").
     pub label: String,
-    /// Absolute path to the repo root. Branch detection runs `git rev-parse` in this dir.
+    /// Absolute path to the repo root. Local Git status detection runs in this directory.
     pub source_path: String,
     /// Current branch. `None` until first watcher tick, or when detection fails.
     #[serde(default)]
     pub branch: Option<String>,
-    /// #1028 - worktree dirty: untracked, unstaged, or staged-but-uncommitted changes.
-    /// `Some(true)` paints the badge letters red. `None` = never successfully detected
-    /// for this path since process start, rendered violet like clean; a failed detection
+    /// #1028/#1078 - local work not confirmed by cached origin tracking: Git emitted a
+    /// non-ignored worktree/index entry, or the checked-out `HEAD` was not confirmed
+    /// reachable from the current branch's configured cached `origin/*` upstream.
+    /// `Some(true)` paints the badge letters red. `None` means never successfully
+    /// detected for this path since process start, rendered violet like clean; a failed detection
     /// holds the last known answer instead (`git_watcher::remember_dirty`), so `None`
     /// means "no first answer yet", not "flaked once".
     ///

--- a/src/sidebar/components/ProjectPanel.dirty-repo-badge.test.tsx
+++ b/src/sidebar/components/ProjectPanel.dirty-repo-badge.test.tsx
@@ -13,7 +13,9 @@ import {
 import { projectStore } from "../stores/project";
 import { replicaVolatileStore } from "../stores/replica-volatile";
 
-// #1028 - the repo badge's letters go red when that repo's worktree is dirty.
+// #1028/#1078 - the repo badge's letters go red when that repo has local work not
+// confirmed by cached origin tracking: a dirty worktree, but also a clean local-ahead
+// commit, a missing/gone origin target, or a detached HEAD.
 //
 // These render the real ProjectPanel through the FakeTransport harness and assert
 // the DOM, per the frontend-visual-verification discipline. They cover the CLASS and
@@ -130,7 +132,7 @@ describe("ProjectPanel dirty repo badge (#1028)", () => {
         // ADDITIVE variant: `.branch` must survive alongside it, or the badge loses
         // its background and the `.branch.dirty` rule stops matching at all.
         expect(badge.className).toBe("ac-discovery-badge branch dirty");
-        expect(badge.title).toBe(`${REPO_A} (uncommitted changes)`);
+        expect(badge.title).toBe(`${REPO_A} (local work not confirmed by cached origin tracking)`);
         expect(badge.textContent).toBe("AgentsCommander/main");
       });
     } finally {
@@ -219,7 +221,7 @@ describe("ProjectPanel dirty repo badge (#1028)", () => {
         expect(a.classList.contains("dirty")).toBe(false);
         expect(b.classList.contains("dirty")).toBe(true);
         expect(a.title).toBe(REPO_A);
-        expect(b.title).toBe(`${REPO_B} (uncommitted changes)`);
+        expect(b.title).toBe(`${REPO_B} (local work not confirmed by cached origin tracking)`);
       });
     } finally {
       rendered.cleanup();
@@ -249,7 +251,7 @@ describe("ProjectPanel dirty repo badge (#1028)", () => {
       await waitFor(() => {
         const badge = badgeIn(rendered.root, TREE, "dev-webpage-ui", 0, "AgentsCommander")!;
         expect(badge.classList.contains("dirty")).toBe(true);
-        expect(badge.title).toBe(`${REPO_A} (uncommitted changes)`);
+        expect(badge.title).toBe(`${REPO_A} (local work not confirmed by cached origin tracking)`);
       });
     } finally {
       rendered.cleanup();

--- a/src/sidebar/components/replica-repo-badges.test.ts
+++ b/src/sidebar/components/replica-repo-badges.test.ts
@@ -292,9 +292,9 @@ describe("#1028 per-repo dirty is merged BY PATH", () => {
 describe("#1028 badge title carries the third state", () => {
   const REPO = "C:\\proj\\.ac\\wg-1-team\\repo-AgentsCommander";
 
-  it("names the uncommitted work when the repo is dirty", () => {
+  it("names local work not confirmed by cached origin tracking when the repo is red", () => {
     expect(formatReplicaRepoBadgeTitle({ sourcePath: REPO, dirty: true })).toBe(
-      `${REPO} (uncommitted changes)`
+      `${REPO} (local work not confirmed by cached origin tracking)`
     );
   });
 

--- a/src/sidebar/components/replica-repo-badges.ts
+++ b/src/sidebar/components/replica-repo-badges.ts
@@ -21,7 +21,7 @@ export function formatReplicaRepoBadgeLabel(repo: Pick<SessionRepo, "label" | "b
 }
 
 export function formatReplicaRepoBadgeTitle(repo: Pick<SessionRepo, "sourcePath" | "dirty">): string {
-  if (repo.dirty === true) return `${repo.sourcePath} (uncommitted changes)`;
+  if (repo.dirty === true) return `${repo.sourcePath} (local work not confirmed by cached origin tracking)`;
   if (repo.dirty === false) return repo.sourcePath;
   return `${repo.sourcePath} (status unknown)`;
 }


### PR DESCRIPTION
## Summary

Repository badges now stay red until local work is confirmed reachable from the cached `origin` tracking target — not merely when the worktree has uncommitted changes. A badge is red for any non-ignored worktree/index entry, and whenever local `HEAD` is not confirmed contained in the locally cached `origin/*` tracking target: ahead, diverged-with-ahead, no upstream, non-origin upstream, gone target, unborn branch, and detached HEAD. Synchronized and behind-only remain normal.

No fetch, live remote query, network polling, schema/wire change, CSS change, or cadence change is added. Detection forces `--untracked-files=normal`, reuses the existing single local `git` call and the pre-existing red rendering, and fails closed on every ambiguous/unknown branch-header marker (so unpushed local work can never render normal).

The true-state tooltip now ends with `(local work not confirmed by cached origin tracking)`.

## Changes

Backend (dev-rust):
- `src-tauri/src/pty/git_watcher.rs` — new pure `cached_origin_contains_head` helper + porcelain/branch parser; `detect_git_status` runs `--no-optional-locks status --porcelain --branch --untracked-files=normal --ahead-behind`; every existing guard retained; both watcher feeds and the dirty cache unchanged.
- `src-tauri/src/commands/ac_discovery.rs`, `src-tauri/src/session/session.rs` — semantic doc-comment updates only (no serde/field/wire-shape change).

Frontend (dev-webpage-ui):
- `src/sidebar/components/replica-repo-badges.ts` — true-state tooltip copy (no style/color/class/icon change).
- `src/sidebar/components/replica-repo-badges.test.ts`, `src/sidebar/components/ProjectPanel.dirty-repo-badge.test.tsx` — focused tests.

## Review & verification

- Implemented from an architect-certified frozen plan (`plans/1078-red-until-origin.md`).
- dev-rust-grinch adversarial review: **PASS** (full §6 truth table traced; fail-closed verified in the dangerous direction). Focused re-review after syncing `origin/main`: **PASS** (clean disjoint merge, no semantic interaction).
- Gates green: rustfmt; `cargo check --all-targets`; `cargo clippy --all-targets -- -D warnings`; full Rust tests (2860 passed); focused vitest (27) + full frontend suite (1281 passed); `npm run typecheck`; `npm run test:debt`; `git diff --check`.
- Branch synced with latest `origin/main` (clean merge of disjoint file sets).

Closes #1078
