### PR TITLE
fix: persist absolute and instance-relative project paths (#1077)

### DIFF
--- a/docs/features/portable-instances.md
+++ b/docs/features/portable-instances.md
@@ -49,6 +49,25 @@ That's it. The instance creates its own config directory on first launch, gets a
 - **Per-team workspaces.** One instance per team you operate, each with its own coding-agent credentials and project list.
 - **Reset experiments cheaply.** Want to try a different settings layout without losing your current one? Copy the `.exe`, rename it, experiment, delete when done.
 
+## Portable project paths
+
+Every project you register is stored two ways in `settings.json`: the usual absolute path, and a portable path **relative to the folder that holds the running binary** (the same folder the config directory sits next to). Move the whole tree together (the binary, its `.agentscommander_<suffix>/` directory, and the project folders) to a new location, and each project whose relative form still resolves is picked up at its new absolute path automatically. AC reconciles `settings.json` to the new absolute path on the next load.
+
+The relative form is anchored to the executable's own directory, never the process working directory, so it does not matter which shell or folder you launch AC from.
+
+Relocation carries a project across the move when:
+
+- the project keeps the same position relative to the binary's folder (they move together under a new parent), and
+- the binary and the project still share one filesystem root (same Windows drive letter or UNC share).
+
+It does not help when only one side moves, or when the project lives on a different drive or share than the binary. A project on a different drive/share has no relative form at all: its companion value is stored as `null`, it keeps working in place through the absolute path, and it is simply not portable if you later move the install folder.
+
+**Packaging layout.** The anchor is the directory of the real native executable, not a wrapper or an app root. On Windows that is the folder containing `agentscommander*.exe`. On macOS it is `Foo.app/Contents/MacOS` inside the bundle, not the `.app` root. On Linux it is the directory of the raw binary or the running AppImage. A project stored relative to `Contents/MacOS` relocates correctly only when it keeps that relationship to the bundle.
+
+**Conflict handling.** Both stored forms are resolved and validated on every load. If they point at the same directory (symlinks and Windows aliases included), the project loads once. If they resolve to two different real directories, that registration is a conflict: AC loads neither side, writes nothing to disk for it, and the sidebar shows one sticky red error toast listing both resolved paths. Other, non-conflicting projects still load normally. Dismiss the toast, then fix the registration (remove it, then re-open the folder you want) to clear the conflict.
+
+**Sessions stay absolute.** This portability applies to project registrations only. Saved sessions in `sessions.json` keep absolute working directories and absolute nested repo paths, and they follow the existing retention and purge rules. Relocating an instance does not rewrite session paths.
+
 ## What is NOT isolated
 
 A portable instance still shares:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -552,15 +552,19 @@ agentscommander open-project /path/to/project
 
 | Argument | Description |
 |---|---|
-| `PATH` | Absolute or relative path. Relative is resolved against your CWD; the persisted entry is the absolute form. |
+| `PATH` | Absolute or relative path. Relative is resolved against your current working directory. |
 
 Idempotent — re-registering the same path is a no-op (`Project already registered`).
 
 If the folder does not contain `.ac/`, the CLI suggests `new-project` instead.
 
+**Persisted forms.** Relative `PATH` still resolves against your CWD, but the registration records two paths: the canonical absolute path and a portable companion relative to the AC binary's own directory (not your CWD). See [Portable instances](../features/portable-instances.md#portable-project-paths) and the [`projectPaths` schema](settings.md#projects). A project on a different drive or UNC share than the binary records a `null` companion and remains absolute-only.
+
+**Strict settings write.** `open-project` loads `settings.json` strictly before writing: a present-but-unparseable file, or structurally malformed project metadata, is refused with an error and no changes, rather than being silently overwritten.
+
 **No token required** — project registration mutates the local `settings.json`, which any shell-capable process can already write to.
 
-**GUI concurrency caveat**: when AC is running, the in-memory settings are authoritative; a subsequent GUI `update_settings` built from a stale snapshot can clobber a CLI-registered entry. A watcher/reload story is a follow-up issue.
+**GUI concurrency caveat**: when AC is running, the in-memory settings are authoritative; a subsequent GUI `update_settings` built from a stale snapshot can clobber a CLI-registered entry. This last-writer race between separate CLI and GUI processes is unchanged; the dual-path work adds no interprocess lock. A watcher/reload story is a follow-up issue.
 
 ---
 
@@ -577,6 +581,8 @@ agentscommander new-project /path/to/project
 | `PATH` | Absolute or relative. Folder created if it does not yet exist. |
 
 Idempotent: re-running on a folder that already has `.ac/` only sweeps the Project AC Root gitignore and deduplicates the registration.
+
+Registration records both the absolute path and the instance-relative companion, and uses the same strict settings-write behavior as [`open-project`](#open-project).
 
 **No token required** — same reasoning as `open-project`.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -138,10 +138,41 @@ The copied file is a full-account credential (access token plus long-lived refre
 
 ### Projects
 
+Each registered project is stored in two forms: a canonical absolute path (the existing fields) and a portable path relative to the folder holding the running binary (the companion fields, added for [portable instances](../features/portable-instances.md#portable-project-paths)). The three absolute fields and their three companions are index-aligned.
+
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `projectPath` | string \| null | `null` | Legacy single-project field. Kept for backward compat. |
-| `projectPaths` | string[] | `[]` | All projects registered in the sidebar. New entries appended by `new-project` / `open-project`. |
+| `projectPath` | string \| null | `null` | Legacy single-project field: the first active registration's absolute path. Kept for backward compat. |
+| `projectPathRelativeToInstance` | string \| null | `null` | Companion of `projectPath`. Portable form relative to the binary's directory, or `null` when there is no portable form. |
+| `projectPaths` | string[] | `[]` | All active projects registered in the sidebar. New entries appended by `new-project` / `open-project`. |
+| `projectPathsRelativeToInstance` | (string \| null)[] | `[]` | Companion array of `projectPaths`: one slot per entry, same length and order. `null` where an entry has no portable form. |
+| `archivedProjectPaths` | string[] | `[]` | Absolute paths of archived (registered but hidden) projects. |
+| `archivedProjectPathsRelativeToInstance` | (string \| null)[] | `[]` | Companion array of `archivedProjectPaths`: same length and order. |
+
+**Companion format.** A companion string is relative to the directory of the running executable (see [Portable instances](../features/portable-instances.md#portable-project-paths)), always written with `/` separators on every OS. `.` means the instance folder itself; `..` is allowed as long as it does not climb above the filesystem root. A project on a different Windows drive or UNC share than the binary has no relative form, so its companion slot is `null` and it stays absolute-only.
+
+**Array alignment.** Each plural companion array has exactly the same length and index meaning as its absolute array: slot `i` in `projectPathsRelativeToInstance` is the portable form of `projectPaths[i]`, or `null`. A length mismatch, an orphan companion (a companion present while its absolute field is absent), a wrong-typed field, or a non-null companion beside a `null` primary is structural corruption (see below).
+
+**Legacy migration.** A `settings.json` written by an older build has the three absolute fields and no companions. AC loads it unchanged (absolute-only) and adds a companion only after that project successfully validates, at the first reconciliation boundary or an explicit register/archive operation. Absent companions are valid legacy metadata, never corruption.
+
+**Resolution at load (fail-closed).** On every load AC resolves and validates both candidates for each registration. Validation canonicalizes on the filesystem and requires an existing directory that is either a project containing `.ac/` or a legacy collection root with a project child. The per-registration outcome:
+
+| Absolute side | Relative side | Result |
+|---|---|---|
+| valid | absent, invalid, or unavailable | select the absolute path; add or repair the companion after validation |
+| invalid or missing | valid | select the relative path; refresh the stale absolute side |
+| valid | valid, same directory | select one absolute path (prefers the absolute spelling) |
+| valid | valid, different directory | conflict: select neither, mutate nothing, raise one sticky red toast with both paths |
+| invalid | invalid | load issue: select neither, preserve both raw values |
+| valid | present, but no instance base available | evaluate the absolute side only; keep the relative value for a later normal launch |
+
+"Same" and "different" are decided by filesystem identity, not string comparison, so symlinks and Windows case/alias spellings collapse to one directory. Only validated canonical absolute paths reach startup restoration, team discovery, archive/session gates, and the sidebar. Unresolved or conflicting entries are filtered from the runtime lists but preserved on disk.
+
+**Atomic reconciliation.** When a load selects a path whose companion must be added, repaired, or normalized, AC rewrites only the affected field group (active or archived) through the existing atomic writer (temp file plus rename with retry). Writes are atomic and never torn, but there is no `fsync`, so this is not a power-loss durability guarantee. Generic settings saves use a preserve mode that copies the six raw project fields from disk verbatim rather than rebuilding them, so an unrelated save can never re-pair, reorder, or drop project metadata. A structurally malformed project field blocks all project-list reconciliation and mutation while unrelated settings saves still succeed; the malformed bytes are retained and reported, not normalized.
+
+**Archive pairing.** Archiving, unarchiving, and removing a project move or delete the whole pair (absolute plus companion) together, preserving array order. Archived entries carry their own companion array with the same alignment rules as the active one.
+
+**Downgrade.** An older AgentsCommander build ignores the companion fields and reads only the absolute fields, so a downgraded install still opens your projects. The caveat: if a dual-path conflict exists, the old build does not see it (it reads only the absolute side) and therefore loses the newer build's fail-closed protection for that registration. Resolve conflicts before downgrading.
 
 ### Window & UI
 

--- a/docs/testing/01-project-lifecycle.md
+++ b/docs/testing/01-project-lifecycle.md
@@ -329,3 +329,143 @@ Evidence Required:
 Pass/Fail Criteria:
 
 Pass if cancel leaves registration and filesystem unchanged. Not applicable if the active UI path does not show a create confirmation for the selected folder. Fail if a visible cancel action creates `.ac/` or registers the project despite canceling.
+
+### PRJ-009: Relocate an instance and confirm a CLI-registered project still loads
+
+Purpose:
+
+Verify that after moving a portable instance and its project together, a project registered through the CLI reloads at its new absolute path via the instance-relative companion, without re-registration.
+
+Preconditions:
+
+- A disposable portable tree under a scratch area: a copy of the AC binary in `<tree>/app/` (for example `agentscommander_reloc.exe`), its config directory created next to it on first run, and a disposable AC project at `<tree>/projects/alpha` containing `.ac/`.
+- The tester can move the whole tree and later launch it from an unrelated working directory.
+- Read-only inspection of the disposable `settings.json` is available.
+
+Steps:
+
+1. Register the project from the source tree: `<tree>/app/agentscommander_reloc.exe open-project <tree>/projects/alpha`.
+2. Inspect the disposable `settings.json` and record `projectPaths` and `projectPathsRelativeToInstance` (expect the absolute path plus a companion such as `../projects/alpha`).
+3. Launch the app from the source tree, confirm alpha loads in the sidebar, then close it.
+4. Move the entire tree (the `app/` folder, its `.agentscommander*` config directory, and the `projects/` folder together) to a new parent, for example `<tree2>/`. Remove or rename the original tree.
+5. From an unrelated working directory, launch `<tree2>/app/agentscommander_reloc.exe --app`.
+6. Confirm alpha appears in the sidebar and resolves to the new absolute path under `<tree2>`.
+7. Re-inspect `settings.json` and confirm `projectPaths` reconciled to the new absolute path while the companion is retained.
+
+Expected Result:
+
+The project loads at its new location with no manual re-registration; `settings.json` reconciles the absolute path to the moved location and keeps the companion.
+
+Evidence Required:
+
+- Pre-move `settings.json` snapshot showing both the absolute and companion fields.
+- Post-move sidebar screenshot showing alpha loaded.
+- Post-move `settings.json` snapshot showing the reconciled absolute path.
+
+Pass/Fail Criteria:
+
+Pass if the project reloads at the new path without re-registration and settings reconcile. Partial if it loads but a JSON snapshot could not be captured. Fail if the project is missing, still points at the stale location, or requires manual re-open.
+
+### PRJ-010: Relocate an instance and confirm a GUI-registered project still loads
+
+Purpose:
+
+Verify the same relocation behavior for a project registered through the GUI `New / Open` flow.
+
+Preconditions:
+
+- A disposable portable tree as in PRJ-009, but with no project registered yet.
+- The tester can register through the UI, move the tree, and relaunch from an unrelated working directory.
+
+Steps:
+
+1. Launch the app from the source tree and register `<tree>/projects/alpha` through `New / Open`.
+2. Inspect `settings.json` and record the absolute path plus its companion.
+3. Confirm alpha is visible in the sidebar, then close the app.
+4. Move the entire tree to a new parent `<tree2>/` and remove or rename the original.
+5. Relaunch `<tree2>/app/agentscommander_reloc.exe --app` from an unrelated working directory.
+6. Confirm alpha loads at the new absolute path and `settings.json` reconciled to it.
+
+Expected Result:
+
+A GUI-registered project reloads at the moved location with no re-registration, and its stored pair reconciles to the new absolute path.
+
+Evidence Required:
+
+- Pre-move `settings.json` snapshot.
+- Post-move sidebar screenshot showing alpha loaded.
+- Post-move `settings.json` snapshot showing the reconciled absolute path.
+
+Pass/Fail Criteria:
+
+Pass if the GUI-registered project reloads at the new path and settings reconcile. Partial if it loads but a snapshot is missing. Fail if the project is lost, points at the stale path, or must be re-opened manually.
+
+### PRJ-011: Archive and unarchive a project after relocating the instance
+
+Purpose:
+
+Verify that an archived registration carries its companion, survives relocation, and that list, unarchive, and remove operate on the moved pair with aligned arrays.
+
+Preconditions:
+
+- A disposable portable tree with one registered project alpha (the PRJ-009 or PRJ-010 setup).
+- Read-only inspection of the disposable `settings.json` is available after each step.
+
+Steps:
+
+1. In the source tree, archive alpha through the UI.
+2. Inspect `settings.json`: confirm the entry moved to `archivedProjectPaths` and `archivedProjectPathsRelativeToInstance` with an aligned companion, and that the active arrays no longer contain it.
+3. Close the app, move the entire tree to a new parent `<tree2>/`, and remove the original.
+4. Launch `<tree2>/app/agentscommander_reloc.exe --app`.
+5. List archived projects and confirm the archived entry is present and resolves to the moved absolute path.
+6. Unarchive alpha and confirm it returns to the active list at the moved path with the companion aligned.
+7. Remove alpha and confirm the whole pair is deleted from both the active absolute and companion arrays.
+
+Expected Result:
+
+The archived pair relocates with the tree, and archive, unarchive, and remove each move or delete the whole pair while keeping the companion arrays aligned.
+
+Evidence Required:
+
+- `settings.json` snapshots after archive, after unarchive, and after remove, each showing aligned arrays.
+- Screenshots of the archived list and of alpha back in the active list after unarchive.
+
+Pass/Fail Criteria:
+
+Pass if each operation moves or deletes the whole pair with aligned arrays and the archived entry survives relocation. Partial if behavior is correct but one snapshot is missing. Fail if arrays desynchronize, the archived entry is lost on move, or an operation touches only one side of the pair.
+
+### PRJ-012: Dual-path conflict shows one sticky toast and does not block other projects
+
+Purpose:
+
+Verify that when the absolute and instance-relative forms of one registration resolve to two different real directories, AC loads neither side for that registration, shows exactly one sticky red dismissible toast naming both resolved paths, changes nothing on disk for that entry, and still loads other valid projects.
+
+Preconditions:
+
+- A disposable portable source tree with the binary and a valid project alpha registered so that both stored forms resolve to the same directory.
+- The tester can copy the tree while retaining the original, and can launch the copy.
+- Read-only inspection of the copied `settings.json` is available.
+
+Steps:
+
+1. In the source tree, register alpha and confirm both stored forms resolve to the same directory.
+2. Close the app. Copy the entire tree to a new parent (for example `<copy>/`) while leaving the source tree in place. In the copy the absolute field still points at the source alpha, while the companion resolves from the copied binary to the copy's alpha, so the two forms now target two different real directories.
+3. In the copied tree, register a second, clean project beta so it resolves through both forms to one directory inside the copy. This is the control that should still load.
+4. Launch the copied instance.
+5. Observe the sidebar: confirm alpha does not load, exactly one sticky red error toast appears listing both resolved paths (source alpha and copy alpha), and beta loads normally.
+6. Confirm the toast is dismissible and does not reappear after dismissing and re-initializing (for example a window reload or reconnect).
+7. Inspect the copied `settings.json` and confirm alpha's stored fields are unchanged (no mutation for the conflicted entry).
+
+Expected Result:
+
+One conflict yields exactly one sticky red dismissible toast with both resolved paths; alpha stays unloaded and unmutated on disk; and the unrelated beta project still loads.
+
+Evidence Required:
+
+- Screenshot of the single sticky red toast showing both resolved paths.
+- Screenshot showing beta loaded while alpha is absent.
+- Before and after `settings.json` snapshots for alpha showing no change.
+
+Pass/Fail Criteria:
+
+Pass if exactly one sticky dismissible toast shows both paths, alpha is neither loaded nor mutated, and beta loads. Partial if behavior is correct but one snapshot is missing. Fail if either alpha side loads, more than one toast or a non-sticky toast appears, alpha's disk entry changes, or beta is blocked.

--- a/docs/testing/09-settings-and-persistence.md
+++ b/docs/testing/09-settings-and-persistence.md
@@ -34,6 +34,11 @@ Test data: TBD
 | SET-004 | NOT RUN | No evidence because NOT RUN. | Window geometry persistence checks not executed in this run. |
 | SET-005 | NOT RUN | No evidence because NOT RUN. | Test reset boundary checks not executed in this run. |
 | SET-006 | NOT RUN | No evidence because NOT RUN. | Invalid/missing settings recovery not executed in this run. |
+| SET-007 | NOT RUN | No evidence because NOT RUN. | Dual-path six-field raw inspection not executed in this run. |
+| SET-008 | NOT RUN | No evidence because NOT RUN. | Legacy/new/mixed schema loading not executed in this run. |
+| SET-009 | NOT RUN | No evidence because NOT RUN. | Malformed companion retention not executed in this run. |
+| SET-010 | NOT RUN | No evidence because NOT RUN. | Failed-write byte preservation not executed in this run. |
+| SET-011 | NOT RUN | No evidence because NOT RUN. | CLI/GUI interleaving pair preservation not executed in this run. |
 
 Residual test data:
 
@@ -271,3 +276,179 @@ Evidence Required:
 Pass/Fail Criteria:
 
 PASS if a documented safe method is used and recovery/error behavior is clear and limited to disposable identity. PARTIAL if recovery is safe but one optional cleanup artifact is missing. FAIL if the app corrupts state, touches live settings, or fails without clear error. BLOCKED if no documented safe invalid-settings method exists.
+
+### SET-007: Dual-path project fields are written and aligned
+
+Purpose:
+
+Verify that registering active and archived projects writes all six project fields in `settings.json` with correctly aligned companion arrays, portable companions in `/`-separated form, and a `null` companion for a cross-drive/share project.
+
+Preconditions:
+
+- Depends on SET-001.
+- A disposable testable identity with at least one disposable AC project on the same drive/share as the binary, and, if available, one disposable project on a different drive or UNC share.
+- Read-only inspection of the disposable `settings.json` is available.
+
+Steps:
+
+1. Register one disposable project on the binary's drive/share through the UI or CLI.
+2. If a second drive/share is available, register a disposable project located there.
+3. Archive one registered project so the archived arrays are populated.
+4. Capture a `settings.json` snapshot and inspect the six fields: `projectPath`, `projectPathRelativeToInstance`, `projectPaths`, `projectPathsRelativeToInstance`, `archivedProjectPaths`, `archivedProjectPathsRelativeToInstance`.
+5. Confirm each companion array has the same length and order as its absolute array, companion strings use `/` separators, and the cross-drive/share project (if present) has a `null` companion while keeping its absolute path.
+
+Expected Result:
+
+All six fields are present, companion arrays are index-aligned with their absolute arrays, portable companions are `/`-separated, and a cross-drive/share entry stores `null` and remains absolute-only.
+
+Evidence Required:
+
+- `SET-007-settings-snapshot.json` showing the six fields.
+- Notes mapping each companion slot to its absolute entry, including the `null` cross-drive/share slot when tested.
+
+Pass/Fail Criteria:
+
+PASS if all six fields are present and aligned and the `null` cross-drive/share case is correct (or noted as untested when no second drive/share exists). PARTIAL if fields are correct but the cross-drive/share case could not be exercised. FAIL if arrays are misaligned, a companion is absolute or backslash-separated, or a same-drive project stores `null`. BLOCKED if `settings.json` cannot be inspected.
+
+### SET-008: Legacy, new, and mixed schemas all load
+
+Purpose:
+
+Verify that a legacy absolute-only `settings.json`, a fully paired new-schema file, and a mixed file (some entries paired, some companion-absent) all load their projects, and that a legacy entry gains a companion only after a validating operation.
+
+Preconditions:
+
+- The testable GUI is closed.
+- The test edits only the disposable testable identity's `settings.json` under `.agentscommander_testeable`.
+- Two or more disposable AC projects exist on disk for registration in each variant.
+
+Steps:
+
+1. Prepare variant A (legacy): `settings.json` with `projectPaths` populated and no companion fields at all.
+2. Launch the testable app, confirm the projects load, then close it. Confirm the file still has no companion fields (loading alone does not migrate).
+3. Trigger a validating operation (register or archive a project through the UI/CLI) and confirm a companion is then added for the reconciled entries.
+4. Prepare variant B (new): `settings.json` with fully aligned companion arrays. Launch, confirm the projects load, close.
+5. Prepare variant C (mixed): `projectPaths` with an aligned companion array where one slot is `null` and one legacy singular-only carrier is present. Launch, confirm every valid entry loads and no entry is dropped.
+
+Expected Result:
+
+Each schema variant loads its valid projects; a legacy file gains companions only after a validating operation, not from a plain load.
+
+Evidence Required:
+
+- The three input `settings.json` variants (or diffs) captured before launch.
+- Post-launch sidebar screenshots for each variant.
+- Post-operation `settings.json` snapshot for variant A showing companions added only after the validating operation.
+
+Pass/Fail Criteria:
+
+PASS if all three variants load correctly and legacy migration happens only after a validating operation. PARTIAL if loading is correct but one migration snapshot is missing. FAIL if any valid project fails to load, a plain load rewrites a legacy file, or a mixed entry is dropped. BLOCKED if the disposable `settings.json` cannot be prepared safely.
+
+### SET-009: Misaligned companion is retained, not normalized
+
+Purpose:
+
+Verify that a structurally malformed project pair (a companion array whose length does not match its absolute array) is preserved on disk rather than silently normalized, is reported instead of loaded, and blocks project mutation while unrelated settings saves still succeed.
+
+Preconditions:
+
+- The testable GUI is closed.
+- The test edits only the disposable testable identity's `settings.json` under `.agentscommander_testeable`.
+- A documented safe method exists to create the malformed disposable file. If not, mark this case `BLOCKED`.
+
+Steps:
+
+1. Capture a baseline `settings.json` snapshot and its byte size/mtime.
+2. Edit the disposable file so `projectPathsRelativeToInstance` has a different length than `projectPaths` (a misaligned companion).
+3. Launch the testable app.
+4. Confirm the malformed list produces no loaded projects from that list and the app reports the malformed condition rather than crashing.
+5. Without triggering a project mutation, capture the `settings.json` bytes/mtime and confirm they are unchanged (no auto-normalization write).
+6. Change one unrelated harmless setting and save; confirm the save succeeds and the malformed project fields are still present verbatim.
+7. Attempt a project mutation (open, archive, or remove); confirm it is refused while the malformed field is present.
+
+Expected Result:
+
+The malformed companion is retained byte-for-byte on load, reported rather than loaded, and blocks project mutation, while an unrelated settings save still succeeds and leaves the malformed fields intact.
+
+Evidence Required:
+
+- `SET-009-before.json` and `SET-009-after-load.json` (or a byte/mtime comparison) proving no normalization write.
+- Structured error or log evidence of the malformed report.
+- `SET-009-after-unrelated-save.json` showing the malformed fields preserved after a harmless save.
+- Evidence that a project mutation was refused.
+
+Pass/Fail Criteria:
+
+PASS if the malformed pair is preserved, reported, and blocks mutation while unrelated saves succeed. PARTIAL if behavior is correct but one artifact is missing. FAIL if the file is normalized/overwritten, the malformed entry loads, a project mutation proceeds, or an unrelated save is blocked. BLOCKED if no safe method exists to create the malformed disposable file.
+
+### SET-010: Failed settings write leaves the file intact
+
+Purpose:
+
+Verify that when a settings write cannot complete, the on-disk `settings.json` is left unchanged, the app still uses the validated selected project paths for the current run, and the failure is reported as an actionable diagnostic.
+
+Preconditions:
+
+- The testable GUI is closed for setup.
+- The test operates only on the disposable testable identity directory.
+- A documented safe method exists to make the disposable settings directory or file temporarily unwritable. If not, mark this case `BLOCKED`.
+
+Steps:
+
+1. With a disposable project registered, capture a baseline `settings.json` snapshot and its bytes/mtime.
+2. Make the disposable settings directory or file unwritable using the documented safe method.
+3. Launch the app (or trigger an operation that would reconcile/write settings).
+4. Confirm the registered project still loads and is usable for this run from the validated selected path.
+5. Capture the `settings.json` bytes/mtime and confirm they are unchanged.
+6. Capture the diagnostic warning/error and confirm it is actionable and does not claim a successful write.
+7. Restore writability and confirm a later save succeeds normally.
+
+Expected Result:
+
+A failed write leaves the file byte-identical, the project remains usable for the run via the in-memory selected path, and the failure surfaces as an actionable diagnostic without corrupting or partially writing the file.
+
+Evidence Required:
+
+- `SET-010-before.json` and `SET-010-after.json` (or byte/mtime comparison) showing no change.
+- Screenshot or log of the actionable failure diagnostic.
+- Evidence the project loaded despite the failed write.
+
+Pass/Fail Criteria:
+
+PASS if the file is unchanged, the project stays usable, and the diagnostic is actionable. PARTIAL if behavior is correct but one artifact is missing. FAIL if the file is truncated, partially written, or overwritten, or the failure is silent or misreported as success. BLOCKED if no safe method exists to make the disposable settings unwritable.
+
+### SET-011: CLI and GUI interleaving preserves both pair forms
+
+Purpose:
+
+Verify that a CLI registration performed while the GUI is open, followed by a GUI settings save and a GUI project mutation, preserves every active and archived pair with aligned absolute and companion arrays and loses no registration.
+
+Preconditions:
+
+- Depends on SET-001.
+- The testable GUI is running for the interleaving steps.
+- Two or more disposable AC projects exist for registration.
+- Read-only inspection of the disposable `settings.json` is available.
+
+Steps:
+
+1. With the GUI open and at least one project already registered, capture the baseline project list and `settings.json`.
+2. Run a CLI `open-project` for a second disposable project against the same testable identity.
+3. In the GUI, perform an unrelated settings save (a harmless setting change).
+4. In the GUI, perform a project mutation (archive or unarchive an existing project).
+5. Capture the final `settings.json` and project list.
+6. Confirm both projects remain registered, the CLI-registered entry survives, and every active and archived entry has an aligned absolute path and companion.
+
+Expected Result:
+
+After the interleaving, no registration or companion is lost, the CLI-registered project persists, and all pairs remain aligned and ordered.
+
+Evidence Required:
+
+- Baseline and final `settings.json` snapshots.
+- Baseline and final project-list screenshots.
+- Notes confirming pair alignment for every active and archived entry.
+
+Pass/Fail Criteria:
+
+PASS if all registrations and companions survive the interleaving with aligned pairs. PARTIAL if state is correct but one snapshot is missing. FAIL if the CLI-registered entry is clobbered, a companion is dropped or misaligned, or a project registration is lost. BLOCKED if the interleaving cannot be exercised on the testable identity.

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::register_new_project;
 use crate::config::settings::{
-    load_settings_for_cli_strict, project_state_has_structural, resync_project_state_from_runtime,
-    save_settings_with_project_paths,
+    load_settings_for_cli_strict, project_state_has_structural, refresh_project_paths_from_disk,
+    resync_project_state_from_runtime, save_settings_with_project_paths,
 };
 
 #[derive(Args)]
@@ -52,6 +52,13 @@ pub fn execute(args: NewProjectArgs) -> i32 {
         eprintln!(
             "Error: settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first."
         );
+        return 1;
+    }
+    // #1077: reconcile the runtime list from the RAW disk fields (before any
+    // filesystem effect) so a stored-but-missing project the strict decode
+    // filters out is preserved in place by the resync rather than dropped.
+    if let Err(e) = refresh_project_paths_from_disk(&mut settings) {
+        eprintln!("Error: {}", e);
         return 1;
     }
     let result = match register_new_project(&mut settings, &args.path) {

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::register_new_project;
 use crate::config::settings::{
-    load_settings_for_cli_strict, project_state_has_structural,
-    resync_project_state_from_runtime, save_settings_with_project_paths,
+    load_settings_for_cli_strict, project_state_has_structural, resync_project_state_from_runtime,
+    save_settings_with_project_paths,
 };
 
 #[derive(Args)]

--- a/src-tauri/src/cli/new_project.rs
+++ b/src-tauri/src/cli/new_project.rs
@@ -11,14 +11,21 @@ use std::path::PathBuf;
 
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::register_new_project;
-use crate::config::settings::{load_settings_for_cli, save_settings_with_project_paths};
+use crate::config::settings::{
+    load_settings_for_cli_strict, project_state_has_structural,
+    resync_project_state_from_runtime, save_settings_with_project_paths,
+};
 
 #[derive(Args)]
 #[command(after_help = "\
 PURPOSE: Create an AC project at PATH (mkdir-p `.ac/` and write its \
 `.gitignore` if no Project AC Root exists) and register it in the GUI sidebar's project list.\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
-working directory. The folder is created if it does not yet exist.\n\n\
+working directory. The folder is created if it does not yet exist. The \
+registration is persisted both as the canonical absolute path and as a portable \
+path relative to the AgentsCommander executable's directory (so the project \
+relocates with the install folder); a project on a different drive or share is \
+stored absolute-only.\n\n\
 IDEMPOTENCY: Re-running on a folder that already has `.ac/` is safe; \
 the selected Project AC Root gitignore is swept (missing patterns appended), and the registration step \
 deduplicates against any prior entry.")]
@@ -29,9 +36,24 @@ pub struct NewProjectArgs {
 }
 
 pub fn execute(args: NewProjectArgs) -> i32 {
-    // Round-1 G5: use the CLI-specific loader so we never trigger a spurious
-    // root_token write on first-boot or error-path invocations.
-    let mut settings = load_settings_for_cli();
+    // #786/#1077: strict CLI loader so we never trigger a spurious root_token
+    // write, and we refuse to touch a present-but-unparseable settings.json.
+    let mut settings = match load_settings_for_cli_strict() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    // #1077: reject structural project-metadata corruption BEFORE any filesystem
+    // effect (directory / .ac creation), so a corrupt settings file never causes
+    // a half-registered project.
+    if project_state_has_structural(&settings) {
+        eprintln!(
+            "Error: settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first."
+        );
+        return 1;
+    }
     let result = match register_new_project(&mut settings, &args.path) {
         Ok(r) => r,
         Err(e) => {
@@ -42,9 +64,10 @@ pub fn execute(args: NewProjectArgs) -> i32 {
     // Save when we either created `.ac` or appended a new path entry.
     // (A pure no-op call still prints the status lines.)
     if result.created || result.registered {
-        // #778: CLI verbs load fresh disk (load_settings_for_cli) then upsert, so
-        // the deliberate list is written verbatim via the explicit writer, not the
-        // preserve-disk default (which would discard this append).
+        // #1077: rebuild the hidden pair state from the mutated runtime lists so
+        // the paired reconcile serializer records both persisted forms instead of
+        // dropping the append.
+        resync_project_state_from_runtime(&mut settings);
         if let Err(e) = save_settings_with_project_paths(&settings) {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -19,8 +19,8 @@ use std::path::PathBuf;
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::{register_existing_project, ProjectError};
 use crate::config::settings::{
-    load_settings_for_cli_strict, project_state_has_structural, resync_project_state_from_runtime,
-    save_settings_with_project_paths,
+    load_settings_for_cli_strict, project_state_has_structural, refresh_project_paths_from_disk,
+    resync_project_state_from_runtime, save_settings_with_project_paths,
 };
 
 #[derive(Args)]
@@ -58,6 +58,13 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
         eprintln!(
             "Error: settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first."
         );
+        return 1;
+    }
+    // #1077: reconcile the runtime list from the RAW disk fields (which retain a
+    // stored-but-missing project the strict decode filters out) so a subsequent
+    // resync preserves those records in place instead of dropping them.
+    if let Err(e) = refresh_project_paths_from_disk(&mut settings) {
+        eprintln!("Error: {}", e);
         return 1;
     }
     let result = match register_existing_project(&mut settings, &args.path) {

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -19,8 +19,8 @@ use std::path::PathBuf;
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::{register_existing_project, ProjectError};
 use crate::config::settings::{
-    load_settings_for_cli_strict, project_state_has_structural,
-    resync_project_state_from_runtime, save_settings_with_project_paths,
+    load_settings_for_cli_strict, project_state_has_structural, resync_project_state_from_runtime,
+    save_settings_with_project_paths,
 };
 
 #[derive(Args)]

--- a/src-tauri/src/cli/open_project.rs
+++ b/src-tauri/src/cli/open_project.rs
@@ -18,7 +18,10 @@ use std::path::PathBuf;
 
 use crate::cli::workgroup::write_project_registration_refresh;
 use crate::config::projects::{register_existing_project, ProjectError};
-use crate::config::settings::{load_settings_for_cli, save_settings_with_project_paths};
+use crate::config::settings::{
+    load_settings_for_cli_strict, project_state_has_structural,
+    resync_project_state_from_runtime, save_settings_with_project_paths,
+};
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -26,7 +29,11 @@ PURPOSE: Register an existing AC project so it appears in the GUI sidebar on \
 next launch. The folder must already contain `.ac/` (use `new-project` to \
 create one).\n\n\
 PATH: Absolute or relative — relative paths are resolved against the current \
-working directory. The persisted entry is the absolute form.\n\n\
+working directory. The registration is persisted in two forms: the canonical \
+absolute path, plus a portable path relative to the AgentsCommander \
+executable's directory (used to relocate the project when the whole install \
+folder moves). A project on a different drive or share has no portable form and \
+is stored absolute-only.\n\n\
 IDEMPOTENCY: Re-registering the same path is a no-op; the verb prints \
 \"Project already registered\" and exits 0.")]
 pub struct OpenProjectArgs {
@@ -36,10 +43,23 @@ pub struct OpenProjectArgs {
 }
 
 pub fn execute(args: OpenProjectArgs) -> i32 {
-    // Use the CLI-specific loader (Round-1 G5): unlike `load_settings`, this
-    // does NOT auto-generate or persist a `root_token`, so error paths and
-    // pre-validation reads do not silently rewrite settings.json.
-    let mut settings = load_settings_for_cli();
+    // #786/#1077: strict CLI loader (Round-1 G5): unlike `load_settings`, this
+    // does NOT auto-generate or persist a `root_token`, and it refuses to touch a
+    // present-but-unparseable settings.json rather than silently rewriting it.
+    let mut settings = match load_settings_for_cli_strict() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    // #1077: structural project-metadata corruption blocks any list mutation.
+    if project_state_has_structural(&settings) {
+        eprintln!(
+            "Error: settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first."
+        );
+        return 1;
+    }
     let result = match register_existing_project(&mut settings, &args.path) {
         Ok(r) => r,
         Err(e) => {
@@ -54,8 +74,11 @@ pub fn execute(args: OpenProjectArgs) -> i32 {
         }
     };
     if result.registered {
-        // #778: verbatim explicit writer (fresh disk already loaded above); the
-        // preserve-disk default would discard this deliberate append.
+        // #1077: rebuild the hidden pair state from the mutated runtime lists so
+        // the paired reconcile serializer records both the absolute path and its
+        // instance-relative companion (retaining any preserved conflict/missing
+        // records) instead of dropping the append.
+        resync_project_state_from_runtime(&mut settings);
         if let Err(e) = save_settings_with_project_paths(&settings) {
             eprintln!("Error: failed to persist settings: {}", e);
             return 1;

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -2754,6 +2754,79 @@ mod tests {
         )
     }
 
+    /// The Windows 8.3 short-name form of an existing path, or the path itself
+    /// when the volume has 8.3 generation disabled.
+    #[cfg(windows)]
+    fn short_path(p: &Path) -> PathBuf {
+        use std::os::windows::ffi::{OsStrExt, OsStringExt};
+        use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+        let wide: Vec<u16> = p.as_os_str().encode_wide().chain([0]).collect();
+        let len = unsafe { GetShortPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+        if len == 0 {
+            return p.to_path_buf();
+        }
+        let mut buf = vec![0u16; len as usize];
+        let written = unsafe { GetShortPathNameW(wide.as_ptr(), buf.as_mut_ptr(), len) };
+        if written == 0 {
+            return p.to_path_buf();
+        }
+        buf.truncate(written as usize);
+        PathBuf::from(std::ffi::OsString::from_wide(&buf))
+    }
+
+    /// Regression for the #1080 CI failure: on a Windows runner whose `%TEMP%` is
+    /// an 8.3 short name (`RUNNER~1`), `tempdir()` yields short-form paths and a
+    /// relative `.` archive absolutises to that short form. Storing the raw
+    /// (short) path lets the lexical archive lookup match, while the archived
+    /// RUNTIME field is the decoder's canonical (long) form. Archived must NOT be
+    /// empty (the pre-fix bug: canonical-stored vs short-lookup did not match, the
+    /// project stayed active, and the archived duplicate was dropped by dedupe).
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn archive_relative_path_matches_across_short_name_temp() {
+        let _cwd_lock = cwd_lock().await;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let settings_path = temp.path().join("settings.json");
+        let project = temp.path().join("proj-archive-relative");
+        std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
+        // Force the runner's condition: access the project via its 8.3 short form.
+        let short = short_path(&project);
+        let path = short.to_string_lossy().to_string();
+        let archived_expected = canonical_display(&project);
+        let settings = AppSettings {
+            project_paths: vec![path.clone()],
+            project_path: Some(path.clone()),
+            ..AppSettings::default()
+        };
+        let (app, state, _rx, session_mgr, pty_mgr) = archive_command_app(settings);
+        let app_handle = app.handle().clone();
+        let prev = std::env::current_dir().expect("current dir");
+        let _guard = CwdGuard(prev);
+        std::env::set_current_dir(&short).expect("set cwd");
+
+        archive_project_inner_with_settings_path(
+            &app_handle,
+            &state,
+            &session_mgr,
+            &pty_mgr,
+            ".",
+            Some(&settings_path),
+        )
+        .await
+        .expect("archive relative project on a short-name temp");
+
+        let archived = state.read().await.archived_project_paths.clone();
+        assert_eq!(
+            archived,
+            vec![archived_expected],
+            "archived must be the canonical path, never empty"
+        );
+        assert!(
+            state.read().await.project_paths.is_empty(),
+            "the project must be removed from the active list"
+        );
+    }
+
     /// CWD is process-wide; serialize tests that intentionally use relative paths.
     struct CwdGuard(PathBuf);
     impl Drop for CwdGuard {
@@ -3049,7 +3122,13 @@ mod tests {
         let settings_path = temp.path().join("settings.json");
         let project = temp.path().join("proj-archive-relative");
         std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
-        let path = canonical_display(&project);
+        // Store the RAW path so the relative "." archive lookup (which absolutises
+        // against the CWD, and on a runner whose %TEMP% is an 8.3 short name is the
+        // short form) still matches lexically. The archived RUNTIME field is the
+        // decoder's SELECTED canonical form (#1077 §3.4), which the assertion
+        // below expects; the event still carries the raw absolutised input.
+        let path = project.to_string_lossy().to_string();
+        let archived_expected = canonical_display(&project);
         let settings = AppSettings {
             project_paths: vec![path.clone()],
             project_path: Some(path.clone()),
@@ -3073,7 +3152,7 @@ mod tests {
         .expect("archive relative project");
 
         let stored = state.read().await.archived_project_paths.clone();
-        assert_eq!(stored, vec![path.clone()]);
+        assert_eq!(stored, vec![archived_expected]);
         let event = recv_ws_event(&mut rx);
         assert_eq!(event["event"], json!("project_archive_changed"));
         assert_eq!(event["payload"]["path"], json!(path));

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -2052,38 +2052,54 @@ async fn mutate_project_paths_with_settings_path<T>(
     settings_path: Option<&Path>,
     mutate: impl FnOnce(&mut crate::config::settings::AppSettings) -> Result<T, String>,
 ) -> Result<T, String> {
+    // Resolve the concrete settings path (production uses config_dir).
+    let path_buf;
+    let path: &Path = match settings_path {
+        Some(p) => p,
+        None => {
+            path_buf = crate::config::config_dir()
+                .ok_or("Could not determine settings directory")?
+                .join("settings.json");
+            &path_buf
+        }
+    };
+
     let mut s = settings.write().await;
-    // #778: reconcile project_paths from disk BEFORE the upsert so a concurrent
+    // #778: reconcile project_paths from disk BEFORE the mutation so a concurrent
     // CLI append is folded in, not clobbered. The raw three-field refresh (not
     // the validating decoder) keeps a stored-but-missing project in the list so
     // remove/archive of a vanished directory still matches it lexically (§3.7).
     // Aborts on a non-NotFound read error (G2) or a wrong-typed project field.
-    if let Some(path) = settings_path {
-        crate::config::settings::refresh_project_paths_from_path(&mut s, path)?;
-    } else {
-        crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
-    }
-    // #1077: structural project corruption (from the startup decode) blocks any
-    // list mutation; the three-field read above independently aborts on a
-    // wrong-typed primary field.
+    crate::config::settings::refresh_project_paths_from_path(&mut s, path)?;
+    // #1077: structural project corruption blocks any list mutation; the
+    // three-field read above independently aborts on a wrong-typed primary field.
     if crate::config::settings::project_state_has_structural(&s) {
         return Err(
             "settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first.".to_string(),
         );
     }
-    let result = mutate(&mut s)?;
-    // #1077: rebuild the hidden state to match the mutated runtime lists,
-    // retaining any preserved conflict/missing records, so the reconcile write
-    // emits the new selection plus those raw records (never dropping a project).
-    crate::config::settings::resync_project_state_from_runtime(&mut s);
-    let snapshot = s.clone();
-    if let Some(path) = settings_path {
-        crate::config::settings::save_settings_with_project_paths_to_path(&snapshot, path)?;
-    } else {
-        crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    // #1077 §4.3: apply the operation to a separate candidate clone and publish
+    // only after the atomic save succeeds. On save failure the live guard keeps
+    // the refreshed pre-mutation state (never the unsaved candidate).
+    let mut candidate = s.clone();
+    let result = mutate(&mut candidate)?;
+    // Rebuild the candidate's hidden state to match its mutated runtime lists,
+    // reconciling preserved conflict/missing records against the mutation.
+    crate::config::settings::resync_project_state_from_runtime(&mut candidate);
+    match crate::config::settings::reconcile_project_state_to_path(&candidate, path, true, true) {
+        Ok(written) => {
+            // Publish the fresh-decoded value (selected runtime + hidden state)
+            // that §4.2 requires, not the stale candidate.
+            *s = written;
+            drop(s); // explicit; lock released AFTER the disk write completes
+            Ok(result)
+        }
+        Err(e) => {
+            // Live state is still the refreshed pre-mutation snapshot.
+            drop(s);
+            Err(e)
+        }
     }
-    drop(s); // explicit; lock released AFTER the disk write completes
-    Ok(result)
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -3297,10 +3313,18 @@ mod tests {
         .expect_err("late liveness should roll back vanished project");
 
         assert!(err.contains("open session"), "{err}");
+        // #1077: the rollback is disk-authoritative. The vanished project is
+        // active again on disk, but excluded from the SELECTED active runtime
+        // (session restoration must not restore an unvalidated directory) and it
+        // is not archived, so both in-memory lists are empty.
         let settings = state.read().await;
-        assert_eq!(settings.project_paths, vec![path.clone()]);
+        assert!(settings.project_paths.is_empty());
         assert!(settings.archived_project_paths.is_empty());
         drop(settings);
+        let disk: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(disk["projectPaths"], json!([path]));
+        assert!(disk["archivedProjectPaths"].as_array().unwrap().is_empty());
         let event = recv_ws_event(&mut rx);
         assert_eq!(event["payload"]["path"], json!(path));
         assert_eq!(event["payload"]["archived"], json!(false));
@@ -3527,6 +3551,53 @@ mod tests {
             base(&disk()),
             vec!["proj-b", "proj-c", "proj-d"],
             "B and C must not be lost"
+        );
+    }
+
+    #[tokio::test]
+    async fn mutate_save_failure_does_not_publish_unsaved_candidate() {
+        // Grinch Defect 3: on an atomic-save failure the live state must remain
+        // the refreshed pre-mutation state, never the unsaved mutated candidate.
+        let temp = tempfile::tempdir().expect("tempdir");
+        // A regular FILE where the settings directory is expected, so the writer's
+        // create_dir_all (or the pre-mutation read) fails deterministically.
+        let blocker = temp.path().join("blocker");
+        std::fs::write(&blocker, b"x").expect("write blocker file");
+        let settings_path = blocker.join("settings.json");
+        let mk = |name: &str| {
+            let p = temp.path().join(name);
+            std::fs::create_dir_all(p.join(".ac")).expect("create project .ac");
+            p.to_string_lossy().to_string()
+        };
+        let (x, y) = (mk("keep-x"), mk("new-y"));
+        let settings = crate::config::settings::AppSettings {
+            project_paths: vec![x.clone()],
+            project_path: Some(x.clone()),
+            ..Default::default()
+        };
+        let state: SettingsState = std::sync::Arc::new(tokio::sync::RwLock::new(settings));
+
+        let err = open_project_inner_with_settings_path(&state, &y, Some(&settings_path))
+            .await
+            .expect_err("save into a file-blocked directory must fail");
+        assert!(!err.is_empty());
+
+        let live = state.read().await;
+        let names: Vec<&str> = live
+            .project_paths
+            .iter()
+            .map(|p| {
+                std::path::Path::new(p)
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+            })
+            .collect();
+        assert_eq!(
+            names,
+            vec!["keep-x"],
+            "the unsaved candidate ([keep-x, new-y]) must not leak into the live state"
         );
     }
 

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -2743,6 +2743,17 @@ mod tests {
         }
     }
 
+    /// #1077: the display-canonical form of an existing directory - exactly what
+    /// the six-field decoder selects for a valid project. Storing this (instead
+    /// of the raw temp path) keeps the runtime-path assertions platform-robust:
+    /// on Windows it equals the raw path, on Linux/CI it is the symlink-resolved
+    /// canonical path the decoder actually publishes.
+    fn canonical_display(dir: &Path) -> String {
+        crate::config::projects::display_canonical(
+            &std::fs::canonicalize(dir).unwrap().to_string_lossy(),
+        )
+    }
+
     /// CWD is process-wide; serialize tests that intentionally use relative paths.
     struct CwdGuard(PathBuf);
     impl Drop for CwdGuard {
@@ -3038,7 +3049,7 @@ mod tests {
         let settings_path = temp.path().join("settings.json");
         let project = temp.path().join("proj-archive-relative");
         std::fs::create_dir_all(project.join(".ac")).expect("create .ac");
-        let path = project.to_string_lossy().to_string();
+        let path = canonical_display(&project);
         let settings = AppSettings {
             project_paths: vec![path.clone()],
             project_path: Some(path.clone()),
@@ -3112,7 +3123,7 @@ mod tests {
         let project = temp.path().join("proj-f1");
         let agent = project.join(".ac").join("wg-1").join("__agent_dev");
         std::fs::create_dir_all(&agent).expect("create agent dir");
-        let path = project.to_string_lossy().to_string();
+        let path = canonical_display(&project);
         let settings = AppSettings {
             project_paths: vec![path.clone()],
             project_path: Some(path.clone()),
@@ -3204,7 +3215,7 @@ mod tests {
         let project = temp.path().join("proj-rollback");
         let agent = project.join(".ac").join("wg-1").join("__agent_dev");
         std::fs::create_dir_all(&agent).expect("create agent dir");
-        let path = project.to_string_lossy().to_string();
+        let path = canonical_display(&project);
         let settings = AppSettings {
             project_paths: vec![path.clone()],
             project_path: Some(path.clone()),

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -2054,15 +2054,28 @@ async fn mutate_project_paths_with_settings_path<T>(
 ) -> Result<T, String> {
     let mut s = settings.write().await;
     // #778: reconcile project_paths from disk BEFORE the upsert so a concurrent
-    // CLI append is folded in, not clobbered, then write the deliberate list
-    // verbatim (project_paths is disk-authoritative under Design S). Aborts on a
-    // non-NotFound read error (G2) rather than registering against a stale list.
+    // CLI append is folded in, not clobbered. The raw three-field refresh (not
+    // the validating decoder) keeps a stored-but-missing project in the list so
+    // remove/archive of a vanished directory still matches it lexically (§3.7).
+    // Aborts on a non-NotFound read error (G2) or a wrong-typed project field.
     if let Some(path) = settings_path {
         crate::config::settings::refresh_project_paths_from_path(&mut s, path)?;
     } else {
         crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
     }
+    // #1077: structural project corruption (from the startup decode) blocks any
+    // list mutation; the three-field read above independently aborts on a
+    // wrong-typed primary field.
+    if crate::config::settings::project_state_has_structural(&s) {
+        return Err(
+            "settings.json has malformed project metadata; refusing to modify the project list. Fix or remove the corrupt project fields first.".to_string(),
+        );
+    }
     let result = mutate(&mut s)?;
+    // #1077: rebuild the hidden state to match the mutated runtime lists,
+    // retaining any preserved conflict/missing records, so the reconcile write
+    // emits the new selection plus those raw records (never dropping a project).
+    crate::config::settings::resync_project_state_from_runtime(&mut s);
     let snapshot = s.clone();
     if let Some(path) = settings_path {
         crate::config::settings::save_settings_with_project_paths_to_path(&snapshot, path)?;

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -2530,8 +2530,17 @@ mod tests {
     fn real_ac_project(parent: &Path, name: &str) -> String {
         let dir = parent.join(name);
         std::fs::create_dir_all(dir.join(".ac")).unwrap();
-        let canon = std::fs::canonicalize(&dir).unwrap();
-        crate::config::projects::display_canonical(&canon.to_string_lossy())
+        canonical_display(&dir)
+    }
+
+    /// #1077: the display-canonical form of an existing directory - what the
+    /// six-field decoder selects. Storing this instead of the raw temp path keeps
+    /// runtime-path assertions platform-robust (equal to raw on Windows, the
+    /// symlink-resolved canonical on Linux/CI, which the preserving writer publishes).
+    fn canonical_display(dir: &Path) -> String {
+        crate::config::projects::display_canonical(
+            &std::fs::canonicalize(dir).unwrap().to_string_lossy(),
+        )
     }
 
     /// #1077: seed a whole, valid AppSettings object on disk with `keys` removed
@@ -3672,7 +3681,7 @@ mod tests {
         std::fs::create_dir_all(&kept_workdir).expect("create kept workdir");
         std::fs::create_dir_all(&outside_workdir).expect("create outside workdir");
 
-        let project_path = project.to_string_lossy().to_string();
+        let project_path = canonical_display(&project);
         write_settings_file(
             temp.path(),
             &AppSettings {
@@ -3737,7 +3746,7 @@ mod tests {
         let project = temp.path().join("project-a");
         let kept_workdir = project.join(".ac").join("wg-1").join("__agent_dev");
         std::fs::create_dir_all(&kept_workdir).expect("create kept workdir");
-        let project_path = project.to_string_lossy().to_string();
+        let project_path = canonical_display(&project);
 
         write_sessions_file(
             temp.path(),

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -143,7 +143,11 @@ pub enum IssueSource {
 /// so struct-variant fields are camelCase (plain `rename_all` does not rename
 /// them). Optional `index` is omitted when absent.
 #[derive(Debug, Clone, serde::Serialize)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum ProjectPathIssue {
     Conflict {
         id: String,
@@ -387,7 +391,8 @@ pub(crate) fn settings_snapshot_from(
     settings: &AppSettings,
     reconciliation_error: Option<ProjectPathReconciliationError>,
 ) -> SettingsSnapshot {
-    let resolution = build_project_path_resolution(&settings.project_path_state, reconciliation_error);
+    let resolution =
+        build_project_path_resolution(&settings.project_path_state, reconciliation_error);
     let mut cleaned = settings.clone();
     // Clear so the existing skip_serializing_if omits rootToken (absent, not null).
     cleaned.root_token = None;
@@ -439,9 +444,7 @@ pub(crate) async fn settings_snapshot_helper(
 }
 
 #[tauri::command]
-pub async fn get_settings(
-    settings: State<'_, SettingsState>,
-) -> Result<SettingsSnapshot, String> {
+pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<SettingsSnapshot, String> {
     Ok(settings_snapshot_helper(settings.inner(), None).await)
 }
 
@@ -2275,7 +2278,10 @@ mod tests {
             }
         }
 
-        fn state_with(pairs: Vec<ResolvedPair>, structural: Vec<StructuralIssue>) -> ProjectPathPersistenceState {
+        fn state_with(
+            pairs: Vec<ResolvedPair>,
+            structural: Vec<StructuralIssue>,
+        ) -> ProjectPathPersistenceState {
             let active_registration_count = pairs.len();
             ProjectPathPersistenceState {
                 pairs,
@@ -2292,12 +2298,23 @@ mod tests {
             }
         }
 
+        fn settings_with_state(state: ProjectPathPersistenceState) -> AppSettings {
+            AppSettings {
+                project_path_state: std::sync::Arc::new(state),
+                ..AppSettings::default()
+            }
+        }
+
         #[test]
         fn snapshot_serializes_camelcase_variants_and_omits_root_token() {
-            let mut settings = AppSettings::default();
-            settings.root_token = Some("SUPER-SECRET-TOKEN-VALUE".to_string());
-            settings.project_path_state =
-                std::sync::Arc::new(state_with(vec![conflict_pair(), missing_pair()], vec![]));
+            let settings = AppSettings {
+                root_token: Some("SUPER-SECRET-TOKEN-VALUE".to_string()),
+                project_path_state: std::sync::Arc::new(state_with(
+                    vec![conflict_pair(), missing_pair()],
+                    vec![],
+                )),
+                ..AppSettings::default()
+            };
 
             let snap = settings_snapshot_from(&settings, None);
             let json = serde_json::to_value(&snap).unwrap();
@@ -2305,7 +2322,10 @@ mod tests {
             // rootToken absent from both the flattened settings and anywhere else.
             let text = serde_json::to_string(&json).unwrap();
             assert!(!text.contains("rootToken"), "rootToken leaked: {text}");
-            assert!(!text.contains("SUPER-SECRET-TOKEN-VALUE"), "token value leaked");
+            assert!(
+                !text.contains("SUPER-SECRET-TOKEN-VALUE"),
+                "token value leaked"
+            );
 
             let resolution = &json["projectPathResolution"];
             assert_eq!(resolution["activeRegistrationCount"], 2);
@@ -2322,7 +2342,9 @@ mod tests {
             // id is a full lowercase 64-char hex.
             let id = conflict["id"].as_str().unwrap();
             assert_eq!(id.len(), 64);
-            assert!(id.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+            assert!(id
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
 
             let missing = &issues[1];
             assert_eq!(missing["kind"], "missing");
@@ -2347,8 +2369,7 @@ mod tests {
                     value: None,
                 },
             };
-            let mut settings = AppSettings::default();
-            settings.project_path_state = std::sync::Arc::new(state_with(vec![], vec![structural]));
+            let settings = settings_with_state(state_with(vec![], vec![structural]));
             let snap = settings_snapshot_from(&settings, None);
             let json = serde_json::to_value(&snap).unwrap();
             let resolution = &json["projectPathResolution"];
@@ -2368,17 +2389,14 @@ mod tests {
             let mut a = missing_pair();
             let mut b = missing_pair();
             b.index = Some(9);
-            let mut settings_a = AppSettings::default();
-            settings_a.project_path_state = std::sync::Arc::new(state_with(vec![a.clone()], vec![]));
-            let mut settings_b = AppSettings::default();
-            settings_b.project_path_state = std::sync::Arc::new(state_with(vec![b], vec![]));
+            let settings_a = settings_with_state(state_with(vec![a.clone()], vec![]));
+            let settings_b = settings_with_state(state_with(vec![b], vec![]));
             let id_a = issue_id(&settings_snapshot_from(&settings_a, None));
             let id_b = issue_id(&settings_snapshot_from(&settings_b, None));
             assert_eq!(id_a, id_b);
             // A different raw absolute → different id.
             a.raw_absolute = RawStringField::string("/gone/y");
-            let mut settings_c = AppSettings::default();
-            settings_c.project_path_state = std::sync::Arc::new(state_with(vec![a], vec![]));
+            let settings_c = settings_with_state(state_with(vec![a], vec![]));
             assert_ne!(id_a, issue_id(&settings_snapshot_from(&settings_c, None)));
         }
 
@@ -2448,11 +2466,6 @@ mod tests {
 
     fn write_settings_file(dir: &Path, settings: &AppSettings) {
         let json = serde_json::to_vec_pretty(settings).expect("serialize settings");
-        std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
-    }
-
-    fn write_settings_json(dir: &Path, value: serde_json::Value) {
-        let json = serde_json::to_vec_pretty(&value).expect("serialize settings json");
         std::fs::write(dir.join("settings.json"), json).expect("write settings.json");
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -8,7 +8,13 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
+use sha2::{Digest, Sha256};
+
 use crate::api::auth;
+use crate::config::projects::{
+    display_canonical, IssueKind, ProjectPathPersistenceState, ProjectSource, RawJsonField,
+    RawStringField, ResolvedPair, SideStatus, StructuralIssue,
+};
 use crate::config::settings::{
     load_settings, merge_protected_coding_agent_settings, parse_api_server_socket_addr,
     save_settings, validate_and_repair_settings, AppSettings, CodingAgentEnv,
@@ -88,12 +94,355 @@ pub fn drain_error_logs() -> Vec<crate::logging::ErrorLogEntry> {
     crate::logging::error_sink().drain()
 }
 
+// ── #1077 SettingsSnapshot: the get_settings client response ────────────────
+
+/// Tagged raw string field state (absent vs JSON null vs string). `present ==
+/// false` always pairs with `value == None`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawStringFieldState {
+    pub present: bool,
+    pub value: Option<String>,
+}
+
+/// Tagged raw JSON field state (needed for wrong-typed structural fields and
+/// absent/null parity).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawJsonFieldState {
+    pub present: bool,
+    pub value: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ReconciliationStage {
+    Read,
+    Write,
+}
+
+/// The transport/I-O reconciliation error; structural/candidate issues belong in
+/// `issues`, not here. `retryable` is always true.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectPathReconciliationError {
+    pub stage: ReconciliationStage,
+    pub message: String,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IssueSource {
+    ProjectPath,
+    ProjectPaths,
+    ArchivedProjectPaths,
+}
+
+/// The discriminated project-path issue union. `rename_all_fields` is required
+/// so struct-variant fields are camelCase (plain `rename_all` does not rename
+/// them). Optional `index` is omitted when absent.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum ProjectPathIssue {
+    Conflict {
+        id: String,
+        source: IssueSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        index: Option<usize>,
+        absolute_candidate: String,
+        instance_relative_candidate: String,
+        absolute_resolved_path: String,
+        instance_relative_resolved_path: String,
+        message: String,
+    },
+    Missing {
+        id: String,
+        source: IssueSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        index: Option<usize>,
+        absolute_candidate: RawStringFieldState,
+        instance_relative_candidate: RawStringFieldState,
+        absolute_resolved_path: Option<String>,
+        instance_relative_resolved_path: Option<String>,
+        message: String,
+    },
+    Invalid {
+        id: String,
+        source: IssueSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        index: Option<usize>,
+        absolute_candidate: RawJsonFieldState,
+        instance_relative_candidate: RawJsonFieldState,
+        absolute_resolved_path: Option<String>,
+        instance_relative_resolved_path: Option<String>,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectPathResolution {
+    pub active_registration_count: usize,
+    pub archived_registration_count: usize,
+    pub issues: Vec<ProjectPathIssue>,
+    pub reconciliation_error: Option<ProjectPathReconciliationError>,
+}
+
+/// The flattened `get_settings` response: the runtime-selected `AppSettings`
+/// plus the structured resolution report. Serialize-only.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsSnapshot {
+    #[serde(flatten)]
+    pub settings: AppSettings,
+    pub project_path_resolution: ProjectPathResolution,
+}
+
+fn issue_source(source: ProjectSource) -> IssueSource {
+    match source {
+        ProjectSource::ProjectPath => IssueSource::ProjectPath,
+        ProjectSource::ProjectPaths => IssueSource::ProjectPaths,
+        ProjectSource::ArchivedProjectPaths => IssueSource::ArchivedProjectPaths,
+    }
+}
+
+/// The active|archived logical list of a source (both active fields collapse to
+/// "active"), used in the stable issue id.
+fn source_list(source: ProjectSource) -> &'static str {
+    match source {
+        ProjectSource::ProjectPath | ProjectSource::ProjectPaths => "active",
+        ProjectSource::ArchivedProjectPaths => "archived",
+    }
+}
+
+fn raw_string_to_json(field: &RawStringField) -> RawJsonField {
+    RawJsonField {
+        present: field.present,
+        value: field.value.clone().map(serde_json::Value::String),
+    }
+}
+
+fn raw_string_state(field: &RawStringField) -> RawStringFieldState {
+    RawStringFieldState {
+        present: field.present,
+        value: field.value.clone(),
+    }
+}
+
+fn raw_json_state(field: &RawJsonField) -> RawJsonFieldState {
+    RawJsonFieldState {
+        present: field.present,
+        value: field.value.clone(),
+    }
+}
+
+/// Stable issue id: full lowercase SHA-256 hex of `(kind, active|archived list,
+/// tagged raw absolute, tagged raw relative)`, absent distinct from JSON null,
+/// excluding source index and resolved paths.
+fn compute_issue_id(kind: &str, list: &str, abs: &RawJsonField, rel: &RawJsonField) -> String {
+    let tuple = serde_json::json!([
+        kind,
+        list,
+        { "present": abs.present, "value": abs.value },
+        { "present": rel.present, "value": rel.value },
+    ]);
+    let serialized = serde_json::to_string(&tuple).unwrap_or_default();
+    let digest = Sha256::digest(serialized.as_bytes());
+    digest.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn side_status_label(status: SideStatus) -> &'static str {
+    match status {
+        SideStatus::Absent => "not set",
+        SideStatus::BaseUnavailable => "no portable instance base",
+        SideStatus::Malformed => "malformed",
+        SideStatus::Missing => "not found",
+        SideStatus::Inaccessible => "permission denied",
+        SideStatus::ProbeIoError => "filesystem error",
+        SideStatus::NotADirectory => "not a directory",
+        SideStatus::WorkspaceOrCollectionMissing => "no .ac project or collection",
+        SideStatus::NonUtf8 => "path is not valid UTF-8",
+        SideStatus::ValidDirectProject => "valid project",
+        SideStatus::ValidCollectionRoot => "valid collection root",
+    }
+}
+
+fn pair_to_issue(pair: &ResolvedPair) -> ProjectPathIssue {
+    let source = issue_source(pair.source);
+    let list = source_list(pair.source);
+    let abs_json = raw_string_to_json(&pair.raw_absolute);
+    let rel_json = raw_string_to_json(&pair.raw_relative);
+    let abs_resolved = pair
+        .absolute_side
+        .canonical_path
+        .as_deref()
+        .map(display_canonical);
+    let rel_resolved = pair
+        .relative_side
+        .canonical_path
+        .as_deref()
+        .map(display_canonical);
+    match pair.issue {
+        Some(IssueKind::Conflict) => {
+            let id = compute_issue_id("conflict", list, &abs_json, &rel_json);
+            let abs_path = abs_resolved.clone().unwrap_or_default();
+            let rel_path = rel_resolved.clone().unwrap_or_default();
+            ProjectPathIssue::Conflict {
+                id,
+                source,
+                index: pair.index,
+                absolute_candidate: pair.raw_absolute.value.clone().unwrap_or_default(),
+                instance_relative_candidate: pair.raw_relative.value.clone().unwrap_or_default(),
+                message: format!(
+                    "This project's two stored locations resolve to different directories, so neither was loaded. Absolute path: {abs_path}. Instance-relative path: {rel_path}."
+                ),
+                absolute_resolved_path: abs_path,
+                instance_relative_resolved_path: rel_path,
+            }
+        }
+        Some(IssueKind::Missing) => {
+            let id = compute_issue_id("missing", list, &abs_json, &rel_json);
+            ProjectPathIssue::Missing {
+                id,
+                source,
+                index: pair.index,
+                absolute_candidate: raw_string_state(&pair.raw_absolute),
+                instance_relative_candidate: raw_string_state(&pair.raw_relative),
+                message: "This project directory could not be found. Reconnect the drive or remove it from the list.".to_string(),
+                absolute_resolved_path: pair.absolute_side.syntactic_path.clone(),
+                instance_relative_resolved_path: pair.relative_side.syntactic_path.clone(),
+            }
+        }
+        _ => {
+            let id = compute_issue_id("invalid", list, &abs_json, &rel_json);
+            ProjectPathIssue::Invalid {
+                id,
+                source,
+                index: pair.index,
+                absolute_candidate: raw_json_state(&abs_json),
+                instance_relative_candidate: raw_json_state(&rel_json),
+                reason: format!(
+                    "This project could not be loaded (absolute candidate: {}; instance-relative candidate: {}).",
+                    side_status_label(pair.absolute_side.status),
+                    side_status_label(pair.relative_side.status)
+                ),
+                absolute_resolved_path: pair.absolute_side.syntactic_path.clone(),
+                instance_relative_resolved_path: pair.relative_side.syntactic_path.clone(),
+            }
+        }
+    }
+}
+
+fn structural_to_issue(structural: &StructuralIssue) -> ProjectPathIssue {
+    let id = compute_issue_id(
+        "invalid",
+        source_list(structural.source),
+        &structural.raw_absolute,
+        &structural.raw_relative,
+    );
+    ProjectPathIssue::Invalid {
+        id,
+        source: issue_source(structural.source),
+        index: None,
+        absolute_candidate: raw_json_state(&structural.raw_absolute),
+        instance_relative_candidate: raw_json_state(&structural.raw_relative),
+        absolute_resolved_path: None,
+        instance_relative_resolved_path: None,
+        reason: format!("Malformed project settings: {}.", structural.reason),
+    }
+}
+
+/// Build the structured resolution report from the hidden persistence state.
+pub(crate) fn build_project_path_resolution(
+    state: &ProjectPathPersistenceState,
+    reconciliation_error: Option<ProjectPathReconciliationError>,
+) -> ProjectPathResolution {
+    let mut issues: Vec<ProjectPathIssue> = state.issues().map(pair_to_issue).collect();
+    issues.extend(state.structural_issues.iter().map(structural_to_issue));
+
+    // Counts merged logical records; force a minimum of one for any group that
+    // has a structural issue so a corruption-only startup is never called pristine.
+    let mut active = state.active_registration_count;
+    let mut archived = state.archived_registration_count;
+    for structural in &state.structural_issues {
+        match structural.source {
+            ProjectSource::ProjectPath | ProjectSource::ProjectPaths => active = active.max(1),
+            ProjectSource::ArchivedProjectPaths => archived = archived.max(1),
+        }
+    }
+
+    ProjectPathResolution {
+        active_registration_count: active,
+        archived_registration_count: archived,
+        issues,
+        reconciliation_error,
+    }
+}
+
+/// Pure snapshot builder: clone `settings`, clear the root token, and attach the
+/// resolution report. Shared by the Tauri and WebSocket transports so both
+/// clients receive the identical report and `rootToken` is absent from each.
+pub(crate) fn settings_snapshot_from(
+    settings: &AppSettings,
+    reconciliation_error: Option<ProjectPathReconciliationError>,
+) -> SettingsSnapshot {
+    let resolution = build_project_path_resolution(&settings.project_path_state, reconciliation_error);
+    let mut cleaned = settings.clone();
+    // Clear so the existing skip_serializing_if omits rootToken (absent, not null).
+    cleaned.root_token = None;
+    SettingsSnapshot {
+        settings: cleaned,
+        project_path_resolution: resolution,
+    }
+}
+
+/// The shared, path-injectable settings-snapshot helper. At the first snapshot
+/// boundary it reconciles any eligible pending repair to disk (§4.3), then
+/// returns the report. Tests inject `settings_path`; production resolves it.
+pub(crate) async fn settings_snapshot_helper(
+    settings: &SettingsState,
+    settings_path: Option<PathBuf>,
+) -> SettingsSnapshot {
+    let mut reconciliation_error = None;
+    {
+        // Reconciliation transaction under the write guard; no lock across await.
+        let mut guard = settings.write().await;
+        let state = guard.project_path_state.clone();
+        let eligible = !state.has_structural()
+            && (state.active_reconcile_eligible || state.archived_reconcile_eligible);
+        if eligible {
+            let path = settings_path
+                .clone()
+                .or_else(|| crate::config::config_dir().map(|d| d.join("settings.json")));
+            if let Some(path) = path {
+                match crate::config::settings::reconcile_project_state_to_path(
+                    &guard,
+                    &path,
+                    state.active_reconcile_eligible,
+                    state.archived_reconcile_eligible,
+                ) {
+                    Ok(written) => *guard = written,
+                    Err(message) => {
+                        reconciliation_error = Some(ProjectPathReconciliationError {
+                            stage: ReconciliationStage::Write,
+                            message,
+                            retryable: true,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    let guard = settings.read().await;
+    settings_snapshot_from(&guard, reconciliation_error)
+}
+
 #[tauri::command]
-pub async fn get_settings(settings: State<'_, SettingsState>) -> Result<AppSettings, String> {
-    let s = settings.read().await;
-    let mut result = s.clone();
-    result.root_token = None; // never expose root token to frontend
-    Ok(result)
+pub async fn get_settings(
+    settings: State<'_, SettingsState>,
+) -> Result<SettingsSnapshot, String> {
+    Ok(settings_snapshot_helper(settings.inner(), None).await)
 }
 
 /// #769 Phase 1 - return the externalized coding-agent catalog for the onboarding
@@ -233,6 +582,11 @@ fn build_protected_settings_candidate(
     candidate.project_paths = current.project_paths.clone();
     candidate.project_path = current.project_path.clone();
     candidate.archived_project_paths = current.archived_project_paths.clone();
+    // #1077: restore the hidden project-path pair state too, so a returned
+    // SettingsSnapshot echoed back as an update cannot erase or re-pair the
+    // companion metadata. The disk serializer builds project fields only from
+    // this protected state (or disk truth), never from the incoming payload.
+    candidate.project_path_state = current.project_path_state.clone();
     // #965: rail collapse is mutated only by `set_rail_collapse`. A settings payload
     // from the GUI, CLI, or API must never carry authority for it, so restore both
     // fields from live memory. Same rule and same mechanism as the project lists
@@ -264,6 +618,9 @@ async fn persist_settings_draft_update_with_saver(
     draft.project_paths = current.project_paths.clone();
     draft.project_path = current.project_path.clone();
     draft.archived_project_paths = current.archived_project_paths.clone();
+    // #1077: restore the hidden project-path pair state (see the protected
+    // candidate builder above).
+    draft.project_path_state = current.project_path_state.clone();
     // #965: same protect as `build_protected_settings_candidate`. The SettingsModal
     // Save path lands here, and so does every whole-object writer that reads
     // `settingsStore.current` first (window geometry, zoom, titlebar...). Rail
@@ -1857,6 +2214,182 @@ mod tests {
     use tauri::Manager;
     use tokio::sync::RwLock;
     use tokio_util::sync::CancellationToken;
+
+    // ── #1077 SettingsSnapshot / resolution report ───────────────────────
+    mod snapshot {
+        use super::super::{settings_snapshot_from, ProjectPathIssue};
+        use crate::config::projects::{
+            DirectoryIdentity, IssueKind, ProjectPathPersistenceState, ProjectSource, RawJsonField,
+            RawStringField, RepairKind, ResolvedPair, SideOutcome, SideStatus, StructuralIssue,
+        };
+        use crate::config::settings::AppSettings;
+
+        fn side(status: SideStatus, canonical: Option<&str>) -> SideOutcome {
+            SideOutcome {
+                status,
+                syntactic_path: canonical.map(str::to_string),
+                canonical_path: canonical.map(str::to_string),
+                identity: canonical.map(|_| DirectoryIdentity { volume: 1, file: 1 }),
+            }
+        }
+
+        fn conflict_pair() -> ResolvedPair {
+            ResolvedPair {
+                source: ProjectSource::ProjectPaths,
+                index: Some(0),
+                raw_absolute: RawStringField::string("/abs/alpha"),
+                raw_relative: RawStringField::string("../rel/beta"),
+                absolute_side: side(SideStatus::ValidDirectProject, Some("/abs/alpha")),
+                relative_side: side(SideStatus::ValidDirectProject, Some("/rel/beta")),
+                selected: None,
+                selected_canonical_raw: None,
+                selected_identity: None,
+                issue: Some(IssueKind::Conflict),
+                repair: RepairKind::None,
+            }
+        }
+
+        fn missing_pair() -> ResolvedPair {
+            ResolvedPair {
+                source: ProjectSource::ProjectPaths,
+                index: Some(1),
+                raw_absolute: RawStringField::string("/gone/x"),
+                raw_relative: RawStringField::absent(),
+                absolute_side: SideOutcome {
+                    status: SideStatus::Missing,
+                    syntactic_path: Some("/gone/x".to_string()),
+                    canonical_path: None,
+                    identity: None,
+                },
+                relative_side: SideOutcome {
+                    status: SideStatus::Absent,
+                    syntactic_path: None,
+                    canonical_path: None,
+                    identity: None,
+                },
+                selected: None,
+                selected_canonical_raw: None,
+                selected_identity: None,
+                issue: Some(IssueKind::Missing),
+                repair: RepairKind::None,
+            }
+        }
+
+        fn state_with(pairs: Vec<ResolvedPair>, structural: Vec<StructuralIssue>) -> ProjectPathPersistenceState {
+            let active_registration_count = pairs.len();
+            ProjectPathPersistenceState {
+                pairs,
+                selected_head: None,
+                active_registration_count,
+                archived_registration_count: 0,
+                active_companion_present: true,
+                archived_companion_present: false,
+                has_genuine_singular: false,
+                active_reconcile_eligible: false,
+                archived_reconcile_eligible: false,
+                structural_issues: structural,
+                runtime_authoritative: false,
+            }
+        }
+
+        #[test]
+        fn snapshot_serializes_camelcase_variants_and_omits_root_token() {
+            let mut settings = AppSettings::default();
+            settings.root_token = Some("SUPER-SECRET-TOKEN-VALUE".to_string());
+            settings.project_path_state =
+                std::sync::Arc::new(state_with(vec![conflict_pair(), missing_pair()], vec![]));
+
+            let snap = settings_snapshot_from(&settings, None);
+            let json = serde_json::to_value(&snap).unwrap();
+
+            // rootToken absent from both the flattened settings and anywhere else.
+            let text = serde_json::to_string(&json).unwrap();
+            assert!(!text.contains("rootToken"), "rootToken leaked: {text}");
+            assert!(!text.contains("SUPER-SECRET-TOKEN-VALUE"), "token value leaked");
+
+            let resolution = &json["projectPathResolution"];
+            assert_eq!(resolution["activeRegistrationCount"], 2);
+            assert_eq!(resolution["archivedRegistrationCount"], 0);
+            let issues = resolution["issues"].as_array().unwrap();
+            assert_eq!(issues.len(), 2);
+
+            let conflict = &issues[0];
+            assert_eq!(conflict["kind"], "conflict");
+            assert_eq!(conflict["source"], "projectPaths");
+            assert_eq!(conflict["index"], 0);
+            assert!(conflict["absoluteResolvedPath"].is_string());
+            assert!(conflict["instanceRelativeResolvedPath"].is_string());
+            // id is a full lowercase 64-char hex.
+            let id = conflict["id"].as_str().unwrap();
+            assert_eq!(id.len(), 64);
+            assert!(id.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+
+            let missing = &issues[1];
+            assert_eq!(missing["kind"], "missing");
+            // Tagged raw states: absent relative candidate is present:false, value:null.
+            assert_eq!(missing["instanceRelativeCandidate"]["present"], false);
+            assert!(missing["instanceRelativeCandidate"]["value"].is_null());
+            assert_eq!(missing["absoluteCandidate"]["present"], true);
+            assert_eq!(missing["absoluteCandidate"]["value"], "/gone/x");
+        }
+
+        #[test]
+        fn structural_issue_forces_minimum_count_and_invalid_kind() {
+            let structural = StructuralIssue {
+                source: ProjectSource::ProjectPaths,
+                reason: "plural primary is not an array of strings".to_string(),
+                raw_absolute: RawJsonField {
+                    present: true,
+                    value: Some(serde_json::json!("not-an-array")),
+                },
+                raw_relative: RawJsonField {
+                    present: false,
+                    value: None,
+                },
+            };
+            let mut settings = AppSettings::default();
+            settings.project_path_state = std::sync::Arc::new(state_with(vec![], vec![structural]));
+            let snap = settings_snapshot_from(&settings, None);
+            let json = serde_json::to_value(&snap).unwrap();
+            let resolution = &json["projectPathResolution"];
+            // Corruption-only startup is never pristine: min count of 1.
+            assert_eq!(resolution["activeRegistrationCount"], 1);
+            let issues = resolution["issues"].as_array().unwrap();
+            assert_eq!(issues.len(), 1);
+            assert_eq!(issues[0]["kind"], "invalid");
+            // Invalid candidates are tagged RawJsonFieldState (wrong-typed value).
+            assert_eq!(issues[0]["absoluteCandidate"]["present"], true);
+            assert_eq!(issues[0]["absoluteCandidate"]["value"], "not-an-array");
+        }
+
+        #[test]
+        fn issue_id_is_stable_across_index_and_resolved_paths() {
+            // Same kind/list/raw fields but different index → same id (index excluded).
+            let mut a = missing_pair();
+            let mut b = missing_pair();
+            b.index = Some(9);
+            let mut settings_a = AppSettings::default();
+            settings_a.project_path_state = std::sync::Arc::new(state_with(vec![a.clone()], vec![]));
+            let mut settings_b = AppSettings::default();
+            settings_b.project_path_state = std::sync::Arc::new(state_with(vec![b], vec![]));
+            let id_a = issue_id(&settings_snapshot_from(&settings_a, None));
+            let id_b = issue_id(&settings_snapshot_from(&settings_b, None));
+            assert_eq!(id_a, id_b);
+            // A different raw absolute → different id.
+            a.raw_absolute = RawStringField::string("/gone/y");
+            let mut settings_c = AppSettings::default();
+            settings_c.project_path_state = std::sync::Arc::new(state_with(vec![a], vec![]));
+            assert_ne!(id_a, issue_id(&settings_snapshot_from(&settings_c, None)));
+        }
+
+        fn issue_id(snap: &super::super::SettingsSnapshot) -> String {
+            match &snap.project_path_resolution.issues[0] {
+                ProjectPathIssue::Conflict { id, .. }
+                | ProjectPathIssue::Missing { id, .. }
+                | ProjectPathIssue::Invalid { id, .. } => id.clone(),
+            }
+        }
+    }
 
     fn settings_with_single_agent() -> AppSettings {
         AppSettings {

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1952,6 +1952,32 @@ mod tests {
         assert_eq!(settings.project_path.as_deref(), Some(project));
     }
 
+    /// #1077: create a real AC project dir and return its display-canonical path,
+    /// so the six-field decoder validates it and the SELECTED runtime path (in the
+    /// preserving writer's fresh-decoded return) equals the stored string.
+    fn real_ac_project(parent: &Path, name: &str) -> String {
+        let dir = parent.join(name);
+        std::fs::create_dir_all(dir.join(".ac")).unwrap();
+        let canon = std::fs::canonicalize(&dir).unwrap();
+        crate::config::projects::display_canonical(&canon.to_string_lossy())
+    }
+
+    /// #1077: seed a whole, valid AppSettings object on disk with `keys` removed
+    /// (to simulate an absent-key scenario without tripping the preserve writer's
+    /// whole-object gate).
+    fn write_settings_file_without_keys(dir: &Path, settings: &AppSettings, keys: &[&str]) {
+        let mut value = serde_json::to_value(settings).expect("serialize settings");
+        let object = value.as_object_mut().expect("settings object");
+        for key in keys {
+            object.remove(*key);
+        }
+        std::fs::write(
+            dir.join("settings.json"),
+            serde_json::to_vec_pretty(&value).expect("serialize settings json"),
+        )
+        .expect("write settings.json");
+    }
+
     fn api_server_command_test_app(settings: AppSettings) -> tauri::App {
         let session_mgr = Arc::new(RwLock::new(SessionManager::new()));
         let app = tauri::Builder::default()
@@ -2694,12 +2720,12 @@ mod tests {
     async fn settings_update_does_not_clobber_in_memory_project_lists() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let disk_project = "C:/disk/project-a";
+        let disk_project = real_ac_project(temp.path(), "disk-project-a");
         write_settings_file(
             temp.path(),
             &AppSettings {
-                project_paths: vec![disk_project.to_string()],
-                project_path: Some(disk_project.to_string()),
+                project_paths: vec![disk_project.clone()],
+                project_path: Some(disk_project.clone()),
                 ..AppSettings::default()
             },
         );
@@ -2725,11 +2751,11 @@ mod tests {
             .await
             .unwrap();
 
-        assert_single_project(&saved, disk_project);
+        assert_single_project(&saved, &disk_project);
         assert_eq!(saved.root_token.as_deref(), Some("current-root-token"));
         {
             let live = protected_state.read().await;
-            assert_single_project(&live, disk_project);
+            assert_single_project(&live, &disk_project);
             assert_eq!(live.root_token.as_deref(), Some("current-root-token"));
         }
 
@@ -2748,10 +2774,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_single_project(&saved, disk_project);
+        assert_single_project(&saved, &disk_project);
         {
             let live = draft_state.read().await;
-            assert_single_project(&live, disk_project);
+            assert_single_project(&live, &disk_project);
         }
     }
 
@@ -2759,14 +2785,16 @@ mod tests {
     async fn update_settings_keeps_live_archived_list_when_disk_key_absent() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let live_project = "C:/live/a";
-        let archived_project = "C:/archived/b";
-        write_settings_json(
+        let live_project = real_ac_project(temp.path(), "live-a");
+        let archived_project = real_ac_project(temp.path(), "archived-b");
+        write_settings_file_without_keys(
             temp.path(),
-            serde_json::json!({
-                "projectPaths": [live_project],
-                "projectPath": live_project
-            }),
+            &AppSettings {
+                project_paths: vec![live_project.clone()],
+                project_path: Some(live_project.clone()),
+                ..AppSettings::default()
+            },
+            &["archivedProjectPaths"],
         );
 
         let mut current = settings_with_single_agent();
@@ -2809,14 +2837,16 @@ mod tests {
     async fn save_settings_draft_keeps_live_archived_list_when_disk_key_absent() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let live_project = "C:/live/a";
-        let archived_project = "C:/archived/b";
-        write_settings_json(
+        let live_project = real_ac_project(temp.path(), "live-a");
+        let archived_project = real_ac_project(temp.path(), "archived-b");
+        write_settings_file_without_keys(
             temp.path(),
-            serde_json::json!({
-                "projectPaths": [live_project],
-                "projectPath": live_project
-            }),
+            &AppSettings {
+                project_paths: vec![live_project.clone()],
+                project_path: Some(live_project.clone()),
+                ..AppSettings::default()
+            },
+            &["archivedProjectPaths"],
         );
 
         let mut current = settings_with_single_agent();
@@ -2860,11 +2890,11 @@ mod tests {
     async fn update_settings_keeps_live_project_paths_when_settings_file_absent() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let live_project = "C:/live/a";
+        let live_project = real_ac_project(temp.path(), "live-a");
 
         let mut current = settings_with_single_agent();
-        current.project_paths = vec![live_project.to_string()];
-        current.project_path = Some(live_project.to_string());
+        current.project_paths = vec![live_project.clone()];
+        current.project_path = Some(live_project.clone());
         let state = state_for(current.clone());
         let payload = settings_payload_without_keys(&current, &["projectPaths", "projectPath"]);
 
@@ -2877,26 +2907,26 @@ mod tests {
         .await
         .unwrap();
 
-        assert_single_project(&saved, live_project);
-        assert!(session_retention_project_paths(&saved).contains(&live_project.to_string()));
+        assert_single_project(&saved, &live_project);
+        assert!(session_retention_project_paths(&saved).contains(&live_project));
         {
             let live = state.read().await;
-            assert_single_project(&live, live_project);
+            assert_single_project(&live, &live_project);
         }
         let disk: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
-        assert_single_project(&disk, live_project);
+        assert_single_project(&disk, &live_project);
     }
 
     #[tokio::test]
     async fn save_settings_draft_keeps_live_project_paths_when_settings_file_absent() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let live_project = "C:/live/a";
+        let live_project = real_ac_project(temp.path(), "live-a");
 
         let mut current = settings_with_single_agent();
-        current.project_paths = vec![live_project.to_string()];
-        current.project_path = Some(live_project.to_string());
+        current.project_paths = vec![live_project.clone()];
+        current.project_path = Some(live_project.clone());
         let state = state_for(current.clone());
         let payload = settings_payload_without_keys(&current, &["projectPaths", "projectPath"]);
 
@@ -2910,32 +2940,33 @@ mod tests {
             .await
             .unwrap();
 
-        assert_single_project(&saved, live_project);
-        assert!(session_retention_project_paths(&saved).contains(&live_project.to_string()));
+        assert_single_project(&saved, &live_project);
+        assert!(session_retention_project_paths(&saved).contains(&live_project));
         {
             let live = state.read().await;
-            assert_single_project(&live, live_project);
+            assert_single_project(&live, &live_project);
         }
         let disk: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
-        assert_single_project(&disk, live_project);
+        assert_single_project(&disk, &live_project);
     }
 
     #[tokio::test]
     async fn update_settings_still_takes_disk_archived_list_when_key_present() {
         let temp = tempfile::tempdir().unwrap();
         let settings_path = temp.path().join("settings.json");
-        let live_project = "C:/live/a";
-        let disk_archived = "C:/archived/a";
-        let live_archived = "C:/archived/b";
-        let payload_archived = "C:/archived/c";
-        write_settings_json(
+        let live_project = real_ac_project(temp.path(), "live-a");
+        let disk_archived = real_ac_project(temp.path(), "archived-a");
+        let live_archived = "C:/archived/b"; // distractor: overridden by disk
+        let payload_archived = "C:/archived/c"; // distractor: overridden by disk
+        write_settings_file(
             temp.path(),
-            serde_json::json!({
-                "projectPaths": [live_project],
-                "projectPath": live_project,
-                "archivedProjectPaths": [disk_archived]
-            }),
+            &AppSettings {
+                project_paths: vec![live_project.clone()],
+                project_path: Some(live_project.clone()),
+                archived_project_paths: vec![disk_archived.clone()],
+                ..AppSettings::default()
+            },
         );
 
         let mut current = settings_with_single_agent();

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -413,27 +413,53 @@ pub(crate) async fn settings_snapshot_helper(
     {
         // Reconciliation transaction under the write guard; no lock across await.
         let mut guard = settings.write().await;
-        let state = guard.project_path_state.clone();
-        let eligible = !state.has_structural()
-            && (state.active_reconcile_eligible || state.archived_reconcile_eligible);
-        if eligible {
-            let path = settings_path
+        let pending = {
+            let state = &guard.project_path_state;
+            !state.has_structural()
+                && (state.active_reconcile_eligible || state.archived_reconcile_eligible)
+        };
+        if pending {
+            if let Some(path) = settings_path
                 .clone()
-                .or_else(|| crate::config::config_dir().map(|d| d.join("settings.json")));
-            if let Some(path) = path {
-                match crate::config::settings::reconcile_project_state_to_path(
-                    &guard,
-                    &path,
-                    state.active_reconcile_eligible,
-                    state.archived_reconcile_eligible,
+                .or_else(|| crate::config::config_dir().map(|d| d.join("settings.json")))
+            {
+                // §4.3 step 2: re-decode all six project fields from disk and
+                // re-resolve BEFORE reconciling, so a CLI registration that
+                // happened after startup is authoritative and not clobbered. On a
+                // disk read/parse failure, retain the previously validated state,
+                // perform no write, and report stage `read`.
+                match crate::config::settings::refresh_and_decode_project_paths_from_path(
+                    &mut guard, &path,
                 ) {
-                    Ok(written) => *guard = written,
                     Err(message) => {
                         reconciliation_error = Some(ProjectPathReconciliationError {
-                            stage: ReconciliationStage::Write,
+                            stage: ReconciliationStage::Read,
                             message,
                             retryable: true,
                         });
+                    }
+                    Ok(()) => {
+                        let fresh = guard.project_path_state.clone();
+                        let still_eligible = !fresh.has_structural()
+                            && (fresh.active_reconcile_eligible
+                                || fresh.archived_reconcile_eligible);
+                        if still_eligible {
+                            match crate::config::settings::reconcile_project_state_to_path(
+                                &guard,
+                                &path,
+                                fresh.active_reconcile_eligible,
+                                fresh.archived_reconcile_eligible,
+                            ) {
+                                Ok(written) => *guard = written,
+                                Err(message) => {
+                                    reconciliation_error = Some(ProjectPathReconciliationError {
+                                        stage: ReconciliationStage::Write,
+                                        message,
+                                        retryable: true,
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3543,6 +3569,96 @@ mod tests {
         let disk: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
         assert_eq!(disk.archived_project_paths, vec![disk_archived.to_string()]);
+    }
+
+    /// Build a pending (companion-population-eligible) SettingsState by decoding a
+    /// legacy `[project]` file (no companion) from `settings_path`.
+    fn pending_state_from_legacy(settings_path: &Path, project: &str) -> SettingsState {
+        write_settings_file(
+            settings_path.parent().unwrap(),
+            &AppSettings {
+                project_paths: vec![project.to_string()],
+                project_path: Some(project.to_string()),
+                ..AppSettings::default()
+            },
+        );
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(settings_path).unwrap()).unwrap();
+        let decoded = crate::config::settings::decode_project_state(
+            value.as_object().unwrap(),
+            None,
+            &crate::config::projects::FsCandidateResolver,
+        );
+        let startup = AppSettings {
+            project_paths: decoded.active_selected(),
+            project_path: decoded.selected_head.clone(),
+            project_path_state: std::sync::Arc::new(decoded),
+            ..AppSettings::default()
+        };
+        assert!(
+            startup.project_path_state.active_reconcile_eligible,
+            "legacy no-companion state should be pending"
+        );
+        state_for(startup)
+    }
+
+    #[tokio::test]
+    async fn auto_reconcile_redecodes_and_preserves_intervening_cli_write() {
+        // Grinch Defect 2: the get_settings boundary must re-decode disk before
+        // reconciling, so a CLI registration that landed after startup survives.
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let a = real_ac_project(temp.path(), "A");
+        let b = real_ac_project(temp.path(), "B");
+        let state = pending_state_from_legacy(&settings_path, &a);
+
+        // Intervening CLI registration: disk now carries [A, B].
+        write_settings_file(
+            temp.path(),
+            &AppSettings {
+                project_paths: vec![a.clone(), b.clone()],
+                project_path: Some(a.clone()),
+                ..AppSettings::default()
+            },
+        );
+
+        let _snap = super::settings_snapshot_helper(&state, Some(settings_path.clone())).await;
+
+        let disk: AppSettings =
+            serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+        assert_eq!(
+            disk.project_paths,
+            vec![a.clone(), b.clone()],
+            "CLI-registered B must not be clobbered by the auto-reconcile"
+        );
+        let live = state.read().await;
+        assert_eq!(live.project_paths, vec![a, b]);
+    }
+
+    #[tokio::test]
+    async fn auto_reconcile_reports_stage_read_on_corrupt_disk() {
+        // Grinch Defect 2: a disk re-decode failure at the boundary reports
+        // stage `read`, performs no write, and retains the prior state.
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join("settings.json");
+        let a = real_ac_project(temp.path(), "A");
+        let state = pending_state_from_legacy(&settings_path, &a);
+
+        // Corrupt the settings file after startup.
+        std::fs::write(&settings_path, b"{ not valid json").unwrap();
+        let snap = super::settings_snapshot_helper(&state, Some(settings_path.clone())).await;
+
+        let err = snap
+            .project_path_resolution
+            .reconciliation_error
+            .expect("a corrupt disk re-decode must surface a reconciliation error");
+        assert!(matches!(err.stage, super::ReconciliationStage::Read));
+        assert!(err.retryable);
+        // No write: the corrupt bytes are untouched.
+        assert_eq!(
+            std::fs::read_to_string(&settings_path).unwrap(),
+            "{ not valid json"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/config/archive_gate.rs
+++ b/src-tauri/src/config/archive_gate.rs
@@ -106,6 +106,14 @@ async fn auto_unarchive_for_activation<R: tauri::Runtime>(
         })?;
 
     crate::config::settings::refresh_project_paths_from_disk(&mut s)?;
+    // #1077: structural project-metadata corruption cannot be mutated; refuse
+    // the auto-unarchive rather than normalizing a corrupt list.
+    if crate::config::settings::project_state_has_structural(&s) {
+        return Err(format!(
+            "Cannot start a session in archived project '{}': settings.json has malformed project metadata. Fix or remove the corrupt project fields first.",
+            folder_name(root)
+        ));
+    }
     let reg = match auto_unarchive_registration(&mut s, root).map_err(|e| {
         format!(
             "Cannot start a session in archived project '{}': {}. Open Archived Projects to restore it, or remove it from the list.",
@@ -117,6 +125,10 @@ async fn auto_unarchive_for_activation<R: tauri::Runtime>(
         None => return Ok(()),
     };
 
+    // #1077: rebuild the hidden pair state from the mutated runtime lists so the
+    // reconcile serializer records the unarchived pair (with its companion)
+    // instead of copying the stale disk list and dropping the move.
+    crate::config::settings::resync_project_state_from_runtime(&mut s);
     let snapshot = s.clone();
     crate::config::settings::save_settings_with_project_paths(&snapshot)?;
     drop(s);

--- a/src-tauri/src/config/archive_gate.rs
+++ b/src-tauri/src/config/archive_gate.rs
@@ -114,7 +114,11 @@ async fn auto_unarchive_for_activation<R: tauri::Runtime>(
             folder_name(root)
         ));
     }
-    let reg = match auto_unarchive_registration(&mut s, root).map_err(|e| {
+    // #1077 §4.3: apply the unarchive to a candidate clone; publish only after the
+    // atomic save succeeds. On failure the live guard keeps the refreshed
+    // pre-mutation (disk-authoritative archived) state, never the unsaved move.
+    let mut candidate = s.clone();
+    let reg = match auto_unarchive_registration(&mut candidate, root).map_err(|e| {
         format!(
             "Cannot start a session in archived project '{}': {}. Open Archived Projects to restore it, or remove it from the list.",
             folder_name(root),
@@ -125,12 +129,20 @@ async fn auto_unarchive_for_activation<R: tauri::Runtime>(
         None => return Ok(()),
     };
 
-    // #1077: rebuild the hidden pair state from the mutated runtime lists so the
-    // reconcile serializer records the unarchived pair (with its companion)
-    // instead of copying the stale disk list and dropping the move.
-    crate::config::settings::resync_project_state_from_runtime(&mut s);
-    let snapshot = s.clone();
-    crate::config::settings::save_settings_with_project_paths(&snapshot)?;
+    // Rebuild the candidate's hidden pairs to match its mutated runtime lists so
+    // the reconcile serializer records the unarchived pair (with its companion).
+    crate::config::settings::resync_project_state_from_runtime(&mut candidate);
+    let path = match crate::config::config_dir() {
+        Some(dir) => dir.join("settings.json"),
+        None => return Err("Could not determine settings directory".to_string()),
+    };
+    match crate::config::settings::reconcile_project_state_to_path(&candidate, &path, true, true) {
+        Ok(written) => *s = written,
+        Err(e) => {
+            drop(s);
+            return Err(e);
+        }
+    }
     drop(s);
 
     log::warn!(

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -24,51 +24,318 @@ pub mod settings;
 pub mod teams;
 pub mod workspace;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+
+/// #1077: authoritative, once-resolved location of the running AgentsCommander
+/// instance. Centralizes the executable-derived facts that `config_dir()`,
+/// `agent_local_dir_name()`, and the portable project-path codec must all agree
+/// on, so none of them independently re-calls `current_exe()` and drifts.
+///
+/// Built once by [`instance_location`] from `resolve_instance_location`, the
+/// pure helper that carries every branch. Tests call the pure helper directly
+/// with injected inputs and never mutate `AGENTSCOMMANDER_TEST_CONFIG_DIR` or
+/// depend on the test-runner executable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstanceLocation {
+    /// The app config directory. Honors the debug `AGENTSCOMMANDER_TEST_CONFIG_DIR`
+    /// override verbatim, then the portable `<exe-parent>/.<exe-stem>` form, then
+    /// the `$HOME/<profile::config_dir_name()>` fallback. `None` only when every
+    /// source is unavailable (no override, no usable `current_exe()` parent/stem,
+    /// and no home directory).
+    pub config_dir: Option<PathBuf>,
+    /// Local agent directory stem derived from the running executable
+    /// (`current_exe().file_stem()`), falling back to `"agentscommander"`. This
+    /// is NEVER derived from the debug override directory: `agent_local_dir_name()`
+    /// returns `format!(".{stem}")`.
+    pub local_dir_stem: String,
+    /// Optional ABSOLUTE instance base directory used to pair portable,
+    /// instance-relative project paths. `Some` only for a packaged/absolute
+    /// executable directory (or an absolute debug override's parent). `None` in
+    /// every degraded mode: a relative executable, a relative override, the home
+    /// fallback, or an unavailable `current_exe()`. Stored raw and
+    /// uncanonicalized; the project codec canonicalizes it at its own boundary
+    /// and never consults the process CWD.
+    pub instance_base: Option<PathBuf>,
+}
+
+/// Pure resolver for [`InstanceLocation`]. All branching for the #1077 instance
+/// base lives here so it can be unit-tested with injected inputs.
+///
+/// - `test_override`: the debug `AGENTSCOMMANDER_TEST_CONFIG_DIR` value when set
+///   (only threaded through in debug builds). An absolute override selects the
+///   config directory verbatim and its parent becomes the instance base; a
+///   relative override selects the config directory verbatim but reports NO
+///   portable base (never absolutized through CWD).
+/// - `current_exe_result`: the outcome of `std::env::current_exe()`.
+/// - `home_dir`: `dirs::home_dir()` for the legacy fallback.
+pub(crate) fn resolve_instance_location(
+    test_override: Option<String>,
+    current_exe_result: Result<PathBuf, std::io::Error>,
+    home_dir: Option<PathBuf>,
+) -> InstanceLocation {
+    // Local agent dir stem: from the running executable only. Independent of the
+    // debug override so `agent_local_dir_name()` keeps naming replica dirs after
+    // the real binary, and falls back to "agentscommander" when unavailable.
+    let local_dir_stem = current_exe_result
+        .as_ref()
+        .ok()
+        .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
+        .unwrap_or_else(|| "agentscommander".to_string());
+
+    // Debug-only override: selects the config directory exactly as the legacy
+    // code did (verbatim `PathBuf::from`, untrimmed). Its parent is the instance
+    // base ONLY when the override is absolute; a relative override yields no base.
+    if let Some(raw) = test_override.as_deref() {
+        if !raw.trim().is_empty() {
+            let override_path = PathBuf::from(raw);
+            let instance_base = if override_path.is_absolute() {
+                override_path.parent().map(Path::to_path_buf)
+            } else {
+                None
+            };
+            return InstanceLocation {
+                config_dir: Some(override_path),
+                local_dir_stem,
+                instance_base,
+            };
+        }
+    }
+
+    // Primary: portable config directory next to the native executable.
+    if let Ok(exe_path) = current_exe_result {
+        match (exe_path.parent(), exe_path.file_stem()) {
+            (Some(parent), Some(stem)) => {
+                let config_dir = parent.join(format!(".{}", stem.to_string_lossy()));
+                // The instance base is the native executable directory, but only
+                // when it is absolute. A relative executable (e.g. `bin/ac`) keeps
+                // its relative config dir yet exposes no portable base rather than
+                // being absolutized through the process CWD.
+                let instance_base = if parent.is_absolute() {
+                    Some(parent.to_path_buf())
+                } else {
+                    None
+                };
+                return InstanceLocation {
+                    config_dir: Some(config_dir),
+                    local_dir_stem,
+                    instance_base,
+                };
+            }
+            _ => {
+                log::warn!(
+                    "[config_dir] current_exe() path has no parent or stem: {:?}, falling back to $HOME",
+                    exe_path
+                );
+            }
+        }
+    }
+
+    // Fallback: legacy $HOME-based config. No portable instance base.
+    InstanceLocation {
+        config_dir: home_dir.map(|home| home.join(profile::config_dir_name())),
+        local_dir_stem,
+        instance_base: None,
+    }
+}
+
+/// Cached, process-wide [`InstanceLocation`], resolved once at first call.
+fn instance_location() -> &'static InstanceLocation {
+    static LOC: OnceLock<InstanceLocation> = OnceLock::new();
+    LOC.get_or_init(|| {
+        // The test override is a debug-only affordance; release builds never read it.
+        #[cfg(debug_assertions)]
+        let test_override = std::env::var("AGENTSCOMMANDER_TEST_CONFIG_DIR").ok();
+        #[cfg(not(debug_assertions))]
+        let test_override: Option<String> = None;
+        resolve_instance_location(test_override, std::env::current_exe(), dirs::home_dir())
+    })
+}
 
 /// Returns the local agent directory name derived from the current binary name.
 /// E.g., "agentscommander-stage.exe" → ".agentscommander-stage"
 /// E.g., "agentscommander.exe" → ".agentscommander"
+///
+/// Projects from the cached [`InstanceLocation`]; the stem comes from the running
+/// executable, never from the debug config-dir override, and falls back to
+/// "agentscommander" when `current_exe()` is unavailable.
 pub fn agent_local_dir_name() -> String {
-    let exe = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
-        .unwrap_or_else(|| "agentscommander".to_string());
-    format!(".{}", exe)
+    format!(".{}", instance_location().local_dir_stem)
 }
 
 /// Returns the app config directory — portable, next to the binary.
 /// Pattern: `<binary_parent_dir>/.<binary_file_stem>/`
 /// E.g., `C:\tools\agentscommander_standalone.exe` → `C:\tools\.agentscommander_standalone\`
 /// Fallback: `$HOME/<profile::config_dir_name()>` if current_exe() fails.
-/// Cached via OnceLock — resolved once at first call.
+/// Cached via the shared [`InstanceLocation`] — resolved once at first call.
 pub fn config_dir() -> Option<PathBuf> {
-    static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
-    DIR.get_or_init(|| {
-        #[cfg(debug_assertions)]
-        if let Ok(path) = std::env::var("AGENTSCOMMANDER_TEST_CONFIG_DIR") {
-            if !path.trim().is_empty() {
-                return Some(PathBuf::from(path));
-            }
-        }
+    instance_location().config_dir.clone()
+}
 
-        // Primary: portable config next to the binary
-        if let Ok(exe_path) = std::env::current_exe() {
-            match (exe_path.parent(), exe_path.file_stem()) {
-                (Some(parent), Some(stem)) => {
-                    return Some(parent.join(format!(".{}", stem.to_string_lossy())));
-                }
-                _ => {
-                    log::warn!(
-                        "[config_dir] current_exe() path has no parent or stem: {:?}, falling back to $HOME",
-                        exe_path
-                    );
-                }
-            }
-        }
-        // Fallback: old $HOME-based path
-        dirs::home_dir().map(|home| home.join(profile::config_dir_name()))
-    })
-    .clone()
+/// #1077: the authoritative ABSOLUTE instance base for portable project-path
+/// pairing, or `None` in any degraded mode. Consumed by the project codec, which
+/// canonicalizes it at its own boundary. Returns raw, uncanonicalized bytes.
+pub(crate) fn instance_base() -> Option<PathBuf> {
+    instance_location().instance_base.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+    use std::path::PathBuf;
+
+    fn exe_err() -> Result<PathBuf, Error> {
+        Err(Error::new(ErrorKind::NotFound, "no current_exe"))
+    }
+
+    #[test]
+    fn packaged_absolute_executable_yields_portable_config_and_base() {
+        let exe = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle\agentscommander.exe")
+        } else {
+            PathBuf::from("/opt/bundle/agentscommander")
+        };
+        let loc = resolve_instance_location(None, Ok(exe), Some(PathBuf::from("/home/u")));
+        let expected_config = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle\.agentscommander")
+        } else {
+            PathBuf::from("/opt/bundle/.agentscommander")
+        };
+        let expected_base = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle")
+        } else {
+            PathBuf::from("/opt/bundle")
+        };
+        assert_eq!(loc.config_dir.as_deref(), Some(expected_config.as_path()));
+        assert_eq!(loc.instance_base.as_deref(), Some(expected_base.as_path()));
+        assert_eq!(loc.local_dir_stem, "agentscommander");
+    }
+
+    #[test]
+    fn renamed_executable_keeps_per_stem_config_and_base() {
+        let exe = if cfg!(windows) {
+            PathBuf::from(r"C:\tools\agentscommander_standalone.exe")
+        } else {
+            PathBuf::from("/tools/agentscommander_standalone")
+        };
+        let loc = resolve_instance_location(None, Ok(exe), Some(PathBuf::from("/home/u")));
+        let expected_config = if cfg!(windows) {
+            PathBuf::from(r"C:\tools\.agentscommander_standalone")
+        } else {
+            PathBuf::from("/tools/.agentscommander_standalone")
+        };
+        assert_eq!(loc.config_dir.as_deref(), Some(expected_config.as_path()));
+        assert_eq!(loc.local_dir_stem, "agentscommander_standalone");
+        assert!(loc.instance_base.is_some());
+    }
+
+    #[test]
+    fn absolute_debug_override_sets_config_verbatim_and_parent_base() {
+        let override_dir = if cfg!(windows) {
+            r"C:\bundle\.agentscommander"
+        } else {
+            "/opt/bundle/.agentscommander"
+        };
+        let exe = if cfg!(windows) {
+            PathBuf::from(r"C:\somewhere\else\ac.exe")
+        } else {
+            PathBuf::from("/somewhere/else/ac")
+        };
+        let loc = resolve_instance_location(
+            Some(override_dir.to_string()),
+            Ok(exe),
+            Some(PathBuf::from("/home/u")),
+        );
+        assert_eq!(loc.config_dir.as_deref(), Some(Path::new(override_dir)));
+        let expected_base = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle")
+        } else {
+            PathBuf::from("/opt/bundle")
+        };
+        assert_eq!(loc.instance_base.as_deref(), Some(expected_base.as_path()));
+        // The local dir stem still comes from the executable, not the override.
+        assert_eq!(loc.local_dir_stem, "ac");
+    }
+
+    #[test]
+    fn relative_debug_override_sets_config_but_no_base() {
+        let loc = resolve_instance_location(
+            Some("relative/.acdir".to_string()),
+            exe_err(),
+            Some(PathBuf::from("/home/u")),
+        );
+        assert_eq!(loc.config_dir.as_deref(), Some(Path::new("relative/.acdir")));
+        assert_eq!(loc.instance_base, None);
+        assert_eq!(loc.local_dir_stem, "agentscommander");
+    }
+
+    #[test]
+    fn blank_debug_override_is_ignored() {
+        let exe = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle\ac.exe")
+        } else {
+            PathBuf::from("/opt/bundle/ac")
+        };
+        let loc = resolve_instance_location(
+            Some("   ".to_string()),
+            Ok(exe),
+            Some(PathBuf::from("/home/u")),
+        );
+        // Falls through to the portable executable-derived config.
+        let expected_config = if cfg!(windows) {
+            PathBuf::from(r"C:\bundle\.ac")
+        } else {
+            PathBuf::from("/opt/bundle/.ac")
+        };
+        assert_eq!(loc.config_dir.as_deref(), Some(expected_config.as_path()));
+        assert!(loc.instance_base.is_some());
+    }
+
+    #[test]
+    fn relative_executable_keeps_relative_config_but_no_base() {
+        let loc = resolve_instance_location(
+            None,
+            Ok(PathBuf::from("bin/agentscommander")),
+            Some(PathBuf::from("/home/u")),
+        );
+        assert_eq!(
+            loc.config_dir.as_deref(),
+            Some(Path::new("bin/.agentscommander"))
+        );
+        assert_eq!(loc.instance_base, None, "relative exe exposes no portable base");
+        assert_eq!(loc.local_dir_stem, "agentscommander");
+    }
+
+    #[test]
+    fn missing_parent_takes_home_fallback() {
+        // A bare root path has a stem-less/parent-less shape → home fallback.
+        let root = if cfg!(windows) {
+            PathBuf::from(r"C:\")
+        } else {
+            PathBuf::from("/")
+        };
+        let loc =
+            resolve_instance_location(None, Ok(root), Some(PathBuf::from("/home/u")));
+        let expected = PathBuf::from("/home/u").join(profile::config_dir_name());
+        assert_eq!(loc.config_dir.as_deref(), Some(expected.as_path()));
+        assert_eq!(loc.instance_base, None);
+    }
+
+    #[test]
+    fn current_exe_failure_uses_home_fallback_and_default_stem() {
+        let loc =
+            resolve_instance_location(None, exe_err(), Some(PathBuf::from("/home/u")));
+        let expected = PathBuf::from("/home/u").join(profile::config_dir_name());
+        assert_eq!(loc.config_dir.as_deref(), Some(expected.as_path()));
+        assert_eq!(loc.instance_base, None);
+        assert_eq!(loc.local_dir_stem, "agentscommander");
+    }
+
+    #[test]
+    fn current_exe_failure_and_no_home_yields_none_config() {
+        let loc = resolve_instance_location(None, exe_err(), None);
+        assert_eq!(loc.config_dir, None);
+        assert_eq!(loc.instance_base, None);
+    }
 }

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -265,7 +265,10 @@ mod tests {
             exe_err(),
             Some(PathBuf::from("/home/u")),
         );
-        assert_eq!(loc.config_dir.as_deref(), Some(Path::new("relative/.acdir")));
+        assert_eq!(
+            loc.config_dir.as_deref(),
+            Some(Path::new("relative/.acdir"))
+        );
         assert_eq!(loc.instance_base, None);
         assert_eq!(loc.local_dir_stem, "agentscommander");
     }
@@ -303,7 +306,10 @@ mod tests {
             loc.config_dir.as_deref(),
             Some(Path::new("bin/.agentscommander"))
         );
-        assert_eq!(loc.instance_base, None, "relative exe exposes no portable base");
+        assert_eq!(
+            loc.instance_base, None,
+            "relative exe exposes no portable base"
+        );
         assert_eq!(loc.local_dir_stem, "agentscommander");
     }
 
@@ -315,8 +321,7 @@ mod tests {
         } else {
             PathBuf::from("/")
         };
-        let loc =
-            resolve_instance_location(None, Ok(root), Some(PathBuf::from("/home/u")));
+        let loc = resolve_instance_location(None, Ok(root), Some(PathBuf::from("/home/u")));
         let expected = PathBuf::from("/home/u").join(profile::config_dir_name());
         assert_eq!(loc.config_dir.as_deref(), Some(expected.as_path()));
         assert_eq!(loc.instance_base, None);
@@ -324,8 +329,7 @@ mod tests {
 
     #[test]
     fn current_exe_failure_uses_home_fallback_and_default_stem() {
-        let loc =
-            resolve_instance_location(None, exe_err(), Some(PathBuf::from("/home/u")));
+        let loc = resolve_instance_location(None, exe_err(), Some(PathBuf::from("/home/u")));
         let expected = PathBuf::from("/home/u").join(profile::config_dir_name());
         assert_eq!(loc.config_dir.as_deref(), Some(expected.as_path()));
         assert_eq!(loc.instance_base, None);

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -1300,11 +1300,21 @@ impl ProjectPathPersistenceState {
             .filter_map(|p| p.selected.clone())
             .collect()
     }
-    /// Selected canonical (display) archived paths, in order.
-    pub(crate) fn archived_selected(&self) -> Vec<String> {
+    /// Archived management projection (§3.6): every archived pair that is either
+    /// selected or a non-conflicting removable stored row (missing/invalid),
+    /// keeping "Remove from list" working for a project whose directory vanished
+    /// while never exposing one side of an archived conflict. This is the runtime
+    /// `archivedProjectPaths` projection; the active list stays selected-only so
+    /// session restoration never restores an unvalidated project.
+    pub(crate) fn archived_management_paths(&self) -> Vec<String> {
         self.archived_pairs()
             .iter()
-            .filter_map(|p| p.selected.clone())
+            .filter_map(|p| match (&p.selected, p.issue) {
+                (Some(sel), _) => Some(sel.clone()),
+                (None, Some(IssueKind::Conflict)) => None,
+                (None, Some(_)) => p.raw_absolute.value.clone(),
+                (None, None) => None,
+            })
             .collect()
     }
     /// Blocking issues (registrations that selected no path), in `pairs` order.
@@ -1393,8 +1403,10 @@ fn combine_sides(pair: RawPair, abs: SideOutcome, rel: SideOutcome) -> ResolvedP
             );
             match same {
                 SameDir::Same => {
-                    // Prefer the absolute candidate's canonical form.
-                    let canon = abs.canonical_path.clone().unwrap();
+                    // Prefer the absolute candidate's canonical form. A valid side
+                    // always carries a canonical path; default defensively rather
+                    // than panicking if that invariant is ever weakened.
+                    let canon = abs.canonical_path.clone().unwrap_or_default();
                     selected = Some(display_canonical(&canon));
                     selected_canonical_raw = Some(canon);
                     selected_identity = abs.identity;
@@ -1413,7 +1425,7 @@ fn combine_sides(pair: RawPair, abs: SideOutcome, rel: SideOutcome) -> ResolvedP
             }
         }
         (true, false) => {
-            let canon = abs.canonical_path.clone().unwrap();
+            let canon = abs.canonical_path.clone().unwrap_or_default();
             selected = Some(display_canonical(&canon));
             selected_canonical_raw = Some(canon);
             selected_identity = abs.identity;
@@ -1421,7 +1433,7 @@ fn combine_sides(pair: RawPair, abs: SideOutcome, rel: SideOutcome) -> ResolvedP
             repair = RepairKind::PopulateCompanion;
         }
         (false, true) => {
-            let canon = rel.canonical_path.clone().unwrap();
+            let canon = rel.canonical_path.clone().unwrap_or_default();
             selected = Some(display_canonical(&canon));
             selected_canonical_raw = Some(canon);
             selected_identity = rel.identity;
@@ -2669,6 +2681,37 @@ mod tests {
                 Err(RelDecodeError::Backslash)
             );
         }
+
+        #[test]
+        fn posix_paths_are_case_distinct() {
+            // Two POSIX projects differing only by case must produce distinct
+            // wires (encode preserves case) and distinct decoded targets.
+            let base = Path::new("/opt");
+            let upper = encode_instance_relative(Path::new("/opt/Repo"), base).unwrap();
+            let lower = encode_instance_relative(Path::new("/opt/repo"), base).unwrap();
+            assert_eq!(upper, "Repo");
+            assert_eq!(lower, "repo");
+            assert_ne!(upper, lower);
+            assert_ne!(
+                decode_instance_relative(&upper, base).unwrap(),
+                decode_instance_relative(&lower, base).unwrap()
+            );
+        }
+
+        #[test]
+        fn unicode_and_dot_round_trip() {
+            let base = Path::new("/opt/bundle");
+            // `.` names the base itself.
+            assert_eq!(
+                decode_instance_relative(".", base).unwrap(),
+                PathBuf::from("/opt/bundle")
+            );
+            // Non-ASCII components survive an encode/decode round-trip.
+            let project = Path::new("/opt/bundle/проект/Ω-α");
+            let wire = encode_instance_relative(project, base).unwrap();
+            assert_eq!(wire, "проект/Ω-α");
+            assert_eq!(decode_instance_relative(&wire, base).unwrap(), project);
+        }
     }
 
     #[cfg(windows)]
@@ -2793,6 +2836,45 @@ mod tests {
             assert_eq!(
                 decode_instance_relative("../../x", Path::new(r"C:\bundle")),
                 Err(RelDecodeError::EscapesRoot)
+            );
+        }
+
+        #[test]
+        fn decode_rejects_all_illegal_windows_chars_and_controls() {
+            let base = Path::new(r"C:\bundle");
+            for illegal in ["a<b", "a>b", "a\"b", "a|b", "a?b", "a*b"] {
+                assert_eq!(
+                    decode_instance_relative(illegal, base),
+                    Err(RelDecodeError::IllegalWindowsChar),
+                    "must reject {illegal:?}"
+                );
+            }
+            // Control characters (below 0x20) are rejected.
+            assert_eq!(
+                decode_instance_relative("a\u{0001}b", base),
+                Err(RelDecodeError::IllegalWindowsChar)
+            );
+            assert_eq!(
+                decode_instance_relative("a\u{001f}b", base),
+                Err(RelDecodeError::IllegalWindowsChar)
+            );
+        }
+
+        #[test]
+        fn encode_device_namespace_has_no_portable_form() {
+            // A `\\.\` device-namespace path is unsupported and must NOT be
+            // stripped into an ordinary path; it yields no relative companion.
+            assert_eq!(
+                encode_instance_relative(Path::new(r"\\.\COM1"), Path::new(r"C:\bundle")),
+                None
+            );
+            // A verbatim non-disk device path is likewise unsupported.
+            assert_eq!(
+                encode_instance_relative(
+                    Path::new(r"\\?\GLOBALROOT\Device\HarddiskVolume1\x"),
+                    Path::new(r"C:\bundle")
+                ),
+                None
             );
         }
     }
@@ -3043,7 +3125,7 @@ mod tests {
             );
             assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
             assert!(
-                report.archived_selected().is_empty(),
+                report.archived_management_paths().is_empty(),
                 "archived dup of active must drop"
             );
         }

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -813,7 +813,10 @@ pub(crate) enum SideStatus {
 
 impl SideStatus {
     pub(crate) fn is_valid(self) -> bool {
-        matches!(self, SideStatus::ValidDirectProject | SideStatus::ValidCollectionRoot)
+        matches!(
+            self,
+            SideStatus::ValidDirectProject | SideStatus::ValidCollectionRoot
+        )
     }
 }
 
@@ -1143,13 +1146,22 @@ pub(crate) struct RawStringField {
 
 impl RawStringField {
     pub(crate) fn absent() -> Self {
-        RawStringField { present: false, value: None }
+        RawStringField {
+            present: false,
+            value: None,
+        }
     }
     pub(crate) fn string(s: impl Into<String>) -> Self {
-        RawStringField { present: true, value: Some(s.into()) }
+        RawStringField {
+            present: true,
+            value: Some(s.into()),
+        }
     }
     pub(crate) fn null() -> Self {
-        RawStringField { present: true, value: None }
+        RawStringField {
+            present: true,
+            value: None,
+        }
     }
 }
 
@@ -1545,9 +1557,17 @@ fn singular_mirrors_first(singular: &ResolvedPair, first: &ResolvedPair) -> bool
             return true;
         }
     }
-    if let (Some(a), Some(b)) = (&singular.selected_canonical_raw, &first.selected_canonical_raw) {
+    if let (Some(a), Some(b)) = (
+        &singular.selected_canonical_raw,
+        &first.selected_canonical_raw,
+    ) {
         return matches!(
-            compare_dirs(a, singular.selected_identity.as_ref(), b, first.selected_identity.as_ref()),
+            compare_dirs(
+                a,
+                singular.selected_identity.as_ref(),
+                b,
+                first.selected_identity.as_ref()
+            ),
             SameDir::Same
         );
     }
@@ -1676,7 +1696,9 @@ fn group_reconcile_eligible(
     companion_present: bool,
     genuine_singular: bool,
 ) -> bool {
-    let has_dirty = pairs.iter().any(|p| p.is_selected() && p.repair != RepairKind::None);
+    let has_dirty = pairs
+        .iter()
+        .any(|p| p.is_selected() && p.repair != RepairKind::None);
     if !has_dirty {
         return false;
     }
@@ -2507,7 +2529,10 @@ mod tests {
         #[test]
         fn encode_child_of_base() {
             assert_eq!(
-                encode_instance_relative(Path::new("/opt/bundle/projects/alpha"), Path::new("/opt/bundle")),
+                encode_instance_relative(
+                    Path::new("/opt/bundle/projects/alpha"),
+                    Path::new("/opt/bundle")
+                ),
                 Some("projects/alpha".to_string())
             );
         }
@@ -2515,7 +2540,10 @@ mod tests {
         #[test]
         fn encode_sibling_uses_dotdot() {
             assert_eq!(
-                encode_instance_relative(Path::new("/opt/projects/alpha"), Path::new("/opt/bundle")),
+                encode_instance_relative(
+                    Path::new("/opt/projects/alpha"),
+                    Path::new("/opt/bundle")
+                ),
                 Some("../projects/alpha".to_string())
             );
         }
@@ -2553,7 +2581,10 @@ mod tests {
             let base = Path::new("/opt/bundle");
             let project = Path::new("/opt/projects/alpha");
             let wire = encode_instance_relative(project, base).unwrap();
-            assert_eq!(decode_instance_relative(&wire, base).unwrap(), PathBuf::from("/opt/projects/alpha"));
+            assert_eq!(
+                decode_instance_relative(&wire, base).unwrap(),
+                PathBuf::from("/opt/projects/alpha")
+            );
         }
 
         #[test]
@@ -2567,15 +2598,42 @@ mod tests {
         #[test]
         fn decode_rejects_noncanonical_and_injection() {
             let base = Path::new("/opt/bundle");
-            assert_eq!(decode_instance_relative("", base), Err(RelDecodeError::Empty));
-            assert_eq!(decode_instance_relative("a\0b", base), Err(RelDecodeError::Nul));
-            assert_eq!(decode_instance_relative("a\\b", base), Err(RelDecodeError::Backslash));
-            assert_eq!(decode_instance_relative("/abs", base), Err(RelDecodeError::EmptySegment));
-            assert_eq!(decode_instance_relative("a/", base), Err(RelDecodeError::EmptySegment));
-            assert_eq!(decode_instance_relative("a//b", base), Err(RelDecodeError::EmptySegment));
-            assert_eq!(decode_instance_relative("a/./b", base), Err(RelDecodeError::DotSegment));
-            assert_eq!(decode_instance_relative("C:/x", base), Err(RelDecodeError::DriveRelative));
-            assert_eq!(decode_instance_relative("C:", base), Err(RelDecodeError::DriveRelative));
+            assert_eq!(
+                decode_instance_relative("", base),
+                Err(RelDecodeError::Empty)
+            );
+            assert_eq!(
+                decode_instance_relative("a\0b", base),
+                Err(RelDecodeError::Nul)
+            );
+            assert_eq!(
+                decode_instance_relative("a\\b", base),
+                Err(RelDecodeError::Backslash)
+            );
+            assert_eq!(
+                decode_instance_relative("/abs", base),
+                Err(RelDecodeError::EmptySegment)
+            );
+            assert_eq!(
+                decode_instance_relative("a/", base),
+                Err(RelDecodeError::EmptySegment)
+            );
+            assert_eq!(
+                decode_instance_relative("a//b", base),
+                Err(RelDecodeError::EmptySegment)
+            );
+            assert_eq!(
+                decode_instance_relative("a/./b", base),
+                Err(RelDecodeError::DotSegment)
+            );
+            assert_eq!(
+                decode_instance_relative("C:/x", base),
+                Err(RelDecodeError::DriveRelative)
+            );
+            assert_eq!(
+                decode_instance_relative("C:", base),
+                Err(RelDecodeError::DriveRelative)
+            );
         }
 
         #[test]
@@ -2621,7 +2679,10 @@ mod tests {
         #[test]
         fn encode_child_and_sibling() {
             assert_eq!(
-                encode_instance_relative(Path::new(r"C:\bundle\projects\alpha"), Path::new(r"C:\bundle")),
+                encode_instance_relative(
+                    Path::new(r"C:\bundle\projects\alpha"),
+                    Path::new(r"C:\bundle")
+                ),
                 Some("projects/alpha".to_string())
             );
             assert_eq!(
@@ -2667,7 +2728,10 @@ mod tests {
         #[test]
         fn encode_verbatim_disk_normalizes_for_comparison() {
             assert_eq!(
-                encode_instance_relative(Path::new(r"\\?\C:\bundle\alpha"), Path::new(r"C:\bundle")),
+                encode_instance_relative(
+                    Path::new(r"\\?\C:\bundle\alpha"),
+                    Path::new(r"C:\bundle")
+                ),
                 Some("alpha".to_string())
             );
         }
@@ -2681,17 +2745,44 @@ mod tests {
             );
             // ADS colon not in drive position → illegal char (drive-position
             // `X:` is caught earlier as DriveRelative, also a rejection).
-            assert_eq!(decode_instance_relative("foo:bar", base), Err(RelDecodeError::IllegalWindowsChar));
-            assert_eq!(decode_instance_relative("a*b", base), Err(RelDecodeError::IllegalWindowsChar));
-            assert_eq!(decode_instance_relative("a:b", base), Err(RelDecodeError::DriveRelative));
+            assert_eq!(
+                decode_instance_relative("foo:bar", base),
+                Err(RelDecodeError::IllegalWindowsChar)
+            );
+            assert_eq!(
+                decode_instance_relative("a*b", base),
+                Err(RelDecodeError::IllegalWindowsChar)
+            );
+            assert_eq!(
+                decode_instance_relative("a:b", base),
+                Err(RelDecodeError::DriveRelative)
+            );
             // Trailing dot/space.
-            assert_eq!(decode_instance_relative("alpha ", base), Err(RelDecodeError::TrailingDotOrSpace));
-            assert_eq!(decode_instance_relative("alpha.", base), Err(RelDecodeError::TrailingDotOrSpace));
+            assert_eq!(
+                decode_instance_relative("alpha ", base),
+                Err(RelDecodeError::TrailingDotOrSpace)
+            );
+            assert_eq!(
+                decode_instance_relative("alpha.", base),
+                Err(RelDecodeError::TrailingDotOrSpace)
+            );
             // Reserved DOS device names, with and without extension.
-            assert_eq!(decode_instance_relative("CON", base), Err(RelDecodeError::ReservedDosName));
-            assert_eq!(decode_instance_relative("con.txt", base), Err(RelDecodeError::ReservedDosName));
-            assert_eq!(decode_instance_relative("COM1", base), Err(RelDecodeError::ReservedDosName));
-            assert_eq!(decode_instance_relative("LPT9", base), Err(RelDecodeError::ReservedDosName));
+            assert_eq!(
+                decode_instance_relative("CON", base),
+                Err(RelDecodeError::ReservedDosName)
+            );
+            assert_eq!(
+                decode_instance_relative("con.txt", base),
+                Err(RelDecodeError::ReservedDosName)
+            );
+            assert_eq!(
+                decode_instance_relative("COM1", base),
+                Err(RelDecodeError::ReservedDosName)
+            );
+            assert_eq!(
+                decode_instance_relative("LPT9", base),
+                Err(RelDecodeError::ReservedDosName)
+            );
             // COM0 / COM10 are not reserved.
             assert!(decode_instance_relative("COM0", base).is_ok());
             assert!(decode_instance_relative("COM10", base).is_ok());
@@ -2808,7 +2899,10 @@ mod tests {
                 false,
                 &resolver,
             );
-            assert_eq!(report.active_selected(), vec![display_canonical(&rel_target)]);
+            assert_eq!(
+                report.active_selected(),
+                vec![display_canonical(&rel_target)]
+            );
             assert_eq!(report.pairs[0].repair, RepairKind::ReplaceStaleAbsolute);
         }
 
@@ -2882,7 +2976,10 @@ mod tests {
                 false,
                 &resolver,
             );
-            assert!(report.active_selected().is_empty(), "alpha reintroduced despite conflict");
+            assert!(
+                report.active_selected().is_empty(),
+                "alpha reintroduced despite conflict"
+            );
             assert_eq!(report.pairs[0].issue, Some(IssueKind::Conflict));
             assert_eq!(report.pairs[1].issue, Some(IssueKind::Invalid));
         }
@@ -2894,9 +2991,18 @@ mod tests {
             let other = abs("elsewhere");
             let child = abs("collection/child");
             let mut map = HashMap::new();
-            map.insert(root.clone(), valid(&root, SideStatus::ValidCollectionRoot, 1, 50));
-            map.insert(other.clone(), valid(&other, SideStatus::ValidDirectProject, 1, 51));
-            map.insert(child.clone(), valid(&child, SideStatus::ValidDirectProject, 1, 52));
+            map.insert(
+                root.clone(),
+                valid(&root, SideStatus::ValidCollectionRoot, 1, 50),
+            );
+            map.insert(
+                other.clone(),
+                valid(&other, SideStatus::ValidDirectProject, 1, 51),
+            );
+            map.insert(
+                child.clone(),
+                valid(&child, SideStatus::ValidDirectProject, 1, 52),
+            );
             let resolver = MapResolver { map };
             let report = resolve_registrations(
                 &[
@@ -2936,7 +3042,10 @@ mod tests {
                 &resolver,
             );
             assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
-            assert!(report.archived_selected().is_empty(), "archived dup of active must drop");
+            assert!(
+                report.archived_selected().is_empty(),
+                "archived dup of active must drop"
+            );
         }
 
         #[test]
@@ -2970,7 +3079,9 @@ mod tests {
         #[test]
         fn neither_valid_definite_notfound_is_missing() {
             let a = abs("gone");
-            let resolver = MapResolver { map: HashMap::new() }; // everything Missing
+            let resolver = MapResolver {
+                map: HashMap::new(),
+            }; // everything Missing
             let report = resolve_registrations(
                 &[active_pair(0, &a, None)],
                 None,
@@ -3000,9 +3111,15 @@ mod tests {
                 &resolver,
             );
             assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
-            assert_eq!(report.pairs[0].relative_side.status, SideStatus::BaseUnavailable);
+            assert_eq!(
+                report.pairs[0].relative_side.status,
+                SideStatus::BaseUnavailable
+            );
             // The raw relative value is retained in hidden state.
-            assert_eq!(report.pairs[0].raw_relative, RawStringField::string("projects/alpha"));
+            assert_eq!(
+                report.pairs[0].raw_relative,
+                RawStringField::string("projects/alpha")
+            );
         }
 
         #[test]
@@ -3028,7 +3145,10 @@ mod tests {
                 false,
                 &resolver,
             );
-            assert_eq!(report.active_registration_count, 2, "genuine singular counts");
+            assert_eq!(
+                report.active_registration_count, 2,
+                "genuine singular counts"
+            );
             assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
             // The unresolved genuine singular blocks active reconciliation.
             assert!(!report.active_reconcile_eligible);
@@ -3055,7 +3175,10 @@ mod tests {
                 false,
                 &resolver,
             );
-            assert_eq!(report.active_registration_count, 1, "redundant singular not counted");
+            assert_eq!(
+                report.active_registration_count, 1,
+                "redundant singular not counted"
+            );
         }
     }
 }

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -500,6 +500,1190 @@ fn path_compare_key(s: &str) -> String {
     normalize_for_compare(&without_extended)
 }
 
+// ── #1077 portable instance-relative path codec ────────────────────────────
+//
+// Encodes/decodes the OS-neutral, `/`-separated companion form that pairs an
+// absolute project path with the running executable's instance base. The wire
+// grammar is deliberately strict and fail-closed: every decode rejection means
+// the companion "did not load" and the absolute side is used instead. See
+// plan #1077 §3.3. JSON extraction/serialization of these strings lives in
+// `config/settings.rs`; this module owns only the lexical grammar.
+
+/// Reasons a persisted instance-relative companion string fails to decode.
+/// Each is a fail-closed rejection (the value is treated as not loading).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RelDecodeError {
+    /// Empty string.
+    Empty,
+    /// Contains a NUL byte.
+    Nul,
+    /// Contains a `\` on any host (Unix filenames with `\` have no portable form).
+    Backslash,
+    /// A leading, trailing, or repeated `/` produced an empty segment.
+    EmptySegment,
+    /// An embedded `.` component (only a whole-string `.` names the base).
+    DotSegment,
+    /// A drive-relative component such as `C:` or `C:dir` (rejected on every host).
+    DriveRelative,
+    /// Parent traversal that would walk above the filesystem root.
+    EscapesRoot,
+    /// A Windows-illegal character (`< > : " | ? *` or a control char).
+    IllegalWindowsChar,
+    /// A reserved DOS device basename (CON, PRN, AUX, NUL, COM1-9, LPT1-9).
+    ReservedDosName,
+    /// A component ending in a space or dot (Win32 strips these).
+    TrailingDotOrSpace,
+    /// The instance base handed in was not absolute.
+    BaseNotAbsolute,
+}
+
+/// Root/prefix identity used only for case-insensitive Windows root-compat
+/// comparison. Ordinary and verbatim disk/UNC roots normalize to the same key;
+/// device namespaces (`\\.\`, non-disk/UNC `\\?\`, GLOBALROOT) are unsupported
+/// and never stripped.
+#[cfg(windows)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RootKey {
+    Disk(u8),
+    Unc(String, String),
+}
+
+#[cfg(not(windows))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RootKey;
+
+/// Split an absolute canonical path into its root key and normal components.
+/// Returns `None` for an unsupported prefix, a non-absolute path, or any
+/// non-normal interior component (canonical inputs never contain `.`/`..`).
+#[cfg(windows)]
+fn split_root_and_normals(path: &Path) -> Option<(RootKey, Vec<std::ffi::OsString>)> {
+    use std::path::{Component, Prefix};
+    let mut comps = path.components();
+    let prefix = match comps.next() {
+        Some(Component::Prefix(p)) => p.kind(),
+        _ => return None,
+    };
+    let root_key = match prefix {
+        Prefix::Disk(l) | Prefix::VerbatimDisk(l) => RootKey::Disk(l.to_ascii_uppercase()),
+        Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => RootKey::Unc(
+            server.to_string_lossy().to_ascii_lowercase(),
+            share.to_string_lossy().to_ascii_lowercase(),
+        ),
+        // Verbatim(non-disk), DeviceNS: unsupported. Never pass through the
+        // broad prefix stripper; return None so the caller writes a null
+        // companion and keeps absolute-only behavior.
+        _ => return None,
+    };
+    // A drive-absolute path has RootDir after the prefix; `C:dir` (drive-relative)
+    // does not and is rejected here.
+    match comps.next() {
+        Some(Component::RootDir) => {}
+        _ => return None,
+    }
+    let mut norms = Vec::new();
+    for c in comps {
+        match c {
+            Component::Normal(s) => norms.push(s.to_os_string()),
+            _ => return None,
+        }
+    }
+    Some((root_key, norms))
+}
+
+#[cfg(not(windows))]
+fn split_root_and_normals(path: &Path) -> Option<(RootKey, Vec<std::ffi::OsString>)> {
+    use std::path::Component;
+    let mut comps = path.components();
+    match comps.next() {
+        Some(Component::RootDir) => {}
+        _ => return None,
+    }
+    let mut norms = Vec::new();
+    for c in comps {
+        match c {
+            Component::Normal(s) => norms.push(s.to_os_string()),
+            _ => return None,
+        }
+    }
+    Some((RootKey, norms))
+}
+
+/// Root compatibility. Windows drive letters and UNC server/share compare
+/// case-insensitively (already normalized in `RootKey`); POSIX roots always
+/// match. Incompatible roots (different drive letters or UNC shares) have no
+/// lexical relative form.
+#[cfg(windows)]
+fn roots_compatible(a: &RootKey, b: &RootKey) -> bool {
+    a == b
+}
+
+#[cfg(not(windows))]
+fn roots_compatible(_a: &RootKey, _b: &RootKey) -> bool {
+    true
+}
+
+/// Encode `project` relative to `base`. Both must be absolute, canonical paths.
+/// Returns the OS-neutral `/`-separated wire form, or `None` when the roots are
+/// incompatible, a prefix is unsupported, or any emitted component cannot be
+/// represented losslessly by the wire grammar (non-UTF-8, contains `/` or `\`,
+/// or is literally `.`/`..`). Interior components are compared EXACTLY (both
+/// come from `canonicalize`, which fixes on-disk casing), so only the root is
+/// case-insensitive on Windows.
+pub(crate) fn encode_instance_relative(project: &Path, base: &Path) -> Option<String> {
+    if !project.is_absolute() || !base.is_absolute() {
+        return None;
+    }
+    let (proj_root, proj_norms) = split_root_and_normals(project)?;
+    let (base_root, base_norms) = split_root_and_normals(base)?;
+    if !roots_compatible(&proj_root, &base_root) {
+        return None;
+    }
+
+    let mut common = 0usize;
+    while common < proj_norms.len()
+        && common < base_norms.len()
+        && proj_norms[common] == base_norms[common]
+    {
+        common += 1;
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    for _ in common..base_norms.len() {
+        out.push("..".to_string());
+    }
+    for c in &proj_norms[common..] {
+        let s = c.to_str()?; // non-UTF-8 → no portable form
+        if s.is_empty() || s.contains('/') || s.contains('\\') || s == "." || s == ".." {
+            return None;
+        }
+        out.push(s.to_string());
+    }
+
+    if out.is_empty() {
+        return Some(".".to_string());
+    }
+    Some(out.join("/"))
+}
+
+/// Decode a persisted `wire` companion against an absolute canonical `base`,
+/// producing the syntactically resolved absolute path (before any filesystem
+/// probe). Fail-closed: every malformed or unsafe spelling is an `Err`.
+pub(crate) fn decode_instance_relative(wire: &str, base: &Path) -> Result<PathBuf, RelDecodeError> {
+    if !base.is_absolute() {
+        return Err(RelDecodeError::BaseNotAbsolute);
+    }
+    if wire.is_empty() {
+        return Err(RelDecodeError::Empty);
+    }
+    if wire.contains('\0') {
+        return Err(RelDecodeError::Nul);
+    }
+    // Reject `\` on every host so a Windows-authored value cannot smuggle a
+    // separator and a Unix filename containing `\` has no portable companion.
+    if wire.contains('\\') {
+        return Err(RelDecodeError::Backslash);
+    }
+    // `.` is the only spelling for the base itself.
+    if wire == "." {
+        return Ok(base.to_path_buf());
+    }
+
+    let mut result = base.to_path_buf();
+    for seg in wire.split('/') {
+        if seg.is_empty() {
+            // Leading/trailing/repeated separator.
+            return Err(RelDecodeError::EmptySegment);
+        }
+        if seg == "." {
+            return Err(RelDecodeError::DotSegment);
+        }
+        if seg == ".." {
+            // Popping past the root is walking above the filesystem root.
+            if !result.pop() {
+                return Err(RelDecodeError::EscapesRoot);
+            }
+            continue;
+        }
+        validate_wire_component(seg)?;
+        result.push(seg);
+    }
+    Ok(result)
+}
+
+/// Validate one non-`.`/`..` wire component before it is pushed onto the base.
+fn validate_wire_component(seg: &str) -> Result<(), RelDecodeError> {
+    // Drive-relative like `C:` or `C:dir` is rejected on every host so a
+    // relative field can never smuggle a drive root.
+    let bytes = seg.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return Err(RelDecodeError::DriveRelative);
+    }
+    #[cfg(windows)]
+    {
+        for ch in seg.chars() {
+            if (ch as u32) < 0x20 || matches!(ch, '<' | '>' | ':' | '"' | '|' | '?' | '*') {
+                return Err(RelDecodeError::IllegalWindowsChar);
+            }
+        }
+        if seg.ends_with(' ') || seg.ends_with('.') {
+            return Err(RelDecodeError::TrailingDotOrSpace);
+        }
+        if is_reserved_dos_name(seg) {
+            return Err(RelDecodeError::ReservedDosName);
+        }
+    }
+    Ok(())
+}
+
+/// Case-insensitive DOS device basename check (CON, PRN, AUX, NUL, COM1-9,
+/// LPT1-9). The device name matches on the portion before the first `.`, so
+/// `CON.txt` and an ADS spelling both resolve to the reserved device.
+#[cfg(windows)]
+fn is_reserved_dos_name(seg: &str) -> bool {
+    let stem = seg.split('.').next().unwrap_or(seg);
+    let upper = stem.to_ascii_uppercase();
+    if matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL") {
+        return true;
+    }
+    let bytes = upper.as_bytes();
+    upper.len() == 4
+        && (upper.starts_with("COM") || upper.starts_with("LPT"))
+        && bytes[3].is_ascii_digit()
+        && bytes[3] != b'0'
+}
+
+// ── #1077 candidate validity and directory identity (§3.4) ─────────────────
+
+/// Filesystem identity of a canonical directory. On Unix `(st_dev, st_ino)`; on
+/// Windows `(dwVolumeSerialNumber, file index)` from an open handle. Used to
+/// decide whether two valid candidate spellings name the same directory without
+/// lowercasing path strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct DirectoryIdentity {
+    pub volume: u64,
+    pub file: u128,
+}
+
+/// Whether a validated directory is a direct project (`<target>/.ac` is a dir)
+/// or a legacy collection root (has a non-dot child project).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectKind {
+    DirectProject,
+    CollectionRoot,
+    None,
+}
+
+/// Classified filesystem-probe failure. Kept distinct so a permission/I-O error
+/// never collapses into "missing".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeError {
+    NotFound,
+    PermissionDenied,
+    Io,
+}
+
+/// Per-side resolution status (internal diagnostics, §3.7). `is_valid()` marks
+/// the two loadable outcomes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SideStatus {
+    /// The field was absent (or its value was JSON null).
+    Absent,
+    /// No authoritative instance base to resolve a relative companion.
+    BaseUnavailable,
+    /// The stored value could not be parsed into an absolute candidate.
+    Malformed,
+    /// Definite `NotFound` at canonicalize/probe.
+    Missing,
+    /// `PermissionDenied` at canonicalize/probe.
+    Inaccessible,
+    /// Any other probe I/O failure.
+    ProbeIoError,
+    /// The canonical target exists but is not a directory.
+    NotADirectory,
+    /// The directory exists but is neither a direct project nor a collection root.
+    WorkspaceOrCollectionMissing,
+    /// The canonical path is not losslessly representable as UTF-8.
+    NonUtf8,
+    ValidDirectProject,
+    ValidCollectionRoot,
+    /// Two spellings had to be compared but no identity could be obtained.
+    IdentityUnavailable,
+}
+
+impl SideStatus {
+    pub(crate) fn is_valid(self) -> bool {
+        matches!(self, SideStatus::ValidDirectProject | SideStatus::ValidCollectionRoot)
+    }
+}
+
+/// Resolution outcome of one side (absolute or instance-relative) of a logical
+/// registration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SideOutcome {
+    pub status: SideStatus,
+    /// The syntactically resolved absolute path (pre-probe), for diagnostics.
+    pub syntactic_path: Option<String>,
+    /// The raw canonical path (verbatim spelling on Windows) when validated.
+    /// Used for comparison and re-encoding; the outward/selected form is derived
+    /// via `display_canonical`.
+    pub canonical_path: Option<String>,
+    /// Directory identity when it could be obtained (best-effort).
+    pub identity: Option<DirectoryIdentity>,
+}
+
+impl SideOutcome {
+    fn failed(status: SideStatus, syntactic: Option<String>) -> Self {
+        SideOutcome {
+            status,
+            syntactic_path: syntactic,
+            canonical_path: None,
+            identity: None,
+        }
+    }
+}
+
+/// Injected seam: resolve one syntactically-absolute candidate path to a
+/// [`SideOutcome`]. The production implementation canonicalizes, proves a
+/// directory, probes project/collection kind, and fetches the handle identity;
+/// tests supply canned outcomes so permission/I-O/identity matrices need no
+/// `chmod` or process-global hooks (§3.4).
+pub(crate) trait CandidateResolver {
+    fn resolve(&self, syntactic: &Path) -> SideOutcome;
+}
+
+/// Production resolver backed by the real filesystem.
+pub(crate) struct FsCandidateResolver;
+
+impl CandidateResolver for FsCandidateResolver {
+    fn resolve(&self, syntactic: &Path) -> SideOutcome {
+        validate_fs_candidate(syntactic)
+    }
+}
+
+fn classify_io_error(e: &std::io::Error) -> SideStatus {
+    match e.kind() {
+        std::io::ErrorKind::NotFound => SideStatus::Missing,
+        std::io::ErrorKind::PermissionDenied => SideStatus::Inaccessible,
+        _ => SideStatus::ProbeIoError,
+    }
+}
+
+fn classify_probe_error(e: &std::io::Error) -> ProbeError {
+    match e.kind() {
+        std::io::ErrorKind::NotFound => ProbeError::NotFound,
+        std::io::ErrorKind::PermissionDenied => ProbeError::PermissionDenied,
+        _ => ProbeError::Io,
+    }
+}
+
+/// Real-filesystem validation of a syntactically-absolute candidate. Follows a
+/// user-supplied symlink/junction to its canonical target (distinct from
+/// `is_real_directory`, which rejects links for child enumeration).
+fn validate_fs_candidate(syntactic: &Path) -> SideOutcome {
+    let syntactic_str = syntactic.to_str().map(str::to_string);
+    let canon = match std::fs::canonicalize(syntactic) {
+        Ok(c) => c,
+        Err(e) => return SideOutcome::failed(classify_io_error(&e), syntactic_str),
+    };
+    let canonical_str = match canon.to_str() {
+        Some(s) => s.to_string(),
+        None => return SideOutcome::failed(SideStatus::NonUtf8, syntactic_str),
+    };
+    match std::fs::metadata(&canon) {
+        Ok(md) if md.is_dir() => {}
+        Ok(_) => {
+            return SideOutcome {
+                status: SideStatus::NotADirectory,
+                syntactic_path: syntactic_str,
+                canonical_path: Some(canonical_str),
+                identity: None,
+            };
+        }
+        Err(e) => {
+            return SideOutcome {
+                status: classify_io_error(&e),
+                syntactic_path: syntactic_str,
+                canonical_path: Some(canonical_str),
+                identity: None,
+            };
+        }
+    }
+    let status = match probe_project_kind(&canon) {
+        Ok(ProjectKind::DirectProject) => SideStatus::ValidDirectProject,
+        Ok(ProjectKind::CollectionRoot) => SideStatus::ValidCollectionRoot,
+        Ok(ProjectKind::None) => {
+            return SideOutcome {
+                status: SideStatus::WorkspaceOrCollectionMissing,
+                syntactic_path: syntactic_str,
+                canonical_path: Some(canonical_str),
+                identity: None,
+            };
+        }
+        Err(ProbeError::NotFound) => {
+            return SideOutcome::failed(SideStatus::Missing, syntactic_str);
+        }
+        Err(ProbeError::PermissionDenied) => {
+            return SideOutcome {
+                status: SideStatus::Inaccessible,
+                syntactic_path: syntactic_str,
+                canonical_path: Some(canonical_str),
+                identity: None,
+            };
+        }
+        Err(ProbeError::Io) => {
+            return SideOutcome {
+                status: SideStatus::ProbeIoError,
+                syntactic_path: syntactic_str,
+                canonical_path: Some(canonical_str),
+                identity: None,
+            };
+        }
+    };
+    let identity = directory_identity(&canon).ok();
+    SideOutcome {
+        status,
+        syntactic_path: syntactic_str,
+        canonical_path: Some(canonical_str),
+        identity,
+    }
+}
+
+/// Probe whether `target` (already canonical + proven a directory) is a direct
+/// project or a legacy one-level collection root. A permission/I-O failure that
+/// prevents proving a collection root is surfaced, never flattened to "missing".
+fn probe_project_kind(target: &Path) -> Result<ProjectKind, ProbeError> {
+    match std::fs::metadata(target.join(".ac")) {
+        Ok(md) if md.is_dir() => return Ok(ProjectKind::DirectProject),
+        Ok(_) => {}
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::NotFound => {}
+            std::io::ErrorKind::PermissionDenied => return Err(ProbeError::PermissionDenied),
+            _ => return Err(ProbeError::Io),
+        },
+    }
+
+    let entries = std::fs::read_dir(target).map_err(|e| classify_probe_error(&e))?;
+    let mut probe_error: Option<ProbeError> = None;
+    for entry in entries {
+        let entry = match entry {
+            Ok(en) => en,
+            Err(e) => {
+                probe_error.get_or_insert(classify_probe_error(&e));
+                continue;
+            }
+        };
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let child = entry.path();
+        match std::fs::metadata(&child) {
+            Ok(md) if md.is_dir() => {}
+            Ok(_) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                probe_error.get_or_insert(classify_probe_error(&e));
+                continue;
+            }
+        }
+        match std::fs::metadata(child.join(".ac")) {
+            Ok(md) if md.is_dir() => return Ok(ProjectKind::CollectionRoot),
+            Ok(_) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                probe_error.get_or_insert(classify_probe_error(&e));
+                continue;
+            }
+        }
+    }
+    match probe_error {
+        Some(err) => Err(err),
+        None => Ok(ProjectKind::None),
+    }
+}
+
+/// Directory identity of a canonical directory via an open handle. Follows the
+/// (already-resolved) target; does not reuse `seed_manifest`'s reparse-detecting
+/// open. Mirrors the reviewed handle pattern without coupling to its types.
+#[cfg(windows)]
+fn directory_identity(path: &Path) -> std::io::Result<DirectoryIdentity> {
+    use std::mem::MaybeUninit;
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+    let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+    let ok =
+        unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, info.as_mut_ptr()) };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let info = unsafe { info.assume_init() };
+    let index = (u64::from(info.nFileIndexHigh) << 32) | u64::from(info.nFileIndexLow);
+    Ok(DirectoryIdentity {
+        volume: u64::from(info.dwVolumeSerialNumber),
+        file: u128::from(index),
+    })
+}
+
+#[cfg(unix)]
+fn directory_identity(path: &Path) -> std::io::Result<DirectoryIdentity> {
+    use std::os::unix::fs::MetadataExt;
+    let md = std::fs::metadata(path)?;
+    Ok(DirectoryIdentity {
+        volume: md.dev(),
+        file: u128::from(md.ino()),
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn directory_identity(_path: &Path) -> std::io::Result<DirectoryIdentity> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "handle identity unavailable on this platform; canonical path equality is the fallback",
+    ))
+}
+
+/// Whether two validated candidates name the same directory. Canonical string
+/// equality short-circuits to `Same`; otherwise identity decides. When identity
+/// cannot be established (unix/windows handle failure) the result is
+/// `Unavailable` and the caller fails closed. On other platforms canonical
+/// equality is the sole, documented signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SameDir {
+    Same,
+    Different,
+    Unavailable,
+}
+
+pub(crate) fn compare_dirs(
+    a_canonical: &str,
+    a_identity: Option<&DirectoryIdentity>,
+    b_canonical: &str,
+    b_identity: Option<&DirectoryIdentity>,
+) -> SameDir {
+    if a_canonical == b_canonical {
+        return SameDir::Same;
+    }
+    #[cfg(any(unix, windows))]
+    {
+        match (a_identity, b_identity) {
+            (Some(x), Some(y)) => {
+                if x == y {
+                    SameDir::Same
+                } else {
+                    SameDir::Different
+                }
+            }
+            _ => SameDir::Unavailable,
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (a_identity, b_identity);
+        SameDir::Different
+    }
+}
+
+/// Convert a canonical path to its outward/selected form: strip only the
+/// ordinary Windows verbatim drive/UNC prefixes for display, preserving any
+/// unsupported device-namespace spelling losslessly (§3.4).
+#[cfg(windows)]
+pub(crate) fn display_canonical(canonical: &str) -> String {
+    if let Some(rest) = canonical.strip_prefix(r"\\?\UNC\") {
+        format!(r"\\{}", rest)
+    } else if let Some(rest) = canonical.strip_prefix(r"\\?\") {
+        let bytes = rest.as_bytes();
+        if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+            rest.to_string()
+        } else {
+            canonical.to_string()
+        }
+    } else {
+        canonical.to_string()
+    }
+}
+
+#[cfg(not(windows))]
+pub(crate) fn display_canonical(canonical: &str) -> String {
+    canonical.to_string()
+}
+
+// ── #1077 resolution matrix, merge, quarantine, dedup (§3.4-§3.7) ───────────
+
+/// Which persisted field group a logical registration belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectSource {
+    /// The legacy singular `projectPath` pair.
+    ProjectPath,
+    /// The active plural `projectPaths` pair.
+    ProjectPaths,
+    /// The archived plural `archivedProjectPaths` pair.
+    ArchivedProjectPaths,
+}
+
+/// Raw presence + value of one persisted string field. `present == false`
+/// requires `value == None` (absent); `present == true, value == None` is an
+/// explicit JSON null.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct RawStringField {
+    pub present: bool,
+    pub value: Option<String>,
+}
+
+impl RawStringField {
+    pub(crate) fn absent() -> Self {
+        RawStringField { present: false, value: None }
+    }
+    pub(crate) fn string(s: impl Into<String>) -> Self {
+        RawStringField { present: true, value: Some(s.into()) }
+    }
+    pub(crate) fn null() -> Self {
+        RawStringField { present: true, value: None }
+    }
+}
+
+/// One logical registration's raw absolute + instance-relative slots, extracted
+/// from the six-field schema before resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RawPair {
+    pub source: ProjectSource,
+    pub index: Option<usize>,
+    pub absolute: RawStringField,
+    pub relative: RawStringField,
+}
+
+/// Blocking issue classification for a registration that selected no path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IssueKind {
+    Conflict,
+    Missing,
+    Invalid,
+}
+
+/// Raw presence + value of a persisted field as arbitrary JSON (absent vs null
+/// vs value). Used to preserve and report structurally-corrupt fields.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct RawJsonField {
+    pub present: bool,
+    pub value: Option<serde_json::Value>,
+}
+
+/// A structural-schema corruption in one project field group (wrong JSON type,
+/// misaligned companion, orphan companion, etc.). Distinct from a per-pair
+/// candidate that merely fails to load: it exposes no entry from the affected
+/// list, preserves the raw bytes, and blocks all reconciliation/mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StructuralIssue {
+    pub source: ProjectSource,
+    pub reason: String,
+    pub raw_absolute: RawJsonField,
+    pub raw_relative: RawJsonField,
+}
+
+/// The write, if any, a resolved pair needs to reconcile its companion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepairKind {
+    /// Clean; no write.
+    None,
+    /// Valid absolute, companion absent/stale → generate a fresh companion.
+    PopulateCompanion,
+    /// Relative won → replace the stale absolute and refresh the companion.
+    ReplaceStaleAbsolute,
+    /// Both valid same directory → normalize a noncanonical pair.
+    NormalizePair,
+}
+
+/// The fully resolved state of one logical registration (hidden persisted state).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedPair {
+    pub source: ProjectSource,
+    pub index: Option<usize>,
+    pub raw_absolute: RawStringField,
+    pub raw_relative: RawStringField,
+    pub absolute_side: SideOutcome,
+    pub relative_side: SideOutcome,
+    /// Selected outward (display) canonical absolute path, if any.
+    pub selected: Option<String>,
+    /// Raw canonical (verbatim on Windows) of the selected side, for identity
+    /// and component-scope comparison.
+    pub selected_canonical_raw: Option<String>,
+    /// Identity of the selected directory, if known.
+    pub selected_identity: Option<DirectoryIdentity>,
+    /// Non-`None` when this registration selected no path (or was quarantined).
+    pub issue: Option<IssueKind>,
+    /// The companion repair this pair needs, when it selected a path.
+    pub repair: RepairKind,
+}
+
+impl ResolvedPair {
+    fn is_selected(&self) -> bool {
+        self.selected.is_some() && self.issue.is_none()
+    }
+}
+
+/// Hidden persisted project-path state carried on `AppSettings` behind an
+/// `Arc` (`#[serde(skip)]`). Retains every resolved pair's source/order/raw
+/// values/selected path/identity/issue and the reconcile-eligibility bits, so
+/// writers can rebuild companion arrays and the snapshot can report issues
+/// without re-reading disk. Mutators use `Arc::make_mut` for copy-on-write.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ProjectPathPersistenceState {
+    /// Every resolved pair (hidden state) in (active plural, genuine singular,
+    /// archived) order. The first `active_registration_count` entries are the
+    /// active group; the rest are archived.
+    pub pairs: Vec<ResolvedPair>,
+    /// Legacy singular head = first active selected path (or None).
+    pub selected_head: Option<String>,
+    /// Merged logical active registration count (before identity dedupe/quarantine).
+    pub active_registration_count: usize,
+    /// Merged logical archived registration count.
+    pub archived_registration_count: usize,
+    /// Whether the active plural companion array was present & aligned on disk.
+    pub active_companion_present: bool,
+    /// Whether the archived plural companion array was present & aligned on disk.
+    pub archived_companion_present: bool,
+    /// Whether a genuinely-different singular is appended to the active group.
+    pub has_genuine_singular: bool,
+    /// Whether the active group has a dirty, eligible repair to write.
+    pub active_reconcile_eligible: bool,
+    /// Whether the archived group has a dirty, eligible repair to write.
+    pub archived_reconcile_eligible: bool,
+    /// Structural-schema corruptions found in the raw fields. Any entry blocks
+    /// all reconciliation and project-list mutation while unrelated preserve
+    /// saves remain allowed.
+    pub structural_issues: Vec<StructuralIssue>,
+}
+
+impl ProjectPathPersistenceState {
+    /// The active-group resolved pairs (plural then genuine singular).
+    pub(crate) fn active_pairs(&self) -> &[ResolvedPair] {
+        &self.pairs[..self.active_registration_count]
+    }
+    /// The archived-group resolved pairs.
+    pub(crate) fn archived_pairs(&self) -> &[ResolvedPair] {
+        &self.pairs[self.active_registration_count..]
+    }
+    /// Selected canonical (display) active paths, in order, filtered of
+    /// unresolved/quarantined/deduped entries.
+    pub(crate) fn active_selected(&self) -> Vec<String> {
+        self.active_pairs()
+            .iter()
+            .filter_map(|p| p.selected.clone())
+            .collect()
+    }
+    /// Selected canonical (display) archived paths, in order.
+    pub(crate) fn archived_selected(&self) -> Vec<String> {
+        self.archived_pairs()
+            .iter()
+            .filter_map(|p| p.selected.clone())
+            .collect()
+    }
+    /// Blocking issues (registrations that selected no path), in `pairs` order.
+    pub(crate) fn issues(&self) -> impl Iterator<Item = &ResolvedPair> {
+        self.pairs.iter().filter(|p| p.issue.is_some())
+    }
+    /// Whether any structural corruption is present (blocks all reconcile/mutation).
+    pub(crate) fn has_structural(&self) -> bool {
+        !self.structural_issues.is_empty()
+    }
+}
+
+/// Resolve one side (absolute or relative) of a registration against the base.
+fn resolve_side(
+    field: &RawStringField,
+    is_relative: bool,
+    base: Option<&Path>,
+    resolver: &dyn CandidateResolver,
+) -> SideOutcome {
+    // Absent or explicit null → nothing to resolve.
+    let value = match (field.present, field.value.as_deref()) {
+        (false, _) | (true, None) => return SideOutcome::failed(SideStatus::Absent, None),
+        (true, Some(v)) => v,
+    };
+
+    if is_relative {
+        let Some(base) = base else {
+            return SideOutcome::failed(SideStatus::BaseUnavailable, None);
+        };
+        match decode_instance_relative(value, base) {
+            Ok(syntactic) => resolver.resolve(&syntactic),
+            Err(_) => SideOutcome::failed(SideStatus::Malformed, None),
+        }
+    } else {
+        let abs = PathBuf::from(value);
+        if !abs.is_absolute() {
+            return SideOutcome::failed(SideStatus::Malformed, Some(value.to_string()));
+        }
+        resolver.resolve(&abs)
+    }
+}
+
+/// Classify a no-selection outcome. Returns `None` for a genuinely empty pair
+/// (both sides absent), `Some(Missing)` when the only non-absent statuses are
+/// definite `NotFound`, and `Some(Invalid)` otherwise.
+fn classify_no_selection(abs: SideStatus, rel: SideStatus) -> Option<IssueKind> {
+    let mut any = false;
+    let mut all_missing = true;
+    for status in [abs, rel] {
+        if status == SideStatus::Absent {
+            continue;
+        }
+        any = true;
+        if status != SideStatus::Missing {
+            all_missing = false;
+        }
+    }
+    if !any {
+        None
+    } else if all_missing {
+        Some(IssueKind::Missing)
+    } else {
+        Some(IssueKind::Invalid)
+    }
+}
+
+/// Combine both resolved sides into a selected path + repair need + issue,
+/// per the §3.5 resolution matrix.
+fn combine_sides(pair: RawPair, abs: SideOutcome, rel: SideOutcome) -> ResolvedPair {
+    let av = abs.status.is_valid();
+    let rv = rel.status.is_valid();
+
+    let mut selected = None;
+    let mut selected_canonical_raw = None;
+    let mut selected_identity = None;
+    let mut issue = None;
+    let mut repair = RepairKind::None;
+
+    match (av, rv) {
+        (true, true) => {
+            let same = compare_dirs(
+                abs.canonical_path.as_deref().unwrap_or_default(),
+                abs.identity.as_ref(),
+                rel.canonical_path.as_deref().unwrap_or_default(),
+                rel.identity.as_ref(),
+            );
+            match same {
+                SameDir::Same => {
+                    // Prefer the absolute candidate's canonical form.
+                    let canon = abs.canonical_path.clone().unwrap();
+                    selected = Some(display_canonical(&canon));
+                    selected_canonical_raw = Some(canon);
+                    selected_identity = abs.identity;
+                    // Normalize if the persisted spellings are not already the
+                    // selected canonical forms.
+                    if !pair_is_canonical(&pair, selected.as_deref(), &rel) {
+                        repair = RepairKind::NormalizePair;
+                    }
+                }
+                SameDir::Different => {
+                    issue = Some(IssueKind::Conflict);
+                }
+                SameDir::Unavailable => {
+                    issue = Some(IssueKind::Invalid);
+                }
+            }
+        }
+        (true, false) => {
+            let canon = abs.canonical_path.clone().unwrap();
+            selected = Some(display_canonical(&canon));
+            selected_canonical_raw = Some(canon);
+            selected_identity = abs.identity;
+            // Populate/repair the companion when the relative side did not load.
+            repair = RepairKind::PopulateCompanion;
+        }
+        (false, true) => {
+            let canon = rel.canonical_path.clone().unwrap();
+            selected = Some(display_canonical(&canon));
+            selected_canonical_raw = Some(canon);
+            selected_identity = rel.identity;
+            repair = RepairKind::ReplaceStaleAbsolute;
+        }
+        (false, false) => {
+            issue = classify_no_selection(abs.status, rel.status);
+        }
+    }
+
+    ResolvedPair {
+        source: pair.source,
+        index: pair.index,
+        raw_absolute: pair.absolute,
+        raw_relative: pair.relative,
+        absolute_side: abs,
+        relative_side: rel,
+        selected,
+        selected_canonical_raw,
+        selected_identity,
+        issue,
+        repair,
+    }
+}
+
+/// Whether the persisted pair already stores the selected absolute path (display
+/// form) plus a present, non-drifting companion, so no normalization is needed.
+fn pair_is_canonical(pair: &RawPair, selected: Option<&str>, rel: &SideOutcome) -> bool {
+    let Some(selected) = selected else {
+        return false;
+    };
+    let abs_matches = pair
+        .absolute
+        .value
+        .as_deref()
+        .map(|v| v == selected)
+        .unwrap_or(false);
+    // The companion is fine if it is present and it resolved to the same dir.
+    let rel_ok = pair.relative.present && rel.status.is_valid();
+    abs_matches && rel_ok
+}
+
+/// Resolve the full six-field record set: run the §3.5 matrix per registration,
+/// merge the legacy singular mirror, quarantine conflict scopes, deduplicate by
+/// identity, and build the runtime selected lists plus hidden state.
+///
+/// `base` is the already-canonicalized instance base (or `None`). The
+/// `*_companion_present` flags say whether each plural relative array was
+/// present and length-aligned on disk (drives reconcile eligibility, §4.2).
+pub(crate) fn resolve_registrations(
+    active_plural: &[RawPair],
+    singular: Option<RawPair>,
+    archived: &[RawPair],
+    base: Option<&Path>,
+    active_companion_present: bool,
+    archived_companion_present: bool,
+    resolver: &dyn CandidateResolver,
+) -> ProjectPathPersistenceState {
+    let resolve_pair = |pair: RawPair| -> ResolvedPair {
+        let abs = resolve_side(&pair.absolute, false, base, resolver);
+        let rel = resolve_side(&pair.relative, true, base, resolver);
+        combine_sides(pair, abs, rel)
+    };
+
+    let mut active: Vec<ResolvedPair> = active_plural.iter().cloned().map(resolve_pair).collect();
+
+    // Merge the legacy singular mirror (§3.6).
+    let mut genuine_singular = false;
+    if let Some(sing) = singular {
+        let resolved_singular = resolve_pair(sing);
+        match active.first() {
+            Some(first) if singular_mirrors_first(&resolved_singular, first) => {
+                // Redundant mirror of the first plural entry; drop it.
+            }
+            _ => {
+                genuine_singular = true;
+                active.push(resolved_singular);
+            }
+        }
+    }
+
+    let mut archived: Vec<ResolvedPair> = archived.iter().cloned().map(resolve_pair).collect();
+
+    // Counts BEFORE dedupe/quarantine (redundant singular already excluded; a
+    // genuinely different singular counts as one extra active record).
+    let active_registration_count = active.len();
+    let archived_registration_count = archived.len();
+
+    // Conflict-quarantine pass (§3.4): suppress any otherwise-selected record
+    // whose identity or component scope overlaps either candidate of a conflict.
+    let quarantine = build_quarantine_set(&active, &archived);
+    apply_quarantine(&mut active, &quarantine);
+    apply_quarantine(&mut archived, &quarantine);
+
+    // Identity dedupe (§3.6): active in order first, then archived; active wins.
+    dedupe_selected(&mut active, &mut archived);
+
+    // Reconcile eligibility per group (§4.2).
+    let active_reconcile_eligible =
+        group_reconcile_eligible(&active, active_companion_present, genuine_singular);
+    let archived_reconcile_eligible =
+        group_reconcile_eligible(&archived, archived_companion_present, false);
+
+    let selected_head = active.iter().find_map(|p| p.selected.clone());
+
+    let mut pairs = active;
+    pairs.extend(archived);
+
+    ProjectPathPersistenceState {
+        pairs,
+        selected_head,
+        active_registration_count,
+        archived_registration_count,
+        active_companion_present,
+        archived_companion_present,
+        has_genuine_singular: genuine_singular,
+        active_reconcile_eligible,
+        archived_reconcile_eligible,
+        structural_issues: Vec::new(),
+    }
+}
+
+/// Whether a resolved singular is the redundant mirror of the first plural
+/// entry: matching raw absolute spelling (platform-correct) or the same
+/// validated directory identity.
+fn singular_mirrors_first(singular: &ResolvedPair, first: &ResolvedPair) -> bool {
+    if let (Some(a), Some(b)) = (
+        singular.raw_absolute.value.as_deref(),
+        first.raw_absolute.value.as_deref(),
+    ) {
+        if normalize_for_compare(a) == normalize_for_compare(b) {
+            return true;
+        }
+    }
+    if let (Some(a), Some(b)) = (&singular.selected_canonical_raw, &first.selected_canonical_raw) {
+        return matches!(
+            compare_dirs(a, singular.selected_identity.as_ref(), b, first.selected_identity.as_ref()),
+            SameDir::Same
+        );
+    }
+    false
+}
+
+/// Both canonical identities and canonical component paths of every
+/// both-valid/different (conflict) pair.
+struct QuarantineSet {
+    identities: Vec<DirectoryIdentity>,
+    canonical_paths: Vec<String>,
+}
+
+fn build_quarantine_set(active: &[ResolvedPair], archived: &[ResolvedPair]) -> QuarantineSet {
+    let mut identities = Vec::new();
+    let mut canonical_paths = Vec::new();
+    for pair in active.iter().chain(archived.iter()) {
+        if pair.issue == Some(IssueKind::Conflict) {
+            for side in [&pair.absolute_side, &pair.relative_side] {
+                if let Some(id) = side.identity {
+                    identities.push(id);
+                }
+                if let Some(canon) = &side.canonical_path {
+                    canonical_paths.push(canon.clone());
+                }
+            }
+        }
+    }
+    QuarantineSet {
+        identities,
+        canonical_paths,
+    }
+}
+
+/// Suppress any selected pair whose identity equals a quarantined candidate or
+/// whose canonical scope overlaps one component-wise (ancestor/descendant/equal).
+fn apply_quarantine(pairs: &mut [ResolvedPair], quarantine: &QuarantineSet) {
+    for pair in pairs.iter_mut() {
+        if !pair.is_selected() {
+            continue;
+        }
+        let id_hit = pair
+            .selected_identity
+            .as_ref()
+            .map(|id| quarantine.identities.contains(id))
+            .unwrap_or(false);
+        let scope_hit = pair
+            .selected_canonical_raw
+            .as_deref()
+            .map(|canon| {
+                quarantine
+                    .canonical_paths
+                    .iter()
+                    .any(|q| paths_overlap(canon, q))
+            })
+            .unwrap_or(false);
+        if id_hit || scope_hit {
+            pair.selected = None;
+            pair.selected_canonical_raw = None;
+            pair.selected_identity = None;
+            pair.repair = RepairKind::None;
+            pair.issue = Some(IssueKind::Invalid);
+        }
+    }
+}
+
+/// Component-wise ancestor/descendant/equal overlap of two canonical paths.
+fn paths_overlap(a: &str, b: &str) -> bool {
+    let (pa, pb) = (Path::new(a), Path::new(b));
+    pa.starts_with(pb) || pb.starts_with(pa)
+}
+
+/// Identity dedupe across selected records: active in order then archived, active
+/// winning over a duplicate archived entry. Identity-unavailable comparison of
+/// two distinct-canonical selected records fails the later one closed.
+fn dedupe_selected(active: &mut [ResolvedPair], archived: &mut [ResolvedPair]) {
+    let mut kept: Vec<(String, Option<DirectoryIdentity>)> = Vec::new();
+    // Two passes over one logical ordering: active first (wins), then archived.
+    for pair in active.iter_mut().chain(archived.iter_mut()) {
+        if !pair.is_selected() {
+            continue;
+        }
+        let canon = pair.selected_canonical_raw.clone().unwrap_or_default();
+        let id = pair.selected_identity;
+        let mut duplicate = false;
+        let mut unavailable = false;
+        for (kcanon, kid) in &kept {
+            match compare_dirs(&canon, id.as_ref(), kcanon, kid.as_ref()) {
+                SameDir::Same => {
+                    duplicate = true;
+                    break;
+                }
+                SameDir::Unavailable => {
+                    unavailable = true;
+                    break;
+                }
+                SameDir::Different => {}
+            }
+        }
+        if duplicate {
+            // Silent dedupe: drop the later duplicate from runtime.
+            pair.selected = None;
+            pair.selected_canonical_raw = None;
+            pair.selected_identity = None;
+            pair.repair = RepairKind::None;
+        } else if unavailable {
+            // Cannot rule out a duplicate → fail closed.
+            pair.selected = None;
+            pair.selected_canonical_raw = None;
+            pair.selected_identity = None;
+            pair.repair = RepairKind::None;
+            pair.issue = Some(IssueKind::Invalid);
+        } else {
+            kept.push((canon, id));
+        }
+    }
+}
+
+/// Whether a field group has a dirty, write-eligible repair (§4.2). A present,
+/// aligned companion array can always copy unresolved slots, so any dirty pair
+/// makes the group eligible. An absent companion array requires every retained
+/// entry to have selected (one unresolved legacy entry blocks the group). A
+/// genuinely different unresolved active singular also blocks the active group.
+fn group_reconcile_eligible(
+    pairs: &[ResolvedPair],
+    companion_present: bool,
+    genuine_singular: bool,
+) -> bool {
+    let has_dirty = pairs.iter().any(|p| p.is_selected() && p.repair != RepairKind::None);
+    if !has_dirty {
+        return false;
+    }
+    let has_unresolved = pairs.iter().any(|p| p.issue.is_some());
+    if genuine_singular && has_unresolved {
+        return false;
+    }
+    if companion_present {
+        true
+    } else {
+        // Absent companion: cannot invent a null slot for an unresolved entry.
+        !has_unresolved
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1303,5 +2487,567 @@ mod tests {
             "snake_case archived field leaked: {}",
             json
         );
+    }
+
+    // ── #1077 instance-relative codec ────────────────────────────────────
+
+    #[cfg(not(windows))]
+    mod codec_posix {
+        use super::super::{decode_instance_relative, encode_instance_relative, RelDecodeError};
+        use std::path::{Path, PathBuf};
+
+        #[test]
+        fn encode_child_of_base() {
+            assert_eq!(
+                encode_instance_relative(Path::new("/opt/bundle/projects/alpha"), Path::new("/opt/bundle")),
+                Some("projects/alpha".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_sibling_uses_dotdot() {
+            assert_eq!(
+                encode_instance_relative(Path::new("/opt/projects/alpha"), Path::new("/opt/bundle")),
+                Some("../projects/alpha".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_base_itself_is_dot() {
+            assert_eq!(
+                encode_instance_relative(Path::new("/opt/bundle"), Path::new("/opt/bundle")),
+                Some(".".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_preserves_case_and_unicode_and_spaces() {
+            assert_eq!(
+                encode_instance_relative(
+                    Path::new("/opt/bundle/Pro Jects/Ä lpha"),
+                    Path::new("/opt/bundle")
+                ),
+                Some("Pro Jects/Ä lpha".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_component_with_backslash_has_no_portable_form() {
+            // A POSIX dir literally named `a\b` cannot be represented.
+            assert_eq!(
+                encode_instance_relative(Path::new("/opt/bundle/a\\b"), Path::new("/opt/bundle")),
+                None
+            );
+        }
+
+        #[test]
+        fn decode_round_trips_encode() {
+            let base = Path::new("/opt/bundle");
+            let project = Path::new("/opt/projects/alpha");
+            let wire = encode_instance_relative(project, base).unwrap();
+            assert_eq!(decode_instance_relative(&wire, base).unwrap(), PathBuf::from("/opt/projects/alpha"));
+        }
+
+        #[test]
+        fn decode_dot_is_base() {
+            assert_eq!(
+                decode_instance_relative(".", Path::new("/opt/bundle")).unwrap(),
+                PathBuf::from("/opt/bundle")
+            );
+        }
+
+        #[test]
+        fn decode_rejects_noncanonical_and_injection() {
+            let base = Path::new("/opt/bundle");
+            assert_eq!(decode_instance_relative("", base), Err(RelDecodeError::Empty));
+            assert_eq!(decode_instance_relative("a\0b", base), Err(RelDecodeError::Nul));
+            assert_eq!(decode_instance_relative("a\\b", base), Err(RelDecodeError::Backslash));
+            assert_eq!(decode_instance_relative("/abs", base), Err(RelDecodeError::EmptySegment));
+            assert_eq!(decode_instance_relative("a/", base), Err(RelDecodeError::EmptySegment));
+            assert_eq!(decode_instance_relative("a//b", base), Err(RelDecodeError::EmptySegment));
+            assert_eq!(decode_instance_relative("a/./b", base), Err(RelDecodeError::DotSegment));
+            assert_eq!(decode_instance_relative("C:/x", base), Err(RelDecodeError::DriveRelative));
+            assert_eq!(decode_instance_relative("C:", base), Err(RelDecodeError::DriveRelative));
+        }
+
+        #[test]
+        fn decode_rejects_traversal_above_root() {
+            // /opt/bundle has two normal components; three `..` walk above root.
+            assert_eq!(
+                decode_instance_relative("../../../etc", Path::new("/opt/bundle")),
+                Err(RelDecodeError::EscapesRoot)
+            );
+        }
+
+        #[test]
+        fn decode_allows_sibling_traversal() {
+            assert_eq!(
+                decode_instance_relative("../projects/alpha", Path::new("/opt/bundle")).unwrap(),
+                PathBuf::from("/opt/projects/alpha")
+            );
+        }
+
+        #[test]
+        fn decode_rejects_relative_base() {
+            assert_eq!(
+                decode_instance_relative("a", Path::new("relative/base")),
+                Err(RelDecodeError::BaseNotAbsolute)
+            );
+        }
+
+        #[test]
+        fn posix_backslash_component_is_not_a_separator_but_is_rejected() {
+            // Wire never contains `\`; a value with one is rejected outright.
+            assert_eq!(
+                decode_instance_relative("a\\b/c", Path::new("/opt/bundle")),
+                Err(RelDecodeError::Backslash)
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    mod codec_windows {
+        use super::super::{decode_instance_relative, encode_instance_relative, RelDecodeError};
+        use std::path::{Path, PathBuf};
+
+        #[test]
+        fn encode_child_and_sibling() {
+            assert_eq!(
+                encode_instance_relative(Path::new(r"C:\bundle\projects\alpha"), Path::new(r"C:\bundle")),
+                Some("projects/alpha".to_string())
+            );
+            assert_eq!(
+                encode_instance_relative(Path::new(r"C:\projects\alpha"), Path::new(r"C:\bundle")),
+                Some("../projects/alpha".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_drive_letter_case_insensitive_root() {
+            assert_eq!(
+                encode_instance_relative(Path::new(r"c:\bundle\alpha"), Path::new(r"C:\bundle")),
+                Some("alpha".to_string())
+            );
+        }
+
+        #[test]
+        fn encode_different_drive_has_no_relative_form() {
+            assert_eq!(
+                encode_instance_relative(Path::new(r"D:\projects\alpha"), Path::new(r"C:\bundle")),
+                None
+            );
+        }
+
+        #[test]
+        fn encode_same_unc_share_ok_different_share_none() {
+            assert_eq!(
+                encode_instance_relative(
+                    Path::new(r"\\server\share\bundle\alpha"),
+                    Path::new(r"\\server\share\bundle")
+                ),
+                Some("alpha".to_string())
+            );
+            assert_eq!(
+                encode_instance_relative(
+                    Path::new(r"\\server\other\alpha"),
+                    Path::new(r"\\server\share\bundle")
+                ),
+                None
+            );
+        }
+
+        #[test]
+        fn encode_verbatim_disk_normalizes_for_comparison() {
+            assert_eq!(
+                encode_instance_relative(Path::new(r"\\?\C:\bundle\alpha"), Path::new(r"C:\bundle")),
+                Some("alpha".to_string())
+            );
+        }
+
+        #[test]
+        fn decode_round_trips_and_rejects_windows_hazards() {
+            let base = Path::new(r"C:\bundle");
+            assert_eq!(
+                decode_instance_relative("projects/alpha", base).unwrap(),
+                PathBuf::from(r"C:\bundle\projects\alpha")
+            );
+            // ADS colon not in drive position → illegal char (drive-position
+            // `X:` is caught earlier as DriveRelative, also a rejection).
+            assert_eq!(decode_instance_relative("foo:bar", base), Err(RelDecodeError::IllegalWindowsChar));
+            assert_eq!(decode_instance_relative("a*b", base), Err(RelDecodeError::IllegalWindowsChar));
+            assert_eq!(decode_instance_relative("a:b", base), Err(RelDecodeError::DriveRelative));
+            // Trailing dot/space.
+            assert_eq!(decode_instance_relative("alpha ", base), Err(RelDecodeError::TrailingDotOrSpace));
+            assert_eq!(decode_instance_relative("alpha.", base), Err(RelDecodeError::TrailingDotOrSpace));
+            // Reserved DOS device names, with and without extension.
+            assert_eq!(decode_instance_relative("CON", base), Err(RelDecodeError::ReservedDosName));
+            assert_eq!(decode_instance_relative("con.txt", base), Err(RelDecodeError::ReservedDosName));
+            assert_eq!(decode_instance_relative("COM1", base), Err(RelDecodeError::ReservedDosName));
+            assert_eq!(decode_instance_relative("LPT9", base), Err(RelDecodeError::ReservedDosName));
+            // COM0 / COM10 are not reserved.
+            assert!(decode_instance_relative("COM0", base).is_ok());
+            assert!(decode_instance_relative("COM10", base).is_ok());
+        }
+
+        #[test]
+        fn decode_rejects_traversal_above_drive_root() {
+            assert_eq!(
+                decode_instance_relative("../../x", Path::new(r"C:\bundle")),
+                Err(RelDecodeError::EscapesRoot)
+            );
+        }
+    }
+
+    // ── #1077 resolution matrix / quarantine / dedupe (injected resolver) ──
+    mod resolution {
+        use super::super::*;
+        use std::collections::HashMap;
+        use std::path::Path;
+
+        /// Injected resolver mapping syntactic path strings to canned outcomes.
+        struct MapResolver {
+            map: HashMap<String, SideOutcome>,
+        }
+
+        impl CandidateResolver for MapResolver {
+            fn resolve(&self, syntactic: &Path) -> SideOutcome {
+                self.map
+                    .get(&syntactic.to_string_lossy().to_string())
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        SideOutcome::failed(
+                            SideStatus::Missing,
+                            syntactic.to_str().map(str::to_string),
+                        )
+                    })
+            }
+        }
+
+        fn valid(canonical: &str, kind: SideStatus, vol: u64, file: u128) -> SideOutcome {
+            SideOutcome {
+                status: kind,
+                syntactic_path: Some(canonical.to_string()),
+                canonical_path: Some(canonical.to_string()),
+                identity: Some(DirectoryIdentity { volume: vol, file }),
+            }
+        }
+
+        fn active_pair(idx: usize, abs: &str, rel: Option<&str>) -> RawPair {
+            RawPair {
+                source: ProjectSource::ProjectPaths,
+                index: Some(idx),
+                absolute: RawStringField::string(abs),
+                relative: match rel {
+                    Some(r) => RawStringField::string(r),
+                    None => RawStringField::absent(),
+                },
+            }
+        }
+
+        // Base has a single normal component so a plain relative wire resolves
+        // directly under `/opt` (matching the `abs()` helper below).
+        fn base() -> &'static Path {
+            Path::new(if cfg!(windows) { r"C:\opt" } else { "/opt" })
+        }
+
+        fn abs(p: &str) -> String {
+            if cfg!(windows) {
+                format!(r"C:\opt\{}", p.replace('/', "\\"))
+            } else {
+                format!("/opt/{}", p)
+            }
+        }
+
+        #[test]
+        fn absolute_only_selects_and_wants_companion() {
+            let a = abs("projects/alpha");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 10));
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, None)],
+                None,
+                &[],
+                Some(base()),
+                false,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
+            assert_eq!(report.pairs[0].repair, RepairKind::PopulateCompanion);
+            assert_eq!(report.active_registration_count, 1);
+            assert!(report.issues().next().is_none());
+        }
+
+        #[test]
+        fn relative_wins_when_absolute_stale() {
+            // Absolute is missing; relative decodes to a valid dir.
+            let stale = abs("old/alpha");
+            let rel_target = abs("projects/alpha");
+            let mut map = HashMap::new();
+            map.insert(
+                rel_target.clone(),
+                valid(&rel_target, SideStatus::ValidDirectProject, 1, 11),
+            );
+            // stale absolute not in map → Missing.
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &stale, Some("projects/alpha"))],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_selected(), vec![display_canonical(&rel_target)]);
+            assert_eq!(report.pairs[0].repair, RepairKind::ReplaceStaleAbsolute);
+        }
+
+        #[test]
+        fn both_valid_different_is_conflict_selecting_neither() {
+            let a = abs("projects/alpha");
+            let rel_target = abs("projects/beta");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 20));
+            map.insert(
+                rel_target.clone(),
+                valid(&rel_target, SideStatus::ValidDirectProject, 1, 21),
+            );
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, Some("projects/beta"))],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert!(report.active_selected().is_empty());
+            assert_eq!(report.pairs[0].issue, Some(IssueKind::Conflict));
+        }
+
+        #[test]
+        fn both_valid_same_identity_selects_absolute() {
+            let a = abs("projects/alpha");
+            let rel_target = abs("aliased/alpha"); // different canonical, same identity
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 7, 30));
+            map.insert(
+                rel_target.clone(),
+                valid(&rel_target, SideStatus::ValidDirectProject, 7, 30),
+            );
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, Some("aliased/alpha"))],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
+            assert!(report.pairs[0].issue.is_none());
+        }
+
+        #[test]
+        fn quarantine_suppresses_duplicate_of_conflict_candidate() {
+            // Registration 0 is a conflict between alpha and beta.
+            // Registration 1 independently selects alpha → must be quarantined.
+            let a = abs("projects/alpha");
+            let b = abs("projects/beta");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 40));
+            map.insert(b.clone(), valid(&b, SideStatus::ValidDirectProject, 1, 41));
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[
+                    active_pair(0, &a, Some("projects/beta")),
+                    active_pair(1, &a, None),
+                ],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert!(report.active_selected().is_empty(), "alpha reintroduced despite conflict");
+            assert_eq!(report.pairs[0].issue, Some(IssueKind::Conflict));
+            assert_eq!(report.pairs[1].issue, Some(IssueKind::Invalid));
+        }
+
+        #[test]
+        fn quarantine_scope_overlap_suppresses_child_registration() {
+            // Conflict on a collection root; a child registration overlaps its scope.
+            let root = abs("collection");
+            let other = abs("elsewhere");
+            let child = abs("collection/child");
+            let mut map = HashMap::new();
+            map.insert(root.clone(), valid(&root, SideStatus::ValidCollectionRoot, 1, 50));
+            map.insert(other.clone(), valid(&other, SideStatus::ValidDirectProject, 1, 51));
+            map.insert(child.clone(), valid(&child, SideStatus::ValidDirectProject, 1, 52));
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[
+                    active_pair(0, &root, Some("elsewhere")),
+                    active_pair(1, &child, None),
+                ],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert!(report.active_selected().is_empty());
+            assert_eq!(report.pairs[1].issue, Some(IssueKind::Invalid));
+        }
+
+        #[test]
+        fn dedupe_keeps_first_active_and_active_beats_archived() {
+            let a = abs("projects/alpha");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 60));
+            let resolver = MapResolver { map };
+            let archived = vec![RawPair {
+                source: ProjectSource::ArchivedProjectPaths,
+                index: Some(0),
+                absolute: RawStringField::string(&a),
+                relative: RawStringField::absent(),
+            }];
+            let report = resolve_registrations(
+                &[active_pair(0, &a, None), active_pair(1, &a, None)],
+                None,
+                &archived,
+                Some(base()),
+                false,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
+            assert!(report.archived_selected().is_empty(), "archived dup of active must drop");
+        }
+
+        #[test]
+        fn identity_unavailable_dual_candidates_fail_closed() {
+            // Both sides valid, different canonical, NO identities → Unavailable.
+            let a = abs("projects/alpha");
+            let rel_target = abs("projects/beta");
+            let no_id = |canon: &str| SideOutcome {
+                status: SideStatus::ValidDirectProject,
+                syntactic_path: Some(canon.to_string()),
+                canonical_path: Some(canon.to_string()),
+                identity: None,
+            };
+            let mut map = HashMap::new();
+            map.insert(a.clone(), no_id(&a));
+            map.insert(rel_target.clone(), no_id(&rel_target));
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, Some("projects/beta"))],
+                None,
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert!(report.active_selected().is_empty());
+            assert_eq!(report.pairs[0].issue, Some(IssueKind::Invalid));
+        }
+
+        #[test]
+        fn neither_valid_definite_notfound_is_missing() {
+            let a = abs("gone");
+            let resolver = MapResolver { map: HashMap::new() }; // everything Missing
+            let report = resolve_registrations(
+                &[active_pair(0, &a, None)],
+                None,
+                &[],
+                Some(base()),
+                false,
+                false,
+                &resolver,
+            );
+            assert!(report.active_selected().is_empty());
+            assert_eq!(report.pairs[0].issue, Some(IssueKind::Missing));
+        }
+
+        #[test]
+        fn base_unavailable_uses_absolute_only_and_preserves_relative() {
+            let a = abs("projects/alpha");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 70));
+            let resolver = MapResolver { map };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, Some("projects/alpha"))],
+                None,
+                &[],
+                None, // no base
+                true,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
+            assert_eq!(report.pairs[0].relative_side.status, SideStatus::BaseUnavailable);
+            // The raw relative value is retained in hidden state.
+            assert_eq!(report.pairs[0].raw_relative, RawStringField::string("projects/alpha"));
+        }
+
+        #[test]
+        fn genuine_singular_appends_and_blocks_active_when_unresolved() {
+            let a = abs("projects/alpha");
+            let sing = abs("gone/singular");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 80));
+            // sing not in map → Missing → unresolved genuine singular.
+            let resolver = MapResolver { map };
+            let singular = RawPair {
+                source: ProjectSource::ProjectPath,
+                index: None,
+                absolute: RawStringField::string(&sing),
+                relative: RawStringField::absent(),
+            };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, None)],
+                Some(singular),
+                &[],
+                Some(base()),
+                true,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_registration_count, 2, "genuine singular counts");
+            assert_eq!(report.active_selected(), vec![display_canonical(&a)]);
+            // The unresolved genuine singular blocks active reconciliation.
+            assert!(!report.active_reconcile_eligible);
+        }
+
+        #[test]
+        fn redundant_singular_is_dropped() {
+            let a = abs("projects/alpha");
+            let mut map = HashMap::new();
+            map.insert(a.clone(), valid(&a, SideStatus::ValidDirectProject, 1, 90));
+            let resolver = MapResolver { map };
+            let singular = RawPair {
+                source: ProjectSource::ProjectPath,
+                index: None,
+                absolute: RawStringField::string(&a),
+                relative: RawStringField::absent(),
+            };
+            let report = resolve_registrations(
+                &[active_pair(0, &a, None)],
+                Some(singular),
+                &[],
+                Some(base()),
+                false,
+                false,
+                &resolver,
+            );
+            assert_eq!(report.active_registration_count, 1, "redundant singular not counted");
+        }
     }
 }

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -806,8 +806,9 @@ pub(crate) enum SideStatus {
     NonUtf8,
     ValidDirectProject,
     ValidCollectionRoot,
-    /// Two spellings had to be compared but no identity could be obtained.
-    IdentityUnavailable,
+    // Note: an identity-unavailable outcome (two spellings that cannot be proven
+    // the same directory) is recorded at the pair level as an `Invalid` issue,
+    // not as a per-side status, so both sides retain their valid classification.
 }
 
 impl SideStatus {
@@ -1262,6 +1263,12 @@ pub(crate) struct ProjectPathPersistenceState {
     /// all reconciliation and project-list mutation while unrelated preserve
     /// saves remain allowed.
     pub structural_issues: Vec<StructuralIssue>,
+    /// Set for a state synthesized from a direct-constructed `AppSettings`'s
+    /// runtime lists (no decoder-produced hidden state). Such a state is legacy
+    /// runtime-authoritative: a Reconcile write emits its groups verbatim rather
+    /// than copying disk, matching pre-#1077 verbatim-writer behavior until the
+    /// explicit mutators maintain a real hidden state.
+    pub runtime_authoritative: bool,
 }
 
 impl ProjectPathPersistenceState {
@@ -1522,6 +1529,7 @@ pub(crate) fn resolve_registrations(
         active_reconcile_eligible,
         archived_reconcile_eligible,
         structural_issues: Vec::new(),
+        runtime_authoritative: false,
     }
 }
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -860,8 +860,19 @@ fn parse_settings_json(contents: &str, source: &str) -> Result<(AppSettings, boo
     let mut value: Value = serde_json::from_str(contents)
         .map_err(|e| format!("Failed to parse settings file: {}", e))?;
     let migrated = migrate_settings_value_to_v2(&mut value);
-    let settings: AppSettings = serde_json::from_value(value)
+    // #1077: decode the six project fields and replace the three runtime fields
+    // with the SELECTED canonical paths BEFORE deserializing the rest of
+    // AppSettings, so a wrong-typed project field cannot fail unrelated settings
+    // deserialization and unresolved/conflicting pairs survive in hidden state.
+    let base = production_instance_base();
+    let state = apply_project_decode_to_value(
+        &mut value,
+        base.as_deref(),
+        &projects::FsCandidateResolver,
+    );
+    let mut settings: AppSettings = serde_json::from_value(value)
         .map_err(|e| format!("Failed to deserialize settings from {source}: {e}"))?;
+    settings.project_path_state = Arc::new(state);
     Ok((settings, migrated))
 }
 
@@ -1732,11 +1743,17 @@ fn load_settings_from_path(path: &Path) -> AppSettings {
             true
         };
         if backup_ok {
-            if let Err(e) = save_settings_to_path(&settings, path) {
-                log::error!(
+            // #1077: route the startup root-token/migration write through PRESERVE
+            // mode so it cannot erase project companions/conflicts before the
+            // first snapshot, and so a present-but-invalid file is never
+            // overwritten (the preserve writer's disk gate returns Err). On
+            // success adopt the fresh-decoded settings so runtime/hidden agree.
+            match save_settings_to_path_preserving_project_paths(&settings, path) {
+                Ok(written) => settings = written,
+                Err(e) => log::error!(
                     "Failed to persist settings (root_token gen and/or settings migration): {}",
                     e
-                );
+                ),
             }
         }
     }
@@ -1945,6 +1962,629 @@ pub fn read_log_level_only() -> Option<String> {
 /// counter so the two can be reasoned about independently in diagnostics.
 static SAVE_OP_ID: AtomicU64 = AtomicU64::new(0);
 
+// ── #1077 six-field project-path codec (JSON extraction / serialization) ────
+//
+// The three legacy primary fields keep their names/types; each gains a paired
+// `…RelativeToInstance` companion (string|null, array-aligned). On load the
+// codec resolves both candidates, replaces the runtime fields with the SELECTED
+// canonical paths, and stashes the raw pairs/outcomes in the hidden
+// `AppSettings.project_path_state`. On write, the preserve/reconcile modes
+// re-inject all six fields (companions are `#[serde(skip)]`, so a plain
+// AppSettings serialization would otherwise drop them). See plan #1077 §3.2-§4.3.
+
+use super::projects::{
+    self, ProjectPathPersistenceState, ProjectSource, RawJsonField, RawPair, RawStringField,
+    RepairKind, ResolvedPair, SideOutcome, SideStatus, StructuralIssue,
+};
+
+/// An absent-side outcome (used when synthesizing a legacy hidden state).
+fn absent_side() -> SideOutcome {
+    SideOutcome {
+        status: SideStatus::Absent,
+        syntactic_path: None,
+        canonical_path: None,
+        identity: None,
+    }
+}
+
+const FIELD_PROJECT_PATH: &str = "projectPath";
+const FIELD_PROJECT_PATH_REL: &str = "projectPathRelativeToInstance";
+const FIELD_PROJECT_PATHS: &str = "projectPaths";
+const FIELD_PROJECT_PATHS_REL: &str = "projectPathsRelativeToInstance";
+const FIELD_ARCHIVED: &str = "archivedProjectPaths";
+const FIELD_ARCHIVED_REL: &str = "archivedProjectPathsRelativeToInstance";
+
+/// The authoritative instance base for path pairing, canonicalized at the codec
+/// boundary. `None` in any degraded mode (no base, or a base that fails to
+/// canonicalize); never falls back to the process CWD.
+fn production_instance_base() -> Option<PathBuf> {
+    let base = super::instance_base()?;
+    std::fs::canonicalize(&base).ok()
+}
+
+/// Presence + JSON value of a raw field (absent vs null vs value).
+fn json_field(v: Option<&Value>) -> RawJsonField {
+    match v {
+        None => RawJsonField {
+            present: false,
+            value: None,
+        },
+        Some(Value::Null) => RawJsonField {
+            present: true,
+            value: None,
+        },
+        Some(other) => RawJsonField {
+            present: true,
+            value: Some(other.clone()),
+        },
+    }
+}
+
+/// Extract one plural group (primary + companion arrays) into ordered raw pairs,
+/// returning the companion-present bit and any structural corruption. On
+/// corruption, no entry is exposed (empty pairs) and the raw values are
+/// preserved via the returned `StructuralIssue`.
+fn extract_group(
+    root: &Map<String, Value>,
+    source: ProjectSource,
+    primary_key: &str,
+    companion_key: &str,
+) -> (Vec<RawPair>, bool, Option<StructuralIssue>) {
+    let primary = root.get(primary_key);
+    let companion = root.get(companion_key);
+    let companion_present = companion.is_some();
+    let raw_absolute = json_field(primary);
+    let raw_relative = json_field(companion);
+    let structural = |reason: &str| StructuralIssue {
+        source,
+        reason: reason.to_string(),
+        raw_absolute: raw_absolute.clone(),
+        raw_relative: raw_relative.clone(),
+    };
+    let corrupt = |reason: &str| (Vec::new(), companion_present, Some(structural(reason)));
+
+    // Companion present while primary absent/null → structural corruption.
+    if companion_present {
+        match primary {
+            None => return corrupt("companion present while primary field is absent"),
+            Some(Value::Null) => return corrupt("companion present while primary field is null"),
+            _ => {}
+        }
+    }
+
+    // Interpret the primary field.
+    let primary_list: Vec<String> = match primary {
+        // Absent or null → no active disk truth (a valid empty group here).
+        None | Some(Value::Null) => return (Vec::new(), companion_present, None),
+        Some(Value::Array(arr)) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for el in arr {
+                match el {
+                    Value::String(s) => out.push(s.clone()),
+                    _ => return corrupt("plural primary contains a non-string element"),
+                }
+            }
+            out
+        }
+        Some(_) => return corrupt("plural primary is not an array of strings"),
+    };
+
+    // Interpret the companion field.
+    let companion_list: Option<Vec<RawStringField>> = match companion {
+        None => None,
+        Some(Value::Array(arr)) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for el in arr {
+                match el {
+                    Value::String(s) => out.push(RawStringField::string(s.clone())),
+                    Value::Null => out.push(RawStringField::null()),
+                    _ => return corrupt("plural companion contains a non-string/non-null element"),
+                }
+            }
+            Some(out)
+        }
+        Some(Value::Null) => return corrupt("plural companion is a present null"),
+        Some(_) => return corrupt("plural companion is not an array"),
+    };
+
+    if let Some(ref comp) = companion_list {
+        if comp.len() != primary_list.len() {
+            return corrupt("companion array length differs from primary array");
+        }
+    }
+
+    let pairs = primary_list
+        .into_iter()
+        .enumerate()
+        .map(|(i, abs)| RawPair {
+            source,
+            index: Some(i),
+            absolute: RawStringField::string(abs),
+            relative: companion_list
+                .as_ref()
+                .map(|c| c[i].clone())
+                .unwrap_or_else(RawStringField::absent),
+        })
+        .collect();
+
+    (pairs, companion_present, None)
+}
+
+/// Extract the legacy singular pair, or a structural corruption.
+fn extract_singular(root: &Map<String, Value>) -> (Option<RawPair>, Option<StructuralIssue>) {
+    let primary = root.get(FIELD_PROJECT_PATH);
+    let companion = root.get(FIELD_PROJECT_PATH_REL);
+    let raw_absolute = json_field(primary);
+    let raw_relative = json_field(companion);
+    let structural = |reason: &str| StructuralIssue {
+        source: ProjectSource::ProjectPath,
+        reason: reason.to_string(),
+        raw_absolute: raw_absolute.clone(),
+        raw_relative: raw_relative.clone(),
+    };
+
+    let primary_field = match primary {
+        None => RawStringField::absent(),
+        Some(Value::Null) => RawStringField::null(),
+        Some(Value::String(s)) => RawStringField::string(s.clone()),
+        Some(_) => return (None, Some(structural("projectPath is not a string or null"))),
+    };
+    let companion_field = match companion {
+        None => RawStringField::absent(),
+        Some(Value::Null) => RawStringField::null(),
+        Some(Value::String(s)) => RawStringField::string(s.clone()),
+        Some(_) => {
+            return (
+                None,
+                Some(structural(
+                    "projectPathRelativeToInstance is not a string or null",
+                )),
+            )
+        }
+    };
+    if companion.is_some() && primary.is_none() {
+        return (
+            None,
+            Some(structural("singular companion present while projectPath is absent")),
+        );
+    }
+    if matches!(companion, Some(Value::String(_))) && matches!(primary, Some(Value::Null)) {
+        return (
+            None,
+            Some(structural("non-null singular companion paired with null projectPath")),
+        );
+    }
+
+    // A pair exists only when the primary is an actual string candidate; a
+    // null/absent primary is the valid empty singular.
+    let pair = primary_field.value.is_some().then(|| RawPair {
+        source: ProjectSource::ProjectPath,
+        index: None,
+        absolute: primary_field,
+        relative: companion_field,
+    });
+    (pair, None)
+}
+
+/// Decode the six raw project fields from a settings object into the hidden
+/// persistence state (selected paths, raw pairs, outcomes, structural issues).
+pub(crate) fn decode_project_state(
+    root: &Map<String, Value>,
+    base: Option<&Path>,
+    resolver: &dyn projects::CandidateResolver,
+) -> ProjectPathPersistenceState {
+    let (active_pairs, active_companion, active_structural) = extract_group(
+        root,
+        ProjectSource::ProjectPaths,
+        FIELD_PROJECT_PATHS,
+        FIELD_PROJECT_PATHS_REL,
+    );
+    let (archived_pairs, archived_companion, archived_structural) = extract_group(
+        root,
+        ProjectSource::ArchivedProjectPaths,
+        FIELD_ARCHIVED,
+        FIELD_ARCHIVED_REL,
+    );
+    let (singular, singular_structural) = extract_singular(root);
+
+    // A structurally-corrupt active group exposes no active entry at all,
+    // including its singular mirror.
+    let effective_singular = if active_structural.is_some() {
+        None
+    } else {
+        singular
+    };
+
+    let mut state = projects::resolve_registrations(
+        &active_pairs,
+        effective_singular,
+        &archived_pairs,
+        base,
+        active_companion,
+        archived_companion,
+        resolver,
+    );
+
+    let mut structural = Vec::new();
+    structural.extend(active_structural);
+    structural.extend(archived_structural);
+    structural.extend(singular_structural);
+    if !structural.is_empty() {
+        // Any structural corruption blocks all reconciliation/mutation.
+        state.active_reconcile_eligible = false;
+        state.archived_reconcile_eligible = false;
+    }
+    state.structural_issues = structural;
+    state
+}
+
+/// Decode the six fields from `value`, then overwrite the three primary runtime
+/// fields with the selected values and drop the companion keys so the remainder
+/// of `AppSettings` deserializes cleanly even when a project field was
+/// wrong-typed. Returns the hidden state to attach.
+pub(crate) fn apply_project_decode_to_value(
+    value: &mut Value,
+    base: Option<&Path>,
+    resolver: &dyn projects::CandidateResolver,
+) -> ProjectPathPersistenceState {
+    let state = match value.as_object() {
+        Some(root) => decode_project_state(root, base, resolver),
+        None => ProjectPathPersistenceState::default(),
+    };
+    if let Some(root) = value.as_object_mut() {
+        root.insert(
+            FIELD_PROJECT_PATH.to_string(),
+            state
+                .selected_head
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        root.insert(
+            FIELD_PROJECT_PATHS.to_string(),
+            Value::Array(state.active_selected().into_iter().map(Value::String).collect()),
+        );
+        root.insert(
+            FIELD_ARCHIVED.to_string(),
+            Value::Array(
+                state
+                    .archived_selected()
+                    .into_iter()
+                    .map(Value::String)
+                    .collect(),
+            ),
+        );
+        // Companion keys are not AppSettings fields; strip so nothing lingers.
+        root.remove(FIELD_PROJECT_PATH_REL);
+        root.remove(FIELD_PROJECT_PATHS_REL);
+        root.remove(FIELD_ARCHIVED_REL);
+    }
+    state
+}
+
+/// The project-field write mode. `Preserve` copies the six raw fields from the
+/// fresh disk object (materializing a group only when disk has no truth for it);
+/// `Reconcile` rebuilds the requested eligible group(s) from hidden state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectWriteMode {
+    Preserve,
+    Reconcile { active: bool, archived: bool },
+}
+
+/// A slot value for a retained (unresolved/conflict/missing) raw field: string
+/// stays a string, absent/null becomes null (inside an array there is no absent).
+fn raw_slot_value(field: &RawStringField) -> Value {
+    match &field.value {
+        Some(s) => Value::String(s.clone()),
+        None => Value::Null,
+    }
+}
+
+/// The companion wire value for a selected pair: encode against the base when
+/// available; otherwise preserve any existing raw companion (or null).
+fn companion_slot_value(pair: &ResolvedPair, base: Option<&Path>) -> Value {
+    match base {
+        Some(base) => match &pair.selected_canonical_raw {
+            Some(canon) => match projects::encode_instance_relative(Path::new(canon), base) {
+                Some(wire) => Value::String(wire),
+                None => Value::Null,
+            },
+            None => raw_slot_value(&pair.raw_relative),
+        },
+        None => raw_slot_value(&pair.raw_relative),
+    }
+}
+
+/// Rebuild one group's (primary array, companion array) from its resolved pairs:
+/// emit selected pairs (repaired), retain unresolved pairs value-for-value, and
+/// drop silent duplicates.
+fn rebuild_group_arrays(pairs: &[ResolvedPair], base: Option<&Path>) -> (Vec<Value>, Vec<Value>) {
+    let mut primary = Vec::new();
+    let mut companion = Vec::new();
+    for pair in pairs {
+        if let Some(sel) = &pair.selected {
+            primary.push(Value::String(sel.clone()));
+            companion.push(companion_slot_value(pair, base));
+        } else if pair.issue.is_some() {
+            primary.push(raw_slot_value(&pair.raw_absolute));
+            companion.push(raw_slot_value(&pair.raw_relative));
+        }
+        // else: silent dedupe drop — emit nothing.
+    }
+    (primary, companion)
+}
+
+/// Insert the four active fields from hidden state.
+fn write_active_group(out: &mut Map<String, Value>, state: &ProjectPathPersistenceState, base: Option<&Path>) {
+    let (primary, companion) = rebuild_group_arrays(state.active_pairs(), base);
+    out.insert(
+        FIELD_PROJECT_PATH.to_string(),
+        primary.first().cloned().unwrap_or(Value::Null),
+    );
+    out.insert(
+        FIELD_PROJECT_PATH_REL.to_string(),
+        companion.first().cloned().unwrap_or(Value::Null),
+    );
+    out.insert(FIELD_PROJECT_PATHS.to_string(), Value::Array(primary));
+    out.insert(FIELD_PROJECT_PATHS_REL.to_string(), Value::Array(companion));
+}
+
+/// Insert the two archived fields from hidden state.
+fn write_archived_group(out: &mut Map<String, Value>, state: &ProjectPathPersistenceState, base: Option<&Path>) {
+    let (primary, companion) = rebuild_group_arrays(state.archived_pairs(), base);
+    out.insert(FIELD_ARCHIVED.to_string(), Value::Array(primary));
+    out.insert(FIELD_ARCHIVED_REL.to_string(), Value::Array(companion));
+}
+
+/// Copy a field from `disk` into `out`, preserving its present/absent bit.
+fn copy_or_remove(out: &mut Map<String, Value>, disk: &Map<String, Value>, key: &str) {
+    match disk.get(key) {
+        Some(v) => {
+            out.insert(key.to_string(), v.clone());
+        }
+        None => {
+            out.remove(key);
+        }
+    }
+}
+
+/// Whether the disk object has authoritative active truth (§4.1): `projectPaths`
+/// is an array, or (absent/null plural) `projectPath` is a string.
+fn active_has_disk_truth(disk: &Map<String, Value>) -> bool {
+    match disk.get(FIELD_PROJECT_PATHS) {
+        Some(Value::Array(_)) => true,
+        None | Some(Value::Null) => matches!(disk.get(FIELD_PROJECT_PATH), Some(Value::String(_))),
+        Some(_) => true, // wrong-typed: structural, but still "present" disk truth to preserve
+    }
+}
+
+/// Whether the disk object has authoritative archived truth: `archivedProjectPaths`
+/// is an array (or any present value to preserve).
+fn archived_has_disk_truth(disk: &Map<String, Value>) -> bool {
+    matches!(disk.get(FIELD_ARCHIVED), Some(v) if !v.is_null())
+}
+
+/// If `AppSettings` was constructed directly (empty hidden state) yet carries
+/// runtime project lists, synthesize a legacy absolute-only state so the writers
+/// behave like a legacy-decoded file (companions null, all entries selected).
+fn hidden_state_for_write(settings: &AppSettings) -> std::borrow::Cow<'_, ProjectPathPersistenceState> {
+    let state = &settings.project_path_state;
+    let empty = state.pairs.is_empty() && state.structural_issues.is_empty();
+    let runtime_nonempty = settings.project_path.is_some()
+        || !settings.project_paths.is_empty()
+        || !settings.archived_project_paths.is_empty();
+    if empty && runtime_nonempty {
+        std::borrow::Cow::Owned(synthesize_legacy_state(settings))
+    } else {
+        std::borrow::Cow::Borrowed(state)
+    }
+}
+
+fn legacy_selected_pair(source: ProjectSource, index: Option<usize>, path: &str) -> ResolvedPair {
+    ResolvedPair {
+        source,
+        index,
+        raw_absolute: RawStringField::string(path),
+        raw_relative: RawStringField::absent(),
+        absolute_side: absent_side(),
+        relative_side: absent_side(),
+        selected: Some(path.to_string()),
+        selected_canonical_raw: None,
+        selected_identity: None,
+        issue: None,
+        repair: RepairKind::None,
+    }
+}
+
+fn synthesize_legacy_state(settings: &AppSettings) -> ProjectPathPersistenceState {
+    let mut pairs: Vec<ResolvedPair> = settings
+        .project_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| legacy_selected_pair(ProjectSource::ProjectPaths, Some(i), p))
+        .collect();
+    let active_registration_count = pairs.len();
+    for (i, p) in settings.archived_project_paths.iter().enumerate() {
+        pairs.push(legacy_selected_pair(
+            ProjectSource::ArchivedProjectPaths,
+            Some(i),
+            p,
+        ));
+    }
+    ProjectPathPersistenceState {
+        pairs,
+        selected_head: settings.project_paths.first().cloned(),
+        active_registration_count,
+        archived_registration_count: settings.archived_project_paths.len(),
+        active_companion_present: false,
+        archived_companion_present: false,
+        has_genuine_singular: false,
+        active_reconcile_eligible: false,
+        archived_reconcile_eligible: false,
+        structural_issues: Vec::new(),
+        runtime_authoritative: true,
+    }
+}
+
+/// Fresh-read the whole disk object for a project-preserving/reconciling write.
+/// `None` = absent (materialize). `Err` = present-but-unreadable/invalid JSON,
+/// non-object root, or non-project settings that fail to deserialize — in which
+/// case the caller must NOT write (§4.1). A valid object is returned for reuse.
+fn read_disk_object_for_write(path: &Path) -> Result<Option<Map<String, Value>>, String> {
+    match std::fs::read_to_string(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!(
+            "Failed to read {} for a project-preserving save (aborting to avoid dropping a project): {e}",
+            path.display()
+        )),
+        Ok(contents) => {
+            let value: Value = serde_json::from_str(&contents).map_err(|e| {
+                format!(
+                    "Refusing to overwrite {}: the existing settings file is not valid JSON ({e})",
+                    path.display()
+                )
+            })?;
+            match value {
+                Value::Object(map) => {
+                    validate_non_project_settings(&map)?;
+                    Ok(Some(map))
+                }
+                _ => Err(format!(
+                    "Refusing to overwrite {}: the existing settings root is not a JSON object",
+                    path.display()
+                )),
+            }
+        }
+    }
+}
+
+/// Confirm the non-project part of a disk object still deserializes as
+/// `AppSettings` (after neutralizing the six project fields), so a present file
+/// with corrupt non-project settings is never silently overwritten.
+fn validate_non_project_settings(disk: &Map<String, Value>) -> Result<(), String> {
+    let mut probe = Value::Object(disk.clone());
+    if let Some(root) = probe.as_object_mut() {
+        root.insert(FIELD_PROJECT_PATH.to_string(), Value::Null);
+        root.insert(FIELD_PROJECT_PATHS.to_string(), Value::Array(Vec::new()));
+        root.insert(FIELD_ARCHIVED.to_string(), Value::Array(Vec::new()));
+        root.remove(FIELD_PROJECT_PATH_REL);
+        root.remove(FIELD_PROJECT_PATHS_REL);
+        root.remove(FIELD_ARCHIVED_REL);
+    }
+    migrate_settings_value_to_v2(&mut probe);
+    serde_json::from_value::<AppSettings>(probe).map(|_| ()).map_err(|e| {
+        format!("Refusing to overwrite present settings whose non-project fields are invalid: {e}")
+    })
+}
+
+/// The #1077 project-aware atomic writer. Builds the output object per `mode`,
+/// writes it atomically, then re-decodes the exact written value so the returned
+/// `AppSettings` carries fresh runtime projections + hidden state (never the
+/// possibly-stale caller state). See §4.2/§4.3.
+fn save_settings_value(
+    settings: &AppSettings,
+    path: &Path,
+    mode: ProjectWriteMode,
+) -> Result<AppSettings, String> {
+    let base = production_instance_base();
+    let disk = read_disk_object_for_write(path)?;
+    let state = hidden_state_for_write(settings);
+
+    let serialize_object = || -> Result<Map<String, Value>, String> {
+        match serde_json::to_value(settings)
+            .map_err(|e| format!("Failed to serialize settings: {e}"))?
+        {
+            Value::Object(m) => Ok(m),
+            _ => Err("settings did not serialize to a JSON object".to_string()),
+        }
+    };
+
+    // Base object: Preserve starts from the incoming settings (non-project edits
+    // apply); Reconcile is project-only and starts from the fresh disk object
+    // (or the live settings when the file is absent).
+    let mut out: Map<String, Value> = match mode {
+        ProjectWriteMode::Preserve => serialize_object()?,
+        ProjectWriteMode::Reconcile { .. } => match &disk {
+            Some(m) => m.clone(),
+            None => serialize_object()?,
+        },
+    };
+
+    match mode {
+        ProjectWriteMode::Preserve => match &disk {
+            None => {
+                write_active_group(&mut out, &state, base.as_deref());
+                write_archived_group(&mut out, &state, base.as_deref());
+            }
+            Some(disk) => {
+                if active_has_disk_truth(disk) {
+                    copy_or_remove(&mut out, disk, FIELD_PROJECT_PATH);
+                    copy_or_remove(&mut out, disk, FIELD_PROJECT_PATH_REL);
+                    copy_or_remove(&mut out, disk, FIELD_PROJECT_PATHS);
+                    copy_or_remove(&mut out, disk, FIELD_PROJECT_PATHS_REL);
+                } else {
+                    write_active_group(&mut out, &state, base.as_deref());
+                }
+                if archived_has_disk_truth(disk) {
+                    copy_or_remove(&mut out, disk, FIELD_ARCHIVED);
+                    copy_or_remove(&mut out, disk, FIELD_ARCHIVED_REL);
+                } else {
+                    write_archived_group(&mut out, &state, base.as_deref());
+                }
+            }
+        },
+        ProjectWriteMode::Reconcile { active, archived } => {
+            let blocked = state.has_structural();
+            // A synthesized (runtime-authoritative) state writes its runtime
+            // groups verbatim, matching the pre-#1077 verbatim writer. A real
+            // decoded state rebuilds only a dirty+eligible group and otherwise
+            // copies disk raw to retain unresolved entries.
+            let write_active_from_state =
+                active && !blocked && (state.runtime_authoritative || state.active_reconcile_eligible);
+            let write_archived_from_state = archived
+                && !blocked
+                && (state.runtime_authoritative || state.archived_reconcile_eligible);
+            // Active group.
+            if write_active_from_state {
+                write_active_group(&mut out, &state, base.as_deref());
+            } else if let Some(disk) = &disk {
+                copy_or_remove(&mut out, disk, FIELD_PROJECT_PATH);
+                copy_or_remove(&mut out, disk, FIELD_PROJECT_PATH_REL);
+                copy_or_remove(&mut out, disk, FIELD_PROJECT_PATHS);
+                copy_or_remove(&mut out, disk, FIELD_PROJECT_PATHS_REL);
+            } else {
+                write_active_group(&mut out, &state, base.as_deref());
+            }
+            // Archived group.
+            if write_archived_from_state {
+                write_archived_group(&mut out, &state, base.as_deref());
+            } else if let Some(disk) = &disk {
+                copy_or_remove(&mut out, disk, FIELD_ARCHIVED);
+                copy_or_remove(&mut out, disk, FIELD_ARCHIVED_REL);
+            } else {
+                write_archived_group(&mut out, &state, base.as_deref());
+            }
+        }
+    }
+
+    // A synthesized legacy state (direct-constructed AppSettings) has no dirty
+    // repair, so the eligible branches above never fire for it; its groups are
+    // written verbatim from the live settings/disk, matching pre-#1077 behavior.
+    let value = Value::Object(out);
+    write_value_atomic(&value, path)?;
+
+    let mut written_value = value;
+    let fresh_state = apply_project_decode_to_value(
+        &mut written_value,
+        base.as_deref(),
+        &projects::FsCandidateResolver,
+    );
+    let mut written: AppSettings = serde_json::from_value(written_value)
+        .map_err(|e| format!("Failed to re-decode written settings: {e}"))?;
+    written.project_path_state = Arc::new(fresh_state);
+    Ok(written)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DiskProjectLists {
     pub project_paths: Vec<String>,
@@ -2125,6 +2765,39 @@ pub fn save_settings(settings: &AppSettings) -> Result<AppSettings, String> {
     save_settings_to_path_preserving_project_paths(settings, &path)
 }
 
+/// #1077: atomic tmp+rename writer over an already-built JSON `Value`. Shared by
+/// the raw and the project-aware writers. Preserves the #774 unique-temp +
+/// `rename_with_retry` behavior; still not fsynced.
+fn write_value_atomic(value: &Value, path: &Path) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| format!("Settings path {} has no parent", path.display()))?;
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("Failed to create settings directory: {}", e))?;
+
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| format!("Failed to serialize settings: {}", e))?;
+
+    let op_id = SAVE_OP_ID.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let tmp_path = dir.join(format!("settings.json.{}.{}.tmp", pid, op_id));
+
+    if let Err(e) = std::fs::write(&tmp_path, &json) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Failed to write temp settings file: {}", e));
+    }
+
+    if let Err((err_msg, _diag)) =
+        crate::config::sessions_persistence::rename_with_retry(&tmp_path, path)
+    {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!("Failed to rename settings file: {}", err_msg));
+    }
+
+    log::debug!("Saved settings to {:?}", path);
+    Ok(())
+}
+
 /// #778/#881: EXPLICIT writer. Persists `project_paths`/`project_path` and
 /// `archived_project_paths` VERBATIM (the
 /// pre-#778 `save_settings` behavior, still #774-hardened). ONLY for deliberate
@@ -2142,75 +2815,40 @@ pub(crate) fn save_settings_with_project_paths_to_path(
     settings: &AppSettings,
     path: &Path,
 ) -> Result<(), String> {
-    save_settings_to_path(settings, path)
+    // #1077: deliberate list mutators reconcile both groups from the hidden
+    // state (retaining unresolved/conflict entries value-for-value), so the
+    // now-filtered runtime lists cannot drop an unresolved project.
+    save_settings_value(
+        settings,
+        path,
+        ProjectWriteMode::Reconcile {
+            active: true,
+            archived: true,
+        },
+    )
+    .map(|_| ())
 }
 
-/// #778/#881: the preserve-disk wrapper behind the default `save_settings`.
-/// Reads the current on-disk project lists (G2 abort policy), substitutes
-/// them into a clone of `settings`, then hands off to the verbatim
-/// #774-hardened writer. Split out with an explicit `path` so tests can drive it
-/// against a `tempfile::tempdir()`.
+/// #778/#881 + #1077: the preserve-disk wrapper behind the default
+/// `save_settings`. Preserves all six on-disk project fields (materializing a
+/// group only when disk has no truth), then hands off to the #774-hardened
+/// atomic writer and returns the fresh-decoded settings.
 pub(crate) fn save_settings_to_path_preserving_project_paths(
     settings: &AppSettings,
     path: &Path,
 ) -> Result<AppSettings, String> {
-    let mut to_write = settings.clone();
-    if let Some(lists) = read_project_paths_from_disk(path)? {
-        to_write.project_paths = lists.project_paths;
-        to_write.project_path = lists.project_path;
-        if let Some(archived) = lists.archived_project_paths {
-            to_write.archived_project_paths = archived;
-        }
-    }
-    save_settings_to_path(&to_write, path)?;
-    Ok(to_write)
+    save_settings_value(settings, path, ProjectWriteMode::Preserve)
 }
 
+/// Raw writer: serialize `AppSettings` verbatim (three primary project fields;
+/// the companion fields are `#[serde(skip)]`, yielding a legacy-shaped file).
+/// Used only for test seeding; production writes go through the preserve/
+/// reconcile modes so companions are materialized.
+#[cfg(test)]
 fn save_settings_to_path(settings: &AppSettings, path: &Path) -> Result<(), String> {
-    let dir = path
-        .parent()
-        .ok_or_else(|| format!("Settings path {} has no parent", path.display()))?;
-    // Ensure directory exists
-    std::fs::create_dir_all(dir)
-        .map_err(|e| format!("Failed to create settings directory: {}", e))?;
-
-    let json = serde_json::to_string_pretty(settings)
+    let value = serde_json::to_value(settings)
         .map_err(|e| format!("Failed to serialize settings: {}", e))?;
-
-    // #774 (A): unique temp filename per save. Combined with rename_with_retry
-    // below, this kills the shared-`settings.json.tmp` race: two cross-process
-    // writers (GUI startup, CLI verbs, closing flush) can never collide on the
-    // temp file, and any leftover `.tmp` from a prior crashed run cannot be
-    // mistaken for ours. Mirrors sessions_persistence.rs:763-765.
-    let op_id = SAVE_OP_ID.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let tmp_path = dir.join(format!("settings.json.{}.{}.tmp", pid, op_id));
-
-    if let Err(e) = std::fs::write(&tmp_path, &json) {
-        // Best-effort cleanup: the partial write may have created the file even
-        // though write returned Err (e.g. ENOSPC mid-stream).
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(format!("Failed to write temp settings file: {}", e));
-    }
-
-    // #774 (B): route the rename through the reviewed retry helper. It absorbs
-    // transient cross-process contention on the DESTINATION (a second AC
-    // instance, AV, or the Indexer briefly holding settings.json; os errors
-    // 5/32/33/1175). With the unique temp above, our source can never be
-    // consumed by another writer, so os error 2 (source absent) is no longer a
-    // concurrency symptom; if it still surfaces it is propagated (with the OS
-    // error in the message) after the bounded retry, not masked.
-    if let Err((err_msg, _diag)) =
-        crate::config::sessions_persistence::rename_with_retry(&tmp_path, path)
-    {
-        // Best-effort cleanup of our unique temp so failed saves don't litter
-        // the config dir. The unique name guarantees this removes only OUR temp.
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(format!("Failed to rename settings file: {}", err_msg));
-    }
-
-    log::debug!("Saved settings to {:?}", path);
-    Ok(())
+    write_value_atomic(&value, path)
 }
 
 pub type SettingsState = Arc<RwLock<AppSettings>>;
@@ -3693,6 +4331,17 @@ mod tests {
         }
     }
 
+    /// #1077: create a real AC project dir (`<parent>/<name>/.ac`) and return its
+    /// display-canonical path, so the six-field decoder validates it and the
+    /// SELECTED runtime path equals the stored string. Used by preserve/reconcile
+    /// tests that assert the returned settings mirror the preserved disk list.
+    fn real_ac_project_path(parent: &std::path::Path, name: &str) -> String {
+        let dir = parent.join(name);
+        std::fs::create_dir_all(dir.join(".ac")).unwrap();
+        let canon = std::fs::canonicalize(&dir).unwrap();
+        crate::config::projects::display_canonical(&canon.to_string_lossy())
+    }
+
     #[test]
     fn read_project_paths_from_disk_returns_list_and_head() {
         let temp = tempfile::tempdir().unwrap();
@@ -3879,25 +4528,31 @@ mod tests {
         // Marquee preserve: disk has [A, X] (X = an append this in-memory candidate
         // never saw); a whole-object save that changed only an unrelated field must
         // leave project_paths = [A, X] on disk (fail-safe) AND persist the field.
+        // #1077: real AC dirs so the selected runtime paths equal the preserved list.
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
-        super::save_settings_to_path(&settings_with_project_paths(&["A", "X"]), &path).unwrap();
+        let a = real_ac_project_path(temp.path(), "A");
+        let x = real_ac_project_path(temp.path(), "X");
+        super::save_settings_to_path(
+            &settings_with_project_paths(&[&a, &x]),
+            &path,
+        )
+        .unwrap();
 
-        let mut candidate = settings_with_project_paths(&["A"]); // stale, missing X
+        let mut candidate = settings_with_project_paths(&[&a]); // stale, missing X
         candidate.sidebar_style = "deep-space".to_string(); // unrelated GUI field
         let written =
             super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
 
         let contents = std::fs::read_to_string(&path).unwrap();
         let reloaded: AppSettings = serde_json::from_str(&contents).unwrap();
-        assert_eq!(
-            reloaded.project_paths,
-            vec!["A".to_string(), "X".to_string()]
-        ); // X preserved, not clobbered
-        assert_eq!(reloaded.project_path.as_deref(), Some("A"));
+        assert_eq!(reloaded.project_paths, vec![a.clone(), x.clone()]); // X preserved, not clobbered
+        assert_eq!(reloaded.project_path.as_deref(), Some(a.as_str()));
         assert_eq!(reloaded.sidebar_style, "deep-space"); // unrelated field persisted
-        assert_eq!(written.project_paths, reloaded.project_paths);
-        assert_eq!(written.project_path, reloaded.project_path);
+        // #1077: the returned settings carry the SELECTED (validated) projection,
+        // which equals the preserved disk list because both dirs are real.
+        assert_eq!(written.project_paths, vec![a.clone(), x.clone()]);
+        assert_eq!(written.project_path.as_deref(), Some(a.as_str()));
     }
 
     #[test]
@@ -3939,45 +4594,47 @@ mod tests {
     fn save_settings_preserves_disk_archived_list() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
+        let a = real_ac_project_path(temp.path(), "A");
+        let archived_a = real_ac_project_path(temp.path(), "ArchivedA");
         super::save_settings_to_path(
-            &settings_with_project_and_archived_paths(&["A"], &["ArchivedA"]),
+            &settings_with_project_and_archived_paths(&[&a], &[&archived_a]),
             &path,
         )
         .unwrap();
-        let candidate = settings_with_project_and_archived_paths(&["A"], &["ArchivedB"]);
+        let candidate = settings_with_project_and_archived_paths(&[&a], &["ArchivedB"]);
 
         let written =
             super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
 
         let reloaded: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(
-            reloaded.archived_project_paths,
-            vec!["ArchivedA".to_string()]
-        );
-        assert_eq!(
-            written.archived_project_paths,
-            reloaded.archived_project_paths
-        );
+        assert_eq!(reloaded.archived_project_paths, vec![archived_a.clone()]);
+        assert_eq!(written.archived_project_paths, vec![archived_a.clone()]);
     }
 
     #[test]
     fn save_settings_returns_caller_archived_list_when_disk_key_absent() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("settings.json");
-        std::fs::write(&path, r#"{"projectPaths":["A"],"projectPath":"A"}"#).unwrap();
-        let caller_archived = vec!["Archived".to_string()];
-        let candidate = settings_with_project_and_archived_paths(&["stale"], &["Archived"]);
+        let a = real_ac_project_path(temp.path(), "A");
+        let archived = real_ac_project_path(temp.path(), "Archived");
+        // Seed a whole, valid AppSettings object but with NO archivedProjectPaths
+        // key (the preserve writer's disk gate requires a valid whole object).
+        let mut seed = serde_json::to_value(settings_with_project_paths(&[&a])).unwrap();
+        seed.as_object_mut().unwrap().remove("archivedProjectPaths");
+        std::fs::write(&path, serde_json::to_string_pretty(&seed).unwrap()).unwrap();
 
+        let candidate = settings_with_project_and_archived_paths(&[&a], &[&archived]);
         let written =
             super::save_settings_to_path_preserving_project_paths(&candidate, &path).unwrap();
 
         let reloaded: AppSettings =
             serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(written.project_paths, vec!["A".to_string()]);
-        assert_eq!(written.project_path.as_deref(), Some("A"));
-        assert_eq!(written.archived_project_paths, caller_archived);
-        assert_eq!(reloaded.archived_project_paths, caller_archived);
+        assert_eq!(written.project_paths, vec![a.clone()]);
+        assert_eq!(written.project_path.as_deref(), Some(a.as_str()));
+        // Disk had no archived key → materialize the caller's live archived list.
+        assert_eq!(written.archived_project_paths, vec![archived.clone()]);
+        assert_eq!(reloaded.archived_project_paths, vec![archived.clone()]);
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2477,6 +2477,19 @@ fn validate_non_project_settings(disk: &Map<String, Value>) -> Result<(), String
     })
 }
 
+/// #1077 automatic reconciliation boundary (§4.3): reconcile the requested
+/// eligible project group(s) from `settings`' hidden state to `path`, returning
+/// the fresh-decoded settings. A structurally-corrupt or no-eligible-repair
+/// state performs no write and returns the settings unchanged.
+pub(crate) fn reconcile_project_state_to_path(
+    settings: &AppSettings,
+    path: &Path,
+    active: bool,
+    archived: bool,
+) -> Result<AppSettings, String> {
+    save_settings_value(settings, path, ProjectWriteMode::Reconcile { active, archived })
+}
+
 /// The #1077 project-aware atomic writer. Builds the output object per `mode`,
 /// writes it atomically, then re-decodes the exact written value so the returned
 /// `AppSettings` carries fresh runtime projections + hidden state (never the

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2256,7 +2256,7 @@ pub(crate) fn apply_project_decode_to_value(
             FIELD_ARCHIVED.to_string(),
             Value::Array(
                 state
-                    .archived_selected()
+                    .archived_management_paths()
                     .into_iter()
                     .map(Value::String)
                     .collect(),
@@ -2488,22 +2488,17 @@ pub(crate) fn resync_project_state_from_runtime(settings: &mut AppSettings) {
         .cloned()
         .collect();
 
-    let mut active: Vec<ResolvedPair> = settings
-        .project_paths
-        .iter()
-        .enumerate()
-        .map(|(i, p)| resynced_selected_pair(ProjectSource::ProjectPaths, i, p))
-        .collect();
-    active.extend(retained_active);
+    let active = reconcile_group_with_retained(
+        &settings.project_paths,
+        ProjectSource::ProjectPaths,
+        retained_active,
+    );
     let active_registration_count = active.len();
-
-    let mut archived: Vec<ResolvedPair> = settings
-        .archived_project_paths
-        .iter()
-        .enumerate()
-        .map(|(i, p)| resynced_selected_pair(ProjectSource::ArchivedProjectPaths, i, p))
-        .collect();
-    archived.extend(retained_archived);
+    let archived = reconcile_group_with_retained(
+        &settings.archived_project_paths,
+        ProjectSource::ArchivedProjectPaths,
+        retained_archived,
+    );
     let archived_registration_count = archived.len();
 
     let mut pairs = active;
@@ -2522,6 +2517,45 @@ pub(crate) fn resync_project_state_from_runtime(settings: &mut AppSettings) {
         structural_issues: old.structural_issues.clone(),
         runtime_authoritative: true,
     });
+}
+
+/// Rebuild one group's pairs from the mutated `runtime` list while reconciling
+/// the pre-mutation `retained` unresolved (missing/conflict/invalid) records:
+///
+/// - a runtime entry that matches a retained record by normalized key reuses
+///   that record IN PLACE (preserving its raw values, companion, and issue), so
+///   a preserved conflict/missing record is never rebuilt as "selected" nor
+///   duplicated;
+/// - a runtime entry with no retained match becomes a fresh selected pair;
+/// - a retained record whose key is absent from the runtime list was removed by
+///   the mutation and is dropped (so "Remove from list" actually removes it).
+fn reconcile_group_with_retained(
+    runtime: &[String],
+    source: ProjectSource,
+    mut retained: Vec<ResolvedPair>,
+) -> Vec<ResolvedPair> {
+    let mut out = Vec::with_capacity(runtime.len());
+    for (i, path) in runtime.iter().enumerate() {
+        let key = projects::normalize_for_compare(path);
+        let matched = retained.iter().position(|r| {
+            r.raw_absolute
+                .value
+                .as_deref()
+                .map(projects::normalize_for_compare)
+                == Some(key.clone())
+        });
+        match matched {
+            Some(pos) => {
+                let mut pair = retained.remove(pos);
+                pair.source = source;
+                pair.index = Some(i);
+                out.push(pair);
+            }
+            None => out.push(resynced_selected_pair(source, i, path)),
+        }
+    }
+    // Any retained record not matched by the runtime list was removed; drop it.
+    out
 }
 
 /// Fresh-read the whole disk object for a project-preserving/reconciling write.
@@ -2853,6 +2887,26 @@ pub(crate) fn refresh_project_paths_from_path(
         if let Some(archived) = lists.archived_project_paths {
             settings.archived_project_paths = archived;
         }
+    }
+    Ok(())
+}
+
+/// #1077 §4.3 step 2: fresh-read and fully re-decode the six disk fields (so a
+/// post-startup CLI write is authoritative), replacing the runtime lists with the
+/// SELECTED canonical paths and installing the fresh hidden pair state. Aborts
+/// (`Err`) on a present-but-invalid whole object; keeps the live runtime/hidden
+/// state when the file is absent.
+pub(crate) fn refresh_and_decode_project_paths_from_path(
+    settings: &mut AppSettings,
+    path: &Path,
+) -> Result<(), String> {
+    if let Some(map) = read_disk_object_for_write(path)? {
+        let base = production_instance_base();
+        let state = decode_project_state(&map, base.as_deref(), &projects::FsCandidateResolver);
+        settings.project_paths = state.active_selected();
+        settings.project_path = state.selected_head.clone();
+        settings.archived_project_paths = state.archived_management_paths();
+        settings.project_path_state = Arc::new(state);
     }
     Ok(())
 }
@@ -4794,6 +4848,101 @@ mod tests {
             lists.archived_project_paths,
             Some(vec!["Archived".to_string()])
         );
+    }
+
+    #[test]
+    fn resync_reconciles_missing_and_conflict_without_duplication() {
+        // Grinch Defect 1: a decoded state carrying a MISSING and a CONFLICT
+        // record, mutated across register/remove, must never duplicate/resurrect
+        // those records, and remove must actually remove.
+        use crate::config::projects::{
+            IssueKind, ProjectPathPersistenceState, ProjectSource, RawStringField, RepairKind,
+            ResolvedPair,
+        };
+        let pair = |idx: usize, raw: &str, selected: Option<&str>, issue: Option<IssueKind>| {
+            ResolvedPair {
+                source: ProjectSource::ProjectPaths,
+                index: Some(idx),
+                raw_absolute: RawStringField::string(raw),
+                raw_relative: RawStringField::absent(),
+                absolute_side: super::absent_side(),
+                relative_side: super::absent_side(),
+                selected: selected.map(String::from),
+                selected_canonical_raw: selected.map(String::from),
+                selected_identity: None,
+                issue,
+                repair: RepairKind::None,
+            }
+        };
+        let state = ProjectPathPersistenceState {
+            pairs: vec![
+                pair(0, "A", Some("A"), None),
+                pair(1, "M", None, Some(IssueKind::Missing)),
+                pair(2, "C", None, Some(IssueKind::Conflict)),
+            ],
+            selected_head: Some("A".to_string()),
+            active_registration_count: 3,
+            archived_registration_count: 0,
+            active_companion_present: true,
+            archived_companion_present: false,
+            has_genuine_singular: false,
+            active_reconcile_eligible: false,
+            archived_reconcile_eligible: false,
+            structural_issues: Vec::new(),
+            runtime_authoritative: false,
+        };
+        let mut s = AppSettings {
+            project_path_state: std::sync::Arc::new(state),
+            ..AppSettings::default()
+        };
+        // Raw runtime (3-field refresh) carries all three stored absolutes.
+        s.project_paths = vec!["A".to_string(), "M".to_string(), "C".to_string()];
+
+        // Register D.
+        s.project_paths.push("D".to_string());
+        super::resync_project_state_from_runtime(&mut s);
+        {
+            let st = &s.project_path_state;
+            assert_eq!(
+                st.active_registration_count, 4,
+                "no duplication on register"
+            );
+            let keys: Vec<String> = st
+                .active_pairs()
+                .iter()
+                .map(|p| p.raw_absolute.value.clone().unwrap())
+                .collect();
+            assert_eq!(
+                keys,
+                vec!["A", "M", "C", "D"],
+                "order preserved, no duplicates"
+            );
+            assert_eq!(st.active_pairs()[1].issue, Some(IssueKind::Missing));
+            assert_eq!(st.active_pairs()[2].issue, Some(IssueKind::Conflict));
+            assert!(st.active_pairs()[3].issue.is_none());
+        }
+
+        // Remove M ("Remove from list" on the missing entry).
+        s.project_paths = vec!["A".to_string(), "C".to_string(), "D".to_string()];
+        super::resync_project_state_from_runtime(&mut s);
+        {
+            let st = &s.project_path_state;
+            assert_eq!(
+                st.active_registration_count, 3,
+                "the missing record must actually be removed, not resurrected"
+            );
+            let keys: Vec<String> = st
+                .active_pairs()
+                .iter()
+                .map(|p| p.raw_absolute.value.clone().unwrap())
+                .collect();
+            assert_eq!(keys, vec!["A", "C", "D"]);
+            assert_eq!(
+                st.active_pairs()[1].issue,
+                Some(IssueKind::Conflict),
+                "unrelated conflict preserved through the removal"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -414,6 +414,14 @@ pub struct AppSettings {
     /// preserves the on-disk copy and only dedicated list commands mutate it.
     #[serde(default)]
     pub archived_project_paths: Vec<String>,
+    /// #1077 - hidden persistence state for the portable dual project paths. Holds
+    /// the resolved raw/selected pairs, their instance-relative companions,
+    /// outcomes, and reconcile-eligibility bits so the codec can rebuild the six
+    /// disk fields without re-reading disk. Never serialized directly (the codec
+    /// owns the six on-disk fields); behind an `Arc` so the ubiquitous
+    /// `AppSettings::clone()` stays cheap and copy-on-write mutation is explicit.
+    #[serde(skip, default)]
+    pub(crate) project_path_state: Arc<crate::config::projects::ProjectPathPersistenceState>,
     /// Sidebar visual style: "noir-minimal", "card-sections", "command-center", "deep-space", "arctic-ops", "obsidian-mesh", "neon-circuit"
     #[serde(default = "default_sidebar_style")]
     pub sidebar_style: String,
@@ -722,6 +730,7 @@ impl Default for AppSettings {
             project_path: None,
             project_paths: vec![],
             archived_project_paths: vec![],
+            project_path_state: Arc::default(),
             sidebar_style: default_sidebar_style(),
             root_token: None,
             onboarding_dismissed: false,

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2426,6 +2426,86 @@ fn synthesize_legacy_state(settings: &AppSettings) -> ProjectPathPersistenceStat
     }
 }
 
+/// A selected pair for a runtime path, canonicalizing so the reconcile write can
+/// encode a real instance-relative companion (a non-existent path yields a null
+/// companion).
+fn resynced_selected_pair(source: ProjectSource, index: usize, path: &str) -> ResolvedPair {
+    let canonical_raw = std::fs::canonicalize(path)
+        .ok()
+        .and_then(|c| c.to_str().map(str::to_string));
+    ResolvedPair {
+        source,
+        index: Some(index),
+        raw_absolute: RawStringField::string(path),
+        raw_relative: RawStringField::absent(),
+        absolute_side: absent_side(),
+        relative_side: absent_side(),
+        selected: Some(path.to_string()),
+        selected_canonical_raw: canonical_raw,
+        selected_identity: None,
+        issue: None,
+        repair: RepairKind::PopulateCompanion,
+    }
+}
+
+/// #1077: after an explicit project mutation updated the three runtime lists,
+/// rebuild the hidden state to match while retaining any unresolved
+/// (conflict/missing/invalid) pairs from the pre-mutation state value-for-value,
+/// so a register/remove/archive/unarchive never drops a preserved conflict or
+/// missing record. The result is runtime-authoritative: a Reconcile write emits
+/// the runtime selection plus the retained raw records. Callers must reject a
+/// structurally-corrupt or conflict-scoped mutation BEFORE calling this.
+pub(crate) fn resync_project_state_from_runtime(settings: &mut AppSettings) {
+    let old = settings.project_path_state.clone();
+    let retained_active: Vec<ResolvedPair> = old
+        .active_pairs()
+        .iter()
+        .filter(|p| p.issue.is_some())
+        .cloned()
+        .collect();
+    let retained_archived: Vec<ResolvedPair> = old
+        .archived_pairs()
+        .iter()
+        .filter(|p| p.issue.is_some())
+        .cloned()
+        .collect();
+
+    let mut active: Vec<ResolvedPair> = settings
+        .project_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| resynced_selected_pair(ProjectSource::ProjectPaths, i, p))
+        .collect();
+    active.extend(retained_active);
+    let active_registration_count = active.len();
+
+    let mut archived: Vec<ResolvedPair> = settings
+        .archived_project_paths
+        .iter()
+        .enumerate()
+        .map(|(i, p)| resynced_selected_pair(ProjectSource::ArchivedProjectPaths, i, p))
+        .collect();
+    archived.extend(retained_archived);
+    let archived_registration_count = archived.len();
+
+    let mut pairs = active;
+    pairs.extend(archived);
+
+    settings.project_path_state = Arc::new(ProjectPathPersistenceState {
+        pairs,
+        selected_head: settings.project_paths.first().cloned(),
+        active_registration_count,
+        archived_registration_count,
+        active_companion_present: old.active_companion_present,
+        archived_companion_present: old.archived_companion_present,
+        has_genuine_singular: false,
+        active_reconcile_eligible: false,
+        archived_reconcile_eligible: false,
+        structural_issues: old.structural_issues.clone(),
+        runtime_authoritative: true,
+    });
+}
+
 /// Fresh-read the whole disk object for a project-preserving/reconciling write.
 /// `None` = absent (materialize). `Err` = present-but-unreadable/invalid JSON,
 /// non-object root, or non-project settings that fail to deserialize — in which
@@ -2748,6 +2828,12 @@ pub(crate) fn refresh_project_paths_from_path(
         }
     }
     Ok(())
+}
+
+/// Whether the current hidden project state carries structural corruption, which
+/// must block any explicit project-list mutation (§4.2).
+pub(crate) fn project_state_has_structural(settings: &AppSettings) -> bool {
+    settings.project_path_state.has_structural()
 }
 
 /// Save settings to the app config directory (see config_dir()).
@@ -4677,6 +4763,37 @@ mod tests {
             lists.archived_project_paths,
             Some(vec!["Archived".to_string()])
         );
+    }
+
+    #[test]
+    fn resync_persists_mutation_against_decoded_state() {
+        // Regression: a mutator that changes only the runtime lists against a
+        // DECODED (non-synthesized) hidden state must resync so the reconcile
+        // write records the new project instead of copying the stale disk list.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        let a = real_ac_project_path(temp.path(), "A");
+        let b = real_ac_project_path(temp.path(), "B");
+        super::save_settings_to_path(&settings_with_project_paths(&[&a]), &path).unwrap();
+
+        // A decoded hidden state as the loader produces (runtime_authoritative=false).
+        let value = serde_json::json!({ "projectPaths": [a.clone()], "projectPath": a.clone() });
+        let state = super::decode_project_state(
+            value.as_object().unwrap(),
+            None,
+            &crate::config::projects::FsCandidateResolver,
+        );
+        assert!(!state.runtime_authoritative);
+        let mut settings = settings_with_project_paths(&[&a]);
+        settings.project_path_state = std::sync::Arc::new(state);
+
+        // Register B into the runtime list, then resync + reconcile-write.
+        settings.project_paths.push(b.clone());
+        super::resync_project_state_from_runtime(&mut settings);
+        super::save_settings_with_project_paths_to_path(&settings, &path).unwrap();
+
+        let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
+        assert_eq!(lists.project_paths, vec![a, b]);
     }
 
     #[test]

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -865,11 +865,8 @@ fn parse_settings_json(contents: &str, source: &str) -> Result<(AppSettings, boo
     // AppSettings, so a wrong-typed project field cannot fail unrelated settings
     // deserialization and unresolved/conflicting pairs survive in hidden state.
     let base = production_instance_base();
-    let state = apply_project_decode_to_value(
-        &mut value,
-        base.as_deref(),
-        &projects::FsCandidateResolver,
-    );
+    let state =
+        apply_project_decode_to_value(&mut value, base.as_deref(), &projects::FsCandidateResolver);
     let mut settings: AppSettings = serde_json::from_value(value)
         .map_err(|e| format!("Failed to deserialize settings from {source}: {e}"))?;
     settings.project_path_state = Arc::new(state);
@@ -1380,10 +1377,7 @@ pub fn validate_and_repair_settings(settings: &mut AppSettings) -> Result<(), St
     validate_resource_settings(settings)
 }
 
-pub(crate) fn parse_api_server_socket_addr(
-    bind: &str,
-    port: u16,
-) -> Result<SocketAddr, String> {
+pub(crate) fn parse_api_server_socket_addr(bind: &str, port: u16) -> Result<SocketAddr, String> {
     let bind = bind.trim();
     if bind.is_empty() {
         return Err("apiServerBind must not be empty".to_string());
@@ -1392,9 +1386,7 @@ pub(crate) fn parse_api_server_socket_addr(
         return Err("apiServerPort must be between 1 and 65535".to_string());
     }
     let ip: IpAddr = bind.parse().map_err(|e| {
-        format!(
-            "apiServerBind must be an IP address such as 127.0.0.1, 0.0.0.0, ::1, or :: ({e})"
-        )
+        format!("apiServerBind must be an IP address such as 127.0.0.1, 0.0.0.0, ::1, or :: ({e})")
     })?;
     Ok(SocketAddr::new(ip, port))
 }
@@ -2127,7 +2119,12 @@ fn extract_singular(root: &Map<String, Value>) -> (Option<RawPair>, Option<Struc
         None => RawStringField::absent(),
         Some(Value::Null) => RawStringField::null(),
         Some(Value::String(s)) => RawStringField::string(s.clone()),
-        Some(_) => return (None, Some(structural("projectPath is not a string or null"))),
+        Some(_) => {
+            return (
+                None,
+                Some(structural("projectPath is not a string or null")),
+            )
+        }
     };
     let companion_field = match companion {
         None => RawStringField::absent(),
@@ -2145,19 +2142,24 @@ fn extract_singular(root: &Map<String, Value>) -> (Option<RawPair>, Option<Struc
     if companion.is_some() && primary.is_none() {
         return (
             None,
-            Some(structural("singular companion present while projectPath is absent")),
+            Some(structural(
+                "singular companion present while projectPath is absent",
+            )),
         );
     }
     if matches!(companion, Some(Value::String(_))) && matches!(primary, Some(Value::Null)) {
         return (
             None,
-            Some(structural("non-null singular companion paired with null projectPath")),
+            Some(structural(
+                "non-null singular companion paired with null projectPath",
+            )),
         );
     }
 
     // A pair exists only when the primary is an actual string candidate; a
     // null/absent primary is the valid empty singular.
-    let pair = primary_field.value.is_some().then(|| RawPair {
+    let has_primary = primary_field.value.is_some();
+    let pair = has_primary.then_some(RawPair {
         source: ProjectSource::ProjectPath,
         index: None,
         absolute: primary_field,
@@ -2242,7 +2244,13 @@ pub(crate) fn apply_project_decode_to_value(
         );
         root.insert(
             FIELD_PROJECT_PATHS.to_string(),
-            Value::Array(state.active_selected().into_iter().map(Value::String).collect()),
+            Value::Array(
+                state
+                    .active_selected()
+                    .into_iter()
+                    .map(Value::String)
+                    .collect(),
+            ),
         );
         root.insert(
             FIELD_ARCHIVED.to_string(),
@@ -2315,7 +2323,11 @@ fn rebuild_group_arrays(pairs: &[ResolvedPair], base: Option<&Path>) -> (Vec<Val
 }
 
 /// Insert the four active fields from hidden state.
-fn write_active_group(out: &mut Map<String, Value>, state: &ProjectPathPersistenceState, base: Option<&Path>) {
+fn write_active_group(
+    out: &mut Map<String, Value>,
+    state: &ProjectPathPersistenceState,
+    base: Option<&Path>,
+) {
     let (primary, companion) = rebuild_group_arrays(state.active_pairs(), base);
     out.insert(
         FIELD_PROJECT_PATH.to_string(),
@@ -2330,7 +2342,11 @@ fn write_active_group(out: &mut Map<String, Value>, state: &ProjectPathPersisten
 }
 
 /// Insert the two archived fields from hidden state.
-fn write_archived_group(out: &mut Map<String, Value>, state: &ProjectPathPersistenceState, base: Option<&Path>) {
+fn write_archived_group(
+    out: &mut Map<String, Value>,
+    state: &ProjectPathPersistenceState,
+    base: Option<&Path>,
+) {
     let (primary, companion) = rebuild_group_arrays(state.archived_pairs(), base);
     out.insert(FIELD_ARCHIVED.to_string(), Value::Array(primary));
     out.insert(FIELD_ARCHIVED_REL.to_string(), Value::Array(companion));
@@ -2367,7 +2383,9 @@ fn archived_has_disk_truth(disk: &Map<String, Value>) -> bool {
 /// If `AppSettings` was constructed directly (empty hidden state) yet carries
 /// runtime project lists, synthesize a legacy absolute-only state so the writers
 /// behave like a legacy-decoded file (companions null, all entries selected).
-fn hidden_state_for_write(settings: &AppSettings) -> std::borrow::Cow<'_, ProjectPathPersistenceState> {
+fn hidden_state_for_write(
+    settings: &AppSettings,
+) -> std::borrow::Cow<'_, ProjectPathPersistenceState> {
     let state = &settings.project_path_state;
     let empty = state.pairs.is_empty() && state.structural_issues.is_empty();
     let runtime_nonempty = settings.project_path.is_some()
@@ -2552,9 +2570,13 @@ fn validate_non_project_settings(disk: &Map<String, Value>) -> Result<(), String
         root.remove(FIELD_ARCHIVED_REL);
     }
     migrate_settings_value_to_v2(&mut probe);
-    serde_json::from_value::<AppSettings>(probe).map(|_| ()).map_err(|e| {
-        format!("Refusing to overwrite present settings whose non-project fields are invalid: {e}")
-    })
+    serde_json::from_value::<AppSettings>(probe)
+        .map(|_| ())
+        .map_err(|e| {
+            format!(
+                "Refusing to overwrite present settings whose non-project fields are invalid: {e}"
+            )
+        })
 }
 
 /// #1077 automatic reconciliation boundary (§4.3): reconcile the requested
@@ -2567,7 +2589,11 @@ pub(crate) fn reconcile_project_state_to_path(
     active: bool,
     archived: bool,
 ) -> Result<AppSettings, String> {
-    save_settings_value(settings, path, ProjectWriteMode::Reconcile { active, archived })
+    save_settings_value(
+        settings,
+        path,
+        ProjectWriteMode::Reconcile { active, archived },
+    )
 }
 
 /// The #1077 project-aware atomic writer. Builds the output object per `mode`,
@@ -2632,8 +2658,9 @@ fn save_settings_value(
             // groups verbatim, matching the pre-#1077 verbatim writer. A real
             // decoded state rebuilds only a dirty+eligible group and otherwise
             // copies disk raw to retain unresolved entries.
-            let write_active_from_state =
-                active && !blocked && (state.runtime_authoritative || state.active_reconcile_eligible);
+            let write_active_from_state = active
+                && !blocked
+                && (state.runtime_authoritative || state.active_reconcile_eligible);
             let write_archived_from_state = archived
                 && !blocked
                 && (state.runtime_authoritative || state.archived_reconcile_eligible);
@@ -2970,7 +2997,11 @@ mod tests {
 
     #[test]
     fn codex_home_template_accepts_each_token_alone_and_as_leading_segment() {
-        for token in ["%AC_REPLICA_ROOT%", "%AC_WORKSPACE_ROOT%", "%AC_MATRIX_ROOT%"] {
+        for token in [
+            "%AC_REPLICA_ROOT%",
+            "%AC_WORKSPACE_ROOT%",
+            "%AC_MATRIX_ROOT%",
+        ] {
             super::validate_codex_home_template_value(token, "ctx")
                 .unwrap_or_else(|e| panic!("{token} alone should be accepted: {e}"));
             super::validate_codex_home_template_value(&format!("{token}\\.codex"), "ctx")
@@ -3053,21 +3084,21 @@ mod tests {
     #[test]
     fn validate_config_seed_dest_rejects_unsafe_names() {
         let bad = [
-            "",                // empty
-            "   ",             // whitespace only
-            ".config/opencode", // forward separator (nested)
-            ".config\\x",      // backslash separator
-            "..",              // parent
-            "a..b",            // contains ..
-            "C:foo",           // drive-relative colon
-            "x:y",             // ADS colon
+            "",                  // empty
+            "   ",               // whitespace only
+            ".config/opencode",  // forward separator (nested)
+            ".config\\x",        // backslash separator
+            "..",                // parent
+            "a..b",              // contains ..
+            "C:foo",             // drive-relative colon
+            "x:y",               // ADS colon
             "%AC_REPLICA_ROOT%", // placeholder marker
-            "$HOME",           // shell marker
-            ".claude.",        // trailing dot (trim does NOT strip dots)
-            "CON",             // reserved device
-            "nul",             // reserved device (case-insensitive)
-            "COM1",            // reserved device
-            "lpt9.claude",     // reserved device before first dot
+            "$HOME",             // shell marker
+            ".claude.",          // trailing dot (trim does NOT strip dots)
+            "CON",               // reserved device
+            "nul",               // reserved device (case-insensitive)
+            "COM1",              // reserved device
+            "lpt9.claude",       // reserved device before first dot
         ];
         for name in bad {
             assert!(
@@ -3120,7 +3151,10 @@ mod tests {
         assert!(json.contains("\"configSeed\""), "{json}");
         assert!(json.contains("\"dest\":\".claude\""), "{json}");
         let back: AgentConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.config_seed.as_ref().map(|c| c.dest.as_str()), Some(".claude"));
+        assert_eq!(
+            back.config_seed.as_ref().map(|c| c.dest.as_str()),
+            Some(".claude")
+        );
 
         // Absent -> key omitted (skip_serializing_if), and old files deserialize to None.
         agent.config_seed = None;
@@ -4086,7 +4120,9 @@ mod tests {
         // Serialize a default, strip ONLY these coordinator keys, deserialize back.
         let mut value =
             serde_json::to_value(AppSettings::default()).expect("serialize default to value");
-        let obj = value.as_object_mut().expect("settings serializes to an object");
+        let obj = value
+            .as_object_mut()
+            .expect("settings serializes to an object");
         obj.remove("coordinatorIdleBadgeYellowMinutes");
         obj.remove("coordinatorIdleBadgeRedMinutes");
         obj.remove("coordinatorAutoCloseEnabled");
@@ -4161,7 +4197,9 @@ mod tests {
         // to the documented defaults: master ON + empty per-agent map.
         let mut value =
             serde_json::to_value(AppSettings::default()).expect("serialize default to value");
-        let obj = value.as_object_mut().expect("settings serializes to an object");
+        let obj = value
+            .as_object_mut()
+            .expect("settings serializes to an object");
         obj.remove("autoSelfClearEnabled");
         obj.remove("autoSelfClearByAgent");
 
@@ -4183,10 +4221,7 @@ mod tests {
         assert!(json.contains("\"autoSelfClearByAgent\":{\"dev-rust\":true}"));
         let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
         assert!(!back.auto_self_clear_enabled);
-        assert_eq!(
-            back.auto_self_clear_by_agent.get("dev-rust"),
-            Some(&true)
-        );
+        assert_eq!(back.auto_self_clear_by_agent.get("dev-rust"), Some(&true));
     }
 
     #[test]
@@ -4632,11 +4667,7 @@ mod tests {
         let path = temp.path().join("settings.json");
         let a = real_ac_project_path(temp.path(), "A");
         let x = real_ac_project_path(temp.path(), "X");
-        super::save_settings_to_path(
-            &settings_with_project_paths(&[&a, &x]),
-            &path,
-        )
-        .unwrap();
+        super::save_settings_to_path(&settings_with_project_paths(&[&a, &x]), &path).unwrap();
 
         let mut candidate = settings_with_project_paths(&[&a]); // stale, missing X
         candidate.sidebar_style = "deep-space".to_string(); // unrelated GUI field
@@ -4648,8 +4679,8 @@ mod tests {
         assert_eq!(reloaded.project_paths, vec![a.clone(), x.clone()]); // X preserved, not clobbered
         assert_eq!(reloaded.project_path.as_deref(), Some(a.as_str()));
         assert_eq!(reloaded.sidebar_style, "deep-space"); // unrelated field persisted
-        // #1077: the returned settings carry the SELECTED (validated) projection,
-        // which equals the preserved disk list because both dirs are real.
+                                                          // #1077: the returned settings carry the SELECTED (validated) projection,
+                                                          // which equals the preserved disk list because both dirs are real.
         assert_eq!(written.project_paths, vec![a.clone(), x.clone()]);
         assert_eq!(written.project_path.as_deref(), Some(a.as_str()));
     }
@@ -5135,8 +5166,8 @@ mod tests {
     #[test]
     fn repair_prunes_invalid_letter_label_overrides_and_keeps_valid() {
         let mut settings = settings_with_agents(&[("Codex", "codex")]); // id = agent-0
-        // Pre-seed the A cell so the config is otherwise repair-clean; the only
-        // change repair makes is dropping the invalid-letter overrides.
+                                                                        // Pre-seed the A cell so the config is otherwise repair-clean; the only
+                                                                        // change repair makes is dropping the invalid-letter overrides.
         settings.coding_agent_profiles.profiles_by_agent.insert(
             "agent-0".to_string(),
             BTreeMap::from([("A".to_string(), super::empty_profile_cell())]),
@@ -5181,10 +5212,7 @@ mod tests {
                 BTreeMap::from([("B".to_string(), "turbo".to_string())]),
             );
 
-        repair_coding_agent_profiles_config(
-            &mut settings.coding_agent_profiles,
-            &settings.agents,
-        );
+        repair_coding_agent_profiles_config(&mut settings.coding_agent_profiles, &settings.agents);
 
         assert_eq!(
             settings.coding_agent_profiles.profile_labels_by_agent["ghost-agent"]["B"],
@@ -5195,7 +5223,7 @@ mod tests {
     #[test]
     fn repair_with_valid_label_map_does_not_flip_changed() {
         let mut settings = settings_with_agents(&[("Codex", "codex")]); // id = agent-0
-        // Make the config otherwise repair-clean: agent-0 already holds its A cell.
+                                                                        // Make the config otherwise repair-clean: agent-0 already holds its A cell.
         settings.coding_agent_profiles.profiles_by_agent.insert(
             "agent-0".to_string(),
             BTreeMap::from([("A".to_string(), super::empty_profile_cell())]),

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -961,14 +961,19 @@ mod tests {
     async fn get_settings_route_returns_snapshot_and_omits_root_token() {
         // #1077: the browser get_settings route must reuse the shared snapshot
         // helper, so it carries the resolution report and never leaks rootToken.
-        let mut settings = AppSettings::default();
-        settings.root_token = Some("WS-ROUTE-ROOT-TOKEN".to_string());
+        let settings = AppSettings {
+            root_token: Some("WS-ROUTE-ROOT-TOKEN".to_string()),
+            ..AppSettings::default()
+        };
         let (state, _rx) = ws_state_for(settings);
         let value = dispatch_inner(&state, "get_settings", &json!({}))
             .await
             .expect("get_settings");
         let text = serde_json::to_string(&value).unwrap();
-        assert!(!text.contains("rootToken"), "rootToken leaked over WS: {text}");
+        assert!(
+            !text.contains("rootToken"),
+            "rootToken leaked over WS: {text}"
+        );
         assert!(!text.contains("WS-ROUTE-ROOT-TOKEN"), "token value leaked");
         let resolution = value
             .get("projectPathResolution")

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -343,8 +343,12 @@ async fn dispatch_inner(state: &WsState, cmd: &str, args: &Value) -> Result<Valu
 
         // --- Settings ---
         "get_settings" => {
-            let cfg = state.settings.read().await;
-            serde_json::to_value(&*cfg).map_err(|e| e.to_string())
+            // #1077: route through the exact shared snapshot helper so browser
+            // and native clients receive the identical resolution report and
+            // `rootToken` is omitted from both transports.
+            let snapshot =
+                crate::commands::config::settings_snapshot_helper(&state.settings, None).await;
+            serde_json::to_value(&snapshot).map_err(|e| e.to_string())
         }
 
         "update_settings" => {
@@ -951,6 +955,28 @@ mod tests {
                 "invalid payload accepted for {event}: {payload}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn get_settings_route_returns_snapshot_and_omits_root_token() {
+        // #1077: the browser get_settings route must reuse the shared snapshot
+        // helper, so it carries the resolution report and never leaks rootToken.
+        let mut settings = AppSettings::default();
+        settings.root_token = Some("WS-ROUTE-ROOT-TOKEN".to_string());
+        let (state, _rx) = ws_state_for(settings);
+        let value = dispatch_inner(&state, "get_settings", &json!({}))
+            .await
+            .expect("get_settings");
+        let text = serde_json::to_string(&value).unwrap();
+        assert!(!text.contains("rootToken"), "rootToken leaked over WS: {text}");
+        assert!(!text.contains("WS-ROUTE-ROOT-TOKEN"), "token value leaked");
+        let resolution = value
+            .get("projectPathResolution")
+            .expect("snapshot must carry projectPathResolution");
+        assert_eq!(resolution["activeRegistrationCount"], 0);
+        assert_eq!(resolution["archivedRegistrationCount"], 0);
+        assert!(resolution["issues"].as_array().unwrap().is_empty());
+        assert!(resolution["reconciliationError"].is_null());
     }
 
     #[tokio::test]

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -107,6 +107,21 @@ fn project_with_workspace(tmp: &Path) -> PathBuf {
     project
 }
 
+/// Assert a CLI-emitted path string points to the same directory/file as
+/// `expected`. #1077: `create-agent-matrix` prints the SELECTED CANONICAL path
+/// (§3.4), so a raw `tmp.path()` expectation breaks on a CI runner whose %TEMP%
+/// is an 8.3 short name (`RUNNER~1` vs the canonical `runneradmin`).
+/// Canonicalizing both sides compares filesystem identity, robust to 8.3
+/// short-name and Windows verbatim-prefix differences. Both paths exist at every
+/// call site (the verb created them), so `canonicalize` always resolves.
+fn assert_same_path(actual: &str, expected: &Path) {
+    let canon_actual = std::fs::canonicalize(actual)
+        .unwrap_or_else(|e| panic!("canonicalize actual path {actual:?}: {e}"));
+    let canon_expected = std::fs::canonicalize(expected)
+        .unwrap_or_else(|e| panic!("canonicalize expected path {expected:?}: {e}"));
+    assert_eq!(canon_actual, canon_expected);
+}
+
 fn session_request_paths(config_dir: &Path) -> Vec<PathBuf> {
     let requests_dir = config_dir.join("session-requests");
     if !requests_dir.exists() {
@@ -197,14 +212,11 @@ fn create_agent_matrix_success_prints_json_and_writes_layout() {
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
     let agent_dir = project.join(".ac").join("_agent_architect");
-    assert_eq!(
-        json["agentPath"].as_str().expect("agentPath"),
-        agent_dir.to_string_lossy().as_ref()
-    );
+    assert_same_path(json["agentPath"].as_str().expect("agentPath"), &agent_dir);
     assert_eq!(json["agentName"], "ProjectAlpha/architect");
-    assert_eq!(
+    assert_same_path(
         json["rolePath"].as_str().expect("rolePath"),
-        agent_dir.join("Role.md").to_string_lossy().as_ref()
+        &agent_dir.join("Role.md"),
     );
     assert_eq!(json["launched"], false);
     assert!(json["launchAgent"].is_null());
@@ -262,10 +274,7 @@ fn create_agent_matrix_resolves_project_name_from_settings_for_unrelated_root() 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
     let agent_dir = project.join(".ac").join("_agent_architect");
-    assert_eq!(
-        json["agentPath"].as_str().expect("agentPath"),
-        agent_dir.to_string_lossy().as_ref()
-    );
+    assert_same_path(json["agentPath"].as_str().expect("agentPath"), &agent_dir);
     assert_eq!(json["agentName"], "ProjectAlpha/architect");
     assert!(agent_dir.join("Role.md").is_file());
     assert_single_project_refresh_request(&config_dir, &project);
@@ -538,9 +547,9 @@ fn create_agent_matrix_project_name_resolves_from_settings_not_cwd() {
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
     let registered_agent_dir = registered_project.join(".ac").join("_agent_architect");
     let cwd_agent_dir = cwd_project.join(".ac").join("_agent_architect");
-    assert_eq!(
+    assert_same_path(
         json["agentPath"].as_str().expect("agentPath"),
-        registered_agent_dir.to_string_lossy().as_ref()
+        &registered_agent_dir,
     );
     assert!(registered_agent_dir.join("Role.md").is_file());
     assert!(
@@ -590,14 +599,11 @@ fn create_agent_project_mode_delegates_to_matrix_creation() {
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
     let agent_dir = project.join(".ac").join("_agent_architect");
-    assert_eq!(
-        json["agentPath"].as_str().expect("agentPath"),
-        agent_dir.to_string_lossy().as_ref()
-    );
+    assert_same_path(json["agentPath"].as_str().expect("agentPath"), &agent_dir);
     assert_eq!(json["agentName"], "ProjectAlpha/architect");
-    assert_eq!(
+    assert_same_path(
         json["rolePath"].as_str().expect("rolePath"),
-        agent_dir.join("Role.md").to_string_lossy().as_ref()
+        &agent_dir.join("Role.md"),
     );
     assert!(json.get("claudeMd").is_none());
     assert!(agent_dir.join("Role.md").is_file());
@@ -797,10 +803,7 @@ fn create_agent_matrix_launch_writes_session_request() {
         serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
             .expect("request json");
     let agent_dir = project.join(".ac").join("_agent_architect");
-    assert_eq!(
-        request["cwd"].as_str().expect("cwd"),
-        agent_dir.to_string_lossy().as_ref()
-    );
+    assert_same_path(request["cwd"].as_str().expect("cwd"), &agent_dir);
     assert_eq!(request["sessionName"], "ProjectAlpha/architect");
     assert_eq!(request["agentId"], "codex");
 

--- a/src-tauri/tests/cli_workgroup_team.rs
+++ b/src-tauri/tests/cli_workgroup_team.rs
@@ -34,6 +34,21 @@ fn copy_binary_into(tmp: &Path) -> PathBuf {
     dst
 }
 
+/// Assert a CLI-emitted path string points to the same directory as `expected`.
+/// #1077: `workgroup add` prints the SELECTED CANONICAL path (§3.4), so a raw
+/// `tmp.path()` expectation breaks on a CI runner whose %TEMP% is an 8.3 short
+/// name (`RUNNER~1` vs the canonical `runneradmin`). Canonicalizing both sides
+/// compares filesystem identity, robust to 8.3 short-name and Windows
+/// verbatim-prefix differences. Both paths exist at every call site (the verb
+/// created them), so `canonicalize` always resolves.
+fn assert_same_path(actual: &str, expected: &Path) {
+    let canon_actual = std::fs::canonicalize(actual)
+        .unwrap_or_else(|e| panic!("canonicalize actual path {actual:?}: {e}"));
+    let canon_expected = std::fs::canonicalize(expected)
+        .unwrap_or_else(|e| panic!("canonicalize expected path {expected:?}: {e}"));
+    assert_eq!(canon_actual, canon_expected);
+}
+
 fn config_dir_for_bin(bin: &Path) -> PathBuf {
     let stem = bin
         .file_stem()
@@ -240,7 +255,7 @@ fn create_basic_workgroup(tmp: &Path, bin: &Path, config_dir: &Path) -> (PathBuf
         ],
     );
     let wg_dir = project.join(".ac").join("wg-1-dev-team");
-    assert_eq!(created["path"], wg_dir.to_string_lossy().as_ref());
+    assert_same_path(created["path"].as_str().expect("path"), &wg_dir);
     (project, wg_dir)
 }
 
@@ -484,7 +499,7 @@ fn workgroup_add_creates_task_messaging_replicas_and_lists() {
     );
 
     let wg_dir = project.join(".ac").join("wg-1-dev-team");
-    assert_eq!(json["path"], wg_dir.to_string_lossy().as_ref());
+    assert_same_path(json["path"].as_str().expect("path"), &wg_dir);
     assert!(wg_dir.join("TASK.md").is_file());
     assert!(wg_dir.join("messaging").is_dir());
     assert!(wg_dir
@@ -603,7 +618,7 @@ fn workgroup_remove_deletes_and_reuses_number() {
         ],
     );
     let wg_dir = project.join(".ac").join("wg-1-dev-team");
-    assert_eq!(created["path"], wg_dir.to_string_lossy().as_ref());
+    assert_same_path(created["path"].as_str().expect("path"), &wg_dir);
     assert!(wg_dir.is_dir());
 
     let removed = run_json_machine(

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -171,11 +171,14 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
     // `save_settings` is now preserve-disk (it would read the not-yet-existent
     // file as empty and write project_paths: []), which is exactly the fail-safe
     // behavior #778 introduced.
-    save_settings_with_project_paths(&AppSettings {
-        default_shell: "powershell.exe".to_string(),
-        default_shell_args: vec!["-NoLogo".to_string()],
-        project_paths: vec![path_to_string(&repo_root)],
-        ..AppSettings::default()
+    save_settings_with_project_paths(&{
+        // #1077: AppSettings carries a crate-private hidden field, so an
+        // out-of-crate struct literal is not permitted; build from Default.
+        let mut s = AppSettings::default();
+        s.default_shell = "powershell.exe".to_string();
+        s.default_shell_args = vec!["-NoLogo".to_string()];
+        s.project_paths = vec![path_to_string(&repo_root)];
+        s
     })
     .expect("seed isolated settings");
 
@@ -235,11 +238,12 @@ fn make_test_app(
         TelegramBridgeManager::new(Arc::clone(&output_senders)),
     ));
     let idle_detector = IdleDetector::new(|_| {}, |_| {});
-    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new(AppSettings {
-        default_shell: "powershell.exe".to_string(),
-        default_shell_args: vec!["-NoLogo".to_string()],
-        project_paths: vec![path_to_string(repo_root)],
-        ..AppSettings::default()
+    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new({
+        let mut s = AppSettings::default();
+        s.default_shell = "powershell.exe".to_string();
+        s.default_shell_args = vec!["-NoLogo".to_string()];
+        s.project_paths = vec![path_to_string(repo_root)];
+        s
     }));
     let git_app = Box::leak(Box::new(
         tauri::Builder::default()

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -155,6 +155,13 @@ fn make_lifecycle_fixture() -> LifecycleFixture {
     let script_path = temp.path().join("pty-child.ps1");
 
     std::fs::create_dir_all(&repo_root).expect("create repo root");
+    // #1077: a registered project path must resolve to a real AC project (a
+    // directory containing a `.ac` Project Root) for the six-field decoder to
+    // select it into the runtime projectPaths. Without this `.ac`, the CLI loader
+    // (`load_settings_for_cli`) validates repo_root as WorkspaceOrCollectionMissing,
+    // drops it from projectPaths, and session-retention purges the persisted
+    // session — failing the Phase D persistence assertion.
+    std::fs::create_dir_all(repo_root.join(".ac")).expect("create project .ac root");
     if config_dir.exists() {
         std::fs::remove_dir_all(&config_dir).expect("reset config dir");
     }

--- a/src-tauri/tests/wake_consumption_measure.rs
+++ b/src-tauri/tests/wake_consumption_measure.rs
@@ -194,11 +194,13 @@ fn make_ctx(repo_root: &Path) -> HarnessCtx {
     // No-op callbacks: signal 1 is read from the detector's idle_set via
     // purge_readiness, so we do not need to mirror into SessionManager here.
     let idle: Arc<IdleDetector> = IdleDetector::new(|_| {}, |_| {});
-    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new(AppSettings {
-        default_shell: "powershell.exe".to_string(),
-        default_shell_args: vec!["-NoLogo".to_string()],
-        project_paths: vec![repo_root.to_string_lossy().to_string()],
-        ..AppSettings::default()
+    let settings: SettingsState = Arc::new(tokio::sync::RwLock::new({
+        // #1077: AppSettings has a crate-private hidden field; build from Default.
+        let mut s = AppSettings::default();
+        s.default_shell = "powershell.exe".to_string();
+        s.default_shell_args = vec!["-NoLogo".to_string()];
+        s.project_paths = vec![repo_root.to_string_lossy().to_string()];
+        s
     }));
     let git_app = Box::leak(Box::new(
         tauri::Builder::default()

--- a/src/shared/ipc.transport.test.ts
+++ b/src/shared/ipc.transport.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FakeTransport } from "./testing/fake-transport";
-import { baseSettings } from "./testing/ui-harness";
+import { baseSettings, settingsSnapshot } from "./testing/ui-harness";
 import { liveSelection, SESSION_A } from "./testing/session-selection";
 
 describe("shared ipc transport seam", () => {
@@ -38,6 +38,49 @@ describe("shared ipc transport seam", () => {
     expect(fake.lastCall("get_settings")?.args).toEqual({});
     expect(websocketCtor).not.toHaveBeenCalled();
     expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the structured SettingsSnapshot from get_settings without text parsing", async () => {
+    const ipc = await import("./ipc");
+    const fake = new FakeTransport();
+    const snapshot = settingsSnapshot(
+      { projectPaths: ["C:\\bundle\\projects\\alpha"] },
+      {
+        activeRegistrationCount: 2,
+        issues: [
+          {
+            kind: "conflict",
+            id: "a".repeat(64),
+            source: "projectPaths",
+            index: 0,
+            absoluteCandidate: "C:\\bundle\\projects\\alpha",
+            instanceRelativeCandidate: "..\\projects\\beta",
+            absoluteResolvedPath: "C:\\abs\\alpha",
+            instanceRelativeResolvedPath: "C:\\rel\\beta",
+            message: "backend message",
+          },
+        ],
+      },
+    );
+    fake.resolve("get_settings", snapshot);
+    const restore = ipc.__setTransportForTests(fake);
+    try {
+      const result = await ipc.SettingsAPI.get();
+      // The structured report is returned verbatim: no error-string parsing, no
+      // reshaping. AppSettings fields are flattened alongside it.
+      expect(result.projectPaths).toEqual(["C:\\bundle\\projects\\alpha"]);
+      expect(result.projectPathResolution.activeRegistrationCount).toBe(2);
+      expect(result.projectPathResolution.issues).toHaveLength(1);
+      expect(result.projectPathResolution.issues[0]).toMatchObject({
+        kind: "conflict",
+        source: "projectPaths",
+        absoluteResolvedPath: "C:\\abs\\alpha",
+        instanceRelativeResolvedPath: "C:\\rel\\beta",
+      });
+      expect(fake.lastCall("get_settings")?.args).toEqual({});
+    } finally {
+      restore();
+    }
   });
 
   it("decodes selection hydration and events before invoking consumers", async () => {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -16,6 +16,7 @@ import type {
   PtyOutputEvent,
   PtyScreenSnapshot,
   AppSettings,
+  SettingsSnapshot,
   LogLevel,
   UpdateInfo,
   CodingAgentEnv,
@@ -258,7 +259,11 @@ export const CodingAgentsAPI = {
 };
 
 export const SettingsAPI = {
-  get: () => transport.invoke<AppSettings>("get_settings"),
+  // #1077: get_settings returns the flattened SettingsSnapshot (AppSettings +
+  // projectPathResolution). update/save-draft still take a plain AppSettings;
+  // the extra report field riding along on a round-tripped object is ignored by
+  // the backend (non-deny_unknown_fields) and cannot re-pair persisted state.
+  get: () => transport.invoke<SettingsSnapshot>("get_settings"),
   update: (settings: AppSettings) =>
     transport.invoke<void>("update_settings", { newSettings: settings }),
   saveDraft: (settings: AppSettings) =>

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -6,7 +6,9 @@ import type {
   AppSettings,
   BridgeInfo,
   CodingAgentProfilesConfig,
+  ProjectPathResolution,
   Session,
+  SettingsSnapshot,
 } from "../types";
 import { FakeTransport } from "./fake-transport";
 import { toastStore } from "../stores/toasts";
@@ -174,6 +176,31 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     logLevel: null,
     ...overrides,
     codingAgentProfiles: overrides.codingAgentProfiles ?? defaultCodingAgentProfiles(),
+  };
+}
+
+// #1077: baseSettings() stays legacy-shaped (no report) so existing suites keep
+// exercising the absent-report legacy fallback. These focused factories build
+// the new snapshot/report shape only where a test needs it.
+export function projectPathResolution(
+  overrides: Partial<ProjectPathResolution> = {}
+): ProjectPathResolution {
+  return {
+    activeRegistrationCount: 0,
+    archivedRegistrationCount: 0,
+    issues: [],
+    reconciliationError: null,
+    ...overrides,
+  };
+}
+
+export function settingsSnapshot(
+  settingsOverrides: Partial<AppSettings> = {},
+  resolutionOverrides: Partial<ProjectPathResolution> = {}
+): SettingsSnapshot {
+  return {
+    ...baseSettings(settingsOverrides),
+    projectPathResolution: projectPathResolution(resolutionOverrides),
   };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -486,6 +486,112 @@ export interface AppSettings {
   screenshotCaptureHotkey?: string;
 }
 
+// ── #1077 Portable dual project paths: get_settings resolution report ────────
+// These mirror the serialize-only Rust wire shapes in
+// `src-tauri/src/commands/config.rs` (SettingsSnapshot / ProjectPathIssue /
+// Raw{String,Json}FieldState / ProjectPathReconciliationError), all camelCase.
+// The report rides on SettingsAPI.get() but is transport-untrusted: it MUST be
+// runtime-validated at its consumption boundary (see sidebar/stores/project.ts),
+// never trusted on the strength of this transport generic alone.
+
+/** A recursive JSON value: the shape of a wrong-typed structural candidate
+ *  field carried through the report. Validated iteratively, never via `any`. */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** Tagged raw string field state. `present: false` always pairs with
+ *  `value: null`; `present: true, value: null` is an explicit JSON null. */
+export interface RawStringFieldState {
+  present: boolean;
+  value: string | null;
+}
+
+/** Tagged raw JSON field state (needed for wrong-typed structural fields and
+ *  absent-vs-null parity). Same absent/null invariant as RawStringFieldState. */
+export interface RawJsonFieldState {
+  present: boolean;
+  value: JsonValue | null;
+}
+
+export type ReconciliationStage = "read" | "write";
+
+/** Transport/I-O reconciliation error only; structural/candidate issues live in
+ *  `issues`, never here. `retryable` is always `true`. */
+export interface ProjectPathReconciliationError {
+  stage: ReconciliationStage;
+  message: string;
+  retryable: true;
+}
+
+export type ProjectPathIssueSource =
+  | "projectPath"
+  | "projectPaths"
+  | "archivedProjectPaths";
+
+/** Both stored locations resolved to different directories, so neither was
+ *  selected. Both raw candidates and both resolved paths are always present. */
+export interface ProjectPathConflictIssue {
+  kind: "conflict";
+  id: string;
+  source: ProjectPathIssueSource;
+  index?: number;
+  absoluteCandidate: string;
+  instanceRelativeCandidate: string;
+  absoluteResolvedPath: string;
+  instanceRelativeResolvedPath: string;
+  message: string;
+}
+
+/** Every candidate side resolved to a definite NotFound. */
+export interface ProjectPathMissingIssue {
+  kind: "missing";
+  id: string;
+  source: ProjectPathIssueSource;
+  index?: number;
+  absoluteCandidate: RawStringFieldState;
+  instanceRelativeCandidate: RawStringFieldState;
+  absoluteResolvedPath: string | null;
+  instanceRelativeResolvedPath: string | null;
+  message: string;
+}
+
+/** Malformed syntax/type, permission/I-O failure, non-directory, missing `.ac`,
+ *  structural corruption, non-UTF-8, quarantine, or identity failure. */
+export interface ProjectPathInvalidIssue {
+  kind: "invalid";
+  id: string;
+  source: ProjectPathIssueSource;
+  index?: number;
+  absoluteCandidate: RawJsonFieldState;
+  instanceRelativeCandidate: RawJsonFieldState;
+  absoluteResolvedPath: string | null;
+  instanceRelativeResolvedPath: string | null;
+  reason: string;
+}
+
+export type ProjectPathIssue =
+  | ProjectPathConflictIssue
+  | ProjectPathMissingIssue
+  | ProjectPathInvalidIssue;
+
+export interface ProjectPathResolution {
+  activeRegistrationCount: number;
+  archivedRegistrationCount: number;
+  issues: ProjectPathIssue[];
+  reconciliationError: ProjectPathReconciliationError | null;
+}
+
+/** The flattened `get_settings` response: the runtime-selected AppSettings plus
+ *  the structured resolution report. */
+export interface SettingsSnapshot extends AppSettings {
+  projectPathResolution: ProjectPathResolution;
+}
+
 export interface UpdateInfo {
   currentVersion: string;
   latestVersion: string;

--- a/src/sidebar/App.project-path-conflict.test.tsx
+++ b/src/sidebar/App.project-path-conflict.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SidebarApp from "./App";
+import type { ProjectPathIssue } from "../shared/types";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  baseSettings,
+  discovery,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  settingsSnapshot,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import { initialSelection } from "../shared/testing/session-selection";
+
+const VALID_PROJECT = "C:\\bundle\\projects\\valid";
+const VALID_AGENT = `${VALID_PROJECT}\\.ac\\_agent_General`;
+const CONFLICT_ABS = "C:\\abs\\alpha";
+const CONFLICT_REL = "D:\\rel\\alpha";
+
+function conflictIssue(): ProjectPathIssue {
+  return {
+    kind: "conflict",
+    id: "f".repeat(64),
+    source: "projectPaths",
+    absoluteCandidate: "C:\\bundle\\projects\\alpha",
+    instanceRelativeCandidate: "..\\projects\\alpha",
+    absoluteResolvedPath: CONFLICT_ABS,
+    instanceRelativeResolvedPath: CONFLICT_REL,
+    message: "backend message",
+  };
+}
+
+/** The startup IPCs the sidebar drives on mount, minus get_settings (each test
+ *  sets its own so it can inject the resolution report). */
+function wireStartup(fake: FakeTransport): void {
+  fake.resolve("open_project", { path: VALID_PROJECT, registered: true, created: false });
+  fake.resolve(
+    "discover_project",
+    discovery({
+      agents: [{ name: "General", path: VALID_AGENT, roleExists: true }],
+    })
+  );
+  fake.resolve("get_project_groups", { groups: [], showAll: true, showUngrouped: true });
+  fake.resolve("search_repos", []);
+  fake.resolve("list_sessions", []);
+  fake.resolve("get_active_session", initialSelection());
+  fake.resolve("list_detached_sessions", []);
+  fake.resolve("telegram_list_bridges", []);
+  fake.resolve("drain_session_warnings", []);
+  fake.resolve("get_update_status", null);
+}
+
+function errorToasts(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.ownerDocument.querySelectorAll<HTMLElement>('.toast-item[role="alert"]')
+  );
+}
+
+describe("SidebarApp #1077 project-path conflict", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+  });
+
+  it("loads the valid project and shows one sticky red conflict toast with both paths", async () => {
+    const fake = new FakeTransport();
+    wireStartup(fake);
+    fake.resolve(
+      "get_settings",
+      settingsSnapshot(
+        { projectPaths: [VALID_PROJECT], projectPath: VALID_PROJECT },
+        { activeRegistrationCount: 2, issues: [conflictIssue()] }
+      )
+    );
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      // The valid project loads and renders...
+      await waitFor(() => expect(rendered.root.textContent).toContain("General"));
+
+      // ...only the valid project is opened/discovered — never the conflict candidate.
+      expect(fake.callsFor("open_project").map((c) => c.args.path)).toEqual([VALID_PROJECT]);
+      expect(fake.callsFor("discover_project").map((c) => c.args.path)).toEqual([VALID_PROJECT]);
+
+      // Exactly one sticky red error toast, with both resolved paths on their
+      // own labelled lines and a working dismiss button.
+      await waitFor(() => expect(errorToasts(rendered.root)).toHaveLength(1));
+      const [toast] = errorToasts(rendered.root);
+      expect(toast.classList.contains("toast-item--error")).toBe(true);
+      const message = toast.querySelector(".toast-item__message")?.textContent ?? "";
+      expect(message).toContain("Absolute path:");
+      expect(message).toContain(CONFLICT_ABS);
+      expect(message).toContain("Instance-relative path:");
+      expect(message).toContain(CONFLICT_REL);
+      expect(message).toContain("\n");
+
+      const dismiss = toast.querySelector<HTMLButtonElement>(".toast-item__dismiss");
+      expect(dismiss).not.toBeNull();
+      dismiss?.click();
+      await waitFor(() => expect(errorToasts(rendered.root)).toHaveLength(0));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("makes zero open/discover calls for a conflict-only startup but still toasts", async () => {
+    const fake = new FakeTransport();
+    wireStartup(fake);
+    fake.resolve(
+      "get_settings",
+      settingsSnapshot({}, { activeRegistrationCount: 1, issues: [conflictIssue()] })
+    );
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(errorToasts(rendered.root)).toHaveLength(1));
+      expect(fake.callsFor("open_project")).toHaveLength(0);
+      expect(fake.callsFor("discover_project")).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("surfaces two distinct conflicts as two toasts within the existing cap", async () => {
+    const fake = new FakeTransport();
+    wireStartup(fake);
+    const second: ProjectPathIssue = { ...conflictIssue(), id: "e".repeat(64) };
+    fake.resolve(
+      "get_settings",
+      settingsSnapshot({}, { activeRegistrationCount: 2, issues: [conflictIssue(), second] })
+    );
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(errorToasts(rendered.root)).toHaveLength(2));
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("initializes the selected project under a legacy snapshot without a report", async () => {
+    const fake = new FakeTransport();
+    wireStartup(fake);
+    // Legacy-shaped: no projectPathResolution → absent-report legacy fallback.
+    fake.resolve(
+      "get_settings",
+      baseSettings({ projectPaths: [VALID_PROJECT], projectPath: VALID_PROJECT })
+    );
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() => expect(rendered.root.textContent).toContain("General"));
+      expect(errorToasts(rendered.root)).toHaveLength(0);
+      expect(fake.callsFor("open_project").map((c) => c.args.path)).toEqual([VALID_PROJECT]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("fails closed on a present-but-malformed report: no project calls", async () => {
+    const fake = new FakeTransport();
+    wireStartup(fake);
+    // A present report with an unknown issue kind must fail closed.
+    const malformed = {
+      ...baseSettings({ projectPaths: [VALID_PROJECT], projectPath: VALID_PROJECT }),
+      projectPathResolution: {
+        activeRegistrationCount: 1,
+        archivedRegistrationCount: 0,
+        issues: [{ kind: "bogus", id: "f".repeat(64), source: "projectPaths" }],
+        reconciliationError: null,
+      },
+    };
+    fake.resolve("get_settings", malformed);
+
+    const rendered = renderWithFakeTransport(() => <SidebarApp embedded />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="project.loadStatus"]')?.getAttribute("data-ac-state")
+        ).toBe("error")
+      );
+      expect(fake.callsFor("open_project")).toHaveLength(0);
+      expect(fake.callsFor("discover_project")).toHaveLength(0);
+      expect(rendered.root.textContent).not.toContain("General");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/App.tsx
+++ b/src/sidebar/App.tsx
@@ -681,6 +681,10 @@ const SidebarApp: Component<SidebarAppProps> = (props) => {
       appSettings.projectPaths ?? [],
       appSettings.projectPath ?? null,
       appSettings.archivedProjectPaths ?? [],
+      // #1077: pass the resolution report straight through. It is validated as
+      // runtime-unknown inside the store; an absent report (legacy/mixed-version
+      // backend) is the only legacy fallback.
+      appSettings.projectPathResolution,
     );
     if (disposed) return;
 

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "solid-js/web";
 import SettingsModal from "./SettingsModal";
-import type { AppSettings } from "../../shared/types";
+import type { AppSettings, SettingsSnapshot } from "../../shared/types";
 import { SettingsAPI } from "../../shared/ipc";
 import {
   AC_MATRIX_ROOT_PLACEHOLDER,
@@ -67,7 +67,7 @@ vi.mock("../stores/sessions", () => ({
   },
 }));
 
-function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+function settings(overrides: Partial<AppSettings> = {}): SettingsSnapshot {
   return {
     defaultShell: "pwsh",
     defaultShellArgs: [],
@@ -155,6 +155,14 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     logLevel: null,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
+    // #1077: get_settings returns a SettingsSnapshot; SettingsModal ignores the
+    // report, so a pristine empty resolution keeps these mocks well-typed.
+    projectPathResolution: {
+      activeRegistrationCount: 0,
+      archivedRegistrationCount: 0,
+      issues: [],
+      reconciliationError: null,
+    },
   };
 }
 
@@ -749,9 +757,9 @@ describe("SettingsModal automation hooks", () => {
   });
 
   it("keeps an early custom agent draft when the fresh load resolves late", async () => {
-    let resolveLoadedSettings: (value: AppSettings) => void = () => {};
+    let resolveLoadedSettings: (value: SettingsSnapshot) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(
-      new Promise<AppSettings>((resolve) => {
+      new Promise<SettingsSnapshot>((resolve) => {
         resolveLoadedSettings = resolve;
       }),
     );
@@ -783,9 +791,9 @@ describe("SettingsModal automation hooks", () => {
   });
 
   it("keeps early environment edits when the fresh load resolves late", async () => {
-    let resolveLoadedSettings: (value: AppSettings) => void = () => {};
+    let resolveLoadedSettings: (value: SettingsSnapshot) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(
-      new Promise<AppSettings>((resolve) => {
+      new Promise<SettingsSnapshot>((resolve) => {
         resolveLoadedSettings = resolve;
       }),
     );
@@ -1246,9 +1254,9 @@ describe("SettingsModal automation hooks", () => {
   });
 
   it("keeps early profile cell edits when the fresh load resolves late", async () => {
-    let resolveLoadedSettings: (value: AppSettings) => void = () => {};
+    let resolveLoadedSettings: (value: SettingsSnapshot) => void = () => {};
     vi.mocked(SettingsAPI.get).mockReturnValueOnce(
-      new Promise<AppSettings>((resolve) => {
+      new Promise<SettingsSnapshot>((resolve) => {
         resolveLoadedSettings = resolve;
       }),
     );

--- a/src/sidebar/stores/project-refresh.test.ts
+++ b/src/sidebar/stores/project-refresh.test.ts
@@ -54,3 +54,46 @@ describe("project refresh path matching", () => {
     ).toBeNull();
   });
 });
+
+describe("OS-shape aware normalization (#1077)", () => {
+  it("preserves case for POSIX-shaped paths so case-only variants stay distinct", () => {
+    expect(normalizeProjectPathForCompare("/Repo/A")).toBe("/Repo/A");
+    expect(normalizeProjectPathForCompare("/repo/A")).toBe("/repo/A");
+    expect(normalizeProjectPathForCompare("/Repo/A")).not.toBe(
+      normalizeProjectPathForCompare("/repo/A")
+    );
+  });
+
+  it("trims redundant trailing slashes but keeps the bare POSIX root", () => {
+    expect(normalizeProjectPathForCompare("/home/user/project///")).toBe(
+      "/home/user/project"
+    );
+    expect(normalizeProjectPathForCompare("/")).toBe("/");
+  });
+
+  it("preserves a literal backslash inside a POSIX path", () => {
+    // A POSIX filename may legally contain a backslash; it must not be folded to
+    // a separator or reinterpreted as a Windows alias.
+    expect(normalizeProjectPathForCompare("/home/weird\\name")).toBe(
+      "/home/weird\\name"
+    );
+  });
+
+  it("still case-folds Windows drive and UNC aliases to one key", () => {
+    expect(normalizeProjectPathForCompare("C:\\Repo\\A")).toBe(
+      normalizeProjectPathForCompare("c:/repo/a")
+    );
+    expect(normalizeProjectPathForCompare("\\\\Server\\Share\\Repo")).toBe(
+      "//server/share/repo"
+    );
+  });
+
+  it("keeps an unsupported device namespace distinct from an ordinary drive", () => {
+    // The `\\.\` device namespace must not collapse onto the ordinary `\\?\C:\`
+    // / `C:\` keys; its `//./` marker is preserved.
+    const device = normalizeProjectPathForCompare("\\\\.\\C:\\Repo");
+    expect(device).toBe("//./c:/repo");
+    expect(device).not.toBe(normalizeProjectPathForCompare("C:\\Repo"));
+    expect(device).not.toBe(normalizeProjectPathForCompare("\\\\?\\C:\\Repo"));
+  });
+});

--- a/src/sidebar/stores/project-refresh.ts
+++ b/src/sidebar/stores/project-refresh.ts
@@ -1,8 +1,34 @@
+// #1077 §3.4/§5.2: casing is OS-shape aware. Windows-shaped input (drive-rooted,
+// UNC, or verbatim/device `\\?\`/`\\.\` prefixed) is case-folded because its
+// filesystem is case-insensitive and its aliases must collapse. Everything else
+// is treated as POSIX: case- and backslash-preserving, so two projects that
+// differ only by case (or a filename containing a literal `\`) stay distinct.
+const WINDOWS_DRIVE_ROOTED = /^[a-zA-Z]:(?:[\\/]|$)/;
+const WINDOWS_UNC_OR_DEVICE = /^[\\/][\\/]/;
+// Only the ordinary `?` verbatim forms are stripped to a plain key; the `.`
+// device namespace is preserved as an unsupported marker (`//./…`).
+const WINDOWS_VERBATIM_UNC = /^[\\/][\\/]\?[\\/]unc[\\/]/i;
+const WINDOWS_VERBATIM_DRIVE = /^[\\/][\\/]\?[\\/][a-zA-Z]:[\\/]/;
+
+function isWindowsShaped(path: string): boolean {
+  return WINDOWS_DRIVE_ROOTED.test(path) || WINDOWS_UNC_OR_DEVICE.test(path);
+}
+
 export function normalizeProjectPathForCompare(path: string): string {
+  if (!isWindowsShaped(path)) {
+    // POSIX-shaped: preserve case and literal backslashes; trim only redundant
+    // trailing `/` while keeping the bare root `/`.
+    const trimmed = path.replace(/\/+$/, "");
+    if (trimmed === "" && path.startsWith("/")) return "/";
+    return trimmed;
+  }
+
   let normalized = path.replace(/\\/g, "/").toLowerCase();
-  if (normalized.startsWith("//?/unc/")) {
+  if (WINDOWS_VERBATIM_UNC.test(path)) {
+    // \\?\UNC\server\share → //server/share
     normalized = `//${normalized.slice("//?/unc/".length)}`;
-  } else if (/^\/\/\?\/[a-z]:\//.test(normalized)) {
+  } else if (WINDOWS_VERBATIM_DRIVE.test(path)) {
+    // \\?\C:\… → C:\…
     normalized = normalized.slice("//?/".length);
   }
   return normalized.replace(/\/+$/, "");

--- a/src/sidebar/stores/project.test.ts
+++ b/src/sidebar/stores/project.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AcAgentReplica, AcLoopSummary, AcWorkgroup } from "../../shared/types";
+import type {
+  AcAgentReplica,
+  AcLoopSummary,
+  AcWorkgroup,
+  ProjectPathConflictIssue,
+  ProjectPathResolution,
+} from "../../shared/types";
+import { toastStore } from "../../shared/stores/toasts";
 
 const m = vi.hoisted(() => ({
   open: vi.fn(),
@@ -129,6 +136,206 @@ describe("projectStore", () => {
 
     expect(projectStore.lastLoadError).toBeNull();
     expect(projectStore.initState).toEqual({ attempted: false, pathCount: 0 });
+  });
+
+  // #1077 — the get_settings resolution report drives conflict toasts, fail-
+  // closed handling of a malformed report, and actionable active-load status.
+  describe("initFromSettings resolution report (#1077)", () => {
+    const CONFLICT_ID_A = "a".repeat(64);
+    const CONFLICT_ID_B = "b".repeat(64);
+
+    function report(overrides: Partial<ProjectPathResolution> = {}): ProjectPathResolution {
+      return {
+        activeRegistrationCount: 0,
+        archivedRegistrationCount: 0,
+        issues: [],
+        reconciliationError: null,
+        ...overrides,
+      };
+    }
+
+    function conflict(
+      overrides: Partial<ProjectPathConflictIssue> = {}
+    ): ProjectPathConflictIssue {
+      return {
+        kind: "conflict",
+        id: CONFLICT_ID_A,
+        source: "projectPaths",
+        absoluteCandidate: "C:\\bundle\\alpha",
+        instanceRelativeCandidate: "..\\alpha",
+        absoluteResolvedPath: "C:\\abs\\alpha",
+        instanceRelativeResolvedPath: "D:\\rel\\alpha",
+        message: "backend message",
+        ...overrides,
+      };
+    }
+
+    beforeEach(() => {
+      toastStore.clear();
+    });
+
+    afterEach(() => {
+      toastStore.clear();
+    });
+
+    it("surfaces one sticky error toast for a conflict-only startup and makes zero project calls", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+
+      await projectStore.initFromSettings([], null, [], report({
+        activeRegistrationCount: 1,
+        issues: [conflict()],
+      }));
+
+      expect(m.open).not.toHaveBeenCalled();
+      expect(m.discover).not.toHaveBeenCalled();
+      expect(projectStore.projects).toHaveLength(0);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [message, opts] = errorSpy.mock.calls[0];
+      expect(message).toContain("C:\\abs\\alpha");
+      expect(message).toContain("D:\\rel\\alpha");
+      expect(opts).toEqual({ durationMs: null });
+      expect(toastStore.items).toHaveLength(1);
+      expect(toastStore.items[0].kind).toBe("error");
+
+      // Not misreported as pristine: the merged active count is retained, and an
+      // actionable active blocking issue survives.
+      expect(projectStore.initState).toEqual({ attempted: true, pathCount: 1 });
+      expect(projectStore.lastLoadError).toContain("C:\\abs\\alpha");
+    });
+
+    it("opens and discovers only the selected project when a conflict coexists", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+
+      await projectStore.initFromSettings([PROJECT_PATH], null, [], report({
+        activeRegistrationCount: 2,
+        issues: [conflict()],
+      }));
+
+      expect(m.open).toHaveBeenCalledTimes(1);
+      expect(m.open).toHaveBeenCalledWith(PROJECT_PATH);
+      expect(m.discover).toHaveBeenCalledTimes(1);
+      expect(projectStore.projects).toHaveLength(1);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits exactly one toast per conflict id across repeated initialization", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+      const snapshot = report({ activeRegistrationCount: 1, issues: [conflict()] });
+
+      await projectStore.initFromSettings([], null, [], snapshot);
+      await projectStore.initFromSettings([], null, [], snapshot);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits one toast per distinct conflict id", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+
+      await projectStore.initFromSettings([], null, [], report({
+        activeRegistrationCount: 2,
+        issues: [conflict({ id: CONFLICT_ID_A }), conflict({ id: CONFLICT_ID_B })],
+      }));
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("escapes control and bidi characters in the toast without truncating printable path text", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+      const longTail = "verylongsegmentthatmustnotbetruncated";
+      const rlo = String.fromCodePoint(0x202e);
+      await projectStore.initFromSettings([], null, [], report({
+        activeRegistrationCount: 1,
+        issues: [
+          conflict({
+            // A newline (U+000A) and an RLO bidi override (U+202E) inside a POSIX
+            // filename must be neutralised so they cannot forge another label.
+            absoluteResolvedPath: `/tmp/a\nAbsolute path: /forged/${longTail}`,
+            instanceRelativeResolvedPath: `/x/${rlo}evil`,
+          }),
+        ],
+      }));
+
+      const [message] = errorSpy.mock.calls[0];
+      expect(message).toContain("\\u{000A}");
+      expect(message).toContain("\\u{202E}");
+      // The printable tail is preserved (never truncated) ...
+      expect(message).toContain(longTail);
+      // ... and the raw newline never produced a second real "Absolute path:" line.
+      expect(message).not.toContain("\nAbsolute path: /forged");
+    });
+
+    it("retains an actionable lastLoadError for an active missing issue", async () => {
+      await projectStore.initFromSettings([], null, [], report({
+        activeRegistrationCount: 1,
+        issues: [
+          {
+            kind: "missing",
+            id: CONFLICT_ID_A,
+            source: "projectPaths",
+            absoluteCandidate: { present: true, value: "C:\\gone" },
+            instanceRelativeCandidate: { present: false, value: null },
+            absoluteResolvedPath: "C:\\gone",
+            instanceRelativeResolvedPath: null,
+            message: "This project directory could not be found.",
+          },
+        ],
+      }));
+
+      expect(projectStore.lastLoadError).toBe("This project directory could not be found.");
+    });
+
+    it("does not claim an active load failure for an archived-only issue", async () => {
+      const errorSpy = vi.spyOn(toastStore, "error");
+
+      await projectStore.initFromSettings([], null, [], report({
+        archivedRegistrationCount: 1,
+        issues: [conflict({ source: "archivedProjectPaths" })],
+      }));
+
+      // The archived conflict is still surfaced, but it is not an active blocker.
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(projectStore.lastLoadError).toBeNull();
+    });
+
+    it("still loads the returned paths under the legacy absent-report fallback", async () => {
+      await projectStore.initFromSettings([PROJECT_PATH], null, []);
+
+      expect(m.open).toHaveBeenCalledWith(PROJECT_PATH);
+      expect(projectStore.projects).toHaveLength(1);
+      expect(projectStore.initState).toEqual({ attempted: true, pathCount: 1 });
+    });
+
+    it("fails closed on a present-but-malformed report, loading nothing", async () => {
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const badReports: unknown[] = [
+        null,
+        42,
+        { activeRegistrationCount: -1, archivedRegistrationCount: 0, issues: [], reconciliationError: null },
+        { activeRegistrationCount: 1.5, archivedRegistrationCount: 0, issues: [], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [{ kind: "unknown", id: CONFLICT_ID_A, source: "projectPaths" }], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [{ ...conflict(), id: "SHORT" }], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [{ ...conflict(), id: "A".repeat(64) }], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [{ kind: "missing", id: CONFLICT_ID_A, source: "projectPaths", absoluteCandidate: { present: false, value: "not-null" }, instanceRelativeCandidate: { present: false, value: null }, absoluteResolvedPath: null, instanceRelativeResolvedPath: null, message: "m" }], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [{ kind: "invalid", id: CONFLICT_ID_A, source: "projectPaths", absoluteCandidate: { present: true, value: Number.NaN }, instanceRelativeCandidate: { present: false, value: null }, absoluteResolvedPath: null, instanceRelativeResolvedPath: null, reason: "r" }], reconciliationError: null },
+        { activeRegistrationCount: 0, archivedRegistrationCount: 0, issues: [], reconciliationError: { stage: "read", message: "m", retryable: false } },
+      ];
+
+      try {
+        for (const bad of badReports) {
+          vi.clearAllMocks();
+          projectStore.clear();
+          await projectStore.initFromSettings([PROJECT_PATH], null, [], bad);
+
+          expect(m.open, `report ${JSON.stringify(bad)}`).not.toHaveBeenCalled();
+          expect(projectStore.projects).toHaveLength(0);
+          expect(projectStore.lastLoadError).toContain("could not be read");
+          expect(projectStore.initState).toEqual({ attempted: true, pathCount: 0 });
+        }
+      } finally {
+        errorLog.mockRestore();
+      }
+    });
   });
 
   // #748 — identity preservation. Object references drive ProjectPanel's

--- a/src/sidebar/stores/project.ts
+++ b/src/sidebar/stores/project.ts
@@ -7,8 +7,16 @@ import type {
   AcLoopSummary,
   ContextTemplateUpdate,
   ProjectArchiveChanged,
+  ProjectPathConflictIssue,
+  ProjectPathIssue,
+  ProjectPathIssueSource,
+  ProjectPathReconciliationError,
+  ProjectPathResolution,
+  RawJsonFieldState,
+  RawStringFieldState,
 } from "../../shared/types";
 import { ProjectAPI, AgentCreatorAPI } from "../../shared/ipc";
+import { toastStore } from "../../shared/stores/toasts";
 import {
   findLoadedProjectPathForRefresh,
   normalizeProjectPathForCompare,
@@ -38,6 +46,10 @@ const inFlightLoads = new Map<string, Promise<void>>();
 const inFlightReloads = new Map<string, Promise<void>>();
 const archiveChangeTails = new Map<string, Promise<void>>();
 const queuedReloads = new Set<string>();
+// #1077: conflict IDs already surfaced as a sticky toast. Retained across
+// repeated initFromSettings runs (reconnects, remounts) so one conflict yields
+// exactly one toast; cleared by the store's reset lifecycle (clear()).
+const seenConflictIds = new Set<string>();
 let loadingCount = 0;
 
 function normalizePath(p: string): string {
@@ -115,6 +127,228 @@ function formatLoadError(e: unknown): string {
   }
 }
 
+// ── #1077 resolution report: runtime validation + conflict presentation ──────
+
+const INVALID_REPORT_MESSAGE =
+  "The project list could not be read from settings (unexpected response). " +
+  "No projects were loaded. Restart AgentsCommander or check your settings file.";
+
+const ISSUE_ID_HEX = /^[0-9a-f]{64}$/;
+const ISSUE_SOURCES: ReadonlySet<string> = new Set<ProjectPathIssueSource>([
+  "projectPath",
+  "projectPaths",
+  "archivedProjectPaths",
+]);
+
+type ReportValidation =
+  | { status: "absent" }
+  | { status: "invalid" }
+  | { status: "valid"; report: ProjectPathResolution };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+/**
+ * Iteratively validate an arbitrary value as a finite JsonValue. An explicit
+ * work stack plus a visited set keep it cycle-safe for hostile/cyclic test
+ * doubles and free of recursive call-stack trust: a cycle or shared reference
+ * (never present in a real serialized backend response) fails closed rather
+ * than looping or overflowing, and any non-finite number is rejected.
+ */
+function isJsonValue(root: unknown): boolean {
+  const stack: unknown[] = [root];
+  const seen = new Set<object>();
+  while (stack.length > 0) {
+    const value = stack.pop();
+    if (value === null) continue;
+    const kind = typeof value;
+    if (kind === "string" || kind === "boolean") continue;
+    if (kind === "number") {
+      if (!Number.isFinite(value)) return false;
+      continue;
+    }
+    if (Array.isArray(value)) {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      for (const item of value as unknown[]) stack.push(item);
+      continue;
+    }
+    if (isPlainObject(value)) {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      for (const key of Object.keys(value)) stack.push(value[key]);
+      continue;
+    }
+    return false; // undefined, function, symbol, bigint, non-plain object
+  }
+  return true;
+}
+
+function isRawStringFieldState(value: unknown): value is RawStringFieldState {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.present !== "boolean") return false;
+  if (value.present === false) return value.value === null;
+  return isNullableString(value.value);
+}
+
+function isRawJsonFieldState(value: unknown): value is RawJsonFieldState {
+  if (!isPlainObject(value)) return false;
+  if (typeof value.present !== "boolean") return false;
+  if (value.present === false) return value.value === null;
+  return isJsonValue(value.value);
+}
+
+function isValidIssueHead(issue: Record<string, unknown>): boolean {
+  if (typeof issue.id !== "string" || !ISSUE_ID_HEX.test(issue.id)) return false;
+  if (typeof issue.source !== "string" || !ISSUE_SOURCES.has(issue.source)) return false;
+  if (issue.index !== undefined && !isSafeCount(issue.index)) return false;
+  return true;
+}
+
+function isValidIssue(value: unknown): value is ProjectPathIssue {
+  if (!isPlainObject(value)) return false;
+  if (!isValidIssueHead(value)) return false;
+  switch (value.kind) {
+    case "conflict":
+      return (
+        typeof value.absoluteCandidate === "string" &&
+        typeof value.instanceRelativeCandidate === "string" &&
+        typeof value.absoluteResolvedPath === "string" &&
+        typeof value.instanceRelativeResolvedPath === "string" &&
+        typeof value.message === "string"
+      );
+    case "missing":
+      return (
+        isRawStringFieldState(value.absoluteCandidate) &&
+        isRawStringFieldState(value.instanceRelativeCandidate) &&
+        isNullableString(value.absoluteResolvedPath) &&
+        isNullableString(value.instanceRelativeResolvedPath) &&
+        typeof value.message === "string"
+      );
+    case "invalid":
+      return (
+        isRawJsonFieldState(value.absoluteCandidate) &&
+        isRawJsonFieldState(value.instanceRelativeCandidate) &&
+        isNullableString(value.absoluteResolvedPath) &&
+        isNullableString(value.instanceRelativeResolvedPath) &&
+        typeof value.reason === "string"
+      );
+    default:
+      return false; // unknown discriminant
+  }
+}
+
+function isReconciliationError(
+  value: unknown
+): value is ProjectPathReconciliationError {
+  if (!isPlainObject(value)) return false;
+  if (value.stage !== "read" && value.stage !== "write") return false;
+  if (typeof value.message !== "string") return false;
+  return value.retryable === true;
+}
+
+/**
+ * Total validator/normalizer for the transport-untrusted resolution report. An
+ * absent/undefined report is the sole legacy fallback; anything present but
+ * malformed fails closed so no returned project path is trusted. Returns a
+ * freshly built, fully validated report — never the raw transport object.
+ */
+function validateProjectPathResolution(report: unknown): ReportValidation {
+  if (report === undefined) return { status: "absent" };
+  if (!isPlainObject(report)) return { status: "invalid" };
+  if (!isSafeCount(report.activeRegistrationCount)) return { status: "invalid" };
+  if (!isSafeCount(report.archivedRegistrationCount)) return { status: "invalid" };
+
+  let reconciliationError: ProjectPathReconciliationError | null = null;
+  const rawError = report.reconciliationError;
+  if (rawError !== null) {
+    if (!isReconciliationError(rawError)) return { status: "invalid" };
+    reconciliationError = rawError;
+  }
+
+  const rawIssues = report.issues;
+  if (!Array.isArray(rawIssues)) return { status: "invalid" };
+  const issues: ProjectPathIssue[] = [];
+  for (const candidate of rawIssues as unknown[]) {
+    if (!isValidIssue(candidate)) return { status: "invalid" };
+    issues.push(candidate);
+  }
+
+  return {
+    status: "valid",
+    report: {
+      activeRegistrationCount: report.activeRegistrationCount,
+      archivedRegistrationCount: report.archivedRegistrationCount,
+      issues,
+      reconciliationError,
+    },
+  };
+}
+
+function isActiveIssueSource(source: ProjectPathIssueSource): boolean {
+  return source === "projectPath" || source === "projectPaths";
+}
+
+/**
+ * Escape C0/C1 controls and bidi override/isolate marks to visible `\u{…}`
+ * sequences without truncating printable text, iterating by code point so
+ * astral characters survive intact. A hostile POSIX filename containing a
+ * newline or a bidi marker therefore cannot forge a second label line.
+ */
+function escapeControlAndBidi(text: string): string {
+  let out = "";
+  for (const ch of text) {
+    const cp = ch.codePointAt(0) ?? 0;
+    const escape =
+      cp <= 0x1f ||
+      cp === 0x7f ||
+      (cp >= 0x80 && cp <= 0x9f) ||
+      cp === 0x061c ||
+      cp === 0x200e ||
+      cp === 0x200f ||
+      (cp >= 0x202a && cp <= 0x202e) ||
+      (cp >= 0x2066 && cp <= 0x2069);
+    out += escape
+      ? `\\u{${cp.toString(16).toUpperCase().padStart(4, "0")}}`
+      : ch;
+  }
+  return out;
+}
+
+/** Build the sticky conflict notice: both resolved paths, control/bidi-escaped,
+ *  on their own labelled lines (rendered pre-wrap by the existing ToastHost). */
+function formatConflictMessage(issue: ProjectPathConflictIssue): string {
+  const absolute = escapeControlAndBidi(issue.absoluteResolvedPath);
+  const relative = escapeControlAndBidi(issue.instanceRelativeResolvedPath);
+  return (
+    "Project path conflict: two saved locations resolve to different directories, " +
+    "so this project was not loaded.\n" +
+    `Absolute path: ${absolute}\n` +
+    `Instance-relative path: ${relative}`
+  );
+}
+
+/** Actionable text retained in lastLoadError for a blocking active issue. */
+function issueBlockingText(issue: ProjectPathIssue): string {
+  switch (issue.kind) {
+    case "conflict":
+      return formatConflictMessage(issue);
+    case "missing":
+      return issue.message;
+    case "invalid":
+      return issue.reason;
+  }
+}
+
 export const projectStore = {
   get projects() {
     return projects();
@@ -172,19 +406,79 @@ export const projectStore = {
   async initFromSettings(
     projectPaths: string[],
     legacyPath: string | null,
-    archivedProjectPaths: string[] = []
+    archivedProjectPaths: string[] = [],
+    // #1077: the transport-untrusted resolution report. Absent/undefined is the
+    // sole legacy fallback; a present-but-malformed report fails closed.
+    report?: unknown
   ) {
     setArchivedPaths((prev) => {
       const keys = new Set(prev.map(normalizePath));
       return [...prev, ...archivedProjectPaths.filter((p) => !keys.has(normalizePath(p)))];
     });
+
+    const validation = validateProjectPathResolution(report);
+
+    if (validation.status === "invalid") {
+      // Fail closed: a malformed report means the returned paths are not
+      // trustworthy either. Load nothing, keep an actionable status, and log a
+      // single diagnostic without echoing raw candidates.
+      console.error(
+        "[project] Ignoring malformed project-path resolution report; loading no projects."
+      );
+      batch(() => {
+        setLastLoadError(INVALID_REPORT_MESSAGE);
+        setInitState({ attempted: true, pathCount: 0 });
+      });
+      return;
+    }
+
     const paths = [...projectPaths];
     if (legacyPath && !paths.some((p) => normalizePath(p) === normalizePath(legacyPath))) {
       paths.push(legacyPath);
     }
-    setInitState({ attempted: true, pathCount: paths.length });
+
+    if (validation.status === "absent") {
+      // Legacy/mixed-version fallback: treat the returned paths as selected,
+      // with the merged legacy count and no structured issues.
+      setInitState({ attempted: true, pathCount: paths.length });
+      for (const path of paths) {
+        await projectStore.loadProject(path);
+      }
+      return;
+    }
+
+    const { report: resolution } = validation;
+
+    // Surface every conflict once (per ID) BEFORE loading; the selected paths
+    // already exclude conflict/quarantined candidates, so we never open or
+    // discover an issue candidate here.
+    for (const issue of resolution.issues) {
+      if (issue.kind !== "conflict") continue;
+      if (seenConflictIds.has(issue.id)) continue;
+      seenConflictIds.add(issue.id);
+      toastStore.error(formatConflictMessage(issue), { durationMs: null });
+    }
+
+    // Retain the first ACTIVE blocking issue (archived-only issues do not claim
+    // an active load failure). Captured before loads so a later success cannot
+    // silently clear the evidence.
+    const firstActiveIssue = resolution.issues.find((issue) =>
+      isActiveIssueSource(issue.source)
+    );
+    const activeBlockingText = firstActiveIssue
+      ? issueBlockingText(firstActiveIssue)
+      : null;
+
+    // Use the merged logical count so a conflict-only startup is not misreported
+    // as a pristine no-project state.
+    setInitState({ attempted: true, pathCount: resolution.activeRegistrationCount });
+
     for (const path of paths) {
       await projectStore.loadProject(path);
+    }
+
+    if (activeBlockingText !== null) {
+      setLastLoadError(activeBlockingText);
     }
   },
 
@@ -433,6 +727,7 @@ export const projectStore = {
     inFlightReloads.clear();
     archiveChangeTails.clear();
     queuedReloads.clear();
+    seenConflictIds.clear();
     replicaVolatileStore.clearAll();
   },
 };


### PR DESCRIPTION
Closes #1077.

## Problem
Settings persisted project paths as source-machine absolute strings; after a portable instance was moved, startup reused the stale absolute path (e.g. `C:\Users\maria\0_repos\amp-office_iac`) and failed to load the project.

## Change
Persist both the absolute project path and the path relative to the executing AgentsCommander instance across the six project-path settings fields. At load, validate both candidates and resolve to a single absolute path used for the rest of the run:
- exactly one candidate valid -> use that resolved absolute path;
- both valid and identifying the same directory -> continue with one;
- both valid but different directories -> fail closed, choose neither, and show the existing sticky red conflict toast (`toastStore.error(msg, { durationMs: null })`, reusing ToastHost/CSS: role="alert", multiline showing both paths, dismissible).

Backend-only candidate resolution + filesystem directory-identity checks; validated-absolute-only runtime invariant; preserve/reconcile settings writers with a whole-object disk gate; conflict pairs quarantined and never mutated. Portable persisted sessions are out of scope.

## Reviews
- Backend + docs: dev-rust. Frontend typed conflict workflow (Phase 2): dev-webpage-ui.
- Adversarial review by dev-rust-grinch: initial backend review found 4 defects (1 HIGH data-integrity, 1 MED-HIGH reconcile, 1 MED transaction rollback, 1 LOW). All fixed code-only with the frozen plan unchanged; combined backend re-review + frontend review both PASS; merge-resolution review after updating with origin/main PASS (proven clean union).

## Tests
- Backend: `cargo test -p agentscommander-new --lib` 2744 passed / 0 failed; `cargo check --workspace --all-targets` 0 errors; `cargo clippy --workspace --all-targets -- -D warnings` clean; no new rustfmt delta (pre-existing baseline only).
- Frontend: `npm run typecheck` 0 errors; `npm test` 1301 passed / 0 failed; `npm run build` ok.