### PR TITLE
feat(switch): allow Pi as a self-handoff-and-switch source (#1081)

### DIFF
--- a/docs/integrations/coding-agents.md
+++ b/docs/integrations/coding-agents.md
@@ -31,7 +31,7 @@ The full enum is in `session/profile.rs::CodingAgentKind`.
 
 ### Logical clear capability is separate from tuned integration
 
-Remote logical clear and canonical text submission use an operation-specific direct-shell capability table, independent of `CodingAgentKind`. Direct Claude/Codex/Gemini-family shells and Cursor exact stem `agent` map logical clear to `/clear`. An exact-stem direct Pi shell maps it to `/new` and uses the same delayed double-Enter submission timing. Pi compact and Pi-origin `self-handoff-and-switch` remain unsupported.
+Remote logical clear and canonical text submission use an operation-specific direct-shell capability table, independent of `CodingAgentKind`. Direct Claude/Codex/Gemini-family shells and Cursor exact stem `agent` map logical clear to `/clear`. An exact-stem direct Pi shell maps it to `/new` and uses the same delayed double-Enter submission timing. An exact-stem direct Pi shell is also a supported `self-handoff-and-switch` source. Pi compact remains unsupported.
 
 Pi is a tuned `CodingAgentKind` for the auto-resume, profile, and wire behavior described below, but that identity does not authorize logical PTY actions. The logical-clear rule is lexical trusted configuration: a direct shell whose final file stem is exactly `pi` matches, including `pi`, `pi.exe`, and the stock `pi.cmd` shim; file-stem extraction discards any final extension. An outer `cmd`/`pwsh` wrapper does not match this operation-specific rule, even when tuned Pi detection supports its command shape. This is not binary attestation. AgentsCommander does not version-probe or semantically acknowledge production clears; stock Pi 0.80.10 is the validated control, and a successful action records PTY write receipt.
 

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -5970,7 +5970,7 @@ impl MailboxPoller {
                     path,
                     msg,
                     &format!(
-                        "self-handoff-and-switch: session shell '{}' is not a supported source shell (Claude / Codex / Gemini direct family or Cursor agent); switch is not supported here",
+                        "self-handoff-and-switch: session shell '{}' is not a supported source shell (Claude / Codex / Gemini direct family, Cursor agent, or Pi); switch is not supported here",
                         session.shell
                     ),
                 )
@@ -12530,16 +12530,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_self_switch_pi_source_rejected_before_other_work() {
+    async fn handle_self_switch_unsupported_source_rejected_before_other_work() {
         let fixture = make_self_switch_fixture();
         let app = app_handle(&fixture.app);
         let (session_id, token) =
-            seed_self_switch_session(&app, &fixture.replica, "pi", None, None, None).await;
+            seed_self_switch_session(&app, &fixture.replica, "pwsh", None, None, None).await;
         std::fs::write(fixture.replica.join("SELF-FORGET.md"), "must remain").unwrap();
         let (path, message) = build_self_switch_message(
             &fixture.replica,
-            "msg-ss-pi-source",
-            "rid-ss-pi-source",
+            "msg-ss-unsupported-source",
+            "rid-ss-unsupported-source",
             Some(token.to_string()),
             Some("deliberately-invalid-target"),
             Some("not-a-profile"),
@@ -12552,7 +12552,7 @@ mod tests {
             .await
             .unwrap();
 
-        let reason = read_reject_reason(&fixture.replica, "msg-ss-pi-source").unwrap();
+        let reason = read_reject_reason(&fixture.replica, "msg-ss-unsupported-source").unwrap();
         assert!(reason.contains("not a supported source shell"), "{reason}");
         assert!(!reason.contains("deliberately-invalid-target"), "{reason}");
         assert!(!reason.contains("SELF-HANDOFF"), "{reason}");
@@ -12766,6 +12766,499 @@ mod tests {
         .unwrap();
         assert_eq!(saved["tooling"]["currentCodingAgent"], "pi");
         assert_eq!(saved["tooling"]["profile"], "A");
+    }
+
+    #[tokio::test]
+    async fn handle_self_switch_pi_source_queues_with_resolved_targets() {
+        let fixture = make_self_switch_fixture();
+        let app = app_handle(&fixture.app);
+        // A Pi source needs no `pi` agent push: the target is `codex` (already in
+        // the fixture wake_agents) and the source agent_id is never
+        // configured-checked, only used as a target-resolution fallback.
+        let (session_id, token) = seed_self_switch_session(
+            &app,
+            &fixture.replica,
+            "pi",
+            Some("pi"),
+            Some("A"),
+            Some("B"),
+        )
+        .await;
+        seed_self_handoff(&fixture.replica);
+        std::fs::write(fixture.replica.join("SELF-FORGET.md"), "topic to forget").unwrap();
+
+        let (path, msg) = build_self_switch_message(
+            &fixture.replica,
+            "msg-ss-pi-queue",
+            "rid-ss-pi-queue",
+            Some(token.to_string()),
+            Some("codex"),
+            Some("c"),
+            "proj-a:wg-1-dev-team/dev-rust",
+        );
+        let poller = MailboxPoller::new();
+        poller
+            .handle_self_handoff_switch(&app, &path, &msg, false)
+            .await
+            .unwrap();
+
+        let response = read_response_json(&fixture.replica, "rid-ss-pi-queue").unwrap();
+        assert_eq!(response["action"], SELF_SWITCH_ACTION);
+        assert_eq!(response["status"], "queued");
+        assert_eq!(response["target_coding_agent"], "codex");
+        assert_eq!(response["target_profile"], "C");
+        assert!(pending_self_clear_contains(&app, session_id).await);
+        assert_eq!(pending_self_clear_len(&app).await, 1);
+        assert_eq!(count_forget_archives(&fixture.replica), 1);
+        assert!(!fixture.replica.join("SELF-FORGET.md").is_file());
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn self_switch_pi_source_to_established_target_completes() {
+        let fixture = make_self_switch_fixture();
+        let app = app_handle(&fixture.app);
+        let (source_id, token) = seed_self_switch_session(
+            &app,
+            &fixture.replica,
+            "pi",
+            Some("pi"),
+            Some("A"),
+            Some("A"),
+        )
+        .await;
+        {
+            let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = state.read().await;
+            mgr.mark_idle(source_id).await;
+        }
+        seed_self_handoff(&fixture.replica);
+        let (path, message) = build_self_switch_message(
+            &fixture.replica,
+            "msg-ss-pi-to-codex",
+            "rid-ss-pi-to-codex",
+            Some(token.to_string()),
+            Some("codex"),
+            Some("A"),
+            "proj-a:wg-1-dev-team/dev-rust",
+        );
+        let poller = MailboxPoller::new();
+
+        poller
+            .handle_self_handoff_switch(&app, &path, &message, false)
+            .await
+            .unwrap();
+        let response = read_response_json(&fixture.replica, "rid-ss-pi-to-codex").unwrap();
+        assert_eq!(response["status"], "queued");
+        assert_eq!(response["target_coding_agent"], "codex");
+        assert_eq!(response["target_profile"], "A");
+
+        let target_agent = response["target_coding_agent"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let target_profile = response["target_profile"].as_str().unwrap().to_string();
+        let pending = app.state::<Arc<crate::PendingSelfClear>>().inner().clone();
+        let state_ids = Arc::new(Mutex::new(Vec::<Uuid>::new()));
+        let state_ids_seen = Arc::clone(&state_ids);
+        let app_for_state = app.clone();
+        let session_state = move |session_id: Uuid| {
+            let app = app_for_state.clone();
+            let state_ids = Arc::clone(&state_ids_seen);
+            async move {
+                state_ids.lock().unwrap().push(session_id);
+                let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                let mgr = state.read().await;
+                match mgr.get_session(session_id).await {
+                    Some(session) => (true, session.waiting_for_input),
+                    None => (false, false),
+                }
+            }
+        };
+
+        let app_for_persist = app.clone();
+        let persist = move |cwd: PathBuf, agent: String, profile: String| {
+            let app = app_for_persist.clone();
+            async move {
+                let settings = app.state::<SettingsState>();
+                let snapshot = settings.read().await.clone();
+                crate::config::coding_agent_profiles::set_replica_coding_agent_selection(
+                    &snapshot, &cwd, &agent, &profile,
+                )
+            }
+        };
+
+        let restarted_id = Arc::new(Mutex::new(None::<Uuid>));
+        let restarted_id_seen = Arc::clone(&restarted_id);
+        let app_for_restart = app.clone();
+        let replica_for_restart = fixture.replica.clone();
+        let restart = move |session_id: Uuid, agent: String, profile: String| {
+            let app = app_for_restart.clone();
+            let replica = replica_for_restart.clone();
+            let restarted_id = Arc::clone(&restarted_id_seen);
+            async move {
+                assert_eq!(session_id, source_id);
+                assert_eq!(agent, "codex");
+                assert_eq!(profile, "A");
+                {
+                    let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                    let mgr = state.read().await;
+                    mgr.destroy_session(session_id).await.unwrap();
+                }
+                let (new_id, _token) = seed_self_switch_session(
+                    &app,
+                    &replica,
+                    "codex",
+                    Some("codex"),
+                    Some(&profile),
+                    Some(&profile),
+                )
+                .await;
+                {
+                    let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                    let mgr = state.read().await;
+                    mgr.mark_idle(new_id).await;
+                }
+                register_mock_pty_route(&app, new_id);
+                *restarted_id.lock().unwrap() = Some(new_id);
+                Ok(new_id.to_string())
+            }
+        };
+
+        let injected_prompts = Arc::new(Mutex::new(Vec::<(Uuid, String)>::new()));
+        let injected_prompts_seen = Arc::clone(&injected_prompts);
+        let app_for_inject = app.clone();
+        let inject = move |session_id: Uuid, prompt: String| {
+            let app = app_for_inject.clone();
+            let injected_prompts = Arc::clone(&injected_prompts_seen);
+            async move {
+                injected_prompts
+                    .lock()
+                    .unwrap()
+                    .push((session_id, prompt.clone()));
+                crate::pty::inject::inject_text_into_session(&app, session_id, &prompt).await
+            }
+        };
+        let boundaries = Arc::new(Mutex::new(Vec::<(Uuid, SelfClearBoundary)>::new()));
+        let boundaries_seen = Arc::clone(&boundaries);
+        let note_boundary = move |session_id: Uuid, boundary: SelfClearBoundary| {
+            let boundaries = Arc::clone(&boundaries_seen);
+            async move {
+                boundaries.lock().unwrap().push((session_id, boundary));
+            }
+        };
+
+        MailboxPoller::drive_self_switch_after_sustained_idle(
+            source_id,
+            fixture.replica.clone(),
+            target_agent,
+            target_profile,
+            None,
+            Arc::clone(&pending),
+            Duration::ZERO,
+            Duration::ZERO,
+            Duration::from_secs(30),
+            session_state,
+            persist,
+            restart,
+            inject,
+            note_boundary,
+        )
+        .await;
+
+        let target_id = restarted_id
+            .lock()
+            .unwrap()
+            .expect("restart seam must return the configured target session id");
+        assert_ne!(target_id, source_id);
+        assert_eq!(*state_ids.lock().unwrap(), vec![source_id, target_id]);
+        let prompts = injected_prompts.lock().unwrap().clone();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].0, target_id);
+        assert!(prompts[0].1.contains("self-clear/"), "{}", prompts[0].1);
+        assert_eq!(
+            mock_pty_writes_for(&app, target_id),
+            vec![
+                prompts[0].1.as_bytes().to_vec(),
+                b"\r".to_vec(),
+                b"\r".to_vec()
+            ]
+        );
+        assert_eq!(
+            *boundaries.lock().unwrap(),
+            vec![(target_id, SelfClearBoundary::ContentInjected)]
+        );
+        let manager = {
+            let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = state.read().await;
+            guard.clone()
+        };
+        assert!(manager.get_session(source_id).await.is_none());
+        let target = manager.get_session(target_id).await.unwrap();
+        assert_eq!(target.shell, "codex");
+        assert_eq!(target.agent_id.as_deref(), Some("codex"));
+        assert!(pending.0.lock().unwrap().is_empty());
+        let saved: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(fixture.replica.join("config.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(saved["tooling"]["currentCodingAgent"], "codex");
+        assert_eq!(saved["tooling"]["profile"], "A");
+    }
+
+    #[tokio::test]
+    async fn self_switch_pi_source_omitted_target_hard_resets_to_pi() {
+        let fixture = make_self_switch_fixture();
+        let app = app_handle(&fixture.app);
+        // The target resolves to `pi` (the source agent_id fallback), so `pi`
+        // must be configured for target spawn validation.
+        {
+            let settings = app.state::<SettingsState>();
+            settings
+                .write()
+                .await
+                .agents
+                .push(wake_agent("pi", "Pi", "pi"));
+        }
+        let (source_id, token) = seed_self_switch_session(
+            &app,
+            &fixture.replica,
+            "pi",
+            Some("pi"),
+            Some("A"),
+            Some("A"),
+        )
+        .await;
+        {
+            let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let mgr = state.read().await;
+            mgr.mark_idle(source_id).await;
+        }
+        seed_self_handoff(&fixture.replica);
+        // Both --coding-agent and --profile omitted: the target resolves from the
+        // source agent_id fallback back to `pi` (the #1081 hard-reset headline).
+        let (path, message) = build_self_switch_message(
+            &fixture.replica,
+            "msg-ss-pi-hard-reset",
+            "rid-ss-pi-hard-reset",
+            Some(token.to_string()),
+            None,
+            None,
+            "proj-a:wg-1-dev-team/dev-rust",
+        );
+        let poller = MailboxPoller::new();
+
+        poller
+            .handle_self_handoff_switch(&app, &path, &message, false)
+            .await
+            .unwrap();
+        let response = read_response_json(&fixture.replica, "rid-ss-pi-hard-reset").unwrap();
+        assert_eq!(response["status"], "queued");
+        assert_eq!(response["target_coding_agent"], "pi");
+        assert_eq!(response["target_profile"], "A");
+
+        let target_agent = response["target_coding_agent"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let target_profile = response["target_profile"].as_str().unwrap().to_string();
+        let pending = app.state::<Arc<crate::PendingSelfClear>>().inner().clone();
+        let state_ids = Arc::new(Mutex::new(Vec::<Uuid>::new()));
+        let state_ids_seen = Arc::clone(&state_ids);
+        let app_for_state = app.clone();
+        let session_state = move |session_id: Uuid| {
+            let app = app_for_state.clone();
+            let state_ids = Arc::clone(&state_ids_seen);
+            async move {
+                state_ids.lock().unwrap().push(session_id);
+                let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                let mgr = state.read().await;
+                match mgr.get_session(session_id).await {
+                    Some(session) => (true, session.waiting_for_input),
+                    None => (false, false),
+                }
+            }
+        };
+
+        let app_for_persist = app.clone();
+        let persist = move |cwd: PathBuf, agent: String, profile: String| {
+            let app = app_for_persist.clone();
+            async move {
+                let settings = app.state::<SettingsState>();
+                let snapshot = settings.read().await.clone();
+                crate::config::coding_agent_profiles::set_replica_coding_agent_selection(
+                    &snapshot, &cwd, &agent, &profile,
+                )
+            }
+        };
+
+        let restarted_id = Arc::new(Mutex::new(None::<Uuid>));
+        let restarted_id_seen = Arc::clone(&restarted_id);
+        let app_for_restart = app.clone();
+        let replica_for_restart = fixture.replica.clone();
+        let restart = move |session_id: Uuid, agent: String, profile: String| {
+            let app = app_for_restart.clone();
+            let replica = replica_for_restart.clone();
+            let restarted_id = Arc::clone(&restarted_id_seen);
+            async move {
+                assert_eq!(session_id, source_id);
+                assert_eq!(agent, "pi");
+                assert_eq!(profile, "A");
+                {
+                    let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                    let mgr = state.read().await;
+                    mgr.destroy_session(session_id).await.unwrap();
+                }
+                let (new_id, _token) = seed_self_switch_session(
+                    &app,
+                    &replica,
+                    "pi",
+                    Some("pi"),
+                    Some(&profile),
+                    Some(&profile),
+                )
+                .await;
+                {
+                    let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+                    let mgr = state.read().await;
+                    mgr.mark_idle(new_id).await;
+                }
+                register_mock_pty_route(&app, new_id);
+                *restarted_id.lock().unwrap() = Some(new_id);
+                Ok(new_id.to_string())
+            }
+        };
+
+        let injected_prompts = Arc::new(Mutex::new(Vec::<(Uuid, String)>::new()));
+        let injected_prompts_seen = Arc::clone(&injected_prompts);
+        let app_for_inject = app.clone();
+        let inject = move |session_id: Uuid, prompt: String| {
+            let app = app_for_inject.clone();
+            let injected_prompts = Arc::clone(&injected_prompts_seen);
+            async move {
+                injected_prompts
+                    .lock()
+                    .unwrap()
+                    .push((session_id, prompt.clone()));
+                crate::pty::inject::inject_text_into_session(&app, session_id, &prompt).await
+            }
+        };
+        let boundaries = Arc::new(Mutex::new(Vec::<(Uuid, SelfClearBoundary)>::new()));
+        let boundaries_seen = Arc::clone(&boundaries);
+        let note_boundary = move |session_id: Uuid, boundary: SelfClearBoundary| {
+            let boundaries = Arc::clone(&boundaries_seen);
+            async move {
+                boundaries.lock().unwrap().push((session_id, boundary));
+            }
+        };
+
+        MailboxPoller::drive_self_switch_after_sustained_idle(
+            source_id,
+            fixture.replica.clone(),
+            target_agent,
+            target_profile,
+            None,
+            Arc::clone(&pending),
+            Duration::ZERO,
+            Duration::ZERO,
+            Duration::from_secs(30),
+            session_state,
+            persist,
+            restart,
+            inject,
+            note_boundary,
+        )
+        .await;
+
+        let target_id = restarted_id
+            .lock()
+            .unwrap()
+            .expect("restart seam must return the reseeded Pi session id");
+        assert_ne!(target_id, source_id);
+        assert_eq!(*state_ids.lock().unwrap(), vec![source_id, target_id]);
+        let prompts = injected_prompts.lock().unwrap().clone();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].0, target_id);
+        assert!(prompts[0].1.contains("self-clear/"), "{}", prompts[0].1);
+        assert_eq!(
+            mock_pty_writes_for(&app, target_id),
+            vec![
+                prompts[0].1.as_bytes().to_vec(),
+                b"\r".to_vec(),
+                b"\r".to_vec()
+            ]
+        );
+        assert_eq!(
+            *boundaries.lock().unwrap(),
+            vec![(target_id, SelfClearBoundary::ContentInjected)]
+        );
+        let manager = {
+            let state = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+            let guard = state.read().await;
+            guard.clone()
+        };
+        assert!(manager.get_session(source_id).await.is_none());
+        let target = manager.get_session(target_id).await.unwrap();
+        assert_eq!(target.shell, "pi");
+        assert_eq!(target.agent_id.as_deref(), Some("pi"));
+        assert!(pending.0.lock().unwrap().is_empty());
+        let saved: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(fixture.replica.join("config.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(saved["tooling"]["currentCodingAgent"], "pi");
+        assert_eq!(saved["tooling"]["profile"], "A");
+    }
+
+    #[tokio::test]
+    async fn self_switch_pi_source_none_agent_id_omitted_target_resolves_pi_via_replica() {
+        // A real Pi session may spawn with agent_id = None. With no --coding-agent
+        // and no live agent_id, target resolution takes the third arm
+        // (read_replica_current_coding_agent), which must yield `pi`.
+        let fixture = make_self_switch_fixture();
+        let app = app_handle(&fixture.app);
+        {
+            let settings = app.state::<SettingsState>();
+            settings
+                .write()
+                .await
+                .agents
+                .push(wake_agent("pi", "Pi", "pi"));
+        }
+        {
+            let settings = app.state::<SettingsState>();
+            let snapshot = settings.read().await.clone();
+            crate::config::coding_agent_profiles::set_replica_coding_agent_selection(
+                &snapshot,
+                &fixture.replica,
+                "pi",
+                "A",
+            )
+            .unwrap();
+        }
+        let (session_id, token) =
+            seed_self_switch_session(&app, &fixture.replica, "pi", None, None, None).await;
+        seed_self_handoff(&fixture.replica);
+        let (path, message) = build_self_switch_message(
+            &fixture.replica,
+            "msg-ss-pi-none-agent",
+            "rid-ss-pi-none-agent",
+            Some(token.to_string()),
+            None,
+            None,
+            "proj-a:wg-1-dev-team/dev-rust",
+        );
+        let poller = MailboxPoller::new();
+
+        poller
+            .handle_self_handoff_switch(&app, &path, &message, false)
+            .await
+            .unwrap();
+        let response = read_response_json(&fixture.replica, "rid-ss-pi-none-agent").unwrap();
+        assert_eq!(response["status"], "queued");
+        assert_eq!(response["target_coding_agent"], "pi");
+        assert_eq!(response["target_profile"], "A");
+        assert!(pending_self_clear_contains(&app, session_id).await);
     }
 
     #[tokio::test]

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -95,7 +95,7 @@ pub(crate) fn supports_auto_self_maintenance(shell: &str) -> bool {
 pub(crate) fn supports_self_handoff_switch(shell: &str) -> bool {
     matches!(
         pty_injection_profile(shell),
-        PtyInjectionProfile::Established | PtyInjectionProfile::Cursor
+        PtyInjectionProfile::Established | PtyInjectionProfile::Cursor | PtyInjectionProfile::Pi
     )
 }
 
@@ -369,7 +369,7 @@ mod tests {
                 "Pi compact remains unsupported: {shell:?}"
             );
             assert!(supports_auto_self_maintenance(shell));
-            assert!(!supports_self_handoff_switch(shell));
+            assert!(supports_self_handoff_switch(shell), "Pi switch source: {shell:?}");
         }
 
         let unsupported = [


### PR DESCRIPTION
## Summary

Allows **Pi** to be a valid **source** shell for `self-handoff-and-switch`. Pi is a first-class built-in coding agent, but the switch source gate deliberately excluded it (a dedicated `supports_self_handoff_switch` predicate, locked by a test). A user running Pi was blocked from switching. This flips exactly one capability bit so a Pi source passes the gate; the rest of the switch flow is already target-keyed and unchanged.

Closes #1081.

## Changes (3 files, +502 / -9)

- `src-tauri/src/pty/inject.rs`: `supports_self_handoff_switch` now accepts `Established | Cursor | Pi`; unit matrix assertion flipped for Pi. The Pi-lookalike regression lock (`pip`, `pipx`, `ping`, ...) is unchanged.
- `src-tauri/src/phone/mailbox.rs`: gate error string now names Pi among supported sources (required substrings preserved); repurposed the source-rejection lock to a genuinely-unsupported shell (`pwsh`); added the positive Pi-source handler test (9.3), the Pi -> established-target end-to-end driver test (9.4), and the Pi -> Pi omitted-target hard-reset test including the `agent_id = None` replica-arm case (9.6).
- `docs/integrations/coding-agents.md`: line 34 now states an exact-stem Pi shell is a supported `self-handoff-and-switch` source; "Pi compact remains unsupported" is kept.

## Approach

Design + verification (architect plan, plus dev-rust and grinch enrichment) established that the source shell is read at exactly one point — the source gate (`mailbox.rs:5967`). Everything downstream (target resolution, respawn, resume-prompt injection with the double Enter) is keyed off the TARGET agent, not the source. Enabling the predicate therefore removes a gate from an already-proven flow; no switch/respawn/injection logic changed.

## Verification

- Full delivery pipeline: architect plan certified (`Plan-SHA256: AC0FD88683...`) -> dev-rust + grinch enrichment -> architect consensus `READY_FOR_IMPLEMENTATION` -> implementation -> grinch review **PASS**.
- `cargo test --all-targets` (src-tauri): **2904 passed, 14 ignored, 0 failed**. `cargo clippy --all-targets`: clean.
- Grinch review PASS: faithful to the frozen plan, test assertions verified as real (not tautological), no out-of-scope changes.

## Out of scope

The broader structural recognition rework (derive coding-agent identity from the catalog single source; also fixes `hermes` / `opencode`, currently classified `Unsupported`) is tracked separately in #1082.
