### PR TITLE
style(rust): restore formatter gate (#1124)

### DIFF
--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -10,9 +10,7 @@ use clap::Args;
 use serde::{Deserialize, Serialize};
 
 use crate::cli::create_agent;
-use crate::commands::entity_creation::{
-    create_agent_matrix_on_disk, CreateAgentMatrixDiskArgs,
-};
+use crate::commands::entity_creation::{create_agent_matrix_on_disk, CreateAgentMatrixDiskArgs};
 use crate::config::projects::resolve_project_reference;
 
 #[derive(Args)]

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -525,7 +525,11 @@ fn detect_wg_replica(root: &str) -> Result<Option<WgReplicaInfo>, String> {
     let Some(layout) = crate::config::workspace::wg_replica_layout_from_agent_dir(&canon)? else {
         return Ok(None);
     };
-    let Some(my_project) = layout.project_dir.file_name().and_then(|name| name.to_str()) else {
+    let Some(my_project) = layout
+        .project_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
         return Ok(None);
     };
 
@@ -1984,7 +1988,10 @@ mod tests {
 
         peer.context_percent = None;
         let json = serde_json::to_string(&peer).unwrap();
-        assert!(!json.contains("contextPercent"), "None must omit the key: {json}");
+        assert!(
+            !json.contains("contextPercent"),
+            "None must omit the key: {json}"
+        );
     }
 
     #[test]
@@ -2000,7 +2007,10 @@ mod tests {
         let lean = LeanPeerInfo::from(&peer);
         assert_eq!(lean.context_percent, None);
         let json = serde_json::to_string(&lean).unwrap();
-        assert!(!json.contains("contextPercent"), "None must omit the key: {json}");
+        assert!(
+            !json.contains("contextPercent"),
+            "None must omit the key: {json}"
+        );
     }
 
     // §6.3 — field preservation parity

--- a/src-tauri/src/cli/role_experiment.rs
+++ b/src-tauri/src/cli/role_experiment.rs
@@ -11,9 +11,8 @@ use sha2::{Digest, Sha256};
 use crate::cli::session_safety::{find_live_sessions_under, LiveSessionBlocker};
 use crate::cli::workgroup;
 use crate::commands::entity_creation::{
-    agent_ref_bare_name, create_agent_matrix_from_role,
-    resolve_agent_ref, sanitize_name, validate_existing_name,
-    CreateAgentMatrixFromRoleArgs,
+    agent_ref_bare_name, create_agent_matrix_from_role, resolve_agent_ref, sanitize_name,
+    validate_existing_name, CreateAgentMatrixFromRoleArgs,
 };
 
 #[derive(Args)]

--- a/src-tauri/src/cli/task_ops.rs
+++ b/src-tauri/src/cli/task_ops.rs
@@ -1519,7 +1519,11 @@ mod tests {
         // lowercase duplicate (Grinch MUST-FIX #1 second half).
         let parsed = parse_task("---\nTitle: Old\n---\nbody\n");
         let p = apply_set_title(&parsed, "Auto");
-        let title_lines = p.frontmatter.iter().filter(|l| title_line(l).is_some()).count();
+        let title_lines = p
+            .frontmatter
+            .iter()
+            .filter(|l| title_line(l).is_some())
+            .count();
         assert_eq!(title_lines, 1, "exactly one title line after replacement");
         assert_eq!(p.frontmatter, vec!["title: 'Auto'".to_string()]);
     }
@@ -1537,7 +1541,11 @@ mod tests {
         let now = || fixed_now_at(2026, 1, 1, 0, 0, 0);
         let r = perform_inner(&wg, TaskOp::SetTitle("USER: forged".into()), now);
         assert!(matches!(r, Err(TaskOpError::ReservedUserTitlePrefix)));
-        assert_eq!(std::fs::read(&task).unwrap(), before, "unchanged on invalid input");
+        assert_eq!(
+            std::fs::read(&task).unwrap(),
+            before,
+            "unchanged on invalid input"
+        );
         assert_eq!(bak_count(&wg), 0, "no backup on invalid input");
     }
 

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -150,9 +150,7 @@ fn validate_definition(def: &CodingAgentDefinition) -> Result<(), String> {
     validate_env_rows(&def.envs, &context)?;
     if let Some(name) = def.instructions_filename.as_deref() {
         if !is_safe_instructions_filename(name) {
-            return Err(format!(
-                "{context}: unsafe instructions filename '{name}'"
-            ));
+            return Err(format!("{context}: unsafe instructions filename '{name}'"));
         }
     }
     if let Some(cfg) = def.config_seed.as_ref() {
@@ -192,7 +190,10 @@ fn validate_and_filter(
 /// The embedded default, validated (defensive; also dedups). Used as the
 /// in-memory fallback when the on-disk manifest is missing or unparseable.
 fn validated_embedded_default() -> Vec<CodingAgentDefinition> {
-    validate_and_filter(embedded_default_catalog().agents, "embedded default catalog")
+    validate_and_filter(
+        embedded_default_catalog().agents,
+        "embedded default catalog",
+    )
 }
 
 /// Load the catalog for the `get_coding_agent_catalog` command.
@@ -264,7 +265,10 @@ pub fn ensure_seeded(config_dir: &Path) {
     }
 
     match write_manifest_atomic(&path, EMBEDDED_DEFAULT_CATALOG_JSON.as_bytes()) {
-        Ok(()) => log::info!("[coding-agents] seeded default catalog at {}", path.display()),
+        Ok(()) => log::info!(
+            "[coding-agents] seeded default catalog at {}",
+            path.display()
+        ),
         Err(e) => log::warn!("[coding-agents] failed to seed {} ({e})", path.display()),
     }
 }
@@ -421,8 +425,7 @@ pub fn reseedable_command_basenames() -> Vec<String> {
 /// Reduce a coding-agent command to its executable basename (lowercase), mirroring
 /// the settings save path. `None` if the command does not tokenize.
 fn command_executable_basename(command: &str) -> Option<String> {
-    let normalized =
-        crate::config::agent_command::normalize_legacy_agent_command(command).ok()?;
+    let normalized = crate::config::agent_command::normalize_legacy_agent_command(command).ok()?;
     Some(crate::config::settings::command_token_basename(
         &normalized.shell,
     ))
@@ -479,7 +482,10 @@ pub fn ensure_seeded_masters(config_dir: &Path) {
             ),
             Err(e) => {
                 let _ = std::fs::remove_dir_all(&staging);
-                log::warn!("[coding-agents] failed to seed master {} ({e})", dir.display());
+                log::warn!(
+                    "[coding-agents] failed to seed master {} ({e})",
+                    dir.display()
+                );
             }
         }
     }
@@ -574,7 +580,10 @@ fn backup_master_dir(dir: &Path) -> Result<PathBuf, String> {
             .map_err(|e| format!("backup {} -> {}: {e}", dir.display(), bak.display()))?;
         return Ok(bak);
     }
-    Err(format!("could not find a unique .bak path for {}", dir.display()))
+    Err(format!(
+        "could not find a unique .bak path for {}",
+        dir.display()
+    ))
 }
 
 fn unique_suffix() -> String {
@@ -607,11 +616,51 @@ mod tests {
     /// frontend keeps a parallel `FALLBACK_CODING_AGENTS` test (E7).
     #[allow(clippy::type_complexity)]
     const EXPECTED_PRESETS: [(&str, &str, &str, &str, &str, &str, Option<&str>); 6] = [
-        ("claude", "Claude Code", "Coding Agent by Anthropic", "#d97706", "claude", "CLAUDE.md", Some(".claude")),
-        ("codex", "Codex", "Coding Agent by OpenAI", "#10b981", "codex", "AGENTS.md", Some(".codex")),
-        ("hermes", "Hermes", "Coding Agent by Nous Research", "#8b5cf6", "hermes", "AGENTS.md", None),
-        ("cursor", "Cursor CLI", "Coding Agent by Cursor", "#22d3ee", "agent", "AGENTS.md", None),
-        ("pi", "Pi", "Coding Agent by Earendil Inc", "#ec4899", "pi", "AGENTS.md", None),
+        (
+            "claude",
+            "Claude Code",
+            "Coding Agent by Anthropic",
+            "#d97706",
+            "claude",
+            "CLAUDE.md",
+            Some(".claude"),
+        ),
+        (
+            "codex",
+            "Codex",
+            "Coding Agent by OpenAI",
+            "#10b981",
+            "codex",
+            "AGENTS.md",
+            Some(".codex"),
+        ),
+        (
+            "hermes",
+            "Hermes",
+            "Coding Agent by Nous Research",
+            "#8b5cf6",
+            "hermes",
+            "AGENTS.md",
+            None,
+        ),
+        (
+            "cursor",
+            "Cursor CLI",
+            "Coding Agent by Cursor",
+            "#22d3ee",
+            "agent",
+            "AGENTS.md",
+            None,
+        ),
+        (
+            "pi",
+            "Pi",
+            "Coding Agent by Earendil Inc",
+            "#ec4899",
+            "pi",
+            "AGENTS.md",
+            None,
+        ),
         (
             "opencode",
             "OpenCode",
@@ -636,11 +685,17 @@ mod tests {
         let catalog = embedded_default_catalog();
         assert_eq!(catalog.schema_version, CATALOG_SCHEMA_VERSION);
         let keys: Vec<&str> = catalog.agents.iter().map(|a| a.key.as_str()).collect();
-        assert_eq!(keys, ["claude", "codex", "hermes", "cursor", "pi", "opencode"]);
+        assert_eq!(
+            keys,
+            ["claude", "codex", "hermes", "cursor", "pi", "opencode"]
+        );
         // OpenCode is last and carries the #768 "by Anomaly" subtitle.
         let last = catalog.agents.last().unwrap();
         assert_eq!(last.key, "opencode");
-        assert_eq!(last.description, "Open-source terminal coding agent by Anomaly");
+        assert_eq!(
+            last.description,
+            "Open-source terminal coding agent by Anomaly"
+        );
     }
 
     #[test]
@@ -668,7 +723,10 @@ mod tests {
                     assert!(cs.enabled, "{key} configSeed must be enabled");
                     assert_eq!(cs.dest, dest, "{key} configSeed dest");
                 }
-                None => assert!(def.config_seed.is_none(), "{key} must ship configSeed UNSET"),
+                None => assert!(
+                    def.config_seed.is_none(),
+                    "{key} must ship configSeed UNSET"
+                ),
             }
             assert!(def.removable, "{key} must be removable");
             assert!(def.envs.is_empty());
@@ -695,7 +753,16 @@ mod tests {
         for ok in ["claude", "cursor-cli", "pi", "a1", "opencode", "x-2-y"] {
             assert!(validate_catalog_key(ok).is_ok(), "should accept {ok:?}");
         }
-        for bad in ["", "Claude", "cursor_cli", "cursor cli", "café", "a.b", "UP", "a/b"] {
+        for bad in [
+            "",
+            "Claude",
+            "cursor_cli",
+            "cursor cli",
+            "café",
+            "a.b",
+            "UP",
+            "a/b",
+        ] {
             assert!(validate_catalog_key(bad).is_err(), "should reject {bad:?}");
         }
     }
@@ -717,7 +784,11 @@ mod tests {
         std::fs::write(&path, garbage).unwrap();
 
         let agents = load_catalog(dir.path());
-        assert_eq!(agents.len(), 6, "corrupt file self-heals to embedded default");
+        assert_eq!(
+            agents.len(),
+            6,
+            "corrupt file self-heals to embedded default"
+        );
         // G3: the corrupt file is preserved byte-for-byte, never overwritten.
         assert_eq!(std::fs::read(&path).unwrap(), garbage);
     }
@@ -842,8 +913,15 @@ mod tests {
                 .as_ref()
                 .unwrap_or_else(|| panic!("{} def missing configSeed", m.command_basename));
             assert!(cs.enabled);
-            assert_eq!(cs.dest, m.dest, "master dest must match the def configSeed dest");
-            assert!(!m.files.is_empty(), "master {} must ship >=1 file", m.command_basename);
+            assert_eq!(
+                cs.dest, m.dest,
+                "master dest must match the def configSeed dest"
+            );
+            assert!(
+                !m.files.is_empty(),
+                "master {} must ship >=1 file",
+                m.command_basename
+            );
         }
     }
 
@@ -900,7 +978,10 @@ mod tests {
 
         let result = reseed_master_for_command(dir.path(), "codex").unwrap();
         assert_eq!(result.dest, ".codex");
-        assert!(result.backup_path.is_empty(), "no backup when master was absent");
+        assert!(
+            result.backup_path.is_empty(),
+            "no backup when master was absent"
+        );
         assert_eq!(
             std::fs::read(master_dir.join(m.files[0].rel_path)).unwrap(),
             m.files[0].bytes
@@ -921,7 +1002,13 @@ mod tests {
             );
         }
         // Path/extension forms of a real master command still resolve by basename.
-        for good in ["claude", "codex", "opencode", "claude.exe", "codex --model x"] {
+        for good in [
+            "claude",
+            "codex",
+            "opencode",
+            "claude.exe",
+            "codex --model x",
+        ] {
             assert!(
                 reseed_master_for_command(dir.path(), good).is_ok(),
                 "should accept {good:?}"
@@ -933,6 +1020,12 @@ mod tests {
     fn master_dir_for_dest_is_under_seed_subdir() {
         let dir = seed_dir();
         let p = master_dir_for_dest(dir.path(), ".claude");
-        assert_eq!(p, dir.path().join("coding-agents").join("_seed").join(".claude"));
+        assert_eq!(
+            p,
+            dir.path()
+                .join("coding-agents")
+                .join("_seed")
+                .join(".claude")
+        );
     }
 }

--- a/src-tauri/src/config/coordinator_clocks.rs
+++ b/src-tauri/src/config/coordinator_clocks.rs
@@ -558,7 +558,10 @@ mod tests {
         let mut clocks = CoordinatorClocks::default();
         let fqn = "proj:wg-1-team/coord";
 
-        assert!(clocks.mark_auto_closed(fqn, ts(0)), "first mark transitions None -> Some");
+        assert!(
+            clocks.mark_auto_closed(fqn, ts(0)),
+            "first mark transitions None -> Some"
+        );
         assert_eq!(clocks.auto_closed_at(fqn), Some(ts(0)));
         assert!(
             !clocks.mark_auto_closed(fqn, ts(50)),
@@ -614,7 +617,10 @@ mod tests {
 
         clocks.note_user_message(fqn, ts(0));
         clocks.mark_manually_closed(fqn, ts(1));
-        assert!(clocks.clear_manually_closed(fqn), "Some -> None returns true");
+        assert!(
+            clocks.clear_manually_closed(fqn),
+            "Some -> None returns true"
+        );
         assert_eq!(clocks.manually_closed_at(fqn), None);
         // The badge clock survives the clear.
         assert_eq!(clocks.last_user_message_at(fqn), Some(ts(0)));
@@ -749,12 +755,18 @@ mod tests {
         // An older candidate is a no-op (monotonic forward) and does not dirty.
         assert!(!clocks.note_activity(fqn, ts(150)));
         assert_eq!(clocks.last_activity_at(fqn), Some(ts(200)));
-        assert!(!clocks.take_dirty(), "an older candidate must not dirty the store");
+        assert!(
+            !clocks.take_dirty(),
+            "an older candidate must not dirty the store"
+        );
 
         // An equal candidate is also a no-op (advance is strictly-newer).
         assert!(!clocks.note_activity(fqn, ts(200)));
         assert_eq!(clocks.last_activity_at(fqn), Some(ts(200)));
-        assert!(!clocks.take_dirty(), "an equal candidate must not dirty the store");
+        assert!(
+            !clocks.take_dirty(),
+            "an equal candidate must not dirty the store"
+        );
     }
 
     #[test]
@@ -897,8 +909,12 @@ mod tests {
         assert!(clocks.take_dirty(), "a real removal dirties the store");
         assert_eq!(clocks.last_user_message_at("proj:wg-1-team/coord"), None);
         assert_eq!(clocks.last_user_message_at("proj:wg-1-team/dev"), None);
-        assert!(clocks.last_user_message_at("proj:wg-2-team/coord").is_some());
-        assert!(clocks.last_user_message_at("other:wg-1-team/coord").is_some());
+        assert!(clocks
+            .last_user_message_at("proj:wg-2-team/coord")
+            .is_some());
+        assert!(clocks
+            .last_user_message_at("other:wg-1-team/coord")
+            .is_some());
         assert!(clocks.last_user_message_at("proj/architect").is_some());
     }
 
@@ -921,14 +937,17 @@ mod tests {
         clocks.note_user_message("proj:wg-2-team/coord", ts(0));
         let _ = clocks.take_dirty();
         assert_eq!(clocks.remove_workgroup("proj", "wg-1-team"), 0);
-        assert!(!clocks.take_dirty(), "removing nothing must not dirty the store");
+        assert!(
+            !clocks.take_dirty(),
+            "removing nothing must not dirty the store"
+        );
     }
 
     #[test]
     fn remove_workgroup_is_case_insensitive() {
         let mut clocks = CoordinatorClocks::default();
         clocks.note_user_message("MyProj:WG-1-Team/coord", ts(0)); // key carries spawn case
-        // Caller passes a different case (e.g. project resolved as a read_dir child).
+                                                                   // Caller passes a different case (e.g. project resolved as a read_dir child).
         assert_eq!(clocks.remove_workgroup("myproj", "wg-1-team"), 1);
         assert_eq!(clocks.last_user_message_at("MyProj:WG-1-Team/coord"), None);
     }
@@ -945,13 +964,22 @@ mod tests {
         // Live wg dir present -> KEEP.
         assert!(should_keep_clock_key("MyProj:wg-1-live/coord", &candidates));
         // Wg dir confirmed absent -> PRUNE.
-        assert!(!should_keep_clock_key("MyProj:wg-2-gone/coord", &candidates));
+        assert!(!should_keep_clock_key(
+            "MyProj:wg-2-gone/coord",
+            &candidates
+        ));
         // Origin agent (no ':') -> KEEP.
         assert!(should_keep_clock_key("MyProj/architect", &candidates));
         // Unknown/unregistered project -> KEEP (cannot confirm).
-        assert!(should_keep_clock_key("Unregistered:wg-1/coord", &candidates));
+        assert!(should_keep_clock_key(
+            "Unregistered:wg-1/coord",
+            &candidates
+        ));
         // Project name resolves case-insensitively (matches resolve_project_reference).
-        assert!(!should_keep_clock_key("myproj:wg-2-gone/coord", &candidates));
+        assert!(!should_keep_clock_key(
+            "myproj:wg-2-gone/coord",
+            &candidates
+        ));
     }
 
     #[test]
@@ -1001,13 +1029,21 @@ mod tests {
         let empty: HashSet<String> = HashSet::new();
         let mut probe = CoordinatorClocks::default();
         probe.note_user_message("app:wg-5-team/coord", ts(0));
-        assert_eq!(prune_with(&mut probe, &candidates, &empty), 1, "unprotected -> pruned");
+        assert_eq!(
+            prune_with(&mut probe, &candidates, &empty),
+            1,
+            "unprotected -> pruned"
+        );
 
         // With the persisted-session keep-set the live key survives.
         let mut clocks = CoordinatorClocks::default();
         clocks.note_user_message("app:wg-5-team/coord", ts(0)); // live coord of the OTHER "app"
         let live: HashSet<String> = HashSet::from(["app:wg-5-team/coord".to_string()]);
-        assert_eq!(prune_with(&mut clocks, &candidates, &live), 0, "live key protected");
+        assert_eq!(
+            prune_with(&mut clocks, &candidates, &live),
+            0,
+            "live key protected"
+        );
         assert!(clocks.last_user_message_at("app:wg-5-team/coord").is_some());
     }
 }

--- a/src-tauri/src/config/project_settings.rs
+++ b/src-tauri/src/config/project_settings.rs
@@ -656,8 +656,11 @@ mod tests {
     fn save_persists_non_stop_and_preserves_unknown_keys() {
         let project = project_with_workspace();
         let path = settings_path(project.path());
-        std::fs::write(&path, r#"{"agents":[{"id":"a1"}],"tooling":{"custom":true}}"#)
-            .expect("write settings");
+        std::fs::write(
+            &path,
+            r#"{"agents":[{"id":"a1"}],"tooling":{"custom":true}}"#,
+        )
+        .expect("write settings");
         let config = WorkgroupGroupsConfig {
             groups: vec![group("bots", "BOTS", "^(wg-9)$")],
             show_all: true,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -677,10 +677,7 @@ struct ScraperPersist {
 }
 
 impl ContextPersistSink for ScraperPersist {
-    fn commit(
-        &self,
-        changed: Vec<(uuid::Uuid, Option<u8>)>,
-    ) -> futures::future::BoxFuture<'_, ()> {
+    fn commit(&self, changed: Vec<(uuid::Uuid, Option<u8>)>) -> futures::future::BoxFuture<'_, ()> {
         // Clone the Arc before the `async move` so the returned future is
         // 'static + Send (it captures the Arc, not `&self`).
         let mgr = Arc::clone(&self.session_mgr);

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -15,7 +15,7 @@
 use std::collections::VecDeque;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 static INIT: OnceLock<()> = OnceLock::new();
@@ -349,8 +349,8 @@ fn install_format(builder: &mut env_logger::Builder, log_state: Arc<Option<Arc<A
             if let Ok(mut f) = state.file.lock() {
                 let _ = f.write_all(line.as_bytes());
             }
-            let new_total = state.bytes.fetch_add(line.len() as u64, Ordering::Relaxed)
-                + line.len() as u64;
+            let new_total =
+                state.bytes.fetch_add(line.len() as u64, Ordering::Relaxed) + line.len() as u64;
             if new_total >= APP_LOG_MAX_BYTES {
                 rotate(state);
             }

--- a/src-tauri/src/loops/non_stop_watchdog.rs
+++ b/src-tauri/src/loops/non_stop_watchdog.rs
@@ -400,7 +400,13 @@ mod tests {
     }
 
     async fn disparity_since(state: &NonStopWatchdogState, project: &str) -> Option<Instant> {
-        state.inner.lock().await.get(project).unwrap().disparity_since
+        state
+            .inner
+            .lock()
+            .await
+            .get(project)
+            .unwrap()
+            .disparity_since
     }
 
     async fn is_fired(state: &NonStopWatchdogState, project: &str) -> bool {
@@ -492,7 +498,12 @@ mod tests {
         state.ingest(vec![report("p", true, 30)]).await;
         backdate_disparity(&state, "p", Duration::from_secs(31)).await;
         // Frontend went silent well past the ceiling.
-        backdate_last_seen(&state, "p", REPORT_STALENESS_CEILING + Duration::from_secs(1)).await;
+        backdate_last_seen(
+            &state,
+            "p",
+            REPORT_STALENESS_CEILING + Duration::from_secs(1),
+        )
+        .await;
 
         // One collection disarms instead of firing.
         assert!(fireable(&state).await.is_empty());

--- a/src-tauri/src/phone/messaging.rs
+++ b/src-tauri/src/phone/messaging.rs
@@ -831,7 +831,11 @@ mod tests {
         assert_eq!(rendered.matches(rid).count(), 2);
         assert_eq!(
             rendered.len(),
-            PTY_WRAP_FIXED + "wg7-me".len() + "hi".len() + PTY_RESPONSE_MARKER_FIXED + 2 * rid.len()
+            PTY_WRAP_FIXED
+                + "wg7-me".len()
+                + "hi".len()
+                + PTY_RESPONSE_MARKER_FIXED
+                + 2 * rid.len()
         );
         assert!(rendered.starts_with('\n'));
         assert!(rendered.ends_with("\n\r"));

--- a/src-tauri/src/pty/container_credentials.rs
+++ b/src-tauri/src/pty/container_credentials.rs
@@ -129,8 +129,7 @@ pub fn copy_in(plan: &ContainerCredentialPlan) -> std::io::Result<CopyOutcome> {
         use std::os::unix::fs::PermissionsExt;
         // F4 - do not silently swallow a perms failure; a token left broadly
         // readable must at least be observable in the log.
-        if let Err(e) =
-            std::fs::set_permissions(&plan.dest, std::fs::Permissions::from_mode(0o600))
+        if let Err(e) = std::fs::set_permissions(&plan.dest, std::fs::Permissions::from_mode(0o600))
         {
             log::warn!(
                 "[container-cred] failed to set 0o600 on {}: {}",
@@ -159,7 +158,10 @@ pub fn remove_copied(dest: &Path) {
         return;
     }
     match std::fs::remove_file(dest) {
-        Ok(()) => log::info!("[container-cred] removed copied credential {}", dest.display()),
+        Ok(()) => log::info!(
+            "[container-cred] removed copied credential {}",
+            dest.display()
+        ),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => log::warn!(
             "[container-cred] failed to remove copied credential {}: {}",
@@ -508,7 +510,10 @@ mod tests {
         );
         // Untouched: pre-existing keys and unrelated project entries.
         assert_eq!(v["userID"], serde_json::json!("abc"));
-        assert_eq!(v["oauthAccount"]["emailAddress"], serde_json::json!("x@y.z"));
+        assert_eq!(
+            v["oauthAccount"]["emailAddress"],
+            serde_json::json!("x@y.z")
+        );
         assert_eq!(
             v["projects"]["/other"]["hasTrustDialogAccepted"],
             serde_json::json!(false)

--- a/src-tauri/src/pty/container_repos.rs
+++ b/src-tauri/src/pty/container_repos.rs
@@ -66,14 +66,16 @@ impl RepoMountResolution {
     /// The Docker consumer: canonical host path + container target for each
     /// mounted repo, in config order.
     pub fn mounts(&self) -> impl Iterator<Item = (&Path, &str)> {
-        self.entries.iter().filter_map(|entry| match &entry.outcome {
-            RepoOutcome::Mounted {
-                host_path,
-                container_path,
-                ..
-            } => Some((host_path.as_path(), container_path.as_str())),
-            RepoOutcome::NotFound => None,
-        })
+        self.entries
+            .iter()
+            .filter_map(|entry| match &entry.outcome {
+                RepoOutcome::Mounted {
+                    host_path,
+                    container_path,
+                    ..
+                } => Some((host_path.as_path(), container_path.as_str())),
+                RepoOutcome::NotFound => None,
+            })
     }
 }
 

--- a/src-tauri/src/pty/inject.rs
+++ b/src-tauri/src/pty/inject.rs
@@ -350,7 +350,11 @@ where
 
     // Write the text block through the held permit.
     PtyManager::write_with_permit(&permit, text.as_bytes()).map_err(|error| {
-        log::error!("[inject] PTY write FAILED session={}: {}", session_id, error);
+        log::error!(
+            "[inject] PTY write FAILED session={}: {}",
+            session_id,
+            error
+        );
         format!("PTY write failed: {}", error)
     })?;
     log::info!(
@@ -747,7 +751,10 @@ mod tests {
                 "Pi compact remains unsupported: {shell:?}"
             );
             assert!(supports_auto_self_maintenance(shell));
-            assert!(supports_self_handoff_switch(shell), "Pi switch source: {shell:?}");
+            assert!(
+                supports_self_handoff_switch(shell),
+                "Pi switch source: {shell:?}"
+            );
         }
 
         let unsupported = [

--- a/src-tauri/src/pty/job.rs
+++ b/src-tauri/src/pty/job.rs
@@ -31,11 +31,13 @@ pub use stub_impl::JobObject;
 mod windows_impl {
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
     use windows_sys::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject, TerminateJobObject,
-        JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
     };
-    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+    };
 
     /// Owns a Job Object handle. Dropping it closes the handle; because the job is
     /// created with KILL_ON_JOB_CLOSE and we hold the only handle, the OS kills the

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -108,9 +108,7 @@ impl<'a> PtyRouteWriteGuard<'a> {
 
     pub(crate) fn retain_settings_guard(
         &mut self,
-        settings_guard: tokio::sync::OwnedRwLockReadGuard<
-            crate::config::settings::AppSettings,
-        >,
+        settings_guard: tokio::sync::OwnedRwLockReadGuard<crate::config::settings::AppSettings>,
     ) {
         self._settings_guard = Some(settings_guard);
     }

--- a/src-tauri/src/pty/spawn_diagnostics.rs
+++ b/src-tauri/src/pty/spawn_diagnostics.rs
@@ -256,7 +256,10 @@ fn env_u64(key: &str, default: u64, max: u64) -> u64 {
 #[derive(Debug, Clone)]
 pub enum ChildLiveness {
     Alive,
-    Exited { code: u32, success: bool },
+    Exited {
+        code: u32,
+        success: bool,
+    },
     /// The OS would not tell us. Distinct from `Alive` on purpose: reporting an
     /// unanswerable handle as "running" is the same ambiguity class as the
     /// `ExitStatus { code: 1 }` trap this module exists to kill.
@@ -613,7 +616,10 @@ impl SpawnRecord {
         let episode_open = self.stop_episode_open();
         self.record_witness(pre_stop, episode_open);
 
-        *self.ac_stop_source.lock().unwrap_or_else(|e| e.into_inner()) = Some(source.to_string());
+        *self
+            .ac_stop_source
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(source.to_string());
         let stamp = (self.started.elapsed().as_micros().min(u64::MAX as u128) as u64).max(1);
         self.ac_stop_at_us.store(stamp, Ordering::SeqCst);
         // Published last: any thread that sees this flag also sees the source, the
@@ -672,8 +678,8 @@ impl SpawnRecord {
             + chunk.len() as u64;
 
         let needs_first = self.first_output_us.load(Ordering::Relaxed) == 0;
-        let needs_paint =
-            self.first_paint_us.load(Ordering::Relaxed) == 0 && total >= self.thresholds.paint_floor;
+        let needs_paint = self.first_paint_us.load(Ordering::Relaxed) == 0
+            && total >= self.thresholds.paint_floor;
 
         if needs_first || needs_paint {
             let elapsed = self.started.elapsed();
@@ -834,7 +840,8 @@ impl SpawnRecord {
         // status, is the #942 smoking gun. A clean exit from a session that did come up
         // is just someone quitting.
         let never_came_up = self.is_stalled();
-        let unexpected = cause == ExitCause::ChildInitiated && (never_came_up || !liveness.exited_ok());
+        let unexpected =
+            cause == ExitCause::ChildInitiated && (never_came_up || !liveness.exited_ok());
         // The head bytes and the argv go out whenever the session never came up, whoever
         // ended it. The user who kills a blank terminal at t=3s (before the deadline
         // report can fire) is reporting THIS bug, and we must not answer with a one-line
@@ -1212,7 +1219,10 @@ mod tests {
 
         let shell = aged_record(None);
         shell.note_output(b"C:\\repo>");
-        assert!(!shell.is_stalled(), "a tiny shell prompt is a healthy start");
+        assert!(
+            !shell.is_stalled(),
+            "a tiny shell prompt is a healthy start"
+        );
 
         let painted = aged_record(Some(CodingAgentKind::Codex));
         painted.note_output(&vec![b'x'; painted.thresholds.paint_floor as usize]);
@@ -1603,13 +1613,22 @@ mod tests {
         let head = record.head_log();
         let argv = record.argv_log();
         for secret in [windows_path, quoted, control, unicode] {
-            assert!(!head.contains(secret), "raw secret survived in head: {head}");
-            assert!(!argv.contains(secret), "raw secret survived in argv: {argv}");
+            assert!(
+                !head.contains(secret),
+                "raw secret survived in head: {head}"
+            );
+            assert!(
+                !argv.contains(secret),
+                "raw secret survived in argv: {argv}"
+            );
         }
         // The escaped shapes must not survive either: escaping happens after the scrub.
         assert!(!head.contains("auth.json"), "escaped path survived: {head}");
         assert!(!argv.contains("auth.json"), "escaped path survived: {argv}");
-        assert!(!head.contains("9876"), "escaped non-ASCII secret survived: {head}");
+        assert!(
+            !head.contains("9876"),
+            "escaped non-ASCII secret survived: {head}"
+        );
         assert!(head.contains("<redacted>"));
         assert!(argv.contains("<redacted>"));
         assert!(
@@ -1625,8 +1644,14 @@ mod tests {
 ");
 
         let head = record.head_log();
-        assert!(!head.contains("AIzaSyFAKE_KEY_VALUE"), "url key survived: {head}");
-        assert!(head.contains("error: GET"), "the error text still has to be readable");
+        assert!(
+            !head.contains("AIzaSyFAKE_KEY_VALUE"),
+            "url key survived: {head}"
+        );
+        assert!(
+            head.contains("error: GET"),
+            "the error text still has to be readable"
+        );
     }
 
     #[test]
@@ -1894,7 +1919,9 @@ mod tests {
             wait_until(Duration::from_secs(2), || handle.is_finished()),
             "a panicking probe must end the monitor, not the app"
         );
-        handle.join().expect("the panic is caught inside the thread");
+        handle
+            .join()
+            .expect("the panic is caught inside the thread");
         assert!(!record.exit_reported.load(Ordering::Relaxed));
     }
 

--- a/src-tauri/src/resource_monitor/windows.rs
+++ b/src-tauri/src/resource_monitor/windows.rs
@@ -424,7 +424,11 @@ mod platform {
                 no_memory,
             );
 
-            assert!(tree.errors.is_empty(), "unexpected errors: {:?}", tree.errors);
+            assert!(
+                tree.errors.is_empty(),
+                "unexpected errors: {:?}",
+                tree.errors
+            );
             assert_eq!(tree.processes.len(), 2);
             assert_eq!(tree.processes[0].identity, identity(1000, 111));
             assert_eq!(tree.processes[0].depth, 0);
@@ -551,7 +555,11 @@ mod platform {
                 no_memory,
             );
 
-            assert!(tree.errors.is_empty(), "unexpected errors: {:?}", tree.errors);
+            assert!(
+                tree.errors.is_empty(),
+                "unexpected errors: {:?}",
+                tree.errors
+            );
             assert_eq!(tree.processes.len(), 2);
             assert!(probed.contains(&1000) && probed.contains(&1001));
             assert!(

--- a/src-tauri/src/update_check.rs
+++ b/src-tauri/src/update_check.rs
@@ -64,7 +64,9 @@ fn read_cache() -> Option<UpdateCache> {
 
 fn write_cache(cache: &UpdateCache) {
     let Some(path) = cache_path() else { return };
-    let Ok(json) = serde_json::to_string_pretty(cache) else { return };
+    let Ok(json) = serde_json::to_string_pretty(cache) else {
+        return;
+    };
     // Atomic write (L3/E1): write a sibling temp file, then rename over the
     // target so a concurrent reader (the Phase-2 CLI) never observes a
     // half-written file. On Windows, std::fs::rename maps to MoveFileExW with
@@ -242,7 +244,11 @@ pub async fn run_startup_check(app: AppHandle, cache_state: Arc<OnceLock<UpdateI
             info.latest_version
         );
     } else {
-        log::debug!("[update-check] up to date (current {}, latest {})", current, latest);
+        log::debug!(
+            "[update-check] up to date (current {}, latest {})",
+            current,
+            latest
+        );
     }
 }
 
@@ -342,8 +348,7 @@ pub fn read_cached_notice() -> Option<String> {
     if !is_newer(&cache.latest_version, current) {
         return None;
     }
-    let enabled =
-        crate::config::settings::load_settings_for_cli().npm_update_notifications_enabled;
+    let enabled = crate::config::settings::load_settings_for_cli().npm_update_notifications_enabled;
     cli_notice(&cache, current, enabled)
 }
 
@@ -436,7 +441,10 @@ mod tests {
             latest_version: "0.9.16".into(),
         };
         // Toggle off -> Skip, even with a fresh cache.
-        assert_eq!(plan_check(false, &Some(fresh.clone()), now), CheckPlan::Skip);
+        assert_eq!(
+            plan_check(false, &Some(fresh.clone()), now),
+            CheckPlan::Skip
+        );
         // Enabled + no cache -> Fetch.
         assert_eq!(plan_check(true, &None, now), CheckPlan::Fetch);
         // Enabled + fresh cache (throttle hit) -> UseCached.

--- a/src-tauri/tests/cli_ui_automation.rs
+++ b/src-tauri/tests/cli_ui_automation.rs
@@ -749,7 +749,14 @@ fn fake_response_makes_ui_hover_leave_succeed() {
 
     let (code, stdout, stderr) = run(
         &bin,
-        &["ui-hover", "--window", "main", "--leave", "--timeout-ms", "3000"],
+        &[
+            "ui-hover",
+            "--window",
+            "main",
+            "--leave",
+            "--timeout-ms",
+            "3000",
+        ],
     );
     responder.join().unwrap();
     assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");


### PR DESCRIPTION
## Summary

- Apply the repository-selected rustfmt normalization to the exact 20 certified Rust paths.
- Restore the formatter check baseline without semantic, dependency, workflow, API, schema, protocol, or test-behavior changes.

## Verification

- Exact 20-path and 67-zero-context-Git-hunk matrix verified.
- `cargo fmt --all -- --check` passed under the certified toolchain.
- `git diff --check` passed.
- Standalone detached-base byte-for-byte verifier passed.
- WG2 `dev-rust-grinch` completed adversarial review with PASS and no findings.
- Branch contains current `origin/main`.

## Delivery

N/A - non-visual change. No shipper build or GUI validation is required.

Closes #1124