### PR TITLE
test: repair session-context resolver call (#1125)

### DIFF
--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -7070,6 +7070,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             &no_skill_section(),
             &new_replica,
             None,
+            None,
         );
 
         // Restore write perms before any assertion so tempdir cleanup works.


### PR DESCRIPTION
## Summary

- Pass the intentionally absent sixth `repo_mounts` argument explicitly as `None` in the Unix test `heal_failure_is_non_fatal_and_preserves_render`.
- Restore the stale test call to the current resolver signature without changing production behavior.

## Review evidence

- Dev implementation: PASS
- Grinch adversarial review: PASS
- Impact classification: NON_VISUAL

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml --lib heal_failure_is_non_fatal_and_preserves_render -- --test-threads=1` — 1 passed, 0 failed
- `cargo check --manifest-path src-tauri/Cargo.toml` — passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml` — passed with only pre-existing unrelated warnings
- `git diff --check` — passed

Ship status: N/A - non-visual change

Closes #1125