### PR TITLE
test: own raise-hand simulator IDs (#1126)

### DIFF
--- a/src-tauri/tests/cli_raise_hand.rs
+++ b/src-tauri/tests/cli_raise_hand.rs
@@ -328,7 +328,10 @@ fn simulate_daemon_response(
             continue;
         };
 
-        break (path, body, msg, msg_id.to_string(), request_id.to_string());
+        let msg_id = msg_id.to_string();
+        let request_id = request_id.to_string();
+
+        break (path, body, msg, msg_id, request_id);
     };
 
     validate_raise_hand_message(&msg).map_err(|e| format!("contract violation: {}", e))?;


### PR DESCRIPTION
## Summary

- own the validated non-Windows `id` and `requestId` strings before moving the parsed JSON value
- preserve the same parsed JSON value, simulator protocol, file identity, error behavior, timing, cleanup, return value, and Windows-gated bytes
- keep the change limited to the focused `cli_raise_hand` integration-test helper

## Verification

- frozen plan SHA-256: `07929B510F9E57A9535C808FB6D2B8C49CE2D451FE637D37598D9EF0C8166682`
- Linux focused test: `3 passed; 0 failed`
- `cargo check`: passed
- `cargo clippy`: passed with pre-existing unrelated warnings
- native Windows focused verification: `3 passed; 0 failed` on exact SHA `199166f47653c9dbd065e5ad0bf1bb7e8ab0d47c`
- native Windows evidence: #1140
- adversarial Grinch review: `PASS`, no findings
- Step 9.5: branch contains current `origin/main`
- visual classification: non-visual
- final shipper build: N/A — non-visual change

Closes #1126
