### PR TITLE
test: own close-session simulator IDs (#1127)

### DIFF
--- a/src-tauri/tests/cli_close_session.rs
+++ b/src-tauri/tests/cli_close_session.rs
@@ -418,7 +418,10 @@ fn simulate_daemon_response(
             continue;
         };
 
-        break (path, body, msg, msg_id.to_string(), request_id.to_string());
+        let msg_id = msg_id.to_string();
+        let request_id = request_id.to_string();
+
+        break (path, body, msg, msg_id, request_id);
     };
 
     validate_close_session_message(&msg, expected_target, expected_timeout_secs)


### PR DESCRIPTION
## Summary

- Own the already-validated close-session simulator message and request IDs before moving the parsed JSON payload.
- Preserve the exact simulator behavior while satisfying Rust ownership rules.

## Verification

- Dev verification: `cargo test --manifest-path src-tauri/Cargo.toml --test cli_close_session -- --test-threads=1` — 6 passed, 0 failed.
- Independent Grinch review: PASS on candidate `0cf69a55e65d0cca9808c42a0cbfff00eaf7a1d8`; independent focused test — 6 passed, 0 failed.
- Windows: `N/A - no high or known Windows risk`. Maria confirmed the current behavior works on Windows as-is and accepted proceeding; this is not a claim that the former native Windows test command ran. Follow-up #1142 was closed as not planned / not required.
- Required repository CI remains enabled and must pass before merge.

## Delivery

- Lite, single-delivery, non-visual change.
- Shipper build: `N/A - non-visual change`.
- 0_AC GUI validation: `N/A - non-visual change`.

Closes #1127