### PR TITLE
fix(resource-monitor): prevent phantom non-Windows cap exhaustion (#1144)

### DIFF
--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -42,16 +42,19 @@ pub async fn get_resource_snapshot(
 /// budget-exhausted `Terminating`) result leaves the instance/job intact for a
 /// Force/Retry and never marks a possibly-alive agent `Exited`.
 #[tauri::command]
-pub async fn kill_resource_group(
-    app: AppHandle,
+pub async fn kill_resource_group<R: tauri::Runtime>(
+    app: AppHandle<R>,
     request: ResourceKillRequest,
-    _monitor: State<'_, Arc<ResourceMonitorState>>,
+    monitor: State<'_, Arc<ResourceMonitorState>>,
     _pty_mgr: State<'_, Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>,
     _session_mgr: State<'_, Arc<tokio::sync::RwLock<crate::session::manager::SessionManager>>>,
 ) -> Result<ResourceKillResult, String> {
     let session_id = Uuid::parse_str(&request.session_id).map_err(|e| e.to_string())?;
     if request.reason != ResourceKillReason::User {
         return Err("resourceMonitor user command requires reason=user".to_string());
+    }
+    if !monitor.supports_process_tree_enforcement() {
+        return Ok(unsupported_kill_result(session_id));
     }
     let coordinator = app
         .try_state::<SelectionCoordinator>()
@@ -70,14 +73,17 @@ pub(crate) async fn execute_resource_kill_transaction<R: tauri::Runtime>(
         TrustedResourceIntent::User => ResourceKillReason::User,
         TrustedResourceIntent::Watchdog => ResourceKillReason::Watchdog,
     };
-    let pty_mgr = transaction
-        .app()
-        .state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
     let monitor = transaction
         .app()
         .state::<Arc<ResourceMonitorState>>()
         .inner()
         .clone();
+    if !monitor.supports_process_tree_enforcement() {
+        return Ok(unsupported_kill_result(session_id));
+    }
+    let pty_mgr = transaction
+        .app()
+        .state::<Arc<std::sync::Mutex<crate::pty::manager::PtyManager>>>();
 
     // Fire the Job Object FIRST (pure: keeps the instance/job for a Retry). The
     // std-Mutex guard is dropped before any await.
@@ -182,6 +188,20 @@ pub(crate) async fn execute_resource_kill_transaction<R: tauri::Runtime>(
     Ok(result)
 }
 
+fn unsupported_kill_result(session_id: Uuid) -> ResourceKillResult {
+    ResourceKillResult {
+        session_id: session_id.to_string(),
+        state: ResourceGroupState::Running,
+        killed_processes: Vec::new(),
+        quarantined: false,
+        message:
+            "resource monitor enforcement is unsupported on this platform; no process was killed"
+                .to_string(),
+        blocked_by_security: false,
+        finalized: false,
+    }
+}
+
 /// Upper bound on how long `verify_kill_settled` waits for a concurrent kill to leave
 /// `Terminating`. After the job fire the concurrent reaper sees an AlreadyGone tree, so
 /// the common case settles in one or two ~75ms polls. The budget sits ABOVE the
@@ -234,7 +254,10 @@ fn should_finalize_kill(state: ResourceGroupState) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_finalize_kill, verify_kill_settled};
+    use super::{
+        execute_resource_kill_transaction, kill_resource_group, should_finalize_kill,
+        verify_kill_settled,
+    };
     use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
     use crate::pty::manager::PtyManager;
     use crate::resource_monitor::registry::{
@@ -242,13 +265,14 @@ mod tests {
     };
     use crate::resource_monitor::types::{
         ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory, ResourceGroupState,
-        ResourceKillReason, ResourceLaunchMetadata, ResourceLimits, TerminateOutcome,
+        ResourceKillReason, ResourceKillResult, ResourceLaunchMetadata, ResourceLimits,
+        TerminateOutcome,
     };
     use crate::resource_monitor::ResourceMonitorState;
     use crate::session::manager::SessionManager;
     use crate::session::selection::{
         CriticalAdmissionKind, CriticalAdmissionOutcome, SelectionCoordinator, SelectionMode,
-        SelectionSource, TrustedResourceIntent,
+        SelectionSource, SelectionTransaction, TrustedResourceIntent,
     };
     use crate::session::session::SessionStatus;
     use crate::web::broadcast::WsBroadcaster;
@@ -259,7 +283,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
-    use tauri::Listener;
+    use tauri::{Listener, Manager};
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
 
@@ -268,6 +292,47 @@ mod tests {
         live: Mutex<HashSet<Uuid>>,
         terminate_count: AtomicUsize,
         kill_count: AtomicUsize,
+    }
+
+    #[derive(Default)]
+    struct UnsupportedKillBackend {
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+        current_process_memory_calls: AtomicUsize,
+    }
+
+    impl ProcessTreeBackend for UnsupportedKillBackend {
+        fn supports_process_tree_enforcement(&self) -> bool {
+            false
+        }
+
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ObservedProcessTree::default())
+        }
+
+        fn observe_identity(&self, _pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        }
+
+        fn terminate_verified(
+            &self,
+            _process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            self.current_process_memory_calls
+                .fetch_add(1, Ordering::SeqCst);
+            Ok(ProcessMemory::default())
+        }
     }
 
     impl ResourcePtyBackend {
@@ -352,6 +417,131 @@ mod tests {
         fn kill_all_jobs(&self) -> (usize, usize) {
             (0, 0)
         }
+    }
+
+    fn assert_unsupported_kill_result(result: &ResourceKillResult, session_id: Uuid) {
+        assert_eq!(result.session_id, session_id.to_string());
+        assert_eq!(result.state, ResourceGroupState::Running);
+        assert!(result.killed_processes.is_empty());
+        assert!(!result.quarantined);
+        assert_eq!(
+            result.message,
+            "resource monitor enforcement is unsupported on this platform; no process was killed"
+        );
+        assert!(!result.blocked_by_security);
+        assert!(!result.finalized);
+    }
+
+    #[tokio::test]
+    async fn unsupported_backend_manual_kill_is_side_effect_free() {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let session = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "/tmp/unsupported-resource-kill".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        let pty_backend = Arc::new(ResourcePtyBackend::default());
+        pty_backend.set_live(session.id);
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(pty_backend.clone())));
+        pty.lock()
+            .unwrap()
+            .record_route(session.id, SessionBackendKind::LocalProcess);
+        let process_backend = Arc::new(UnsupportedKillBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            process_backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let before_selection = manager.read().await.selection_payload().await;
+
+        let app = tauri::test::mock_builder()
+            .invoke_handler(tauri::generate_handler![kill_resource_group])
+            .manage(Arc::clone(&manager))
+            .manage(Arc::clone(&pty))
+            .manage(Arc::clone(&monitor))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build unsupported resource-kill app");
+        assert!(app.try_state::<SelectionCoordinator>().is_none());
+        let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .unwrap();
+        let public_response = tauri::test::get_ipc_response(
+            &webview,
+            tauri::webview::InvokeRequest {
+                cmd: "kill_resource_group".into(),
+                callback: tauri::ipc::CallbackFn(0),
+                error: tauri::ipc::CallbackFn(1),
+                url: "http://tauri.localhost".parse().unwrap(),
+                body: tauri::ipc::InvokeBody::Json(serde_json::json!({
+                    "request": {
+                        "sessionId": session.id,
+                        "reason": "user",
+                    }
+                })),
+                headers: Default::default(),
+                invoke_key: tauri::test::INVOKE_KEY.to_string(),
+            },
+        )
+        .expect("unsupported public kill returns success")
+        .deserialize::<ResourceKillResult>()
+        .unwrap();
+        assert_unsupported_kill_result(&public_response, session.id);
+
+        let transaction = SelectionTransaction::for_test(app.handle().clone());
+        let inner_response = execute_resource_kill_transaction(
+            &transaction,
+            session.id,
+            TrustedResourceIntent::Watchdog,
+        )
+        .await
+        .unwrap();
+        assert_unsupported_kill_result(&inner_response, session.id);
+
+        assert_eq!(process_backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            process_backend
+                .observe_identity_calls
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            process_backend
+                .terminate_verified_calls
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            process_backend
+                .current_process_memory_calls
+                .load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(pty_backend.terminate_count.load(Ordering::SeqCst), 0);
+        assert_eq!(pty_backend.kill_count.load(Ordering::SeqCst), 0);
+        assert!(pty.lock().unwrap().has_session(session.id));
+        assert!(!monitor.has_registered_group(session.id));
+        assert_eq!(monitor.active_agent_groups(), 0);
+        let after_selection = manager.read().await.selection_payload().await;
+        assert_eq!(after_selection.revision(), before_selection.revision());
+        assert_eq!(after_selection.id(), before_selection.id());
+        assert_eq!(
+            manager
+                .read()
+                .await
+                .get_session(session.id)
+                .await
+                .unwrap()
+                .status,
+            SessionStatus::Active
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -2132,7 +2132,7 @@ async fn create_session_inner_impl<R: tauri::Runtime>(
                 None,
                 resource_permit
                     .take()
-                    .map(|permit| resource_monitor.hold_logical_agent_slot(permit)),
+                    .and_then(|permit| resource_monitor.hold_logical_agent_slot(permit)),
             ),
         };
 

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -32,6 +32,10 @@ impl From<&str> for ResourceError {
 }
 
 pub trait ProcessTreeBackend: Send + Sync + 'static {
+    fn supports_process_tree_enforcement(&self) -> bool {
+        true
+    }
+
     fn observe_tree(&self, root: ProcessIdentity) -> Result<ObservedProcessTree, ResourceError>;
     fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError>;
     fn terminate_verified(
@@ -127,7 +131,13 @@ impl ResourceLaunchRegistration {
         }
     }
 
-    pub fn register_root_pid(&mut self, pid: u32) -> Result<ProcessIdentity, String> {
+    pub fn register_root_pid(&mut self, pid: u32) -> Result<Option<ProcessIdentity>, String> {
+        if !self.monitor.supports_process_tree_enforcement() {
+            if let Some(permit) = self.permit.take() {
+                self.monitor.release_unregistered_permit(permit);
+            }
+            return Ok(None);
+        }
         let identity = self
             .monitor
             .observe_identity(pid)?
@@ -148,7 +158,7 @@ impl ResourceLaunchRegistration {
             identity,
         )?;
         self.registered = true;
-        Ok(identity)
+        Ok(Some(identity))
     }
 
     pub fn rollback_registered(&self) {
@@ -177,11 +187,19 @@ impl ResourceMonitorState {
         }
     }
 
+    pub fn supports_process_tree_enforcement(&self) -> bool {
+        self.backend.supports_process_tree_enforcement()
+    }
+
+    pub fn is_effectively_enabled(&self, configured_enabled: bool) -> bool {
+        configured_enabled && self.supports_process_tree_enforcement()
+    }
+
     pub fn try_reserve_agent_slot(
         &self,
         limits: ResourceLimits,
     ) -> Result<Option<AgentLaunchPermit>, String> {
-        if !limits.monitor_enabled {
+        if !self.is_effectively_enabled(limits.monitor_enabled) {
             return Ok(None);
         }
         let mut inner = self
@@ -207,11 +225,18 @@ impl ResourceMonitorState {
         }
     }
 
-    pub fn hold_logical_agent_slot(&self, permit: AgentLaunchPermit) -> ResourceLogicalAgentSlot {
-        ResourceLogicalAgentSlot {
+    pub fn hold_logical_agent_slot(
+        &self,
+        permit: AgentLaunchPermit,
+    ) -> Option<ResourceLogicalAgentSlot> {
+        if !self.supports_process_tree_enforcement() {
+            self.release_unregistered_permit(permit);
+            return None;
+        }
+        Some(ResourceLogicalAgentSlot {
             monitor: self.clone(),
             permit: Some(permit),
-        }
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -302,6 +327,9 @@ impl ResourceMonitorState {
     }
 
     pub fn active_agent_groups(&self) -> usize {
+        if !self.supports_process_tree_enforcement() {
+            return 0;
+        }
         self.inner
             .lock()
             .map(|inner| active_count(&inner))
@@ -328,6 +356,9 @@ impl ResourceMonitorState {
     }
 
     pub fn snapshot(&self, limits: ResourceLimits) -> ResourceSnapshot {
+        if !self.is_effectively_enabled(limits.monitor_enabled) {
+            return disabled_snapshot(limits);
+        }
         let samples = self.sample_running_groups();
         let mut warnings = Vec::new();
         let mut reap_candidates: Vec<(Uuid, ProcessIdentity)> = Vec::new();
@@ -1122,6 +1153,22 @@ fn group_snapshot(group: &ResourceAgentGroup) -> ResourceAgentGroupSnapshot {
     }
 }
 
+fn disabled_snapshot(limits: ResourceLimits) -> ResourceSnapshot {
+    ResourceSnapshot {
+        captured_at: Utc::now(),
+        overall_state: ResourceOverallState::Unknown,
+        monitor_enabled: false,
+        active_agent_groups: 0,
+        max_concurrent_agent_groups: limits.max_concurrent_agent_processes,
+        app_private_bytes: None,
+        app_working_set_bytes: None,
+        network_state: ResourceNetworkState::Unknown,
+        network_summary: "Socket attribution unavailable".to_string(),
+        groups: Vec::new(),
+        warnings: Vec::new(),
+    }
+}
+
 fn sum_optional(values: impl Iterator<Item = Option<u64>>) -> Option<u64> {
     let mut any = false;
     let mut total = 0_u64;
@@ -1135,6 +1182,7 @@ fn sum_optional(values: impl Iterator<Item = Option<u64>>) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -1153,6 +1201,66 @@ mod tests {
         /// failed enumeration. The Err arm of snapshot() must never reach the strike
         /// counter or reap.
         fail_observe: Mutex<BTreeSet<ProcessIdentity>>,
+    }
+
+    struct CapabilityTestBackend {
+        supported: AtomicBool,
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+        current_process_memory_calls: AtomicUsize,
+    }
+
+    impl CapabilityTestBackend {
+        fn new(supported: bool) -> Self {
+            Self {
+                supported: AtomicBool::new(supported),
+                observe_tree_calls: AtomicUsize::new(0),
+                observe_identity_calls: AtomicUsize::new(0),
+                terminate_verified_calls: AtomicUsize::new(0),
+                current_process_memory_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn set_supported(&self, supported: bool) {
+            self.supported.store(supported, Ordering::SeqCst);
+        }
+    }
+
+    impl ProcessTreeBackend for CapabilityTestBackend {
+        fn supports_process_tree_enforcement(&self) -> bool {
+            self.supported.load(Ordering::SeqCst)
+        }
+
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ObservedProcessTree::default())
+        }
+
+        fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(ProcessIdentity {
+                pid,
+                creation_time_100ns: u64::from(pid),
+            }))
+        }
+
+        fn terminate_verified(
+            &self,
+            _process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            self.current_process_memory_calls
+                .fetch_add(1, Ordering::SeqCst);
+            Ok(ProcessMemory::default())
+        }
     }
 
     impl FakeProcessTreeBackend {
@@ -1390,6 +1498,109 @@ mod tests {
             group_kill_private_bytes: 200,
             process_kill_private_bytes: 200,
         }
+    }
+
+    fn assert_disabled_snapshot(snapshot: &ResourceSnapshot, expected_limits: ResourceLimits) {
+        assert_eq!(snapshot.overall_state, ResourceOverallState::Unknown);
+        assert!(!snapshot.monitor_enabled);
+        assert_eq!(snapshot.active_agent_groups, 0);
+        assert_eq!(
+            snapshot.max_concurrent_agent_groups,
+            expected_limits.max_concurrent_agent_processes
+        );
+        assert_eq!(snapshot.app_private_bytes, None);
+        assert_eq!(snapshot.app_working_set_bytes, None);
+        assert_eq!(snapshot.network_state, ResourceNetworkState::Unknown);
+        assert_eq!(snapshot.network_summary, "Socket attribution unavailable");
+        assert!(snapshot.groups.is_empty());
+        assert!(snapshot.warnings.is_empty());
+    }
+
+    #[test]
+    fn unsupported_backend_never_consumes_agent_capacity() {
+        let backend = Arc::new(CapabilityTestBackend::new(false));
+        let state =
+            ResourceMonitorState::with_backend(backend.clone() as Arc<dyn ProcessTreeBackend>);
+        let test_limits = limits(1);
+
+        for _ in 0..33 {
+            assert!(state.try_reserve_agent_slot(test_limits).unwrap().is_none());
+            assert_eq!(state.active_agent_groups(), 0);
+            assert_disabled_snapshot(&state.snapshot(test_limits), test_limits);
+        }
+
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.terminate_verified_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            backend.current_process_memory_calls.load(Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[test]
+    fn supported_backend_still_enforces_agent_capacity() {
+        let (state, _backend) = state_with_fake();
+        let first = state
+            .try_reserve_agent_slot(limits(1))
+            .unwrap()
+            .expect("default-supported backend reserves the first slot");
+
+        let error = state.try_reserve_agent_slot(limits(1)).unwrap_err();
+        assert!(error.contains("1/1"), "unexpected cap error: {error}");
+
+        state.release_unregistered_permit(first);
+        let next = state
+            .try_reserve_agent_slot(limits(1))
+            .unwrap()
+            .expect("released default-supported permit restores capacity");
+        state.release_unregistered_permit(next);
+    }
+
+    #[test]
+    fn unsupported_backend_releases_preissued_permits_before_registration() {
+        let backend = Arc::new(CapabilityTestBackend::new(true));
+        let state =
+            ResourceMonitorState::with_backend(backend.clone() as Arc<dyn ProcessTreeBackend>);
+        let test_limits = limits(1);
+
+        let logical_permit = state.try_reserve_agent_slot(test_limits).unwrap().unwrap();
+        backend.set_supported(false);
+        assert!(state.hold_logical_agent_slot(logical_permit).is_none());
+        backend.set_supported(true);
+        let replacement = state
+            .try_reserve_agent_slot(test_limits)
+            .unwrap()
+            .expect("logical-slot rejection releases the preissued permit");
+        state.release_unregistered_permit(replacement);
+
+        let registration_permit = state.try_reserve_agent_slot(test_limits).unwrap().unwrap();
+        let session_id = Uuid::new_v4();
+        let mut registration = ResourceLaunchRegistration::new(
+            state.clone(),
+            registration_permit,
+            ResourceLaunchMetadata {
+                session_id,
+                name: "agent".to_string(),
+                agent_id: None,
+                agent_label: None,
+                workgroup: None,
+                agent: None,
+                project: None,
+            },
+        );
+        backend.set_supported(false);
+        assert_eq!(registration.register_root_pid(77).unwrap(), None);
+        assert!(!state.has_registered_group(session_id));
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+
+        backend.set_supported(true);
+        let replacement = state
+            .try_reserve_agent_slot(test_limits)
+            .unwrap()
+            .expect("registration rejection releases the preissued permit");
+        state.release_unregistered_permit(replacement);
     }
 
     #[test]

--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -31,6 +31,9 @@ pub fn start(
     coordinator: SelectionCoordinator,
     shutdown: ShutdownSignal,
 ) {
+    if !watchdog_eligible(&monitor) {
+        return;
+    }
     tauri::async_runtime::spawn(async move {
         loop {
             tokio::select! {
@@ -41,6 +44,10 @@ pub fn start(
             }
         }
     });
+}
+
+fn watchdog_eligible(monitor: &ResourceMonitorState) -> bool {
+    monitor.supports_process_tree_enforcement()
 }
 
 async fn next_delay(monitor: &ResourceMonitorState, settings: &SettingsState) -> Duration {
@@ -57,6 +64,9 @@ async fn run_tick(
     settings: &SettingsState,
     coordinator: &SelectionCoordinator,
 ) {
+    if !watchdog_eligible(monitor) {
+        return;
+    }
     let cfg = settings.read().await.clone();
     if !cfg.resource_monitor_enabled {
         return;
@@ -163,9 +173,58 @@ pub fn evaluate_watchdog_groups(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::AppSettings;
+    use crate::resource_monitor::registry::{ProcessTreeBackend, ResourceError};
     use crate::resource_monitor::types::{
-        ProcessIdentity, ResourceAgentGroupSnapshot, ResourceNetworkState, ResourceProcessSnapshot,
+        ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory,
+        ResourceAgentGroupSnapshot, ResourceNetworkState, ResourceProcessSnapshot,
+        TerminateOutcome,
     };
+    use crate::session::manager::SessionManager;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    #[derive(Default)]
+    struct UnsupportedWatchdogBackend {
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+        current_process_memory_calls: AtomicUsize,
+    }
+
+    impl ProcessTreeBackend for UnsupportedWatchdogBackend {
+        fn supports_process_tree_enforcement(&self) -> bool {
+            false
+        }
+
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ObservedProcessTree::default())
+        }
+
+        fn observe_identity(&self, _pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        }
+
+        fn terminate_verified(
+            &self,
+            _process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            self.current_process_memory_calls
+                .fetch_add(1, Ordering::SeqCst);
+            Ok(ProcessMemory::default())
+        }
+    }
 
     fn limits() -> ResourceLimits {
         ResourceLimits {
@@ -224,6 +283,56 @@ mod tests {
             kill_allowed: true,
             last_error: None,
         }
+    }
+
+    #[tokio::test]
+    async fn unsupported_backend_is_ineligible_for_start_and_tick() {
+        let backend = Arc::new(UnsupportedWatchdogBackend::default());
+        let monitor =
+            ResourceMonitorState::with_backend(backend.clone() as Arc<dyn ProcessTreeBackend>);
+        assert!(!watchdog_eligible(&monitor));
+
+        let cfg = AppSettings {
+            resource_monitor_enabled: true,
+            ..AppSettings::default()
+        };
+        let settings = Arc::new(tokio::sync::RwLock::new(cfg));
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let coordinator = SelectionCoordinator::new(manager, CancellationToken::new());
+        let shutdown = ShutdownSignal::new();
+
+        let start_fn: fn(
+            ResourceMonitorState,
+            SettingsState,
+            SelectionCoordinator,
+            ShutdownSignal,
+        ) = start;
+        start_fn(
+            monitor.clone(),
+            Arc::clone(&settings),
+            coordinator.clone(),
+            shutdown.clone(),
+        );
+        tokio::task::yield_now().await;
+
+        let settings_guard = settings.write().await;
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            run_tick(&monitor, &settings, &coordinator),
+        )
+        .await
+        .expect("unsupported tick returns before reading settings");
+        shutdown.trigger();
+        drop(settings_guard);
+        tokio::task::yield_now().await;
+
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.terminate_verified_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            backend.current_process_memory_calls.load(Ordering::SeqCst),
+            0
+        );
     }
 
     #[test]

--- a/src-tauri/src/resource_monitor/windows.rs
+++ b/src-tauri/src/resource_monitor/windows.rs
@@ -583,6 +583,10 @@ mod platform {
     }
 
     impl ProcessTreeBackend for PlatformProcessTreeBackend {
+        fn supports_process_tree_enforcement(&self) -> bool {
+            false
+        }
+
         fn observe_tree(
             &self,
             _root: ProcessIdentity,
@@ -611,6 +615,18 @@ mod platform {
 
         fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
             Ok(ProcessMemory::default())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn non_windows_production_backend_disables_process_tree_enforcement() {
+            let backend = PlatformProcessTreeBackend::new();
+
+            assert!(!backend.supports_process_tree_enforcement());
         }
     }
 }

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -1016,6 +1016,15 @@ async fn handle_resource_watchdog_backend_request(
     app: &AppHandle,
     request: &UiAutomationRequest,
 ) -> UiAutomationResponse {
+    let cfg = crate::config::settings::load_settings();
+    handle_resource_watchdog_backend_request_with_config(app, request, &cfg).await
+}
+
+async fn handle_resource_watchdog_backend_request_with_config<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    request: &UiAutomationRequest,
+    cfg: &crate::config::settings::AppSettings,
+) -> UiAutomationResponse {
     let mode = match BackendWatchdogMode::parse(request.value.as_deref()) {
         Ok(mode) => mode,
         Err(message) => {
@@ -1032,8 +1041,8 @@ async fn handle_resource_watchdog_backend_request(
         );
     };
 
-    let cfg = crate::config::settings::load_settings();
-    let limits = crate::resource_monitor::ResourceLimits::from(&cfg);
+    let limits = crate::resource_monitor::ResourceLimits::from(cfg);
+    let resource_monitor_enabled = monitor.is_effectively_enabled(cfg.resource_monitor_enabled);
     let snapshot = monitor.snapshot(limits);
     let groups = snapshot
         .groups
@@ -1054,12 +1063,11 @@ async fn handle_resource_watchdog_backend_request(
         .filter(|decision| decision.kill_required)
         .count();
 
-    let kill_enabled = cfg.resource_monitor_enabled
-        && matches!(mode, BackendWatchdogMode::KillGroup)
-        || (cfg.resource_monitor_enabled
-            && matches!(mode, BackendWatchdogMode::Tick)
-            && cfg.resource_watchdog_action
-                == crate::config::settings::ResourceWatchdogAction::KillGroup);
+    let kill_enabled = resource_monitor_enabled
+        && (matches!(mode, BackendWatchdogMode::KillGroup)
+            || (matches!(mode, BackendWatchdogMode::Tick)
+                && cfg.resource_watchdog_action
+                    == crate::config::settings::ResourceWatchdogAction::KillGroup));
 
     let mut kill_results = Vec::new();
     if kill_enabled {
@@ -1100,7 +1108,7 @@ async fn handle_resource_watchdog_backend_request(
         }
     }
 
-    let state = if !cfg.resource_monitor_enabled {
+    let state = if !resource_monitor_enabled {
         "disabled"
     } else if !kill_results.is_empty() {
         "enforcing"
@@ -1110,6 +1118,27 @@ async fn handle_resource_watchdog_backend_request(
         "warn"
     } else {
         "ok"
+    };
+
+    let snapshot_diagnostics = if monitor.supports_process_tree_enforcement() {
+        json!({
+            "capturedAt": snapshot.captured_at,
+            "overallState": snapshot.overall_state,
+            "activeAgentGroups": snapshot.active_agent_groups,
+            "appPrivateBytes": snapshot.app_private_bytes,
+            "networkState": snapshot.network_state,
+            "networkSummary": snapshot.network_summary,
+            "warnings": snapshot.warnings,
+        })
+    } else {
+        json!({
+            "overallState": snapshot.overall_state,
+            "activeAgentGroups": snapshot.active_agent_groups,
+            "appPrivateBytes": snapshot.app_private_bytes,
+            "networkState": snapshot.network_state,
+            "networkSummary": snapshot.network_summary,
+            "warnings": snapshot.warnings,
+        })
     };
 
     UiAutomationResponse {
@@ -1139,7 +1168,7 @@ async fn handle_resource_watchdog_backend_request(
         diagnostics: Some(json!({
             "mode": mode.as_str(),
             "configuredAction": cfg.resource_watchdog_action,
-            "resourceMonitorEnabled": cfg.resource_monitor_enabled,
+            "resourceMonitorEnabled": resource_monitor_enabled,
             "killApplied": kill_enabled,
             "limits": {
                 "maxConcurrentAgentGroups": limits.max_concurrent_agent_processes,
@@ -1147,15 +1176,7 @@ async fn handle_resource_watchdog_backend_request(
                 "groupKillPrivateBytes": limits.group_kill_private_bytes,
                 "processKillPrivateBytes": limits.process_kill_private_bytes,
             },
-            "snapshot": {
-                "capturedAt": snapshot.captured_at,
-                "overallState": snapshot.overall_state,
-                "activeAgentGroups": snapshot.active_agent_groups,
-                "appPrivateBytes": snapshot.app_private_bytes,
-                "networkState": snapshot.network_state,
-                "networkSummary": snapshot.network_summary,
-                "warnings": snapshot.warnings,
-            },
+            "snapshot": snapshot_diagnostics,
             "decisions": decisions,
             "killResults": kill_results,
         })),
@@ -1882,6 +1903,53 @@ impl RequestFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::settings::{AppSettings, ResourceWatchdogAction};
+    use crate::resource_monitor::registry::{ProcessTreeBackend, ResourceError};
+    use crate::resource_monitor::types::{
+        ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory, TerminateOutcome,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Default)]
+    struct UnsupportedAutomationBackend {
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+        current_process_memory_calls: AtomicUsize,
+    }
+
+    impl ProcessTreeBackend for UnsupportedAutomationBackend {
+        fn supports_process_tree_enforcement(&self) -> bool {
+            false
+        }
+
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ObservedProcessTree::default())
+        }
+
+        fn observe_identity(&self, _pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(None)
+        }
+
+        fn terminate_verified(
+            &self,
+            _process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            self.current_process_memory_calls
+                .fetch_add(1, Ordering::SeqCst);
+            Ok(ProcessMemory::default())
+        }
+    }
 
     fn sample_request(request_id: String, selector: &str) -> UiAutomationRequest {
         UiAutomationRequest {
@@ -1905,6 +1973,92 @@ mod tests {
             UiAutomationAction::TypeText => "typeText",
             UiAutomationAction::Backend => "backend",
         }
+    }
+
+    #[tokio::test]
+    async fn unsupported_backend_reports_disabled_and_never_kills() {
+        let backend = Arc::new(UnsupportedAutomationBackend::default());
+        let monitor = Arc::new(crate::resource_monitor::ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>,
+        ));
+        let app = tauri::test::mock_builder()
+            .manage(monitor)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build unsupported resource-watchdog automation app");
+        let cfg = AppSettings {
+            resource_monitor_enabled: true,
+            resource_watchdog_action: ResourceWatchdogAction::KillGroup,
+            max_concurrent_agent_processes: 7,
+            agent_group_warn_private_bytes: 101,
+            agent_group_kill_private_bytes: 202,
+            agent_process_kill_private_bytes: 303,
+            ..AppSettings::default()
+        };
+
+        for mode in ["sample", "warn", "killGroup", "tick"] {
+            let request = UiAutomationRequest {
+                request_id: Uuid::new_v4().to_string(),
+                token: "token".to_string(),
+                window: BACKEND_AUTOMATION_WINDOW.to_string(),
+                action: UiAutomationAction::Backend,
+                selector: RESOURCE_WATCHDOG_BACKEND_SELECTOR.to_string(),
+                value: Some(mode.to_string()),
+                expires_at_unix_ms: Some(now_unix_ms() + 1_000),
+            };
+
+            let response =
+                handle_resource_watchdog_backend_request_with_config(app.handle(), &request, &cfg)
+                    .await;
+
+            assert!(response.ok);
+            assert_eq!(
+                response.target,
+                Some(json!({
+                    "testId": RESOURCE_WATCHDOG_BACKEND_SELECTOR,
+                    "role": "backend",
+                    "state": "disabled",
+                    "tag": "backend",
+                    "text": format!(
+                        "resource monitor watchdog {mode}: 0 group(s), 0 warn match(es), 0 kill match(es)"
+                    ),
+                    "visible": true,
+                    "disabled": false,
+                }))
+            );
+            assert_eq!(
+                response.diagnostics,
+                Some(json!({
+                    "mode": mode,
+                    "configuredAction": cfg.resource_watchdog_action,
+                    "resourceMonitorEnabled": false,
+                    "killApplied": false,
+                    "limits": {
+                        "maxConcurrentAgentGroups": 7,
+                        "groupWarnPrivateBytes": 101,
+                        "groupKillPrivateBytes": 202,
+                        "processKillPrivateBytes": 303,
+                    },
+                    "snapshot": {
+                        "overallState": "unknown",
+                        "activeAgentGroups": 0,
+                        "appPrivateBytes": null,
+                        "networkState": "unknown",
+                        "networkSummary": "Socket attribution unavailable",
+                        "warnings": [],
+                    },
+                    "decisions": [],
+                    "killResults": [],
+                }))
+            );
+        }
+
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.terminate_verified_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            backend.current_process_memory_calls.load(Ordering::SeqCst),
+            0
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a backend capability contract that defaults to supported and opts out only for the production non-Windows backend.
- Prevent unsupported backends from reserving agent capacity, registering or sampling process groups, starting or ticking watchdog enforcement, or performing manual/automation kill side effects.
- Return truthful disabled snapshots and kill results, release defensive preissued permits, and preserve supported-backend behavior and the public IPC schema.

## Review and verification

- Frozen plan SHA-256: `5ACCCDA3FEB5A29B391FCBAFC291631B683D1CABEA0D9A7FD66393C4A64B5181`
- Implementation commit: `35bcf4953931e7d7a5953fa5eda03cbf138e93c9`
- Current-with-main merge: `25548cea8130f1eceb86e242ad9348508ad20774`
- Cold-start Grinch implementation review: **PASS**, no findings.
- Focused post-merge Grinch review: **PASS**; the effective feature patch is byte-identical to the originally reviewed patch.

Passed locally on Linux:

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test unsupported_backend_ -- --nocapture` (5 passed)
- supported-backend capacity test (1 passed)
- production non-Windows capability test (1 passed)
- `cargo test --test cli_close_session -- --nocapture` (6 passed)
- Resource Monitor focused suite (52 passed)
- `npm run test:debt`
- `npm run build`
- `npm run typecheck`
- `npm test` (139 files, 1,312 tests)
- `git diff --check`

Native Windows and macOS verification are `NOT_REQUIRED` under the certified platform-risk assessment; repository CI remains mandatory.

## Delivery note

The source diff is backend-only, but the corrected `monitorEnabled: false` value activates the existing visible disabled banner on unsupported platforms. The workflow therefore classifies this as **VISUAL** and requires the post-merge Step 11 shipper build/deploy.

Closes #1144
