### PR TITLE
test: mark close-session temp path intentional (#1128)

### DIFF
--- a/src-tauri/tests/cli_close_session.rs
+++ b/src-tauri/tests/cli_close_session.rs
@@ -269,7 +269,7 @@ impl SimulatorHandle {
 }
 
 fn spawn_daemon_simulator(
-    tmp: &Path,
+    _tmp: &Path,
     outbox_dir: &Path,
     responses_dir: &Path,
     response_body: &str,
@@ -278,9 +278,9 @@ fn spawn_daemon_simulator(
 ) -> SimulatorHandle {
     #[cfg(target_os = "windows")]
     {
-        let response_body_path = tmp.join("response-body.json");
+        let response_body_path = _tmp.join("response-body.json");
         std::fs::write(&response_body_path, response_body).expect("write response body");
-        let script = write_windows_simulator_script(tmp);
+        let script = write_windows_simulator_script(_tmp);
 
         let child = Command::new("powershell.exe")
             .args([


### PR DESCRIPTION
Closes #1128

## Summary

- mark the close-session simulator temporary-path binding as intentionally unused on non-Windows
- update the two Windows-only references to the renamed binding
- preserve all simulator paths, control flow, fixtures, assertions, and production behavior

## Verification

- focused `cargo check` for the `cli_close_session` integration target: PASS
- focused `cargo clippy` for the same target: PASS
- exact one-file, 3-addition/3-deletion scope and hunk predicates: PASS
- independent Grinch review: PASS, no findings
- Step 9.5 branch-current check against `origin/main`: PASS

## Delivery classification

- Lite, single delivery
- non-visual; final shipper build: N/A
- native Windows: N/A - no high or known Windows risk
- repository-required automatic CI remains enabled
