### PR TITLE
fix(screenshot): remove unused State import (#1129)

### DIFF
--- a/src-tauri/src/screenshot/unsupported.rs
+++ b/src-tauri/src/screenshot/unsupported.rs
@@ -5,7 +5,7 @@
 //! layer and `lib.rs` wiring are identical across targets: every capture path
 //! reports an unsupported status, and hotkey "registration" only validates syntax.
 
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Manager};
 
 use super::{
     ScreenshotCaptureResult, ScreenshotCaptureState, ScreenshotHotkeyState, ScreenshotOverlayState,


### PR DESCRIPTION
## Summary

- Remove only the unused `tauri::State` import from the non-Windows screenshot stub.
- Preserve `AppHandle`, `Manager`, all screenshot behavior, command wiring, platform gates, dependencies, and tests.
- Keep the Windows screenshot compilation path byte-for-byte outside the change.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml --lib --message-format=json` — PASS; the exact targeted `unused_imports` diagnostic tuple for `State` is absent.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --message-format=json` — PASS; no diagnostic points to the changed path or hunk.
- Frozen-plan path, hunk, numstat, byte-count, SHA-256, and diff-check oracles — PASS.
- Native Windows: `N/A - no high or known Windows risk`.

## Review and delivery

- Developer implementation: PASS at `9ab6dbe26f89482d9c73d3ca7e85675bec4aa1a8`.
- Independent Grinch review: PASS with no findings.
- Visual classification: non-visual.
- Final shipper build: N/A - non-visual change.

Closes #1129
