### PR TITLE
fix: gate file-in-use classifier by platform (#1130)

### DIFF
--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -4294,6 +4294,7 @@ pub(crate) fn is_rename_blocked_by_handle(e: &std::io::Error) -> bool {
 ///
 /// `pub(crate)` so the unit test in `wg_delete_diagnostic::tests` can exercise it
 /// without moving the test into this module.
+#[cfg(any(windows, test))]
 pub(crate) fn is_file_in_use_error(e: &std::io::Error) -> bool {
     #[cfg(windows)]
     {


### PR DESCRIPTION
## Summary

- compile `is_file_in_use_error` only for Windows production builds or tests
- preserve the helper body, visibility, and existing Win32 classification semantics
- eliminate the non-Windows normal-library `dead_code` diagnostic without a lint suppression

## Verification

- Candidate: `e25b9563e250a84aef7002ef48984b44e33f1c23`; exact diff is one added cfg attribute in `src-tauri/src/commands/entity_creation.rs`
- Dev verification: isolated fresh Linux `cargo check --lib --message-format=json`, focused non-Windows classifier test, `cargo clippy --lib`, and candidate/diff/blob identity checks all passed
- Grinch review: PASS with no findings; classified non-visual
- Native Windows verification: #1148 PASS on the exact candidate and blob; all four required commands exited 0, all named classifier tests passed, production `cargo check --lib` passed, and the restrictive-share behavior remained intact
- Current-branch gate: candidate contains current `origin/main`

## Shipping

N/A - non-visual change.

Closes #1130