### PR TITLE
fix: gate workgroup diagnostic helpers by platform (#1131)

### DIFF
--- a/src-tauri/src/commands/wg_delete_diagnostic.rs
+++ b/src-tauri/src/commands/wg_delete_diagnostic.rs
@@ -102,10 +102,12 @@ struct ExternalProcessScan {
     cwd_scan_error: Option<DiagnosticError>,
 }
 
+#[cfg(windows)]
 const MAX_FILES_PER_PROCESS: usize = 5;
 #[cfg(windows)]
 const MAX_FILES_TO_PROBE: usize = 200;
 
+#[cfg(any(windows, test))]
 fn win32_meaning(code: u32) -> &'static str {
     match code {
         2 => "File not found",
@@ -119,6 +121,7 @@ fn win32_meaning(code: u32) -> &'static str {
     }
 }
 
+#[cfg(any(windows, test))]
 fn win32_error(context: &str, code: u32) -> DiagnosticError {
     let meaning = win32_meaning(code);
     DiagnosticError {
@@ -128,6 +131,7 @@ fn win32_error(context: &str, code: u32) -> DiagnosticError {
     }
 }
 
+#[cfg(windows)]
 fn diagnostic_error(message: impl Into<String>) -> DiagnosticError {
     DiagnosticError {
         message: message.into(),


### PR DESCRIPTION
## Summary

- compile `MAX_FILES_PER_PROCESS` and `diagnostic_error` only for Windows
  production builds;
- keep `win32_meaning` and `win32_error` available for Windows production and
  unit-test builds;
- preserve all helper bodies, values, callers, wire fields, logs, diagnostics,
  Restart Manager behavior, process scanning, and tests.

The complete delivery delta is four `cfg` attributes in
`src-tauri/src/commands/wg_delete_diagnostic.rs`: four additions, zero
deletions, and no functional-body change.

## Verification

- Frozen single-delivery plan remained byte-identical at SHA-256
  `53F2FE05A6F30B34DEC15506B35B58F30F32090274A3D81B10B9FF322BABE549`.
- Cold Linux verification passed from a fresh Cargo target:
  - normal-library JSON: 798 valid records, one successful
    `build-finished`, zero errors, and zero targeted dead-code diagnostics;
  - focused filters: exact `2/5/1` results, all passed;
  - both frozen diff/topology gates and final clean-state checks passed.
- Independent adversarial implementation review passed and classified the
  change as non-visual. Review artifact SHA-256:
  `bff1059ce0a25220cdee44241a2b6468f299bf6ce1abd05b4d0467132ac1f600`.
- Required native-Windows verification passed and was independently
  re-reviewed from the immutable 22-file raw packet in #1153:
  - Cargo JSON: 757 valid records, one successful `build-finished`, zero
    compiler-message errors or warnings;
  - eight focused filters: exact `2/2/1/5/5/3/1/1`, 20 passed, zero failed;
  - exact executed PowerShell block, fresh-path boundary, candidate topology,
    clean state, and unchanged refs all verified;
  - final gate verdict: `PASS — NATIVE_GATE_SATISFIED`;
  - raw-evidence review artifact SHA-256:
    `f334604d8dfcb0426ca685300a8b75500f3ed7c605dd9c17c3e85de76fed8b08`.
- Final Step 9.5 passed with literal `main`
  `1e7f2350b481918c1e63abdf86149630d924ef2f`, candidate
  `f56cafe051c729ad422abd5892846afdc059a436`, clean worktree, correct
  ancestry, and `git diff --check`.

Native evidence: #1153.

## Delivery classification

- Visual change: no
- Final application build/deploy: `N/A - non-visual change`
- Version bump: none

Closes #1131
