### PR TITLE
fix(resource-monitor): recover orphaned quarantined Windows groups, refs #1151

### DIFF
--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -1118,10 +1118,18 @@ mod tests {
     /// once armed, BLOCKS inside `observe_tree`, which is `kill_group_inner`'s first
     /// backend call and therefore a deterministic barrier. Releasing the gate also makes
     /// the child verifiably gone, so the parked retry settles to Terminated.
+    ///
+    /// The barrier is announced through a Condvar rather than an AtomicBool so the test
+    /// thread can wait for it with a plain `std` wait. W6 must never need the async
+    /// runtime to make progress in order to report, because the defect it exists to catch
+    /// is exactly the one that stops the runtime from making progress.
     struct QuarantineGatedBackend {
         root: ProcessIdentity,
         armed: AtomicBool,
-        entered: AtomicBool,
+        entered: (Mutex<bool>, Condvar),
+        /// The thread that ran the armed `observe_tree`, recorded before it blocks. This
+        /// is the subject of W6's assertion 1.
+        observer: Mutex<Option<std::thread::ThreadId>>,
         child_gone: AtomicBool,
         gate: (Mutex<bool>, Condvar),
     }
@@ -1131,10 +1139,26 @@ mod tests {
             Self {
                 root,
                 armed: AtomicBool::new(false),
-                entered: AtomicBool::new(false),
+                entered: (Mutex::new(false), Condvar::new()),
+                observer: Mutex::new(None),
                 child_gone: AtomicBool::new(false),
                 gate: (Mutex::new(false), Condvar::new()),
             }
+        }
+
+        /// Blocks the calling thread, using `std` only, until the armed `observe_tree` has
+        /// recorded its thread and is about to park on the release gate. Returns false on
+        /// timeout so the caller reports an assertion failure instead of hanging.
+        fn wait_entered(&self, timeout: Duration) -> bool {
+            let (lock, condvar) = &self.entered;
+            let (entered, wait) = condvar
+                .wait_timeout_while(lock.lock().unwrap(), timeout, |entered| !*entered)
+                .unwrap();
+            !wait.timed_out() && *entered
+        }
+
+        fn observer(&self) -> Option<std::thread::ThreadId> {
+            *self.observer.lock().unwrap()
         }
 
         fn child(&self) -> ProcessIdentity {
@@ -1179,7 +1203,14 @@ mod tests {
             _root: ProcessIdentity,
         ) -> Result<ObservedProcessTree, ResourceError> {
             if self.armed.load(Ordering::SeqCst) {
-                self.entered.store(true, Ordering::SeqCst);
+                // Record the observer BEFORE announcing the barrier, so a waiter that
+                // sees `entered` always sees the thread id too.
+                *self.observer.lock().unwrap() = Some(std::thread::current().id());
+                {
+                    let (lock, condvar) = &self.entered;
+                    *lock.lock().unwrap() = true;
+                    condvar.notify_all();
+                }
                 let mut released = self.gate.0.lock().unwrap();
                 while !*released {
                     released = self.gate.1.wait(released).unwrap();
@@ -1388,10 +1419,31 @@ mod tests {
     }
 
     // #1151 (W6) - the orphan retry runs OFF the async runtime. kill_group can cost about
-    // two seconds per stubborn PID, so inlining it would stall a Tokio worker. While the
-    // retry is parked inside observe_tree, an independent task must still make progress.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    // two seconds per stubborn PID, so inlining it would stall a Tokio worker.
+    //
+    // Exactly ONE worker thread is load-bearing, not a style choice: it makes "the async
+    // runtime" an enumerable set of one OS thread, so the thread-identity assertion below
+    // is a complete statement rather than a sample. At two workers an inline call lands on
+    // the worker the test did not sample, and the test passes on a broken build.
+    //
+    // Every wait here is a `std` wait on the test thread, capped so a failure is an
+    // assertion and not a hang. `tokio::time` must not appear in this test: a shape that
+    // needs the runtime to make progress in order to REPORT cannot report the very defect
+    // that stops the runtime from making progress.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn orphan_retry_runs_off_the_async_runtime() {
+        // Harness self-check, taken while the runtime is still idle: spawned tasks really
+        // do run on a worker thread rather than on the block_on thread. If a future Tokio
+        // ever changed that, every assertion below would be silently vacuous.
+        let test_thread = std::thread::current().id();
+        let worker_thread = tokio::spawn(async { std::thread::current().id() })
+            .await
+            .expect("the worker identity probe joins");
+        assert_ne!(
+            worker_thread, test_thread,
+            "spawned tasks must run on the runtime's worker thread, not on the test thread"
+        );
+
         let root = ProcessIdentity {
             pid: 5500,
             creation_time_100ns: 1100,
@@ -1433,6 +1485,9 @@ mod tests {
         let _release_guard = ReleaseOnDrop(process_backend.clone());
         process_backend.armed.store(true, Ordering::SeqCst);
 
+        // tokio::spawn is load-bearing too: it is what puts an inlined blocking call on
+        // the worker thread, instead of on the test thread where it would satisfy
+        // assertion 1 for the wrong reason.
         let retry = {
             let monitor = Arc::clone(&monitor);
             let coordinator = coordinator.clone();
@@ -1446,32 +1501,51 @@ mod tests {
                 .await
             })
         };
-        tokio::time::timeout(Duration::from_secs(2), async {
-            while !process_backend.entered.load(Ordering::SeqCst) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("the orphan retry enters the backend barrier");
+        assert!(
+            process_backend.wait_entered(Duration::from_secs(5)),
+            "the orphan retry enters the backend barrier"
+        );
+        let observer = process_backend
+            .observer()
+            .expect("the barrier records its thread before parking");
 
-        let counter = Arc::new(AtomicUsize::new(0));
-        let ticker = {
-            let counter = Arc::clone(&counter);
-            tokio::spawn(async move {
-                for _ in 0..50 {
-                    counter.fetch_add(1, Ordering::SeqCst);
-                    tokio::task::yield_now().await;
-                }
-            })
-        };
-        tokio::time::timeout(Duration::from_secs(2), ticker)
-            .await
-            .expect("the async runtime keeps running while the orphan retry blocks")
-            .unwrap();
-        assert_eq!(counter.load(Ordering::SeqCst), 50);
-        assert!(!process_backend.released());
+        // Assertion 2's probe, taken while the gate is still held: a task that the runtime
+        // polls right now proves the runtime is still polling tasks. The channel is `std`,
+        // so its result reaches the test thread whether or not the runtime is alive.
+        let (tx, rx) = std::sync::mpsc::channel();
+        tokio::spawn(async move {
+            let _ = tx.send(());
+        });
+        let runtime_polled_a_task = rx.recv_timeout(Duration::from_secs(5)).is_ok();
 
+        assert!(
+            !process_backend.released(),
+            "the barrier must still be held while both facts are captured"
+        );
         process_backend.release();
+
+        // Assertion 1: the blocking work ran on neither the runtime's single worker nor
+        // the test thread, so it ran on the blocking pool. With one worker those two are
+        // the only non-blocking-pool threads, so this is exhaustive. It rejects an inline
+        // call and tokio::task::block_in_place alike.
+        assert_ne!(
+            observer, worker_thread,
+            "the orphan retry must not run on the async runtime's worker thread"
+        );
+        assert_ne!(
+            observer, test_thread,
+            "the orphan retry must not run on the test thread"
+        );
+        // Assertion 2: the runtime kept making progress while the blocking call was in
+        // flight. This is what rejects std::thread::spawn(..).join(), which is off the
+        // runtime by identity yet parks the worker for the whole call. Never assert WHICH
+        // thread sent it: block_in_place legitimately migrates the scheduler to a
+        // replacement thread, so pinning the sender would add a false-failure mode.
+        assert!(
+            runtime_polled_a_task,
+            "the async runtime must keep polling tasks while the orphan retry blocks"
+        );
+
         let report = retry.await.unwrap();
         assert_eq!(
             report.path,

--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -1113,4 +1113,372 @@ mod tests {
         guard.finish();
         coordinator.close_and_join().await;
     }
+
+    /// #1151 (W6) - a backend that quarantines the first cleanup on a stubborn child and,
+    /// once armed, BLOCKS inside `observe_tree`, which is `kill_group_inner`'s first
+    /// backend call and therefore a deterministic barrier. Releasing the gate also makes
+    /// the child verifiably gone, so the parked retry settles to Terminated.
+    struct QuarantineGatedBackend {
+        root: ProcessIdentity,
+        armed: AtomicBool,
+        entered: AtomicBool,
+        child_gone: AtomicBool,
+        gate: (Mutex<bool>, Condvar),
+    }
+
+    impl QuarantineGatedBackend {
+        fn new(root: ProcessIdentity) -> Self {
+            Self {
+                root,
+                armed: AtomicBool::new(false),
+                entered: AtomicBool::new(false),
+                child_gone: AtomicBool::new(false),
+                gate: (Mutex::new(false), Condvar::new()),
+            }
+        }
+
+        fn child(&self) -> ProcessIdentity {
+            ProcessIdentity {
+                pid: self.root.pid + 1,
+                creation_time_100ns: self.root.creation_time_100ns + 1,
+            }
+        }
+
+        fn released(&self) -> bool {
+            *self.gate.0.lock().unwrap()
+        }
+
+        fn release(&self) {
+            self.child_gone.store(true, Ordering::SeqCst);
+            *self.gate.0.lock().unwrap() = true;
+            self.gate.1.notify_all();
+        }
+
+        fn observed(
+            identity: ProcessIdentity,
+            depth: u32,
+            parent_pid: Option<u32>,
+        ) -> ObservedProcess {
+            ObservedProcess {
+                identity,
+                parent_pid,
+                parent_identity: None,
+                exe_name: format!("p{}", identity.pid),
+                depth,
+                private_bytes: None,
+                working_set_bytes: None,
+                cpu_percent: None,
+                kill_allowed: true,
+            }
+        }
+    }
+
+    impl ProcessTreeBackend for QuarantineGatedBackend {
+        fn observe_tree(
+            &self,
+            _root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            if self.armed.load(Ordering::SeqCst) {
+                self.entered.store(true, Ordering::SeqCst);
+                let mut released = self.gate.0.lock().unwrap();
+                while !*released {
+                    released = self.gate.1.wait(released).unwrap();
+                }
+            }
+            let mut processes = vec![Self::observed(self.root, 0, None)];
+            if !self.child_gone.load(Ordering::SeqCst) {
+                processes.push(Self::observed(self.child(), 1, Some(self.root.pid)));
+            }
+            Ok(ObservedProcessTree {
+                processes,
+                errors: Vec::new(),
+            })
+        }
+
+        fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            if pid == self.root.pid {
+                return Ok(Some(self.root));
+            }
+            if pid == self.child().pid && !self.child_gone.load(Ordering::SeqCst) {
+                return Ok(Some(self.child()));
+            }
+            Ok(None)
+        }
+
+        fn terminate_verified(
+            &self,
+            process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            if process.identity == self.child() && !self.child_gone.load(Ordering::SeqCst) {
+                return Err(ResourceError::Message(format!(
+                    "pid {}: process still alive after terminate",
+                    process.identity.pid
+                )));
+            }
+            Ok(TerminateOutcome::AlreadyGone)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            Ok(ProcessMemory::default())
+        }
+    }
+
+    // #1151 (W2) - a LIVE public session keeps the coordinator plus Job Object path
+    // exactly as before: the transaction runs, the session finalizes once, and the
+    // registry-only orphan path is never entered.
+    #[tokio::test]
+    async fn live_public_session_still_uses_coordinator() {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let session = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "C:/orphan-live-session".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        let pty_backend = Arc::new(ResourcePtyBackend::default());
+        pty_backend.set_live(session.id);
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(pty_backend.clone())));
+        pty.lock()
+            .unwrap()
+            .record_route(session.id, SessionBackendKind::LocalProcess);
+        let root = ProcessIdentity {
+            pid: 5300,
+            creation_time_100ns: 900,
+        };
+        let process_backend = Arc::new(GatedBackend::new(root));
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            process_backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        register_running(monitor.as_ref(), session.id, root);
+        assert_eq!(monitor.active_agent_groups(), 1);
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(Arc::clone(&pty))
+            .manage(Arc::clone(&monitor))
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build live-session orphan-retry app");
+        coordinator.start(app.handle().clone()).unwrap();
+        coordinator.submit_restore_first().await.unwrap().finish();
+
+        let report = crate::resource_monitor::watchdog::retry_quarantined_group(
+            monitor.as_ref(),
+            &coordinator,
+            session.id,
+            root,
+        )
+        .await;
+
+        assert_eq!(
+            report.path,
+            crate::resource_monitor::watchdog::QuarantineRetryPath::Coordinator
+        );
+        assert_eq!(report.root_pid, root.pid);
+        assert_eq!(report.state, Some(ResourceGroupState::Terminated));
+        assert!(!report.still_counts_toward_admission);
+        assert_eq!(report.active_agent_groups, 0);
+        assert_eq!(
+            manager
+                .read()
+                .await
+                .get_session(session.id)
+                .await
+                .unwrap()
+                .status,
+            SessionStatus::Exited(0)
+        );
+        // Finalized exactly once, through the coordinator: one PTY teardown and the route
+        // gone. The registry-only path never touches the PTY at all.
+        assert_eq!(pty_backend.terminate_count.load(Ordering::SeqCst), 1);
+        assert!(!pty.lock().unwrap().has_session(session.id));
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (W5) - NON-REGRESSION. A destroy-retained root agent keeps its row as Exited,
+    // so contains_public_or_pending is still true and the coordinator path stays. An
+    // implementation that keyed the orphan decision on "the PTY is gone" rather than "the
+    // session row is gone" would silently divert this working path onto the new one.
+    #[tokio::test]
+    async fn exited_row_still_uses_coordinator() {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let session = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "C:/orphan-exited-row".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        // mark_exited's bool reports whether a raise-hand flag was cleared, not success.
+        manager.read().await.mark_exited(session.id, 0).await;
+        assert_eq!(
+            manager
+                .read()
+                .await
+                .get_session(session.id)
+                .await
+                .unwrap()
+                .status,
+            SessionStatus::Exited(0)
+        );
+        let pty_backend = Arc::new(ResourcePtyBackend::default());
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(pty_backend.clone())));
+        let root = ProcessIdentity {
+            pid: 5400,
+            creation_time_100ns: 1000,
+        };
+        let process_backend = Arc::new(GatedBackend::new(root));
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            process_backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        register_running(monitor.as_ref(), session.id, root);
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(Arc::clone(&pty))
+            .manage(Arc::clone(&monitor))
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build exited-row orphan-retry app");
+        coordinator.start(app.handle().clone()).unwrap();
+        coordinator.submit_restore_first().await.unwrap().finish();
+
+        let report = crate::resource_monitor::watchdog::retry_quarantined_group(
+            monitor.as_ref(),
+            &coordinator,
+            session.id,
+            root,
+        )
+        .await;
+
+        assert_eq!(
+            report.path,
+            crate::resource_monitor::watchdog::QuarantineRetryPath::Coordinator
+        );
+        assert_eq!(
+            manager
+                .read()
+                .await
+                .get_session(session.id)
+                .await
+                .unwrap()
+                .status,
+            SessionStatus::Exited(0)
+        );
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (W6) - the orphan retry runs OFF the async runtime. kill_group can cost about
+    // two seconds per stubborn PID, so inlining it would stall a Tokio worker. While the
+    // retry is parked inside observe_tree, an independent task must still make progress.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn orphan_retry_runs_off_the_async_runtime() {
+        let root = ProcessIdentity {
+            pid: 5500,
+            creation_time_100ns: 1100,
+        };
+        let process_backend = Arc::new(QuarantineGatedBackend::new(root));
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            process_backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        // No session row is ever created: that is what makes this group an orphan.
+        let session_id = Uuid::new_v4();
+        register_running(monitor.as_ref(), session_id, root);
+        let quarantine = monitor
+            .kill_group(session_id, ResourceKillReason::SessionDestroy)
+            .expect("first cleanup runs");
+        assert!(quarantine.quarantined);
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            ResourcePtyBackend::default(),
+        ))));
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(pty)
+            .manage(Arc::clone(&monitor))
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build off-runtime orphan-retry app");
+        coordinator.start(app.handle().clone()).unwrap();
+        coordinator.submit_restore_first().await.unwrap().finish();
+
+        struct ReleaseOnDrop(Arc<QuarantineGatedBackend>);
+        impl Drop for ReleaseOnDrop {
+            fn drop(&mut self) {
+                self.0.release();
+            }
+        }
+        let _release_guard = ReleaseOnDrop(process_backend.clone());
+        process_backend.armed.store(true, Ordering::SeqCst);
+
+        let retry = {
+            let monitor = Arc::clone(&monitor);
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move {
+                crate::resource_monitor::watchdog::retry_quarantined_group(
+                    monitor.as_ref(),
+                    &coordinator,
+                    session_id,
+                    root,
+                )
+                .await
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !process_backend.entered.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the orphan retry enters the backend barrier");
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let ticker = {
+            let counter = Arc::clone(&counter);
+            tokio::spawn(async move {
+                for _ in 0..50 {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(2), ticker)
+            .await
+            .expect("the async runtime keeps running while the orphan retry blocks")
+            .unwrap();
+        assert_eq!(counter.load(Ordering::SeqCst), 50);
+        assert!(!process_backend.released());
+
+        process_backend.release();
+        let report = retry.await.unwrap();
+        assert_eq!(
+            report.path,
+            crate::resource_monitor::watchdog::QuarantineRetryPath::Orphan
+        );
+        assert_eq!(report.state, Some(ResourceGroupState::Terminated));
+        assert!(!report.still_counts_toward_admission);
+        coordinator.close_and_join().await;
+    }
 }

--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -271,8 +271,8 @@ mod tests {
     use crate::resource_monitor::ResourceMonitorState;
     use crate::session::manager::SessionManager;
     use crate::session::selection::{
-        CriticalAdmissionKind, CriticalAdmissionOutcome, SelectionCoordinator, SelectionMode,
-        SelectionSource, SelectionTransaction, TrustedResourceIntent,
+        CriticalAdmissionKind, SelectionCoordinator, SelectionMode, SelectionSource,
+        SelectionTransaction, TrustedResourceIntent, WatchdogKillOutcome,
     };
     use crate::session::session::SessionStatus;
     use crate::web::broadcast::WsBroadcaster;
@@ -843,7 +843,7 @@ mod tests {
             let watchdog_result = watchdog.await.unwrap().unwrap();
             assert!(matches!(
                 watchdog_result,
-                CriticalAdmissionOutcome::Completed(ref result) if result.finalized
+                WatchdogKillOutcome::Completed(ref result) if result.finalized
             ));
             assert!(user.await.unwrap().unwrap().finalized);
         } else {
@@ -877,7 +877,7 @@ mod tests {
             let watchdog_result = watchdog.await.unwrap().unwrap();
             assert!(matches!(
                 watchdog_result,
-                CriticalAdmissionOutcome::Completed(ref result) if result.finalized
+                WatchdogKillOutcome::Completed(ref result) if result.finalized
             ));
         }
 
@@ -989,7 +989,7 @@ mod tests {
                 .watchdog_resource_kill(session.id)
                 .await
                 .unwrap(),
-            CriticalAdmissionOutcome::AlreadyPending
+            WatchdogKillOutcome::AlreadyInFlight
         ));
 
         drop(reservations.pop());
@@ -1010,7 +1010,7 @@ mod tests {
         let result = waiter.await.unwrap().unwrap();
         assert!(matches!(
             result,
-            CriticalAdmissionOutcome::Completed(ref result) if result.finalized
+            WatchdogKillOutcome::Completed(ref result) if result.finalized
         ));
         drop(reservations);
 
@@ -1030,7 +1030,7 @@ mod tests {
                 .watchdog_resource_kill(session.id)
                 .await
                 .unwrap(),
-            CriticalAdmissionOutcome::Completed(_)
+            WatchdogKillOutcome::Completed(_)
         ));
         assert!(events_rx.try_recv().is_err());
         coordinator.close_and_join().await;

--- a/src-tauri/src/commands/resource_monitor.rs
+++ b/src-tauri/src/commands/resource_monitor.rs
@@ -1423,8 +1423,10 @@ mod tests {
     //
     // Exactly ONE worker thread is load-bearing, not a style choice: it makes "the async
     // runtime" an enumerable set of one OS thread, so the thread-identity assertion below
-    // is a complete statement rather than a sample. At two workers an inline call lands on
-    // the worker the test did not sample, and the test passes on a broken build.
+    // is a complete statement rather than a sample. At two workers it degrades to sampling
+    // one worker out of two, and whether the mutation is caught becomes scheduler
+    // dependent. That is not acceptable for a regression pin, however it happens to land
+    // in any one environment.
     //
     // Every wait here is a `std` wait on the test thread, capped so a failure is an
     // assertion and not a hang. `tokio::time` must not appear in this test: a shape that

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -89,6 +89,37 @@ pub struct AgentLaunchPermit {
     generation: u64,
 }
 
+/// #1151 - outcome of `retry_orphaned_quarantine`. `Skipped` performs ZERO backend
+/// calls, so an ineligible group costs nothing and cannot be confused with a cleanup
+/// that ran and found the group already gone.
+#[derive(Debug, Clone)]
+pub(crate) enum QuarantineRetryOutcome {
+    Completed(ResourceKillResult),
+    Skipped(QuarantineRetrySkip),
+}
+
+/// #1151 - why an orphan quarantine retry did not run. `NotRegistered` is defensive
+/// only: a Quarantined row can never be removed from the group map, so a UUID sampled
+/// as Quarantined in the same tick is always still there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QuarantineRetrySkip {
+    Unsupported,
+    NotRegistered,
+    NotQuarantined(ResourceGroupState),
+    RootMismatch,
+}
+
+impl QuarantineRetrySkip {
+    pub(crate) fn as_reason(self) -> &'static str {
+        match self {
+            Self::Unsupported => "unsupported",
+            Self::NotRegistered => "notRegistered",
+            Self::NotQuarantined(_) => "notQuarantined",
+            Self::RootMismatch => "rootMismatch",
+        }
+    }
+}
+
 pub struct ResourceLaunchRegistration {
     monitor: ResourceMonitorState,
     permit: Option<AgentLaunchPermit>,
@@ -355,6 +386,28 @@ impl ResourceMonitorState {
         }
     }
 
+    /// #1151 - on the real impl, not inside `mod tests`, so watchdog.rs's tests can reach
+    /// it. Mirrors PtyManager::new_for_test (pty/manager.rs), which is `#[cfg(test)]
+    /// pub(crate)` on the real impl for exactly this cross-module need.
+    ///
+    /// `checked_sub` rather than plain subtraction: `Instant`'s epoch is unspecified
+    /// (machine boot on Windows), so `Instant::now() - QUARANTINE_RETRY_BACKOFF` can
+    /// panic. The `expect` makes a failure loud rather than producing a test that
+    /// silently is not due. Setting `kill_started_at = None` is deliberately NOT used:
+    /// `quarantine_retry_due` calls that branch dead-but-defensive, and a test depending
+    /// on it would convert a defensive branch into a load-bearing one.
+    #[cfg(test)]
+    pub(crate) fn test_backdate_quarantine_retry(&self, id: Uuid) {
+        if let Ok(mut inner) = self.inner.lock() {
+            if let Some(group) = inner.groups.get_mut(&id) {
+                let backdated = Instant::now()
+                    .checked_sub(QUARANTINE_RETRY_BACKOFF + Duration::from_millis(1))
+                    .expect("backdated quarantine retry instant is representable");
+                group.kill_started_at = Some(backdated);
+            }
+        }
+    }
+
     pub fn snapshot(&self, limits: ResourceLimits) -> ResourceSnapshot {
         if !self.is_effectively_enabled(limits.monitor_enabled) {
             return disabled_snapshot(limits);
@@ -428,7 +481,80 @@ impl ResourceMonitorState {
         session_id: Uuid,
         reason: ResourceKillReason,
     ) -> Result<ResourceKillResult, String> {
-        self.kill_group_inner(session_id, reason, false)
+        self.kill_group_inner(session_id, reason, false, None)
+    }
+
+    /// #1151 - registry-only cleanup retry for an ORPHANED quarantined group: one whose
+    /// public session row is gone, so `SelectionCoordinator::watchdog_resource_kill`
+    /// returns `NoPublicSession` and no production caller can ever reach `kill_group`
+    /// for it again. Without this the group's admission permit leaks permanently.
+    ///
+    /// It decides only WHETHER `kill_group_inner` runs, never what it concludes: the
+    /// permit is still released only by a full verified cleanup pass. The absence of a
+    /// session row is never an input to that decision.
+    ///
+    /// `expected_root` binds the retry to the registration the watchdog sampled, and is
+    /// re-checked inside the same critical section that flips the group to `Terminating`.
+    pub(crate) fn retry_orphaned_quarantine(
+        &self,
+        session_id: Uuid,
+        expected_root: ProcessIdentity,
+    ) -> Result<QuarantineRetryOutcome, String> {
+        if !self.supports_process_tree_enforcement() {
+            return Ok(QuarantineRetryOutcome::Skipped(
+                QuarantineRetrySkip::Unsupported,
+            ));
+        }
+        // Classify under the lock. A Quarantined row can never be removed from the map
+        // (register_group's retain and prune_terminated_groups both filter on
+        // Terminated), so a passing classification cannot be invalidated by a removal,
+        // only by a concurrent state transition, which kill_group_inner reports honestly.
+        {
+            let inner = self
+                .inner
+                .lock()
+                .map_err(|_| "resource monitor lock poisoned")?;
+            let Some(group) = inner.groups.get(&session_id) else {
+                return Ok(QuarantineRetryOutcome::Skipped(
+                    QuarantineRetrySkip::NotRegistered,
+                ));
+            };
+            if !matches!(group.state, ResourceGroupState::Quarantined) {
+                return Ok(QuarantineRetryOutcome::Skipped(
+                    QuarantineRetrySkip::NotQuarantined(group.state),
+                ));
+            }
+            if group.root_identity != expected_root {
+                return Ok(QuarantineRetryOutcome::Skipped(
+                    QuarantineRetrySkip::RootMismatch,
+                ));
+            }
+        }
+        let result = self.kill_group_inner(
+            session_id,
+            ResourceKillReason::Watchdog,
+            false,
+            Some(expected_root),
+        )?;
+        Ok(QuarantineRetryOutcome::Completed(result))
+    }
+
+    /// #1151 - true if this single group still counts toward the admission cap. Mirrors
+    /// the `active_count` predicate for one group so callers never re-derive it. An
+    /// absent group returns false: it cannot be occupying a slot. Returns false on an
+    /// unsupported backend, matching `active_agent_groups()`.
+    pub(crate) fn group_counts_toward_admission(&self, session_id: Uuid) -> bool {
+        if !self.supports_process_tree_enforcement() {
+            return false;
+        }
+        self.inner
+            .lock()
+            .map(|inner| {
+                inner.groups.get(&session_id).is_some_and(|group| {
+                    !matches!(group.state, ResourceGroupState::Terminated) || !group.permit_released
+                })
+            })
+            .unwrap_or(false)
     }
 
     /// #632 B2a - shared kill implementation. `fresh_targets_only` controls only the
@@ -437,11 +563,18 @@ impl ResourceMonitorState {
     /// is targeted, so the reaper does not walk hundreds of stale-dead PIDs (each of
     /// which would force a full toolhelp snapshot). The Job Object kill already
     /// terminated the live tree at shutdown, so the fresh set is normally empty.
+    ///
+    /// #1151 - `expected_quarantined_root` is the same kind of knob for AUTHORITY rather
+    /// than targets: a caller-supplied binding that narrows which registration this kill
+    /// may act on. It is checked inside the SAME critical section that flips the group to
+    /// `Terminating`, so a stale watchdog sample cannot act on a replacement row. Like
+    /// `fresh_targets_only` it never weakens verification; it can only refuse to start.
     fn kill_group_inner(
         &self,
         session_id: Uuid,
         reason: ResourceKillReason,
         fresh_targets_only: bool,
+        expected_quarantined_root: Option<ProcessIdentity>,
     ) -> Result<ResourceKillResult, String> {
         let kill_started = Instant::now();
         let (root_identity, previous_targets) = {
@@ -460,6 +593,28 @@ impl ResourceMonitorState {
                     finalized: false,
                 });
             };
+            // #1151 - when a caller binds this kill to a specific quarantined
+            // registration, verify state and root identity inside the SAME critical
+            // section that flips to Terminating. A stale watchdog sample must never act
+            // on a replacement row (the only way one can exist under the same UUID is
+            // register_group's insert below). Placed before the `match` so the guard is
+            // strictly stronger than the Terminating/Terminated early returns, and before
+            // mark_ac_stop so a rejected retry never latches a stop attribution.
+            if let Some(expected) = expected_quarantined_root {
+                if !matches!(group.state, ResourceGroupState::Quarantined)
+                    || group.root_identity != expected
+                {
+                    return Ok(ResourceKillResult {
+                        session_id: session_id.to_string(),
+                        state: group.state,
+                        killed_processes: Vec::new(),
+                        quarantined: matches!(group.state, ResourceGroupState::Quarantined),
+                        message: "resource group quarantine retry guard rejected".to_string(),
+                        blocked_by_security: false,
+                        finalized: false,
+                    });
+                }
+            }
             match group.state {
                 ResourceGroupState::Terminating => {
                     return Ok(ResourceKillResult {
@@ -723,7 +878,7 @@ impl ResourceMonitorState {
             .map(|inner| inner.groups.keys().copied().collect::<Vec<_>>())
             .unwrap_or_default();
         ids.into_iter()
-            .filter_map(|id| self.kill_group_inner(id, reason, true).ok())
+            .filter_map(|id| self.kill_group_inner(id, reason, true, None).ok())
             .collect()
     }
 
@@ -1201,6 +1356,11 @@ mod tests {
         /// failed enumeration. The Err arm of snapshot() must never reach the strike
         /// counter or reap.
         fail_observe: Mutex<BTreeSet<ProcessIdentity>>,
+        /// #1151 - call counters so a test can assert that an ineligible orphan retry
+        /// touched the backend zero times.
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
     }
 
     struct CapabilityTestBackend {
@@ -1345,6 +1505,15 @@ mod tests {
         fn terminated(&self) -> Vec<ProcessIdentity> {
             self.terminated.lock().unwrap().clone()
         }
+
+        /// #1151 - (observe_tree, observe_identity, terminate_verified) call counts.
+        fn call_counts(&self) -> (usize, usize, usize) {
+            (
+                self.observe_tree_calls.load(Ordering::SeqCst),
+                self.observe_identity_calls.load(Ordering::SeqCst),
+                self.terminate_verified_calls.load(Ordering::SeqCst),
+            )
+        }
     }
 
     impl ProcessTreeBackend for FakeProcessTreeBackend {
@@ -1352,6 +1521,7 @@ mod tests {
             &self,
             root: ProcessIdentity,
         ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
             if self.fail_observe.lock().unwrap().contains(&root) {
                 return Err(ResourceError::Message("observe failed".into()));
             }
@@ -1365,6 +1535,7 @@ mod tests {
         }
 
         fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
             let current = self.identities.lock().unwrap().get(&pid).copied();
             if current.is_none() {
                 return Ok(None);
@@ -1381,6 +1552,7 @@ mod tests {
             &self,
             process: &ObservedProcess,
         ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
             if self.stale.lock().unwrap().contains(&process.identity) {
                 return Ok(TerminateOutcome::AlreadyGone);
             }
@@ -2222,6 +2394,15 @@ mod tests {
         fn test_state(&self, id: Uuid) -> Option<ResourceGroupState> {
             self.inner.lock().unwrap().groups.get(&id).map(|g| g.state)
         }
+
+        /// #1151 - deterministic stand-in for a concurrent transition, so R6 can drive
+        /// the Terminating classification without threads. Stays inside `mod tests`
+        /// because its only caller is in this file.
+        fn test_force_state(&self, id: Uuid, state: ResourceGroupState) {
+            if let Some(group) = self.inner.lock().unwrap().groups.get_mut(&id) {
+                group.state = state;
+            }
+        }
     }
 
     fn missing_root_error(root: ProcessIdentity) -> Vec<String> {
@@ -2484,6 +2665,367 @@ mod tests {
         assert_eq!(retry.state, ResourceGroupState::Terminated);
         assert_eq!(state.active_agent_groups(), 0);
         assert!(state.try_reserve_agent_slot(limits(1)).is_ok());
+    }
+
+    /// #1151 - registers a group whose cleanup quarantines on a stubborn child, which is
+    /// the shape every orphan takes: the root and one descendant, the descendant refusing
+    /// to verify gone at teardown. Returns the group's root and child identities.
+    fn quarantined_group(
+        state: &ResourceMonitorState,
+        backend: &FakeProcessTreeBackend,
+        id: Uuid,
+        root_pid: u32,
+        max: u32,
+        workgroup: Option<String>,
+        agent: Option<String>,
+        project: Option<String>,
+    ) -> (ProcessIdentity, ProcessIdentity) {
+        let root = identity(root_pid, u64::from(root_pid));
+        let child = identity(root_pid + 1, u64::from(root_pid + 1));
+        backend.add_tree(
+            root,
+            vec![
+                observed(root_pid, u64::from(root_pid), None, 0),
+                observed(root_pid + 1, u64::from(root_pid + 1), Some(root_pid), 1),
+            ],
+        );
+        backend.mark_stubborn(child);
+        let permit = state.try_reserve_agent_slot(limits(max)).unwrap().unwrap();
+        state
+            .register_group(
+                permit,
+                id,
+                "agent".into(),
+                None,
+                None,
+                workgroup,
+                agent,
+                project,
+                root,
+            )
+            .unwrap();
+        let first = state
+            .kill_group(id, ResourceKillReason::SessionDestroy)
+            .unwrap();
+        assert!(first.quarantined);
+        assert_eq!(first.state, ResourceGroupState::Quarantined);
+        (root, child)
+    }
+
+    // #1151 (R1) - the fix itself at registry level: once the blocker is verifiably gone,
+    // the registry-only retry releases the permit and the next launch is admitted.
+    #[test]
+    fn orphan_quarantine_retry_reclaims_slot() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (root, child) = quarantined_group(&state, &backend, id, 80, 1, None, None, None);
+        assert_eq!(state.active_agent_groups(), 1);
+
+        backend.mark_gone(child);
+        let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
+        let QuarantineRetryOutcome::Completed(result) = outcome else {
+            panic!("an eligible orphan retry runs the cleanup: {outcome:?}");
+        };
+        assert!(!result.quarantined);
+        assert_eq!(result.state, ResourceGroupState::Terminated);
+        assert!(!state.group_counts_toward_admission(id));
+        assert_eq!(state.active_agent_groups(), 0);
+        assert!(state.try_reserve_agent_slot(limits(1)).is_ok());
+    }
+
+    // #1151 (R2) - the safety half of R1: an owned descendant that is still unverifiable
+    // keeps blocking capacity. The retry decides only WHETHER kill_group runs.
+    #[test]
+    fn orphan_retry_keeps_live_descendant_quarantined() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (root, _child) = quarantined_group(&state, &backend, id, 82, 1, None, None, None);
+
+        let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
+        let QuarantineRetryOutcome::Completed(result) = outcome else {
+            panic!("an eligible orphan retry runs the cleanup: {outcome:?}");
+        };
+        assert!(result.quarantined);
+        assert_eq!(result.state, ResourceGroupState::Quarantined);
+        assert!(state.group_counts_toward_admission(id));
+        assert_eq!(state.active_agent_groups(), 1);
+        assert!(state.try_reserve_agent_slot(limits(1)).is_err());
+    }
+
+    // #1151 (R3) - a stale sample bound to a different root identity cannot act.
+    #[test]
+    fn orphan_retry_rejects_root_mismatch() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (_root, _child) = quarantined_group(&state, &backend, id, 84, 1, None, None, None);
+
+        let before = backend.call_counts();
+        let outcome = state
+            .retry_orphaned_quarantine(id, identity(999, 999))
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::RootMismatch)
+        ));
+        assert_eq!(state.test_state(id), Some(ResourceGroupState::Quarantined));
+        assert_eq!(backend.call_counts(), before);
+    }
+
+    // #1151 (R4) - a Running group is never taken by the orphan path. That case belongs
+    // to the missing-root strike reaper (#1040), not to this fix.
+    #[test]
+    fn orphan_retry_rejects_non_quarantined_state() {
+        let (state, backend) = state_with_fake();
+        let root = identity(86, 86);
+        backend.add_tree(root, vec![observed(86, 86, None, 0)]);
+        let permit = state.try_reserve_agent_slot(limits(1)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(
+                permit,
+                id,
+                "agent".into(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                root,
+            )
+            .unwrap();
+
+        let before = backend.call_counts();
+        let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::NotQuarantined(
+                ResourceGroupState::Running
+            ))
+        ));
+        assert_eq!(backend.call_counts(), before);
+    }
+
+    // #1151 (R5) - defensive arm only. A Quarantined row can never be removed from the
+    // group map, so this is unreachable through real sampling and must be driven with a
+    // fabricated UUID.
+    #[test]
+    fn orphan_retry_rejects_unregistered() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (root, _child) = quarantined_group(&state, &backend, id, 88, 1, None, None, None);
+
+        let before = backend.call_counts();
+        let outcome = state
+            .retry_orphaned_quarantine(Uuid::new_v4(), root)
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::NotRegistered)
+        ));
+        assert_eq!(state.test_state(id), Some(ResourceGroupState::Quarantined));
+        assert_eq!(backend.call_counts(), before);
+    }
+
+    // #1151 (R6) - deterministic stand-in for the concurrent-kill case: another caller
+    // already owns the transition, so the orphan retry must not touch it.
+    #[test]
+    fn orphan_retry_rejects_terminating_state() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (root, _child) = quarantined_group(&state, &backend, id, 90, 1, None, None, None);
+        state.test_force_state(id, ResourceGroupState::Terminating);
+
+        let before = backend.call_counts();
+        let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::NotQuarantined(
+                ResourceGroupState::Terminating
+            ))
+        ));
+        assert_eq!(state.test_state(id), Some(ResourceGroupState::Terminating));
+        assert_eq!(backend.call_counts(), before);
+    }
+
+    // #1151 (R7) - a second retry after a successful one is a no-op. The watchdog
+    // re-samples every tick, so this runs in production whenever a tick overlaps a
+    // just-completed reclaim.
+    #[test]
+    fn orphan_retry_is_idempotent_after_success() {
+        let (state, backend) = state_with_fake();
+        let id = Uuid::new_v4();
+        let (root, child) = quarantined_group(&state, &backend, id, 92, 1, None, None, None);
+
+        backend.mark_gone(child);
+        assert!(matches!(
+            state.retry_orphaned_quarantine(id, root).unwrap(),
+            QuarantineRetryOutcome::Completed(_)
+        ));
+        assert_eq!(state.active_agent_groups(), 0);
+
+        let before = backend.call_counts();
+        let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::NotQuarantined(
+                ResourceGroupState::Terminated
+            ))
+        ));
+        assert_eq!(state.active_agent_groups(), 0);
+        assert_eq!(backend.call_counts(), before);
+    }
+
+    // #1151 (R8) - defense in depth. The watchdog is already gated on capability, so this
+    // check is unreachable on Windows; it must still cost nothing where it is reachable.
+    #[test]
+    fn unsupported_backend_orphan_retry_is_noop() {
+        let backend = Arc::new(CapabilityTestBackend::new(false));
+        let state =
+            ResourceMonitorState::with_backend(backend.clone() as Arc<dyn ProcessTreeBackend>);
+
+        let outcome = state
+            .retry_orphaned_quarantine(Uuid::new_v4(), identity(94, 94))
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            QuarantineRetryOutcome::Skipped(QuarantineRetrySkip::Unsupported)
+        ));
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.terminate_verified_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            backend.current_process_memory_calls.load(Ordering::SeqCst),
+            0
+        );
+    }
+
+    // #1151 (R9) - group_counts_toward_admission is the admission predicate itself, not
+    // an inference, so the watchdog can report the fact without claiming authorship.
+    // Compared against the active_count FILTER (the delta this group contributes), not
+    // against active_agent_groups() directly, which also counts pending permits.
+    #[test]
+    fn group_counts_toward_admission_matches_the_active_count_filter() {
+        let (state, backend) = state_with_fake();
+        let absent = Uuid::new_v4();
+        assert_eq!(state.active_agent_groups(), 0);
+        assert!(!state.group_counts_toward_admission(absent));
+
+        let root = identity(96, 96);
+        let child = identity(97, 97);
+        backend.add_tree(
+            root,
+            vec![observed(96, 96, None, 0), observed(97, 97, Some(96), 1)],
+        );
+        backend.mark_stubborn(child);
+        let permit = state.try_reserve_agent_slot(limits(2)).unwrap().unwrap();
+        let id = Uuid::new_v4();
+        state
+            .register_group(
+                permit,
+                id,
+                "agent".into(),
+                None,
+                None,
+                None,
+                None,
+                None,
+                root,
+            )
+            .unwrap();
+
+        // Running: included by the filter, so the figure rises by exactly this group.
+        assert!(state.group_counts_toward_admission(id));
+        assert_eq!(state.active_agent_groups(), 1);
+
+        // Quarantined: still included. This is the whole reason the permit leaks.
+        state
+            .kill_group(id, ResourceKillReason::SessionDestroy)
+            .unwrap();
+        assert_eq!(state.test_state(id), Some(ResourceGroupState::Quarantined));
+        assert!(state.group_counts_toward_admission(id));
+        assert_eq!(state.active_agent_groups(), 1);
+
+        // Terminated with the permit released: excluded, back to the empty figure.
+        backend.mark_gone(child);
+        state.retry_orphaned_quarantine(id, root).unwrap();
+        assert_eq!(state.test_state(id), Some(ResourceGroupState::Terminated));
+        assert!(!state.group_counts_toward_admission(id));
+        assert_eq!(state.active_agent_groups(), 0);
+
+        // Absent: never included.
+        assert!(!state.group_counts_toward_admission(absent));
+    }
+
+    // #1151 (R10) - the restart shape at registry level. A restart replacement carries the
+    // same workgroup/agent/project under a NEW uuid, so register_group's relaunch dedup
+    // WOULD have collected the old row and does not, because it is Quarantined rather
+    // than Terminated. That is the accumulator; the retry is what drains it.
+    #[test]
+    fn restart_shaped_orphan_retry_unblocks_relaunch_dedup() {
+        let (state, backend) = state_with_fake();
+        let wg = || Some("wg-1".to_string());
+        let agent = || Some("dev-rust".to_string());
+        let project = || Some("ac".to_string());
+
+        let id_a = Uuid::new_v4();
+        let (root_a, child_a) =
+            quarantined_group(&state, &backend, id_a, 100, 2, wg(), agent(), project());
+
+        // The restart replacement: a NEW uuid with the SAME identity triple.
+        let id_b = Uuid::new_v4();
+        let root_b = identity(110, 110);
+        backend.add_tree(root_b, vec![observed(110, 110, None, 0)]);
+        let permit_b = state.try_reserve_agent_slot(limits(2)).unwrap().unwrap();
+        state
+            .register_group(
+                permit_b,
+                id_b,
+                "agent".into(),
+                None,
+                None,
+                wg(),
+                agent(),
+                project(),
+                root_b,
+            )
+            .unwrap();
+
+        // A's row survives the dedup because it is Quarantined, and both rows count.
+        assert_eq!(
+            state.test_state(id_a),
+            Some(ResourceGroupState::Quarantined)
+        );
+        assert_eq!(state.active_agent_groups(), 2);
+
+        // The blocker clears and the orphan retry drains A.
+        backend.mark_gone(child_a);
+        assert!(matches!(
+            state.retry_orphaned_quarantine(id_a, root_a).unwrap(),
+            QuarantineRetryOutcome::Completed(_)
+        ));
+        assert_eq!(state.test_state(id_a), Some(ResourceGroupState::Terminated));
+        assert_eq!(state.active_agent_groups(), 1);
+
+        // A third launch of the same triple now reclaims A's row instead of stacking.
+        let id_c = Uuid::new_v4();
+        let root_c = identity(120, 120);
+        backend.add_tree(root_c, vec![observed(120, 120, None, 0)]);
+        let permit_c = state.try_reserve_agent_slot(limits(2)).unwrap().unwrap();
+        state
+            .register_group(
+                permit_c,
+                id_c,
+                "agent".into(),
+                None,
+                None,
+                wg(),
+                agent(),
+                project(),
+                root_c,
+            )
+            .unwrap();
+        assert_eq!(state.test_state(id_a), None);
+        assert_eq!(state.active_agent_groups(), 2);
     }
 
     // (c) H3 - registering the same wg/role drops the prior Terminated duplicate row.

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -2676,9 +2676,7 @@ mod tests {
         id: Uuid,
         root_pid: u32,
         max: u32,
-        workgroup: Option<String>,
-        agent: Option<String>,
-        project: Option<String>,
+        identity_triple: Option<(&str, &str, &str)>,
     ) -> (ProcessIdentity, ProcessIdentity) {
         let root = identity(root_pid, u64::from(root_pid));
         let child = identity(root_pid + 1, u64::from(root_pid + 1));
@@ -2690,6 +2688,14 @@ mod tests {
             ],
         );
         backend.mark_stubborn(child);
+        let (workgroup, agent, project) = match identity_triple {
+            Some((workgroup, agent, project)) => (
+                Some(workgroup.to_string()),
+                Some(agent.to_string()),
+                Some(project.to_string()),
+            ),
+            None => (None, None, None),
+        };
         let permit = state.try_reserve_agent_slot(limits(max)).unwrap().unwrap();
         state
             .register_group(
@@ -2718,7 +2724,7 @@ mod tests {
     fn orphan_quarantine_retry_reclaims_slot() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (root, child) = quarantined_group(&state, &backend, id, 80, 1, None, None, None);
+        let (root, child) = quarantined_group(&state, &backend, id, 80, 1, None);
         assert_eq!(state.active_agent_groups(), 1);
 
         backend.mark_gone(child);
@@ -2739,7 +2745,7 @@ mod tests {
     fn orphan_retry_keeps_live_descendant_quarantined() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (root, _child) = quarantined_group(&state, &backend, id, 82, 1, None, None, None);
+        let (root, _child) = quarantined_group(&state, &backend, id, 82, 1, None);
 
         let outcome = state.retry_orphaned_quarantine(id, root).unwrap();
         let QuarantineRetryOutcome::Completed(result) = outcome else {
@@ -2757,7 +2763,7 @@ mod tests {
     fn orphan_retry_rejects_root_mismatch() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (_root, _child) = quarantined_group(&state, &backend, id, 84, 1, None, None, None);
+        let (_root, _child) = quarantined_group(&state, &backend, id, 84, 1, None);
 
         let before = backend.call_counts();
         let outcome = state
@@ -2812,7 +2818,7 @@ mod tests {
     fn orphan_retry_rejects_unregistered() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (root, _child) = quarantined_group(&state, &backend, id, 88, 1, None, None, None);
+        let (root, _child) = quarantined_group(&state, &backend, id, 88, 1, None);
 
         let before = backend.call_counts();
         let outcome = state
@@ -2832,7 +2838,7 @@ mod tests {
     fn orphan_retry_rejects_terminating_state() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (root, _child) = quarantined_group(&state, &backend, id, 90, 1, None, None, None);
+        let (root, _child) = quarantined_group(&state, &backend, id, 90, 1, None);
         state.test_force_state(id, ResourceGroupState::Terminating);
 
         let before = backend.call_counts();
@@ -2854,7 +2860,7 @@ mod tests {
     fn orphan_retry_is_idempotent_after_success() {
         let (state, backend) = state_with_fake();
         let id = Uuid::new_v4();
-        let (root, child) = quarantined_group(&state, &backend, id, 92, 1, None, None, None);
+        let (root, child) = quarantined_group(&state, &backend, id, 92, 1, None);
 
         backend.mark_gone(child);
         assert!(matches!(
@@ -2963,13 +2969,13 @@ mod tests {
     #[test]
     fn restart_shaped_orphan_retry_unblocks_relaunch_dedup() {
         let (state, backend) = state_with_fake();
-        let wg = || Some("wg-1".to_string());
-        let agent = || Some("dev-rust".to_string());
-        let project = || Some("ac".to_string());
+        let triple = ("wg-1", "dev-rust", "ac");
+        let wg = || Some(triple.0.to_string());
+        let agent = || Some(triple.1.to_string());
+        let project = || Some(triple.2.to_string());
 
         let id_a = Uuid::new_v4();
-        let (root_a, child_a) =
-            quarantined_group(&state, &backend, id_a, 100, 2, wg(), agent(), project());
+        let (root_a, child_a) = quarantined_group(&state, &backend, id_a, 100, 2, Some(triple));
 
         // The restart replacement: a NEW uuid with the SAME identity triple.
         let id_b = Uuid::new_v4();

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -320,7 +320,7 @@ impl ResourceMonitorState {
                     && g.project == project)
             });
         }
-        inner.groups.insert(
+        let replaced = inner.groups.insert(
             session_id,
             ResourceAgentGroup {
                 session_id,
@@ -341,6 +341,23 @@ impl ResourceMonitorState {
                 terminated_at: None,
             },
         );
+        // #1151 - no flow reuses a session UUID today (relaunch and restart both allocate
+        // a new one), so this insert should only ever replace a Terminated row the dedup
+        // above chose to keep. If it ever replaces a live or Quarantined one, that row's
+        // permit accounting is lost silently and the cap drifts. Diagnostic only:
+        // an assert here would turn a bookkeeping drift into a panic on the launch path,
+        // which is a strictly worse failure than the hazard it guards.
+        if let Some(previous) = replaced {
+            if !matches!(previous.state, ResourceGroupState::Terminated) {
+                log::error!(
+                    "[resource-monitor] register_group replaced a live row session={} previous_state={:?} previous_root_pid={} permit_released={}",
+                    session_id,
+                    previous.state,
+                    previous.root_identity.pid,
+                    previous.permit_released
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::config::settings::{ResourceWatchdogAction, SettingsState};
 use crate::resource_monitor::types::{ResourceGroupState, ResourceLimits};
 use crate::resource_monitor::ResourceMonitorState;
-use crate::session::selection::{CriticalAdmissionOutcome, SelectionCoordinator};
+use crate::session::selection::{SelectionCoordinator, WatchdogKillOutcome};
 use crate::shutdown::ShutdownSignal;
 use serde::Serialize;
 use uuid::Uuid;
@@ -100,7 +100,7 @@ async fn run_tick(
 
 async fn submit_watchdog_kill(coordinator: &SelectionCoordinator, session_id: Uuid) {
     match coordinator.watchdog_resource_kill(session_id).await {
-        Ok(CriticalAdmissionOutcome::Completed(result)) => {
+        Ok(WatchdogKillOutcome::Completed(result)) => {
             log::info!(
                 "[resource-watchdog] finalized session={} state={:?} finalized={}",
                 session_id,
@@ -108,9 +108,17 @@ async fn submit_watchdog_kill(coordinator: &SelectionCoordinator, session_id: Uu
                 result.finalized
             );
         }
-        Ok(CriticalAdmissionOutcome::AlreadyPending) => {
+        // #1151 - the two conditions the old conflated line merged are now distinct, so a
+        // log reader can tell an in-flight critical admission from a vanished session row.
+        Ok(WatchdogKillOutcome::AlreadyInFlight) => {
             log::debug!(
-                "[resource-watchdog] kill already pending or session no longer public session={}",
+                "[resource-watchdog] kill already in flight session={}",
+                session_id
+            );
+        }
+        Ok(WatchdogKillOutcome::NoPublicSession) => {
+            log::debug!(
+                "[resource-watchdog] session no longer public session={}",
                 session_id
             );
         }

--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use crate::config::settings::{ResourceWatchdogAction, SettingsState};
-use crate::resource_monitor::types::{ResourceGroupState, ResourceLimits};
+use crate::resource_monitor::registry::{QuarantineRetryOutcome, QuarantineRetrySkip};
+use crate::resource_monitor::types::{ProcessIdentity, ResourceGroupState, ResourceLimits};
 use crate::resource_monitor::ResourceMonitorState;
 use crate::session::selection::{SelectionCoordinator, WatchdogKillOutcome};
 use crate::shutdown::ShutdownSignal;
@@ -23,6 +24,61 @@ pub struct ResourceWatchdogDecision {
     pub process_kill_pids: Vec<u32>,
     pub warn_required: bool,
     pub kill_required: bool,
+}
+
+/// #1151 - which branch handled one quarantine retry. `Coordinator` means a live public
+/// session took the normal coordinator plus Job Object path; `Orphan` means the session
+/// row was gone and the registry-only fallback ran.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum QuarantineRetryPath {
+    Coordinator,
+    Orphan,
+    AlreadyInFlight,
+    Skipped,
+    Error,
+}
+
+/// #1151 - structured, NON-CLAIMING report of one quarantine retry.
+/// `still_counts_toward_admission` is read back from the registry after the call using
+/// the admission predicate itself, so nothing here asserts "we reclaimed a slot"; it
+/// states the observable fact and leaves authorship out of it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct QuarantineRetryReport {
+    pub session_id: Uuid,
+    pub root_pid: u32,
+    pub path: QuarantineRetryPath,
+    pub state: Option<ResourceGroupState>,
+    pub quarantined: bool,
+    pub still_counts_toward_admission: bool,
+    pub active_agent_groups: usize,
+    pub skipped: Option<&'static str>,
+    pub message: Option<String>,
+}
+
+impl QuarantineRetryReport {
+    fn new(session_id: Uuid, root_pid: u32, path: QuarantineRetryPath) -> Self {
+        Self {
+            session_id,
+            root_pid,
+            path,
+            state: None,
+            quarantined: false,
+            still_counts_toward_admission: false,
+            active_agent_groups: 0,
+            skipped: None,
+            message: None,
+        }
+    }
+}
+
+/// #1151 - only an explicit `NoPublicSession` may fall through to the registry-only
+/// retry. `AlreadyInFlight` means another critical admission owns the outcome, and
+/// treating it as an orphan is the exact mistake the issue rules out. Extracted so that
+/// rule is directly unit-testable.
+fn should_run_orphan_fallback(outcome: &WatchdogKillOutcome) -> bool {
+    matches!(outcome, WatchdogKillOutcome::NoPublicSession)
 }
 
 pub fn start(
@@ -80,13 +136,15 @@ async fn run_tick(
     // (a still-Quarantined group whose prior retry is mid-flight) is a no-op via
     // kill_group's Terminating/Terminated idempotency guard, so this relies on that
     // guard staying intact.
-    for (session_id, group) in &groups {
-        if group.state == ResourceGroupState::Quarantined
-            && monitor.quarantine_retry_due(*session_id)
-        {
-            submit_watchdog_kill(coordinator, *session_id).await;
-        }
-    }
+    //
+    // #1151 - that guard now has TWO callers. The orphan fallback below reaches
+    // kill_group_inner directly, WITHOUT the coordinator's WatchdogKill dedup key, and
+    // relies on the same Terminating/Terminated transition for mutual exclusion. So
+    // weakening kill_group_inner's state guard now breaks two callers, not one.
+    //
+    // run_tick discards the reports and logs nothing: retry_quarantined_group owns all
+    // logging, or every orphan cleanup would emit its line twice.
+    let _ = run_quarantine_retries(monitor, coordinator, &groups).await;
 
     if cfg.resource_watchdog_action != ResourceWatchdogAction::KillGroup {
         return;
@@ -94,6 +152,188 @@ async fn run_tick(
     for decision in evaluate_watchdog_groups(&groups, limits) {
         if decision.kill_required {
             submit_watchdog_kill(coordinator, decision.session_id).await;
+        }
+    }
+}
+
+/// #1151 - owns the quarantine-retry GATE and the loop, so no caller reimplements the
+/// dispatch decision. `run_tick` calls it, and so does the automation hook, which is what
+/// makes the automation evidence about shipped dispatch logic rather than a mirrored copy.
+pub(crate) async fn run_quarantine_retries(
+    monitor: &ResourceMonitorState,
+    coordinator: &SelectionCoordinator,
+    groups: &[(Uuid, ResourceAgentGroupSnapshot)],
+) -> Vec<QuarantineRetryReport> {
+    let mut reports = Vec::new();
+    for (session_id, group) in groups {
+        if group.state == ResourceGroupState::Quarantined
+            && monitor.quarantine_retry_due(*session_id)
+        {
+            reports.push(
+                retry_quarantined_group(monitor, coordinator, *session_id, group.root_identity)
+                    .await,
+            );
+        }
+    }
+    reports
+}
+
+/// #1151 - the per-group decision. The coordinator is asked FIRST, so a live public
+/// session always takes the coordinator plus Job Object path exactly as before. Only an
+/// explicit `NoPublicSession` falls through to the registry-only retry.
+pub(crate) async fn retry_quarantined_group(
+    monitor: &ResourceMonitorState,
+    coordinator: &SelectionCoordinator,
+    session_id: Uuid,
+    root_identity: ProcessIdentity,
+) -> QuarantineRetryReport {
+    let outcome = match coordinator.watchdog_resource_kill(session_id).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            // Busy or Unavailable means the app is bootstrapping, restoring or closing.
+            // Acting on the registry then is out of policy and buys nothing: the next
+            // tick retries.
+            log::warn!("[resource-watchdog] coordinator kill failed session={session_id}: {error}");
+            let mut report = QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Error,
+            );
+            report.message = Some(error);
+            return report;
+        }
+    };
+
+    if !should_run_orphan_fallback(&outcome) {
+        return match outcome {
+            WatchdogKillOutcome::Completed(result) => {
+                log::info!(
+                    "[resource-watchdog] finalized session={} state={:?} finalized={}",
+                    session_id,
+                    result.state,
+                    result.finalized
+                );
+                let mut report = QuarantineRetryReport::new(
+                    session_id,
+                    root_identity.pid,
+                    QuarantineRetryPath::Coordinator,
+                );
+                report.state = Some(result.state);
+                report.quarantined = result.quarantined;
+                report.still_counts_toward_admission =
+                    monitor.group_counts_toward_admission(session_id);
+                report.active_agent_groups = monitor.active_agent_groups();
+                report.message = Some(result.message);
+                report
+            }
+            WatchdogKillOutcome::AlreadyInFlight => {
+                log::debug!("[resource-watchdog] kill already in flight session={session_id}");
+                QuarantineRetryReport::new(
+                    session_id,
+                    root_identity.pid,
+                    QuarantineRetryPath::AlreadyInFlight,
+                )
+            }
+            // Unreachable: should_run_orphan_fallback is exactly this variant.
+            WatchdogKillOutcome::NoPublicSession => QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Orphan,
+            ),
+        };
+    }
+
+    let monitor_c = monitor.clone();
+    // #1151 - this spawn_blocking is the ONLY production invocation of
+    // retry_orphaned_quarantine. kill_group can cost ~2s per stubborn PID
+    // (windows.rs WaitForSingleObject), so inlining it here would stall a Tokio worker.
+    // Awaited rather than detached: it keeps the loop sequential, keeps the log ordering,
+    // and stops a later tick starting a second retry while the first is still running.
+    let outcome = tokio::task::spawn_blocking(move || {
+        monitor_c.retry_orphaned_quarantine(session_id, root_identity)
+    })
+    .await;
+
+    match outcome {
+        Err(join_error) => {
+            log::warn!(
+                "[resource-watchdog] orphan retry failed session={session_id}: {join_error}"
+            );
+            let mut report = QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Error,
+            );
+            report.message = Some(join_error.to_string());
+            report
+        }
+        Ok(Err(message)) => {
+            log::warn!("[resource-watchdog] orphan retry failed session={session_id}: {message}");
+            let mut report = QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Error,
+            );
+            report.message = Some(message);
+            report
+        }
+        Ok(Ok(QuarantineRetryOutcome::Skipped(reason))) => {
+            log::debug!(
+                "[resource-watchdog] orphan retry skipped session={} reason={}",
+                session_id,
+                reason.as_reason()
+            );
+            let mut report = QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Skipped,
+            );
+            if let QuarantineRetrySkip::NotQuarantined(state) = reason {
+                report.state = Some(state);
+            }
+            report.skipped = Some(reason.as_reason());
+            report.still_counts_toward_admission =
+                monitor.group_counts_toward_admission(session_id);
+            report.active_agent_groups = monitor.active_agent_groups();
+            report
+        }
+        Ok(Ok(QuarantineRetryOutcome::Completed(result))) => {
+            let still_counted = monitor.group_counts_toward_admission(session_id);
+            let active_groups = monitor.active_agent_groups();
+            if result.state == ResourceGroupState::Terminated
+                && !result.quarantined
+                && !still_counted
+            {
+                log::info!(
+                    "[resource-watchdog] orphan cleanup completed session={session_id} root_pid={} state=Terminated still_counted=false active_groups={active_groups}",
+                    root_identity.pid
+                );
+            } else if result.quarantined {
+                // Deliberately warn: this carries the per-PID blocker text a native run
+                // needs before any AV or EDR attribution.
+                log::warn!(
+                    "[resource-watchdog] orphan cleanup still blocked session={session_id} root_pid={} still_counted={still_counted}: {}",
+                    root_identity.pid,
+                    result.message
+                );
+            } else {
+                log::debug!(
+                    "[resource-watchdog] orphan cleanup no-op session={session_id} state={:?} still_counted={still_counted}: {}",
+                    result.state,
+                    result.message
+                );
+            }
+            let mut report = QuarantineRetryReport::new(
+                session_id,
+                root_identity.pid,
+                QuarantineRetryPath::Orphan,
+            );
+            report.state = Some(result.state);
+            report.quarantined = result.quarantined;
+            report.still_counts_toward_admission = still_counted;
+            report.active_agent_groups = active_groups;
+            report.message = Some(result.message);
+            report
         }
     }
 }
@@ -182,15 +422,20 @@ pub fn evaluate_watchdog_groups(
 mod tests {
     use super::*;
     use crate::config::settings::AppSettings;
-    use crate::resource_monitor::registry::{ProcessTreeBackend, ResourceError};
+    use crate::resource_monitor::registry::{
+        ProcessTreeBackend, ResourceError, ResourceLaunchRegistration,
+    };
     use crate::resource_monitor::types::{
         ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory,
-        ResourceAgentGroupSnapshot, ResourceNetworkState, ResourceProcessSnapshot,
-        TerminateOutcome,
+        ResourceAgentGroupSnapshot, ResourceKillReason, ResourceKillResult, ResourceLaunchMetadata,
+        ResourceNetworkState, ResourceProcessSnapshot, TerminateOutcome,
     };
     use crate::session::manager::SessionManager;
+    use crate::web::broadcast::WsBroadcaster;
+    use crate::DetachedSessionsState;
+    use std::collections::HashSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use tokio_util::sync::CancellationToken;
 
     #[derive(Default)]
@@ -378,5 +623,423 @@ mod tests {
         let groups = vec![(id, group)];
 
         assert!(evaluate_watchdog_groups(&groups, limits()).is_empty());
+    }
+
+    /// #1151 - supported backend with the shape every orphan takes: a root plus one owned
+    /// descendant, the descendant refusing to verify gone until it is marked gone. That
+    /// refusal is exactly what parks a group in `Quarantined` with its permit retained.
+    #[derive(Default)]
+    struct QuarantineWatchdogBackend {
+        gone: Mutex<HashSet<u32>>,
+        stubborn: Mutex<HashSet<u32>>,
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+    }
+
+    impl QuarantineWatchdogBackend {
+        fn identity(pid: u32) -> ProcessIdentity {
+            ProcessIdentity {
+                pid,
+                creation_time_100ns: u64::from(pid),
+            }
+        }
+
+        fn child_pid(root_pid: u32) -> u32 {
+            root_pid + 1
+        }
+
+        fn observed(pid: u32, depth: u32, parent_pid: Option<u32>) -> ObservedProcess {
+            ObservedProcess {
+                identity: Self::identity(pid),
+                parent_pid,
+                parent_identity: parent_pid.map(Self::identity),
+                exe_name: format!("p{pid}"),
+                depth,
+                private_bytes: Some(10),
+                working_set_bytes: Some(10),
+                cpu_percent: None,
+                kill_allowed: true,
+            }
+        }
+
+        fn mark_stubborn(&self, pid: u32) {
+            self.stubborn.lock().unwrap().insert(pid);
+        }
+
+        fn mark_gone(&self, pid: u32) {
+            self.stubborn.lock().unwrap().remove(&pid);
+            self.gone.lock().unwrap().insert(pid);
+        }
+
+        /// (observe_tree, observe_identity, terminate_verified) call counts.
+        fn call_counts(&self) -> (usize, usize, usize) {
+            (
+                self.observe_tree_calls.load(Ordering::SeqCst),
+                self.observe_identity_calls.load(Ordering::SeqCst),
+                self.terminate_verified_calls.load(Ordering::SeqCst),
+            )
+        }
+    }
+
+    impl ProcessTreeBackend for QuarantineWatchdogBackend {
+        fn observe_tree(
+            &self,
+            root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            let gone = self.gone.lock().unwrap();
+            let child_pid = Self::child_pid(root.pid);
+            let mut processes = Vec::new();
+            if !gone.contains(&root.pid) {
+                processes.push(Self::observed(root.pid, 0, None));
+            }
+            if !gone.contains(&child_pid) {
+                processes.push(Self::observed(child_pid, 1, Some(root.pid)));
+            }
+            let errors = if gone.contains(&root.pid) {
+                vec![format!("root pid {} was not in process snapshot", root.pid)]
+            } else {
+                Vec::new()
+            };
+            Ok(ObservedProcessTree { processes, errors })
+        }
+
+        fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            if self.gone.lock().unwrap().contains(&pid) {
+                Ok(None)
+            } else {
+                Ok(Some(Self::identity(pid)))
+            }
+        }
+
+        fn terminate_verified(
+            &self,
+            process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            let pid = process.identity.pid;
+            if self.gone.lock().unwrap().contains(&pid) {
+                return Ok(TerminateOutcome::AlreadyGone);
+            }
+            if self.stubborn.lock().unwrap().contains(&pid) {
+                return Err(ResourceError::Message(format!(
+                    "pid {pid}: process still alive after terminate"
+                )));
+            }
+            self.gone.lock().unwrap().insert(pid);
+            Ok(TerminateOutcome::Terminated)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            Ok(ProcessMemory::default())
+        }
+    }
+
+    /// #1151 - the default watchdog action is `Warn` (config/settings.rs), and the
+    /// quarantine retry must run there too. Every orphan test uses the default on purpose.
+    fn orphan_settings(max_groups: u32) -> AppSettings {
+        AppSettings {
+            resource_monitor_enabled: true,
+            max_concurrent_agent_processes: max_groups,
+            ..AppSettings::default()
+        }
+    }
+
+    fn register_agent_group(
+        monitor: &ResourceMonitorState,
+        limits: ResourceLimits,
+        session_id: Uuid,
+        root_pid: u32,
+        identity_triple: Option<(&str, &str, &str)>,
+    ) -> ProcessIdentity {
+        let permit = monitor
+            .try_reserve_agent_slot(limits)
+            .expect("reservation admitted")
+            .expect("supported backend issues a permit");
+        let (workgroup, agent, project) = match identity_triple {
+            Some((workgroup, agent, project)) => (
+                Some(workgroup.to_string()),
+                Some(agent.to_string()),
+                Some(project.to_string()),
+            ),
+            None => (None, None, None),
+        };
+        let mut registration = ResourceLaunchRegistration::new(
+            monitor.clone(),
+            permit,
+            ResourceLaunchMetadata {
+                session_id,
+                name: "agent".to_string(),
+                agent_id: None,
+                agent_label: None,
+                workgroup,
+                agent,
+                project,
+            },
+        );
+        registration
+            .register_root_pid(root_pid)
+            .expect("register root pid")
+            .expect("supported backend observes the root identity")
+    }
+
+    /// #1151 - the coordinator must be at `Running` or `watchdog_resource_kill` answers
+    /// `Err(Busy)` at its phase gate, before the absent-session check. `SelectionCoordinator::new`
+    /// starts at `Bootstrapping` and `CoordinatorPhase` is private, so the supported route
+    /// is `submit_restore_first`, which needs a started worker and therefore an AppHandle.
+    async fn running_coordinator(
+        manager: Arc<tokio::sync::RwLock<SessionManager>>,
+        monitor: Arc<ResourceMonitorState>,
+    ) -> (tauri::App<tauri::test::MockRuntime>, SelectionCoordinator) {
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(monitor)
+            .manage(coordinator.clone())
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build orphan-retry watchdog app");
+        coordinator
+            .start(app.handle().clone())
+            .expect("start orphan-retry coordinator");
+        coordinator
+            .submit_restore_first()
+            .await
+            .expect("restore-first admitted")
+            .finish();
+        (app, coordinator)
+    }
+
+    /// #1151 - drives one group from launch to an orphaned quarantine: register, quarantine
+    /// on the stubborn child, then let the blocker disappear. The public session row never
+    /// exists, which is what makes it an orphan.
+    fn orphan_one_group(
+        monitor: &ResourceMonitorState,
+        backend: &QuarantineWatchdogBackend,
+        limits: ResourceLimits,
+        session_id: Uuid,
+        root_pid: u32,
+        identity_triple: Option<(&str, &str, &str)>,
+    ) -> ProcessIdentity {
+        let child_pid = QuarantineWatchdogBackend::child_pid(root_pid);
+        backend.mark_stubborn(child_pid);
+        let root = register_agent_group(monitor, limits, session_id, root_pid, identity_triple);
+        let quarantine = monitor
+            .kill_group(session_id, ResourceKillReason::SessionDestroy)
+            .expect("first cleanup runs");
+        assert!(quarantine.quarantined);
+        assert_eq!(quarantine.state, ResourceGroupState::Quarantined);
+        backend.mark_gone(child_pid);
+        monitor.test_backdate_quarantine_retry(session_id);
+        root
+    }
+
+    // #1151 (W1) - the issue's minimum supported-backend regression, end to end through
+    // the REAL run_tick: an orphaned quarantined group whose blocker cleared is reclaimed,
+    // the cap recovers, and the next launch is admitted. Runs on the DEFAULT Warn action,
+    // which is what makes a mis-scoped action gate fail here rather than ship silently.
+    #[tokio::test]
+    async fn orphaned_quarantine_recovers_through_real_tick() {
+        let backend = Arc::new(QuarantineWatchdogBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let cfg = orphan_settings(1);
+        assert_eq!(cfg.resource_watchdog_action, ResourceWatchdogAction::Warn);
+        let group_limits = ResourceLimits::from(&cfg);
+
+        let session_id = Uuid::new_v4();
+        orphan_one_group(&monitor, &backend, group_limits, session_id, 200, None);
+        assert_eq!(monitor.active_agent_groups(), 1);
+        assert!(monitor.try_reserve_agent_slot(group_limits).is_err());
+
+        // The public row never existed, so the coordinator can only answer NoPublicSession.
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (_app, coordinator) = running_coordinator(manager, Arc::clone(&monitor)).await;
+        let settings = Arc::new(tokio::sync::RwLock::new(cfg));
+
+        run_tick(&monitor, &settings, &coordinator).await;
+
+        assert!(!monitor.group_counts_toward_admission(session_id));
+        assert_eq!(monitor.active_agent_groups(), 0);
+        let permit = monitor
+            .try_reserve_agent_slot(group_limits)
+            .expect("the reclaimed slot admits the next launch")
+            .expect("supported backend issues a permit");
+        monitor.release_unregistered_permit(permit);
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (W3a) - the rule the issue states explicitly: only NoPublicSession may fall
+    // through to the registry-only retry. Treating AlreadyInFlight as an orphan would
+    // re-enter a cleanup another caller already owns.
+    #[test]
+    fn already_in_flight_is_not_an_orphan_fallback() {
+        let completed = WatchdogKillOutcome::Completed(ResourceKillResult {
+            session_id: Uuid::new_v4().to_string(),
+            state: ResourceGroupState::Terminated,
+            killed_processes: Vec::new(),
+            quarantined: false,
+            message: "resource group terminated and verified".to_string(),
+            blocked_by_security: false,
+            finalized: true,
+        });
+        assert!(!should_run_orphan_fallback(&completed));
+        assert!(!should_run_orphan_fallback(
+            &WatchdogKillOutcome::AlreadyInFlight
+        ));
+        assert!(should_run_orphan_fallback(
+            &WatchdogKillOutcome::NoPublicSession
+        ));
+    }
+
+    // #1151 (W3b) - and the same rule proved through retry_quarantined_group itself: the
+    // AlreadyInFlight arm touches the process-tree backend zero times.
+    #[tokio::test]
+    async fn already_in_flight_performs_zero_registry_calls() {
+        use crate::pty::backend::SessionBackendKind;
+        use crate::session::selection::CriticalAdmissionKind;
+
+        let backend = Arc::new(QuarantineWatchdogBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let cfg = orphan_settings(1);
+        let group_limits = ResourceLimits::from(&cfg);
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let session = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "C:/watchdog-in-flight".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        let root = orphan_one_group(&monitor, &backend, group_limits, session.id, 210, None);
+
+        let (_app, coordinator) =
+            running_coordinator(Arc::clone(&manager), Arc::clone(&monitor)).await;
+        // Fill the queue so the first watchdog kill parks holding ONLY its critical key.
+        let mut reservations = Vec::new();
+        while let Ok(reservation) = coordinator.reserve_auto_close() {
+            reservations.push(reservation);
+        }
+        let waiter = {
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move { coordinator.watchdog_resource_kill(session.id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !coordinator
+                .critical_key_registered_for_test(session.id, CriticalAdmissionKind::WatchdogKill)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the parked watchdog kill registers its critical key");
+
+        let before = backend.call_counts();
+        let report = retry_quarantined_group(&monitor, &coordinator, session.id, root).await;
+        assert_eq!(report.path, QuarantineRetryPath::AlreadyInFlight);
+        assert_eq!(backend.call_counts(), before);
+        assert!(monitor.group_counts_toward_admission(session.id));
+
+        coordinator.close_and_join().await;
+        drop(reservations);
+        let _ = waiter.await;
+    }
+
+    // #1151 (W4) - retry_quarantined_group forwards the SAMPLED root identity verbatim, so
+    // a stale sample is refused by the registry guard instead of acting on whatever row
+    // now holds the uuid.
+    #[tokio::test]
+    async fn stale_sample_root_cannot_touch_replacement() {
+        let backend = Arc::new(QuarantineWatchdogBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let cfg = orphan_settings(1);
+        let group_limits = ResourceLimits::from(&cfg);
+
+        let session_id = Uuid::new_v4();
+        orphan_one_group(&monitor, &backend, group_limits, session_id, 220, None);
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (_app, coordinator) = running_coordinator(manager, Arc::clone(&monitor)).await;
+
+        let stale_root = ProcessIdentity {
+            pid: 220,
+            creation_time_100ns: 999_999,
+        };
+        let report = retry_quarantined_group(&monitor, &coordinator, session_id, stale_root).await;
+
+        assert_eq!(report.path, QuarantineRetryPath::Skipped);
+        assert_eq!(report.skipped, Some("rootMismatch"));
+        assert_eq!(report.root_pid, 220);
+        assert!(report.still_counts_toward_admission);
+        assert_eq!(monitor.active_agent_groups(), 1);
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (W8) - the restart shape end to end. Three consecutive cycles, each a DISTINCT
+    // uuid sharing one workgroup/agent/project at cap 1, which is what "repetition
+    // exhausts the cap" actually means. Rows must not accumulate across cycles.
+    #[tokio::test]
+    async fn three_restart_shaped_cycles_do_not_accumulate_rows() {
+        let backend = Arc::new(QuarantineWatchdogBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let cfg = orphan_settings(1);
+        let group_limits = ResourceLimits::from(&cfg);
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (_app, coordinator) = running_coordinator(manager, Arc::clone(&monitor)).await;
+        let settings = Arc::new(tokio::sync::RwLock::new(cfg));
+
+        for cycle in 0..3u32 {
+            let session_id = Uuid::new_v4();
+            orphan_one_group(
+                &monitor,
+                &backend,
+                group_limits,
+                session_id,
+                230 + cycle * 10,
+                Some(("wg-1", "dev-rust", "ac")),
+            );
+            assert_eq!(
+                monitor.active_agent_groups(),
+                1,
+                "cycle {cycle}: the quarantined row holds the only slot"
+            );
+
+            run_tick(&monitor, &settings, &coordinator).await;
+
+            assert!(
+                !monitor.group_counts_toward_admission(session_id),
+                "cycle {cycle}: the reclaimed row no longer counts"
+            );
+            assert_eq!(
+                monitor.active_agent_groups(),
+                0,
+                "cycle {cycle}: rows must not accumulate"
+            );
+            let permit = monitor
+                .try_reserve_agent_slot(group_limits)
+                .unwrap_or_else(|error| panic!("cycle {cycle}: relaunch rejected: {error}"))
+                .expect("supported backend issues a permit");
+            monitor.release_unregistered_permit(permit);
+        }
+        coordinator.close_and_join().await;
     }
 }

--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -130,6 +130,24 @@ async fn run_tick(
     let limits = ResourceLimits::from(&cfg);
     let groups = monitor.sample_for_watchdog(limits);
 
+    // #1151 - the kill_required loop is evaluated FIRST. Before this fix an orphan
+    // quarantine retry returned immediately, so the quarantine loop was effectively free;
+    // it now performs a real blocking kill_group per orphan, and running it first would
+    // delay every memory-driven kill decision on a KillGroup install. The starvation is
+    // introduced by this change, so mitigating it belongs to this change.
+    //
+    // #559 (H2) - the quarantine retry runs on EVERY configured action, including the
+    // default Warn. The action gate is therefore SCOPED to the kill_required loop; it must
+    // never be an early return from run_tick, which would delete the whole fix on a
+    // default install while the app kept quarantining and kept leaking.
+    if cfg.resource_watchdog_action == ResourceWatchdogAction::KillGroup {
+        for decision in evaluate_watchdog_groups(&groups, limits) {
+            if decision.kill_required {
+                submit_watchdog_kill(coordinator, decision.session_id).await;
+            }
+        }
+    }
+
     // #559 (H2) - retry cleanup for quarantined groups regardless of the configured
     // watchdog action; a leaked slot must be reclaimed even in Warn mode. kill_group
     // already re-observes and releases if the process is now gone. A double-dispatch
@@ -142,18 +160,12 @@ async fn run_tick(
     // relies on the same Terminating/Terminated transition for mutual exclusion. So
     // weakening kill_group_inner's state guard now breaks two callers, not one.
     //
+    // Reordering is behavior-neutral on which groups are dispatched: evaluate_watchdog_groups
+    // is Running-only and this loop is Quarantined-only, over the same immutable sample.
+    //
     // run_tick discards the reports and logs nothing: retry_quarantined_group owns all
     // logging, or every orphan cleanup would emit its line twice.
     let _ = run_quarantine_retries(monitor, coordinator, &groups).await;
-
-    if cfg.resource_watchdog_action != ResourceWatchdogAction::KillGroup {
-        return;
-    }
-    for decision in evaluate_watchdog_groups(&groups, limits) {
-        if decision.kill_required {
-            submit_watchdog_kill(coordinator, decision.session_id).await;
-        }
-    }
 }
 
 /// #1151 - owns the quarantine-retry GATE and the loop, so no caller reimplements the
@@ -871,6 +883,55 @@ mod tests {
             .expect("supported backend issues a permit");
         monitor.release_unregistered_permit(permit);
         coordinator.close_and_join().await;
+    }
+
+    // #1151 (W7) - the named pin for `#559 (H2)`, which has been unpinned since it was
+    // written: the quarantine retry runs on EVERY configured action, starting with the
+    // DEFAULT Warn. This is what fails if the run_tick action gate is ever restored to an
+    // early return instead of a scoped `if` around the kill_required loop.
+    #[tokio::test]
+    async fn quarantine_retry_runs_in_warn_mode() {
+        for (index, action) in [
+            ResourceWatchdogAction::Warn,
+            ResourceWatchdogAction::KillGroup,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let backend = Arc::new(QuarantineWatchdogBackend::default());
+            let monitor = Arc::new(ResourceMonitorState::with_backend(
+                backend.clone() as Arc<dyn ProcessTreeBackend>
+            ));
+            let cfg = AppSettings {
+                resource_watchdog_action: action,
+                ..orphan_settings(1)
+            };
+            let group_limits = ResourceLimits::from(&cfg);
+
+            let session_id = Uuid::new_v4();
+            orphan_one_group(
+                &monitor,
+                &backend,
+                group_limits,
+                session_id,
+                240 + (index as u32) * 10,
+                None,
+            );
+            assert_eq!(monitor.active_agent_groups(), 1);
+
+            let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+            let (_app, coordinator) = running_coordinator(manager, Arc::clone(&monitor)).await;
+            let settings = Arc::new(tokio::sync::RwLock::new(cfg));
+
+            run_tick(&monitor, &settings, &coordinator).await;
+
+            assert!(
+                !monitor.group_counts_toward_admission(session_id),
+                "{action:?}: the quarantine retry must run on every configured action"
+            );
+            assert_eq!(monitor.active_agent_groups(), 0, "{action:?}");
+            coordinator.close_and_join().await;
+        }
     }
 
     // #1151 (W3a) - the rule the issue states explicitly: only NoPublicSession may fall

--- a/src-tauri/src/session/selection.rs
+++ b/src-tauri/src/session/selection.rs
@@ -407,6 +407,17 @@ pub enum CriticalAdmissionOutcome<T> {
     AlreadyPending,
 }
 
+/// #1151 - `watchdog_resource_kill` must distinguish two conditions that the shared
+/// `CriticalAdmissionOutcome::AlreadyPending` conflates: a genuinely in-flight critical
+/// admission for the same UUID, and a session that is no longer public or pending. Only
+/// the second may fall back to a registry-only quarantine retry.
+#[derive(Debug, Clone)]
+pub(crate) enum WatchdogKillOutcome {
+    Completed(crate::resource_monitor::ResourceKillResult),
+    AlreadyInFlight,
+    NoPublicSession,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CoordinatorPhase {
     Bootstrapping = 0,
@@ -1278,7 +1289,7 @@ impl SelectionCoordinator {
     pub(crate) async fn watchdog_resource_kill(
         &self,
         session_id: Uuid,
-    ) -> Result<CriticalAdmissionOutcome<crate::resource_monitor::ResourceKillResult>, String> {
+    ) -> Result<WatchdogKillOutcome, String> {
         if IN_SELECTION_WORKER.try_with(|_| ()).is_ok() {
             return Err(SelectionCoordinatorError::RecursiveSubmission.to_string());
         }
@@ -1293,7 +1304,7 @@ impl SelectionCoordinator {
         }
         let manager = self.inner.manager.read().await.clone();
         if !manager.contains_public_or_pending(session_id).await {
-            return Ok(CriticalAdmissionOutcome::AlreadyPending);
+            return Ok(WatchdogKillOutcome::NoPublicSession);
         }
         let key = CriticalAdmissionKey {
             session_id,
@@ -1305,7 +1316,7 @@ impl SelectionCoordinator {
             guard,
         }) = self.reserve_critical_admission(key).await?
         else {
-            return Ok(CriticalAdmissionOutcome::AlreadyPending);
+            return Ok(WatchdogKillOutcome::AlreadyInFlight);
         };
         let (response, receiver) = oneshot::channel();
         drop(slot.send(CoordinatorEnvelope {
@@ -1321,7 +1332,7 @@ impl SelectionCoordinator {
         let result = receiver
             .await
             .map_err(|_| SelectionCoordinatorError::Unavailable.to_string())??;
-        Ok(CriticalAdmissionOutcome::Completed(result))
+        Ok(WatchdogKillOutcome::Completed(result))
     }
 
     pub(crate) async fn background_destroy(
@@ -4713,7 +4724,7 @@ mod tests {
                 .watchdog_resource_kill(session.id)
                 .await
                 .unwrap(),
-            CriticalAdmissionOutcome::AlreadyPending
+            WatchdogKillOutcome::AlreadyInFlight
         ));
         assert!(matches!(
             coordinator.background_destroy(session.id).await.unwrap(),
@@ -4734,6 +4745,162 @@ mod tests {
         }
         assert!(coordinator.inner.critical_keys.lock().unwrap().is_empty());
         assert!(coordinator.inner.worker.lock().unwrap().is_none());
+    }
+
+    // #1151 (S1) - an absent session UUID reports NoPublicSession, distinctly from the
+    // in-flight case, and does so before any admission is reserved or job enqueued.
+    #[tokio::test]
+    async fn watchdog_kill_reports_no_public_session_for_absent_uuid() {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            LifecycleTestBackend::default(),
+        ))));
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(pty)
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build no-public-session app");
+        coordinator.start(app.handle().clone()).unwrap();
+        let restore = coordinator.submit_restore_first().await.unwrap();
+
+        // Every envelope slot is taken and the restore barrier is still held, so ANY
+        // attempt to reserve a critical admission would park indefinitely. Returning
+        // promptly is therefore proof that the absent-session check runs before the
+        // reservation and before a CoordinatorJob::ResourceKill can be enqueued.
+        let mut reservations = Vec::new();
+        while let Ok(reservation) = coordinator.reserve_auto_close() {
+            reservations.push(reservation);
+        }
+        assert!(!reservations.is_empty());
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(1),
+            coordinator.watchdog_resource_kill(Uuid::new_v4()),
+        )
+        .await
+        .expect("absent-session watchdog kill returns without reserving admission")
+        .unwrap();
+        assert!(matches!(outcome, WatchdogKillOutcome::NoPublicSession));
+        assert!(coordinator.inner.critical_keys.lock().unwrap().is_empty());
+
+        restore.finish();
+        coordinator.close_and_join().await;
+        drop(reservations);
+    }
+
+    // #1151 (S2) - with the WatchdogKill critical key held for a PUBLIC uuid, the second
+    // call reports AlreadyInFlight, never NoPublicSession. The orphan fallback keys off
+    // the second variant only, so conflating them would re-enter a live cleanup.
+    #[tokio::test]
+    async fn watchdog_kill_reports_already_in_flight_when_key_held() {
+        use crate::pty::backend::SessionBackendKind;
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let session = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "C:/watchdog-in-flight".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            LifecycleTestBackend::default(),
+        ))));
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(pty)
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build already-in-flight app");
+        coordinator.start(app.handle().clone()).unwrap();
+        let guard = coordinator.submit_restore_first().await.unwrap();
+        let reservations = (0..COORDINATOR_QUEUE_CAPACITY)
+            .map(|_| coordinator.reserve_auto_close().unwrap())
+            .collect::<Vec<_>>();
+
+        let waiter = {
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move { coordinator.watchdog_resource_kill(session.id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !coordinator
+                .critical_key_registered_for_test(session.id, CriticalAdmissionKind::WatchdogKill)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the first watchdog kill registers its critical key");
+
+        assert!(matches!(
+            coordinator
+                .watchdog_resource_kill(session.id)
+                .await
+                .unwrap(),
+            WatchdogKillOutcome::AlreadyInFlight
+        ));
+
+        coordinator
+            .close_and_join_with_budget(Duration::from_millis(25))
+            .await;
+        guard.finish();
+        drop(reservations);
+        assert_eq!(
+            waiter.await.unwrap().unwrap_err(),
+            SelectionCoordinatorError::Unavailable.to_string()
+        );
+    }
+
+    // #1151 (S3) - the absent-session outcomes of the two SIBLING entry points are
+    // deliberately inconsistent with each other and are left exactly as they are. A
+    // dedicated WatchdogKillOutcome exists so nobody normalizes all three at once.
+    #[tokio::test]
+    async fn absent_session_outcomes_for_route_loss_and_background_destroy_are_unchanged() {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let pty = Arc::new(Mutex::new(PtyManager::new_for_test(Arc::new(
+            LifecycleTestBackend::default(),
+        ))));
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(pty)
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build absent-session sibling app");
+        coordinator.start(app.handle().clone()).unwrap();
+        coordinator.submit_restore_first().await.unwrap().finish();
+
+        assert!(matches!(
+            coordinator
+                .container_lifecycle_sender()
+                .route_lost(Uuid::new_v4(), 7)
+                .await
+                .unwrap(),
+            CriticalAdmissionOutcome::Completed(())
+        ));
+        assert!(matches!(
+            coordinator
+                .background_destroy(Uuid::new_v4())
+                .await
+                .unwrap(),
+            CriticalAdmissionOutcome::AlreadyPending
+        ));
+        assert!(coordinator.inner.critical_keys.lock().unwrap().is_empty());
+        coordinator.close_and_join().await;
     }
 
     #[tokio::test]

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -963,6 +963,10 @@ enum BackendWatchdogMode {
     Warn,
     KillGroup,
     Tick,
+    /// #1151 - runs the production quarantine-retry gate and loop, so native verification
+    /// of the orphan path is a deterministic, assertable artifact rather than log scraping
+    /// behind a 15 second backoff.
+    QuarantineRetry,
 }
 
 impl BackendWatchdogMode {
@@ -972,8 +976,9 @@ impl BackendWatchdogMode {
             "warn" => Ok(Self::Warn),
             "killGroup" | "kill-group" => Ok(Self::KillGroup),
             "tick" => Ok(Self::Tick),
+            "quarantineRetry" | "quarantine-retry" => Ok(Self::QuarantineRetry),
             other => Err(format!(
-                "Unsupported resource monitor watchdog mode '{other}'. Expected sample, warn, killGroup, or tick."
+                "Unsupported resource monitor watchdog mode '{other}'. Expected sample, warn, killGroup, tick, or quarantineRetry."
             )),
         }
     }
@@ -984,6 +989,7 @@ impl BackendWatchdogMode {
             Self::Warn => "warn",
             Self::KillGroup => "killGroup",
             Self::Tick => "tick",
+            Self::QuarantineRetry => "quarantineRetry",
         }
     }
 }
@@ -1118,6 +1124,37 @@ async fn handle_resource_watchdog_backend_request_with_config<R: tauri::Runtime>
         }
     }
 
+    // #1151 - run the PRODUCTION quarantine-retry gate and loop, not a mirrored copy, so
+    // these reports are evidence about shipped dispatch logic. The coordinator is resolved
+    // ONCE before the call, because the loop takes it by reference for every group.
+    let mut quarantine_retries = Vec::new();
+    if resource_monitor_enabled
+        && matches!(
+            mode,
+            BackendWatchdogMode::QuarantineRetry | BackendWatchdogMode::Tick
+        )
+    {
+        match app.try_state::<crate::session::selection::SelectionCoordinator>() {
+            Some(coordinator) => {
+                for report in crate::resource_monitor::watchdog::run_quarantine_retries(
+                    &monitor,
+                    coordinator.inner(),
+                    &groups,
+                )
+                .await
+                {
+                    quarantine_retries.push(serde_json::to_value(&report).unwrap_or_else(
+                        |error| json!({ "ok": false, "message": error.to_string() }),
+                    ));
+                }
+            }
+            None => quarantine_retries.push(json!({
+                "ok": false,
+                "message": "selectionCoordinatorUnavailable",
+            })),
+        }
+    }
+
     let state = if !resource_monitor_enabled {
         "disabled"
     } else if !kill_results.is_empty() {
@@ -1186,9 +1223,14 @@ async fn handle_resource_watchdog_backend_request_with_config<R: tauri::Runtime>
                 "groupKillPrivateBytes": limits.group_kill_private_bytes,
                 "processKillPrivateBytes": limits.process_kill_private_bytes,
             },
+            // #1151 - `snapshot` is captured BEFORE the action loop and is deliberately
+            // left that way. Every post-retry assertion reads `quarantineRetries[i]`
+            // instead; reading `snapshot.activeAgentGroups` after a successful reclaim
+            // still shows the pre-action figure and produces a false FAIL.
             "snapshot": snapshot_diagnostics,
             "decisions": decisions,
             "killResults": kill_results,
+            "quarantineRetries": quarantine_retries,
         })),
         available_windows: None,
         timeout_ms: None,
@@ -2011,6 +2053,15 @@ mod tests {
                 kill_allowed: true,
             }
         }
+
+        fn mark_stubborn(&self, pid: u32) {
+            self.stubborn.lock().unwrap().insert(pid);
+        }
+
+        fn mark_gone(&self, pid: u32) {
+            self.stubborn.lock().unwrap().remove(&pid);
+            self.gone.lock().unwrap().insert(pid);
+        }
     }
 
     impl ProcessTreeBackend for AutomationProcessBackend {
@@ -2162,7 +2213,7 @@ mod tests {
             ..AppSettings::default()
         };
 
-        for mode in ["sample", "warn", "killGroup", "tick"] {
+        for mode in ["sample", "warn", "killGroup", "tick", "quarantineRetry"] {
             let request = UiAutomationRequest {
                 request_id: Uuid::new_v4().to_string(),
                 token: "token".to_string(),
@@ -2215,6 +2266,7 @@ mod tests {
                     },
                     "decisions": [],
                     "killResults": [],
+                    "quarantineRetries": [],
                 }))
             );
         }
@@ -2350,6 +2402,164 @@ mod tests {
         coordinator.close_and_join().await;
         drop(reservations);
         let _ = waiter.await;
+    }
+
+    /// #1151 - registers a group, quarantines its cleanup on a stubborn child, and leaves
+    /// the retry backoff already satisfied. No public session row is ever created, which
+    /// is precisely what makes the group an orphan.
+    fn orphan_automation_group(
+        monitor: &crate::resource_monitor::ResourceMonitorState,
+        backend: &AutomationProcessBackend,
+        limits: crate::resource_monitor::ResourceLimits,
+        session_id: Uuid,
+        root_pid: u32,
+    ) -> ProcessIdentity {
+        backend.mark_stubborn(AutomationProcessBackend::child_pid(root_pid));
+        let root = register_automation_group(monitor, limits, session_id, root_pid);
+        let quarantine = monitor
+            .kill_group(
+                session_id,
+                crate::resource_monitor::types::ResourceKillReason::SessionDestroy,
+            )
+            .expect("first cleanup runs");
+        assert!(quarantine.quarantined);
+        monitor.test_backdate_quarantine_retry(session_id);
+        root
+    }
+
+    async fn automation_app_with_coordinator(
+        monitor: Arc<crate::resource_monitor::ResourceMonitorState>,
+    ) -> (tauri::App<tauri::test::MockRuntime>, SelectionCoordinator) {
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(monitor)
+            .manage(coordinator.clone())
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build quarantine-retry automation app");
+        coordinator
+            .start(app.handle().clone())
+            .expect("start quarantine-retry coordinator");
+        coordinator
+            .submit_restore_first()
+            .await
+            .expect("restore-first admitted")
+            .finish();
+        (app, coordinator)
+    }
+
+    // #1151 (A1) - the deterministic native artifact for a successful reclaim. Everything
+    // is read from quarantineRetries[0], NEVER from diagnostics.snapshot, which is captured
+    // before the action loop and would still read activeAgentGroups = 1 on a correct build.
+    #[tokio::test]
+    async fn quarantine_retry_mode_reports_completed_orphan_cleanup() {
+        let backend = Arc::new(AutomationProcessBackend::default());
+        let monitor = Arc::new(crate::resource_monitor::ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>,
+        ));
+        let cfg = automation_settings();
+        let limits = crate::resource_monitor::ResourceLimits::from(&cfg);
+
+        let session_id = Uuid::new_v4();
+        let root = orphan_automation_group(&monitor, &backend, limits, session_id, 6_100);
+        assert_eq!(monitor.active_agent_groups(), 1);
+        // The blocker finally exits, which is the only thing a retry can discover.
+        backend.mark_gone(AutomationProcessBackend::child_pid(6_100));
+
+        let (app, coordinator) = automation_app_with_coordinator(Arc::clone(&monitor)).await;
+        let response = handle_resource_watchdog_backend_request_with_config(
+            app.handle(),
+            &watchdog_backend_request("quarantineRetry"),
+            &cfg,
+        )
+        .await;
+
+        assert!(response.ok);
+        let diagnostics = response.diagnostics.expect("watchdog diagnostics");
+        let retries = diagnostics["quarantineRetries"]
+            .as_array()
+            .expect("quarantineRetries array");
+        assert_eq!(retries.len(), 1);
+        assert_eq!(retries[0]["sessionId"], json!(session_id));
+        assert_eq!(retries[0]["path"], json!("orphan"));
+        assert_eq!(retries[0]["rootPid"], json!(root.pid));
+        assert_eq!(retries[0]["quarantined"], json!(false));
+        assert_eq!(retries[0]["stillCountsTowardAdmission"], json!(false));
+        assert_eq!(retries[0]["activeAgentGroups"], json!(0));
+        // The pre-action snapshot deliberately still shows the group counted.
+        assert_eq!(diagnostics["snapshot"]["activeAgentGroups"], json!(1));
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (A2) - the safety artifact. An owned descendant that is still unverifiable
+    // keeps blocking capacity, and the report says so instead of claiming a reclaim.
+    #[tokio::test]
+    async fn quarantine_retry_mode_reports_still_blocked_group() {
+        let backend = Arc::new(AutomationProcessBackend::default());
+        let monitor = Arc::new(crate::resource_monitor::ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>,
+        ));
+        let cfg = automation_settings();
+        let limits = crate::resource_monitor::ResourceLimits::from(&cfg);
+
+        let session_id = Uuid::new_v4();
+        // The blocker is deliberately NOT marked gone.
+        orphan_automation_group(&monitor, &backend, limits, session_id, 6_200);
+
+        let (app, coordinator) = automation_app_with_coordinator(Arc::clone(&monitor)).await;
+        let response = handle_resource_watchdog_backend_request_with_config(
+            app.handle(),
+            &watchdog_backend_request("quarantineRetry"),
+            &cfg,
+        )
+        .await;
+
+        let diagnostics = response.diagnostics.expect("watchdog diagnostics");
+        let retries = diagnostics["quarantineRetries"]
+            .as_array()
+            .expect("quarantineRetries array");
+        assert_eq!(retries.len(), 1);
+        assert_eq!(retries[0]["path"], json!("orphan"));
+        assert_eq!(retries[0]["quarantined"], json!(true));
+        assert_eq!(retries[0]["stillCountsTowardAdmission"], json!(true));
+        assert_eq!(retries[0]["activeAgentGroups"], json!(1));
+        assert_eq!(monitor.active_agent_groups(), 1);
+        coordinator.close_and_join().await;
+    }
+
+    // #1151 (A4) - an unsupported backend stays at zero admission and zero enforcement
+    // calls in the new mode too.
+    #[tokio::test]
+    async fn unsupported_backend_quarantine_retry_is_disabled() {
+        let backend = Arc::new(UnsupportedAutomationBackend::default());
+        let monitor = Arc::new(crate::resource_monitor::ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>,
+        ));
+        let cfg = automation_settings();
+
+        let (app, coordinator) = automation_app_with_coordinator(Arc::clone(&monitor)).await;
+        let response = handle_resource_watchdog_backend_request_with_config(
+            app.handle(),
+            &watchdog_backend_request("quarantineRetry"),
+            &cfg,
+        )
+        .await;
+
+        assert!(response.ok);
+        assert_eq!(response.target.expect("target")["state"], json!("disabled"));
+        let diagnostics = response.diagnostics.expect("watchdog diagnostics");
+        assert_eq!(diagnostics["quarantineRetries"], json!([]));
+        assert_eq!(backend.observe_tree_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.observe_identity_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.terminate_verified_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            backend.current_process_memory_calls.load(Ordering::SeqCst),
+            0
+        );
+        coordinator.close_and_join().await;
     }
 
     #[test]

--- a/src-tauri/src/testability/ui_automation.rs
+++ b/src-tauri/src/testability/ui_automation.rs
@@ -1086,19 +1086,29 @@ async fn handle_resource_watchdog_backend_request_with_config<R: tauri::Runtime>
                 .watchdog_resource_kill(decision.session_id)
                 .await
             {
-                Ok(crate::session::selection::CriticalAdmissionOutcome::Completed(result)) => {
+                Ok(crate::session::selection::WatchdogKillOutcome::Completed(result)) => {
                     kill_results.push(json!({
                         "ok": true,
                         "result": result,
                     }))
                 }
-                Ok(crate::session::selection::CriticalAdmissionOutcome::AlreadyPending) => {
-                    kill_results.push(json!({
+                // #1151 - `alreadyPending` keeps its value and type byte-identical so every
+                // existing automation assertion still passes; `reason` is the additive
+                // discriminator that makes the split observable from outside the process.
+                Ok(crate::session::selection::WatchdogKillOutcome::AlreadyInFlight) => kill_results
+                    .push(json!({
                         "ok": true,
                         "sessionId": decision.session_id,
                         "alreadyPending": true,
-                    }))
-                }
+                        "reason": "alreadyInFlight",
+                    })),
+                Ok(crate::session::selection::WatchdogKillOutcome::NoPublicSession) => kill_results
+                    .push(json!({
+                        "ok": true,
+                        "sessionId": decision.session_id,
+                        "alreadyPending": true,
+                        "reason": "noPublicSession",
+                    })),
                 Err(message) => kill_results.push(json!({
                     "ok": false,
                     "sessionId": decision.session_id,
@@ -1904,11 +1914,21 @@ impl RequestFile {
 mod tests {
     use super::*;
     use crate::config::settings::{AppSettings, ResourceWatchdogAction};
-    use crate::resource_monitor::registry::{ProcessTreeBackend, ResourceError};
-    use crate::resource_monitor::types::{
-        ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory, TerminateOutcome,
+    use crate::resource_monitor::registry::{
+        ProcessTreeBackend, ResourceError, ResourceLaunchRegistration,
     };
+    use crate::resource_monitor::types::{
+        ObservedProcess, ObservedProcessTree, ProcessIdentity, ProcessMemory,
+        ResourceLaunchMetadata, TerminateOutcome,
+    };
+    use crate::session::manager::SessionManager;
+    use crate::session::selection::{
+        CriticalAdmissionKind, SelectionCoordinator, WatchdogKillOutcome,
+    };
+    use crate::web::broadcast::WsBroadcaster;
+    use crate::DetachedSessionsState;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio_util::sync::CancellationToken;
 
     #[derive(Default)]
     struct UnsupportedAutomationBackend {
@@ -1948,6 +1968,153 @@ mod tests {
             self.current_process_memory_calls
                 .fetch_add(1, Ordering::SeqCst);
             Ok(ProcessMemory::default())
+        }
+    }
+
+    /// #1151 - supported process-tree backend for the automation tests. `observe_tree`
+    /// synthesises a root plus one child from the requested root identity, so every
+    /// registered group gets distinct identities and a private-bytes total above the
+    /// kill thresholds these tests configure. A pid marked stubborn fails
+    /// `terminate_verified`, which is what parks a group in `Quarantined`; marking it
+    /// gone afterwards is what lets a later retry verify the cleanup.
+    #[derive(Default)]
+    struct AutomationProcessBackend {
+        stubborn: Mutex<HashSet<u32>>,
+        gone: Mutex<HashSet<u32>>,
+        observe_tree_calls: AtomicUsize,
+        observe_identity_calls: AtomicUsize,
+        terminate_verified_calls: AtomicUsize,
+    }
+
+    impl AutomationProcessBackend {
+        fn identity(pid: u32) -> ProcessIdentity {
+            ProcessIdentity {
+                pid,
+                creation_time_100ns: u64::from(pid),
+            }
+        }
+
+        fn child_pid(root_pid: u32) -> u32 {
+            root_pid + 1
+        }
+
+        fn observed(pid: u32, depth: u32, parent_pid: Option<u32>) -> ObservedProcess {
+            ObservedProcess {
+                identity: Self::identity(pid),
+                parent_pid,
+                parent_identity: parent_pid.map(Self::identity),
+                exe_name: format!("p{pid}"),
+                depth,
+                private_bytes: Some(5_000),
+                working_set_bytes: Some(5_000),
+                cpu_percent: None,
+                kill_allowed: true,
+            }
+        }
+    }
+
+    impl ProcessTreeBackend for AutomationProcessBackend {
+        fn observe_tree(
+            &self,
+            root: ProcessIdentity,
+        ) -> Result<ObservedProcessTree, ResourceError> {
+            self.observe_tree_calls.fetch_add(1, Ordering::SeqCst);
+            let gone = self.gone.lock().unwrap();
+            let child_pid = Self::child_pid(root.pid);
+            let mut processes = Vec::new();
+            if !gone.contains(&root.pid) {
+                processes.push(Self::observed(root.pid, 0, None));
+            }
+            if !gone.contains(&child_pid) {
+                processes.push(Self::observed(child_pid, 1, Some(root.pid)));
+            }
+            let errors = if gone.contains(&root.pid) {
+                vec![format!("root pid {} was not in process snapshot", root.pid)]
+            } else {
+                Vec::new()
+            };
+            Ok(ObservedProcessTree { processes, errors })
+        }
+
+        fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+            self.observe_identity_calls.fetch_add(1, Ordering::SeqCst);
+            if self.gone.lock().unwrap().contains(&pid) {
+                Ok(None)
+            } else {
+                Ok(Some(Self::identity(pid)))
+            }
+        }
+
+        fn terminate_verified(
+            &self,
+            process: &ObservedProcess,
+        ) -> Result<TerminateOutcome, ResourceError> {
+            self.terminate_verified_calls.fetch_add(1, Ordering::SeqCst);
+            let pid = process.identity.pid;
+            if self.gone.lock().unwrap().contains(&pid) {
+                return Ok(TerminateOutcome::AlreadyGone);
+            }
+            if self.stubborn.lock().unwrap().contains(&pid) {
+                return Err(ResourceError::Message(format!(
+                    "pid {pid}: process still alive after terminate"
+                )));
+            }
+            self.gone.lock().unwrap().insert(pid);
+            Ok(TerminateOutcome::Terminated)
+        }
+
+        fn current_process_memory(&self) -> Result<ProcessMemory, ResourceError> {
+            Ok(ProcessMemory::default())
+        }
+    }
+
+    fn automation_settings() -> AppSettings {
+        AppSettings {
+            resource_monitor_enabled: true,
+            resource_watchdog_action: ResourceWatchdogAction::KillGroup,
+            max_concurrent_agent_processes: 4,
+            agent_group_warn_private_bytes: 100,
+            agent_group_kill_private_bytes: 200,
+            agent_process_kill_private_bytes: 300,
+            ..AppSettings::default()
+        }
+    }
+
+    fn register_automation_group(
+        monitor: &crate::resource_monitor::ResourceMonitorState,
+        limits: crate::resource_monitor::ResourceLimits,
+        session_id: Uuid,
+        root_pid: u32,
+    ) -> ProcessIdentity {
+        let permit = monitor.try_reserve_agent_slot(limits).unwrap().unwrap();
+        let mut registration = ResourceLaunchRegistration::new(
+            monitor.clone(),
+            permit,
+            ResourceLaunchMetadata {
+                session_id,
+                name: "agent".to_string(),
+                agent_id: None,
+                agent_label: None,
+                workgroup: None,
+                agent: None,
+                project: None,
+            },
+        );
+        registration
+            .register_root_pid(root_pid)
+            .expect("register automation root pid")
+            .expect("supported backend observes the root identity")
+    }
+
+    fn watchdog_backend_request(mode: &str) -> UiAutomationRequest {
+        UiAutomationRequest {
+            request_id: Uuid::new_v4().to_string(),
+            token: "token".to_string(),
+            window: BACKEND_AUTOMATION_WINDOW.to_string(),
+            action: UiAutomationAction::Backend,
+            selector: RESOURCE_WATCHDOG_BACKEND_SELECTOR.to_string(),
+            value: Some(mode.to_string()),
+            expires_at_unix_ms: Some(now_unix_ms() + 1_000),
         }
     }
 
@@ -2059,6 +2226,130 @@ mod tests {
             backend.current_process_memory_calls.load(Ordering::SeqCst),
             0
         );
+    }
+
+    // #1151 (A3) - the automation `killResults` contract for the two split outcomes.
+    // `alreadyPending` keeps its value and type byte-identical so no existing automation
+    // breaks; `reason` is the additive discriminator that makes the split observable.
+    #[tokio::test]
+    async fn watchdog_kill_results_preserve_already_pending_contract() {
+        use crate::pty::backend::SessionBackendKind;
+
+        let backend = Arc::new(AutomationProcessBackend::default());
+        let monitor = Arc::new(crate::resource_monitor::ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>,
+        ));
+        let cfg = automation_settings();
+        let limits = crate::resource_monitor::ResourceLimits::from(&cfg);
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let live = manager
+            .read()
+            .await
+            .create_session(
+                "shell".to_string(),
+                Vec::new(),
+                "C:/automation-kill-results".to_string(),
+                None,
+                None,
+                Vec::new(),
+                false,
+                SessionBackendKind::LocalProcess,
+            )
+            .await
+            .unwrap();
+
+        // One group whose public row exists (the in-flight case) and one whose row never
+        // did (the orphan case). Both are Running with private bytes over the kill limit,
+        // so the hook produces a kill decision for each.
+        let orphan_id = Uuid::new_v4();
+        register_automation_group(&monitor, limits, live.id, 5_100);
+        register_automation_group(&monitor, limits, orphan_id, 5_200);
+
+        let coordinator = SelectionCoordinator::new(Arc::clone(&manager), CancellationToken::new());
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&manager))
+            .manage(Arc::clone(&monitor))
+            .manage(coordinator.clone())
+            .manage(DetachedSessionsState::default())
+            .manage(WsBroadcaster::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build kill-results automation app");
+        coordinator.start(app.handle().clone()).unwrap();
+        let restore = coordinator.submit_restore_first().await.unwrap();
+
+        // Fill the queue so the first watchdog kill parks holding ONLY its critical key,
+        // without ever enqueueing a job.
+        let mut reservations = Vec::new();
+        while let Ok(reservation) = coordinator.reserve_auto_close() {
+            reservations.push(reservation);
+        }
+        let waiter = {
+            let coordinator = coordinator.clone();
+            tokio::spawn(async move { coordinator.watchdog_resource_kill(live.id).await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !coordinator
+                .critical_key_registered_for_test(live.id, CriticalAdmissionKind::WatchdogKill)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the parked watchdog kill registers its critical key");
+
+        assert!(matches!(
+            coordinator.watchdog_resource_kill(live.id).await.unwrap(),
+            WatchdogKillOutcome::AlreadyInFlight
+        ));
+        assert!(matches!(
+            coordinator.watchdog_resource_kill(orphan_id).await.unwrap(),
+            WatchdogKillOutcome::NoPublicSession
+        ));
+
+        let response = handle_resource_watchdog_backend_request_with_config(
+            app.handle(),
+            &watchdog_backend_request("killGroup"),
+            &cfg,
+        )
+        .await;
+        assert!(response.ok);
+        let diagnostics = response.diagnostics.expect("watchdog diagnostics");
+        let kill_results = diagnostics["killResults"]
+            .as_array()
+            .expect("killResults array")
+            .clone();
+        assert_eq!(kill_results.len(), 2);
+        let entry_for = |session_id: Uuid| {
+            kill_results
+                .iter()
+                .find(|entry| entry["sessionId"] == json!(session_id))
+                .cloned()
+                .unwrap_or_else(|| panic!("kill result for session {session_id}"))
+        };
+        assert_eq!(
+            entry_for(live.id),
+            json!({
+                "ok": true,
+                "sessionId": live.id,
+                "alreadyPending": true,
+                "reason": "alreadyInFlight",
+            })
+        );
+        assert_eq!(
+            entry_for(orphan_id),
+            json!({
+                "ok": true,
+                "sessionId": orphan_id,
+                "alreadyPending": true,
+                "reason": "noPublicSession",
+            })
+        );
+
+        restore.finish();
+        coordinator.close_and_join().await;
+        drop(reservations);
+        let _ = waiter.await;
     }
 
     #[test]


### PR DESCRIPTION
Refs #1151

## What this fixes

On the supported Windows Resource Monitor backend, a quarantined agent group could keep its admission permit forever once its public session row disappeared. The watchdog's quarantine retry routed through `SelectionCoordinator::watchdog_resource_kill`, which returned `AlreadyPending` without calling `kill_group` whenever the UUID was no longer public or pending. Nothing else could recover the row: the snapshot reaper only nominates `Running` groups, and `register_group`'s relaunch dedup only removes `Terminated` ones. Repeating the cycle exhausted the configured agent cap and rejected new agents whose sessions and processes were already gone.

Regression introduced by `4dc1908` (`fix(session): serialize lifecycle selection for #1027`, PR #1051), which replaced a direct `monitor.kill_group(session_id, ResourceKillReason::Watchdog)` with `submit_watchdog_kill(coordinator, *session_id).await`. Coordinator serialization is correct for live public sessions but is not behavior-preserving for orphaned registry groups.

## Correction to the issue's analysis

The issue attributes the leak to explicit destroy. Investigation found **restart is the dominant orphan path**, and worse than destroy: `teardown_old_for_restart` quarantines, the replacement spawns under a new UUID and reserves its own permit *before* the old row is removed, so a slot is burned while the user is actively working. Unlike destroy, restart has no root-agent retention branch, so root agents are affected too. The fix is unchanged by this; the evidence chain, test matrix and native reproduction were rewritten around it.

## Approach

- Split the ambiguous watchdog result into a dedicated `WatchdogKillOutcome { Completed, AlreadyInFlight, NoPublicSession }`, leaving the shared `CriticalAdmissionOutcome` untouched.
- Live public sessions keep going through the coordinator and the Windows Job Object path, unchanged.
- `NoPublicSession` runs a registry-only quarantine reconciliation on `spawn_blocking`, awaited, bound to the group's existing `root_identity`, with the load-bearing guard being the state re-check inside `kill_group_inner`'s existing lock scope.
- The watchdog action gate became a scoped `if` around the `kill_required` loop instead of an early `return`, so the quarantine retry runs under the default `Warn` action. Shipped as its own commit so it is separable in review and in `git bisect`.
- A permit is still released only after owned processes are verified gone. A live or unverifiable descendant keeps blocking admission, by design.

## Verification

29 new or reworked tests. Full suite green at the merge commit: `cargo fmt`, `cargo check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib --bins --tests` (3043 passed, 0 failed), `npm run typecheck`, `npm run test` (1312), `npm run test:debt`.

Three properties were proven by mutation rather than by reading, independently by both the implementer and the reviewer:

- Reverting the core wiring fails exactly W1, W7 and W8, the three `run_tick`-level pins.
- Restoring the naive early-`return` action gate fails exactly W1, W7 and W8 — the mis-implementation that would have shipped a dead fix on every default install cannot land silently.
- Deleting `spawn_blocking` and inlining the blocking call fails W6 on the thread-identity assertion, and fails rather than hangs. An earlier version of that test passed under the same mutation; it was rejected and rebuilt for exactly that reason.

Both assertions in W6 were shown to be independently necessary: assertion 1 alone accepts `std::thread::spawn().join()`, assertion 2 alone accepts `block_in_place`.

No public IPC schema change, no dependency change, no frontend change (`git diff -- src/` is empty across the branch). The automation JSON keeps `ok`, `sessionId` and `alreadyPending` byte-identical and adds only a `reason` discriminator.

## Merge with main

`origin/main` moved 13 commits during development (the #1149 activity-log series plus #1131). `session/selection.rs` was touched by both sides in disjoint regions and auto-merged. The merge was verified by recomputing it with `git merge-tree` and comparing the resulting tree OID to the committed one — identical, so no human reconciliation occurred anywhere in the tree. Both patch bodies were additionally hash-compared and survive byte for byte.

One note for future readers, from that review: our quarantine-retry tick does touch `SessionManager`, but only through **reads**, and `main`'s new shutdown spin only fails when a *writer* holds the state. Readers never block readers, so this change can never be the reason that spin turns.

The plan's `file:line` citations are anchored to the base commit `0f0443ab` by construction and several have drifted after the merge; every cited *text* was re-verified as intact.

## Native verification still outstanding

The issue marks Windows native verification `REQUIRED`, and it is not satisfied by Linux or fake-backend tests. **This PR does not discharge it**, which is why the body says `Refs` and not `Closes`: the issue stays open until the native run passes, then gets the final delivery comment.

The native reproduction must use **restarts, not closes**, per the correction above.
