### PR TITLE
test(resource-monitor): pin the 15s quarantine retry backoff gate (refs #1160)

### DIFF
--- a/src-tauri/src/resource_monitor/watchdog.rs
+++ b/src-tauri/src/resource_monitor/watchdog.rs
@@ -828,7 +828,11 @@ mod tests {
     /// #1151 - drives one group from launch to an orphaned quarantine: register, quarantine
     /// on the stubborn child, then let the blocker disappear. The public session row never
     /// exists, which is what makes it an orphan.
-    fn orphan_one_group(
+    ///
+    /// #1160 - the retry backoff is deliberately NOT satisfied here. Callers that want a
+    /// DUE group use `orphan_one_group`, which is this plus the backdate; the not-yet-due
+    /// shape is the only one that can observe the `quarantine_retry_due` gate at all.
+    fn orphan_one_group_not_yet_due(
         monitor: &ResourceMonitorState,
         backend: &QuarantineWatchdogBackend,
         limits: ResourceLimits,
@@ -845,6 +849,28 @@ mod tests {
         assert!(quarantine.quarantined);
         assert_eq!(quarantine.state, ResourceGroupState::Quarantined);
         backend.mark_gone(child_pid);
+        root
+    }
+
+    /// #1151 - the same orphaned quarantine with its retry backoff already satisfied, which
+    /// is what every test that needs the retry to DISPATCH depends on. Behavior is identical
+    /// to the pre-#1160 helper of this name, so its existing callers are unaffected.
+    fn orphan_one_group(
+        monitor: &ResourceMonitorState,
+        backend: &QuarantineWatchdogBackend,
+        limits: ResourceLimits,
+        session_id: Uuid,
+        root_pid: u32,
+        identity_triple: Option<(&str, &str, &str)>,
+    ) -> ProcessIdentity {
+        let root = orphan_one_group_not_yet_due(
+            monitor,
+            backend,
+            limits,
+            session_id,
+            root_pid,
+            identity_triple,
+        );
         monitor.test_backdate_quarantine_retry(session_id);
         root
     }
@@ -877,6 +903,86 @@ mod tests {
 
         assert!(!monitor.group_counts_toward_admission(session_id));
         assert_eq!(monitor.active_agent_groups(), 0);
+        let permit = monitor
+            .try_reserve_agent_slot(group_limits)
+            .expect("the reclaimed slot admits the next launch")
+            .expect("supported backend issues a permit");
+        monitor.release_unregistered_permit(permit);
+        coordinator.close_and_join().await;
+    }
+
+    // #1160 - the pin for the 15s quarantine-retry backoff gate: the
+    // `&& monitor.quarantine_retry_due(*session_id)` clause in run_quarantine_retries.
+    // Phase 1 is the half no other test can express, because every other orphan test
+    // backdates the group DUE before ticking: an orphan whose blocker has already cleared
+    // is still not retried while its backoff is unelapsed. Phase 2 re-ticks the same group
+    // with only the backoff satisfied, so this fails if the gate is inverted as well as if
+    // it is deleted.
+    //
+    // observe_tree is deliberately NOT pinned: sample_for_watchdog re-observes Quarantined
+    // groups on every snapshot by design (#647 C), so it moves even on a correctly skipped
+    // tick. Pinning it would fail on correct code.
+    #[tokio::test]
+    async fn not_yet_due_quarantine_is_skipped_then_retried_after_backoff() {
+        let backend = Arc::new(QuarantineWatchdogBackend::default());
+        let monitor = Arc::new(ResourceMonitorState::with_backend(
+            backend.clone() as Arc<dyn ProcessTreeBackend>
+        ));
+        let cfg = orphan_settings(1);
+        let group_limits = ResourceLimits::from(&cfg);
+
+        let session_id = Uuid::new_v4();
+        orphan_one_group_not_yet_due(&monitor, &backend, group_limits, session_id, 260, None);
+        assert_eq!(monitor.active_agent_groups(), 1);
+
+        let manager = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (_app, coordinator) = running_coordinator(manager, Arc::clone(&monitor)).await;
+        let settings = Arc::new(tokio::sync::RwLock::new(cfg));
+
+        // Phase 1: kill_started_at was set microseconds ago by the setup's kill_group, so
+        // the 15s backoff cannot have elapsed and the gate must skip this group.
+        let (_, identity_before, terminate_before) = backend.call_counts();
+        run_tick(&monitor, &settings, &coordinator).await;
+        let (_, identity_after, terminate_after) = backend.call_counts();
+
+        assert_eq!(
+            terminate_after, terminate_before,
+            "a not-yet-due quarantine must not reach kill_group"
+        );
+        assert_eq!(
+            identity_after, identity_before,
+            "a skipped tick performs no identity syscall either"
+        );
+        assert!(
+            monitor.group_counts_toward_admission(session_id),
+            "the skipped group keeps holding its admission slot"
+        );
+        assert_eq!(monitor.active_agent_groups(), 1);
+        assert!(
+            monitor.try_reserve_agent_slot(group_limits).is_err(),
+            "the permit is still held at cap 1"
+        );
+        let state = monitor
+            .sample_for_watchdog(group_limits)
+            .into_iter()
+            .find(|(id, _)| *id == session_id)
+            .map(|(_, group)| group.state);
+        assert_eq!(state, Some(ResourceGroupState::Quarantined));
+
+        // Phase 2: same group, same tick, only the backoff satisfied.
+        monitor.test_backdate_quarantine_retry(session_id);
+        run_tick(&monitor, &settings, &coordinator).await;
+
+        assert!(
+            !monitor.group_counts_toward_admission(session_id),
+            "the due retry reclaims the slot"
+        );
+        assert_eq!(monitor.active_agent_groups(), 0);
+        let (_, _, terminate_final) = backend.call_counts();
+        assert!(
+            terminate_final > terminate_after,
+            "the due retry actually ran a cleanup pass"
+        );
         let permit = monitor
             .try_reserve_agent_slot(group_limits)
             .expect("the reclaimed slot admits the next launch")


### PR DESCRIPTION
Closes #1160

## What changed

Adds one regression test that pins the 15s quarantine retry backoff gate — the `&& monitor.quarantine_retry_due(*session_id)` clause in `run_quarantine_retries` (`src-tauri/src/resource_monitor/watchdog.rs`).

Nothing pinned it before: every existing orphan test calls `test_backdate_quarantine_retry` first, forcing the group due, so none of them could observe the gate at all. Deleting the clause left the whole library suite green.

One file changed, `+107 / -1`, entirely inside `#[cfg(test)] mod tests`. No production code touched.

- **New test** `not_yet_due_quarantine_is_skipped_then_retried_after_backoff`. Phase 1 builds a quarantined orphan whose blocker has already cleared and does **not** backdate it, so the 15s backoff cannot have elapsed and the gate must skip it. Phase 2 backdates the same group, ticks again, and asserts the reclaim.
- **Helper split**: `orphan_one_group` becomes a thin wrapper over a new non-backdating core `orphan_one_group_not_yet_due`. Chosen over a `backdate: bool` parameter so the five existing call sites stay byte-identical and the diff is purely additive.

`observe_tree_calls` is deliberately **not** pinned: `sample_for_watchdog` re-observes `Quarantined` groups on every snapshot by design (`#647 C`), so it moves even on a correctly skipped tick and pinning it would fail on correct code. Only `terminate_verified_calls` and `observe_identity_calls` are pinned. The reason is recorded both in the plan and as a comment in the test body.

## Acceptance criteria — verified by execution, not by reasoning

The issue's criteria are mutation-based, so each was run for real:

| Check | Result |
|---|---|
| Baseline | `1 passed; 0 failed` |
| Gate **removed** | Test **FAILS** — `a not-yet-due quarantine must not reach kill_group`, `left: 4, right: 2`, exit 101 |
| Gate **inverted** | Test **FAILS** — same assertion, same counts, exit 101 |
| Both mutations reverted | Green again; `run_quarantine_retries` byte-identical to the base commit |

Both mutations die at the same phase-1 assertion, so the failure message is unambiguous in either direction.

## Review

- **Plan**: authored and certified by `architect` (Lite path), frozen at `Plan-SHA256 164580041AE6838DBFA8F33CDAADD39617A0A657C52DBC76196D2A3ED40B191B`, verified by the implementer and the reviewer before each touched the code.
- **Implementation**: `dev-rust`, from a cold start against the frozen plan.
- **Adversarial review**: `dev-rust-grinch` — **PASS, 0 defects**. It re-ran both mutations independently and reproduced them exactly, then added a third probe nobody asked for: multiplying `QUARANTINE_RETRY_BACKOFF` so the gate can never open. Phase 2 failed, proving phase 2 is load-bearing and covers a mutation class (gate stuck closed) that neither required mutation reaches.

## Gates

Green locally and in CI on this branch:

- `cargo check --all-targets` — 0
- `cargo clippy --all-targets -- -D warnings` — 0, zero lints
- `cargo test --lib --bins --tests` — 3057 passed, **0 failed**, 21 ignored
- `npm run test:debt` — 0
- CI: `Validate branch name` ✅, `PR regression gates` ✅ (`rust-regression`, `test-debt`, `frontend-regression`, `windows-release-cli-smoke`)

## Ship

**N/A — non-visual change.** Test-only, no GUI surface, so no build was deployed.

## Known residuals (recorded, none is a defect)

1. The pin covers the gate, not shortening the backoff (15s → 1s would still pass). Explicitly out of scope per the issue. Coverage is better than the plan claimed at both extremes: 15s → 0s **is** caught, and lengthening is caught too.
2. The exact-equality pin on `observe_identity_calls` is fixture-scoped: it holds because this test has exactly one group that stays `Quarantined` for the whole tick. A maintenance note for whoever adds a `Running` group to this test.
