### PR TITLE
fix(sidebar): unify the coding-agent badge style across all rows, refs #1167

### DIFF
--- a/src/sidebar/components/RootAgentBanner.agent-badge.test.tsx
+++ b/src/sidebar/components/RootAgentBanner.agent-badge.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import RootAgentBanner from "./RootAgentBanner";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import { sessionsStore } from "../stores/sessions";
+import type { SessionStatus } from "../../shared/types";
+
+// #1167 - the ROOT AGENT badge must look exactly like a Coordinator row's badge:
+// the same class pair, plus root-agent-badge for inline placement only. jsdom does
+// not apply sidebar.css, so the pin is on the emitted classes and attributes.
+describe("RootAgentBanner coding-agent badge is style-invariant (#1167)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  const CASES: { name: string; status: SessionStatus; label: string }[] = [
+    { name: "live root", status: "running", label: "Codex" },
+    { name: "dormant root", status: { exited: 0 }, label: "Codex" },
+    { name: "custom label", status: "running", label: "Isolated Claude" },
+  ];
+
+  for (const testCase of CASES) {
+    it(`renders the same badge markup: ${testCase.name}`, async () => {
+      sessionsStore.setSessions([
+        session({
+          id: "root-1",
+          name: "Agent's Commander",
+          isRootAgent: true,
+          status: testCase.status,
+          agentLabel: testCase.label,
+        }),
+      ]);
+      const rendered = renderWithFakeTransport(() => <RootAgentBanner />, new FakeTransport());
+      try {
+        await waitFor(() =>
+          expect(rendered.root.querySelector(".ac-discovery-badge.agent")).not.toBeNull(),
+        );
+        const el = rendered.root.querySelector<HTMLElement>(".ac-discovery-badge.agent")!;
+        expect(el.className).toBe("ac-discovery-badge agent root-agent-badge");
+        expect(el.textContent).toBe(testCase.label);
+        expect(el.hasAttribute("data-agent")).toBe(false);
+        expect(el.classList.contains("running")).toBe(false);
+        expect(rendered.root.querySelector(".agent-badge")).toBeNull();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  }
+});

--- a/src/sidebar/components/RootAgentBanner.tsx
+++ b/src/sidebar/components/RootAgentBanner.tsx
@@ -399,19 +399,15 @@ const RootAgentBanner: Component = () => {
           <Show when={!isRecording() && !isProcessing() && !isAutoExecuting() && !isTypingWarning() && !voiceRecorder.micError()}>
             <span class="root-agent-subtitle">
               {subtitle()}
-              {/* #624 - coding-agent badge, mirroring SessionItem. Non-running
-                  styling falls out of hasLivePty() so a dormant/exited root still
-                  shows the badge (no `running` class). data-agent drives the same
-                  per-agent coloring as the session rows; custom labels fall back
-                  to the base .agent-badge. */}
+              {/* #624 / #1167 - coding-agent badge, mirroring SessionItem. Both
+                  now emit the Coordinator row's class pair
+                  (.ac-discovery-badge.agent), so the badge is one constant style
+                  everywhere: no data-agent, no `running`, and identical for a
+                  live and a dormant root. root-agent-badge adds only the inline
+                  placement inside the uppercase .root-agent-subtitle. */}
               <Show when={agentLabel()}>
                 {(label) => (
-                  <span
-                    class={`agent-badge root-agent-badge ${hasLivePty() ? "running" : ""}`}
-                    data-agent={label()}
-                  >
-                    {label()}
-                  </span>
+                  <span class="ac-discovery-badge agent root-agent-badge">{label()}</span>
                 )}
               </Show>
               <Show when={profileBadge()}>

--- a/src/sidebar/components/SessionItem.test.tsx
+++ b/src/sidebar/components/SessionItem.test.tsx
@@ -507,11 +507,60 @@ describe("SessionItem profile-outdated badge (#592)", () => {
     );
     try {
       // The agent badge renders, so the meta container is present; the outdated
-      // badge specifically must not be.
-      await waitFor(() => expect(rendered.root.querySelector(".agent-badge")).not.toBeNull());
+      // badge specifically must not be. #1167 moved the badge to the Coordinator
+      // row's class pair.
+      await waitFor(() =>
+        expect(rendered.root.querySelector(".ac-discovery-badge.agent")).not.toBeNull(),
+      );
       expect(rendered.root.querySelector(".profile-outdated-badge")).toBeNull();
     } finally {
       rendered.cleanup();
     }
   });
+});
+
+// #1167 - the badge must be one constant style in every row. jsdom does not apply
+// sidebar.css, so the pin is on the emitted classes and attributes, which is what
+// the CSS keys off: exactly `ac-discovery-badge agent`, no data-agent, no running.
+describe("SessionItem coding-agent badge is style-invariant (#1167)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  const CASES: { name: string; props: Partial<Session> }[] = [
+    { name: "live session, preset label", props: { agentId: "codex", agentLabel: "Codex", status: "running" } },
+    { name: "live session, custom label", props: { agentId: "claude", agentLabel: "Isolated Claude", status: "running" } },
+    { name: "exited session", props: { agentId: "codex", agentLabel: "Codex", status: { exited: 0 } } },
+    { name: "inactive member row", props: { id: "inactive-1", agentId: "codex", agentLabel: "Codex", status: { exited: 0 } } },
+  ];
+
+  for (const testCase of CASES) {
+    it(`renders the same badge markup: ${testCase.name}`, async () => {
+      const settings = baseSettings({ agents: TWO_AGENTS, codingAgentProfiles: profiles({}) });
+      const rendered = await renderRow(testCase.props, settings);
+      try {
+        await waitFor(() =>
+          expect(rendered.root.querySelector(".ac-discovery-badge.agent")).not.toBeNull(),
+        );
+        const el = rendered.root.querySelector<HTMLElement>(".ac-discovery-badge.agent")!;
+        expect(el.className).toBe("ac-discovery-badge agent");
+        expect(el.hasAttribute("data-agent")).toBe(false);
+        expect(el.classList.contains("running")).toBe(false);
+        expect(el.classList.contains("agent-badge")).toBe(false);
+        expect(rendered.root.querySelector(".agent-badge")).toBeNull();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  }
 });

--- a/src/sidebar/components/SessionItem.tsx
+++ b/src/sidebar/components/SessionItem.tsx
@@ -360,14 +360,15 @@ const SessionItem: Component<{
         <Show when={!isRecording() && !isProcessing() && !isAutoExecuting() && !isTypingWarning() && !voiceRecorder.micError()}>
           <Show when={sessionAgentLabel() || (props.session.isCoordinator && !isInactive() && props.session.gitRepos.length > 0)}>
             <div class="session-item-meta">
+              {/* #1167 - one constant coding-agent style for every sidebar row.
+                  This emits the same class pair the workgroup/Coordinator rows
+                  emit (ProjectPanel.tsx:2271), so the two cannot drift apart
+                  again. No data-agent and no `running`: the badge must not vary
+                  by label or by PTY liveness. Liveness is still carried by the
+                  row status dot and .session-item.inactive-member. */}
               <Show when={sessionAgentLabel()}>
                 {(agentLabel) => (
-                  <span
-                    class={`agent-badge ${sessionHasLivePty() ? "running" : ""}`}
-                    data-agent={agentLabel()}
-                  >
-                    {agentLabel()}
-                  </span>
+                  <span class="ac-discovery-badge agent">{agentLabel()}</span>
                 )}
               </Show>
               <Show when={profileBadge()}>

--- a/src/sidebar/styles/agent-badge-css.test.ts
+++ b/src/sidebar/styles/agent-badge-css.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from "vitest";
 // style, so no rule anywhere may colour .agent-badge by label. The four per-TOOL
 // rules that survive are the Open-Agent modal's repo chips, anchored on
 // .agent-modal-item-badges, and they are pinned here too so the anchor cannot be
-// widened back into the sidebar by accident.
+// widened back into the sidebar by accident. The emerald rule that all three sidebar
+// sites now resolve through is pinned as well: jsdom never applies the stylesheet, so
+// deleting that rule breaks every row's appearance without a single test noticing.
 //
 // The glob supplies the FILE SET and nothing else. It is deliberately NOT eager and
 // carries no ?raw query: under Vitest every CSS module evaluates to
@@ -21,38 +23,146 @@ const CSS_SOURCES: Record<string, string> = Object.fromEntries(
   CSS_FILES.map((file) => [file, readFileSync(new URL(file, import.meta.url), "utf8")]),
 );
 
-const SELECTOR_LINE_RE = /^[^{}]*\{/gm;
+type RuleOpening = { selectorList: string; bodyStart: number };
+type Compound = { file: string; selector: string };
 
-function selectorsMentioning(needle: string): string[] {
-  const hits: string[] = [];
-  for (const [file, source] of Object.entries(CSS_SOURCES)) {
-    const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, "");
-    for (const match of withoutComments.matchAll(SELECTOR_LINE_RE)) {
-      const selector = match[0].slice(0, -1).trim();
-      if (selector.includes(needle)) hits.push(`${file.replace(/\\/g, "/")}: ${selector}`);
+const COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+const BRACE_RE = /[{}]/g;
+const MODAL_ANCHOR = ".agent-modal-item-badges";
+
+// Every rule opening in the file, not just the first one on each line. A line-anchored
+// scan is what used to make this guard blind to `.a { } .evil[data-agent="X"] { }` and
+// to any minified stylesheet, so there is no line boundary anywhere in this scanner: a
+// selector list is the text between the previous brace of EITHER kind and the `{` that
+// opens the rule. Nesting and at-rules fall out of that for free.
+function ruleOpenings(source: string): RuleOpening[] {
+  const openings: RuleOpening[] = [];
+  let segmentStart = 0;
+  for (const match of source.matchAll(BRACE_RE)) {
+    const at = match.index ?? 0;
+    if (match[0] === "{") {
+      openings.push({ selectorList: source.slice(segmentStart, at), bodyStart: at + 1 });
     }
+    segmentStart = at + 1;
   }
-  return hits.sort();
+  return openings;
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+// CSS allows whitespace inside an attribute selector, so `[ data-agent = "Claude" ]`
+// is the same selector as `[data-agent="Claude"]` and browsers honour both. Fold that
+// away before any needle is applied. Descendant spaces are preserved: they carry
+// meaning, and the modal anchor below depends on them.
+function normaliseSelector(selector: string): string {
+  return collapseWhitespace(selector)
+    .replace(/\[\s+/g, "[")
+    .replace(/\s+\]/g, "]")
+    .replace(/\s*([~^$*|]?=)\s*/g, "$1")
+    .trim();
+}
+
+// Criterion 5 is about individual compound selectors, not selector lists: a rule is
+// widened back into the sidebar by adding one comma-separated compound next to the
+// modal-anchored one, and a check that only asks whether the whole list mentions the
+// anchor cannot see that. Depth-aware because the commas in :is(a, b) / :has(a, b) are
+// not list separators. No functional pseudo-class in the tree contains a comma today,
+// so this costs nothing now and cannot silently mangle a compound later.
+function splitSelectorList(selectorList: string): string[] {
+  const compounds: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of selectorList) {
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth = Math.max(0, depth - 1);
+    if (ch === "," && depth === 0) {
+      compounds.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  compounds.push(current);
+  return compounds.map(normaliseSelector).filter((compound) => compound.length > 0);
+}
+
+const ALL_COMPOUNDS: Compound[] = Object.entries(CSS_SOURCES).flatMap(([file, source]) => {
+  const withoutComments = source.replace(COMMENT_RE, "");
+  return ruleOpenings(withoutComments).flatMap((opening) =>
+    splitSelectorList(opening.selectorList).map((selector) => ({
+      file: file.replace(/\\/g, "/"),
+      selector,
+    })),
+  );
+});
+
+function report(compounds: Compound[]): string[] {
+  return compounds.map(({ file, selector }) => `${file}: ${selector}`).sort();
+}
+
+// Attribute NAMES are ASCII case-insensitive against HTML elements, so a selector
+// written [DATA-AGENT="Claude"] really does match a chip and has to count as a hit.
+const DATA_AGENT_COMPOUNDS = ALL_COMPOUNDS.filter((compound) =>
+  compound.selector.toLowerCase().includes("[data-agent"),
+);
+
+// Scoped means the attribute selector is a DESCENDANT of the modal container: the
+// anchor must be present, be followed by a combinator, and come before the
+// [data-agent] part. `.session-item-meta [data-agent="X"]` fails, and so does
+// `[data-agent="X"] .agent-modal-item-badges`.
+function isModalScoped(selector: string): boolean {
+  const at = selector.indexOf(MODAL_ANCHOR);
+  if (at === -1) return false;
+  const afterAnchor = selector.slice(at + MODAL_ANCHOR.length);
+  return /^[\s>+~]/.test(afterAnchor) && afterAnchor.toLowerCase().includes("[data-agent");
+}
+
+// The declarations of the first rule whose selector list contains `wanted` as a whole
+// compound selector, whitespace-collapsed. Exact-compound on purpose: a themed
+// override like `html.light-theme .ac-discovery-badge.agent` is a different rule.
+function declarationsOf(source: string, wanted: string): string | null {
+  const withoutComments = source.replace(COMMENT_RE, "");
+  for (const opening of ruleOpenings(withoutComments)) {
+    if (!splitSelectorList(opening.selectorList).includes(wanted)) continue;
+    const end = withoutComments.indexOf("}", opening.bodyStart);
+    if (end === -1) return null;
+    return collapseWhitespace(withoutComments.slice(opening.bodyStart, end)).trim();
+  }
+  return null;
 }
 
 describe("coding-agent badge CSS (#1167)", () => {
   // Guards the guard, and runs first on purpose: an empty source set makes every
-  // selector assertion below pass vacuously, which is exactly how the CSS-stubbing
-  // trap hid itself the first time this file was written.
+  // assertion below pass vacuously, which is exactly how the CSS-stubbing trap hid
+  // itself the first time this file was written. The compound count covers the second
+  // way to go vacuous: bytes read, but a scanner that parses nothing out of them.
   it("reads real stylesheet text for every file it globs", () => {
     expect(CSS_FILES.length).toBeGreaterThan(0);
     expect(Object.values(CSS_SOURCES).every((source) => source.length > 0)).toBe(true);
     expect(CSS_SOURCES["./sidebar.css"]).toContain(".agent-badge {");
+    expect(ALL_COMPOUNDS.length).toBeGreaterThan(100);
   });
 
   it("has no per-agent colour rule on .agent-badge", () => {
-    const offenders = selectorsMentioning(".agent-badge").filter((s) => s.includes("[data-agent"));
-    expect(offenders).toEqual([]);
+    const offenders = DATA_AGENT_COMPOUNDS.filter((compound) =>
+      compound.selector.includes(".agent-badge"),
+    );
+    expect(report(offenders)).toEqual([]);
   });
 
   it("keeps every surviving data-agent rule scoped to the Open-Agent modal", () => {
-    const dataAgentSelectors = selectorsMentioning("[data-agent");
-    expect(dataAgentSelectors.every((s) => s.includes(".agent-modal-item-badges "))).toBe(true);
-    expect(dataAgentSelectors).toHaveLength(4);
+    const escaped = DATA_AGENT_COMPOUNDS.filter((compound) => !isModalScoped(compound.selector));
+    expect(report(escaped)).toEqual([]);
+    expect(report(DATA_AGENT_COMPOUNDS)).toHaveLength(4);
+  });
+
+  it("keeps the emerald rule every sidebar row now resolves through", () => {
+    const declarations = declarationsOf(CSS_SOURCES["./sidebar.css"], ".ac-discovery-badge.agent");
+    expect(declarations).not.toBeNull();
+    expect(declarations).toContain("background: rgba(16, 185, 129, 0.14);");
+    expect(declarations).toContain("color: #34d399;");
+    expect(declarations).toContain("text-transform: none;");
   });
 });

--- a/src/sidebar/styles/agent-badge-css.test.ts
+++ b/src/sidebar/styles/agent-badge-css.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 // #1167 - acceptance criterion 4: the sidebar coding-agent badge has ONE constant
@@ -6,32 +7,18 @@ import { describe, expect, it } from "vitest";
 // .agent-modal-item-badges, and they are pinned here too so the anchor cannot be
 // widened back into the sidebar by accident.
 //
-// The glob still defines the file set (all 12 CSS files under src/, the same depth
-// idiom as sidebar/watchdog/no-presentation-import.test.ts), but the CONTENT is
-// read from disk: Vitest replaces every CSS module with `export default ""` unless
-// `test.css` is enabled, and `?raw` does not opt out because Vite's isCSSRequest()
-// matches "sidebar.css?raw" too. Measured on this tree, the glob returned all 12
-// keys with "" as the value, which made the second pin fail with 0 selectors and
-// would have made the first pass vacuously forever. `@types/node` is not installed
-// in this frontend tsconfig, so node:fs comes in through a non-literal specifier
-// and is narrowed to the single function this guard needs.
-const CSS_FILES = Object.keys(
-  import.meta.glob<string>("../../**/*.css", {
-    query: "?raw",
-    import: "default",
-    eager: true,
-  }),
-);
-
-interface NodeFileReader {
-  readonly readFileSync: (file: URL, encoding: "utf8") => string;
-}
-
-const FS_SPECIFIER = "node:fs";
-const nodeFs = (await import(/* @vite-ignore */ FS_SPECIFIER)) as unknown as NodeFileReader;
+// The glob supplies the FILE SET and nothing else. It is deliberately NOT eager and
+// carries no ?raw query: under Vitest every CSS module evaluates to
+// `export default ""` unless test.css is enabled, and ?raw does not opt out, because
+// Vite's isCSSRequest() also matches "sidebar.css?raw". Measured on this tree, the
+// eager ?raw form returned all 12 keys with "" as every single value, which made the
+// selector pins below pass vacuously on an empty stylesheet. The bytes therefore come
+// from disk; node:fs is typed in src/vite-env.d.ts because @types/node is not a
+// dependency of this frontend.
+const CSS_FILES = Object.keys(import.meta.glob("../../**/*.css"));
 
 const CSS_SOURCES: Record<string, string> = Object.fromEntries(
-  CSS_FILES.map((file) => [file, nodeFs.readFileSync(new URL(file, import.meta.url), "utf8")]),
+  CSS_FILES.map((file) => [file, readFileSync(new URL(file, import.meta.url), "utf8")]),
 );
 
 const SELECTOR_LINE_RE = /^[^{}]*\{/gm;
@@ -49,8 +36,9 @@ function selectorsMentioning(needle: string): string[] {
 }
 
 describe("coding-agent badge CSS (#1167)", () => {
-  // Guards the guard: an empty source set makes every selector assertion below
-  // pass vacuously, which is exactly how the stylesheet-stubbing bug hid itself.
+  // Guards the guard, and runs first on purpose: an empty source set makes every
+  // selector assertion below pass vacuously, which is exactly how the CSS-stubbing
+  // trap hid itself the first time this file was written.
   it("reads real stylesheet text for every file it globs", () => {
     expect(CSS_FILES.length).toBeGreaterThan(0);
     expect(Object.values(CSS_SOURCES).every((source) => source.length > 0)).toBe(true);

--- a/src/sidebar/styles/agent-badge-css.test.ts
+++ b/src/sidebar/styles/agent-badge-css.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+// #1167 - acceptance criterion 4: the sidebar coding-agent badge has ONE constant
+// style, so no rule anywhere may colour .agent-badge by label. The four per-TOOL
+// rules that survive are the Open-Agent modal's repo chips, anchored on
+// .agent-modal-item-badges, and they are pinned here too so the anchor cannot be
+// widened back into the sidebar by accident.
+//
+// The glob still defines the file set (all 12 CSS files under src/, the same depth
+// idiom as sidebar/watchdog/no-presentation-import.test.ts), but the CONTENT is
+// read from disk: Vitest replaces every CSS module with `export default ""` unless
+// `test.css` is enabled, and `?raw` does not opt out because Vite's isCSSRequest()
+// matches "sidebar.css?raw" too. Measured on this tree, the glob returned all 12
+// keys with "" as the value, which made the second pin fail with 0 selectors and
+// would have made the first pass vacuously forever. `@types/node` is not installed
+// in this frontend tsconfig, so node:fs comes in through a non-literal specifier
+// and is narrowed to the single function this guard needs.
+const CSS_FILES = Object.keys(
+  import.meta.glob<string>("../../**/*.css", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }),
+);
+
+interface NodeFileReader {
+  readonly readFileSync: (file: URL, encoding: "utf8") => string;
+}
+
+const FS_SPECIFIER = "node:fs";
+const nodeFs = (await import(/* @vite-ignore */ FS_SPECIFIER)) as unknown as NodeFileReader;
+
+const CSS_SOURCES: Record<string, string> = Object.fromEntries(
+  CSS_FILES.map((file) => [file, nodeFs.readFileSync(new URL(file, import.meta.url), "utf8")]),
+);
+
+const SELECTOR_LINE_RE = /^[^{}]*\{/gm;
+
+function selectorsMentioning(needle: string): string[] {
+  const hits: string[] = [];
+  for (const [file, source] of Object.entries(CSS_SOURCES)) {
+    const withoutComments = source.replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const match of withoutComments.matchAll(SELECTOR_LINE_RE)) {
+      const selector = match[0].slice(0, -1).trim();
+      if (selector.includes(needle)) hits.push(`${file.replace(/\\/g, "/")}: ${selector}`);
+    }
+  }
+  return hits.sort();
+}
+
+describe("coding-agent badge CSS (#1167)", () => {
+  // Guards the guard: an empty source set makes every selector assertion below
+  // pass vacuously, which is exactly how the stylesheet-stubbing bug hid itself.
+  it("reads real stylesheet text for every file it globs", () => {
+    expect(CSS_FILES.length).toBeGreaterThan(0);
+    expect(Object.values(CSS_SOURCES).every((source) => source.length > 0)).toBe(true);
+    expect(CSS_SOURCES["./sidebar.css"]).toContain(".agent-badge {");
+  });
+
+  it("has no per-agent colour rule on .agent-badge", () => {
+    const offenders = selectorsMentioning(".agent-badge").filter((s) => s.includes("[data-agent"));
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps every surviving data-agent rule scoped to the Open-Agent modal", () => {
+    const dataAgentSelectors = selectorsMentioning("[data-agent");
+    expect(dataAgentSelectors.every((s) => s.includes(".agent-modal-item-badges "))).toBe(true);
+    expect(dataAgentSelectors).toHaveLength(4);
+  });
+});

--- a/src/sidebar/styles/agent-badge-css.test.ts
+++ b/src/sidebar/styles/agent-badge-css.test.ts
@@ -29,6 +29,11 @@ type Compound = { file: string; selector: string };
 const COMMENT_RE = /\/\*[\s\S]*?\*\//g;
 const BRACE_RE = /[{}]/g;
 const MODAL_ANCHOR = ".agent-modal-item-badges";
+// Stands in for every character that sits inside parentheses. All it has to be is a
+// character that occurs in no needle and is NOT whitespace to the [\s>+~] test below.
+// A space would be wrong: it would let a masked functional pseudo-class stand in for
+// the combinator the anchor has to be followed by, which is half of what F1 was.
+const MASKED = "\u0000";
 
 // Every rule opening in the file, not just the first one on each line. A line-anchored
 // scan is what used to make this guard blind to `.a { } .evil[data-agent="X"] { }` and
@@ -64,27 +69,52 @@ function normaliseSelector(selector: string): string {
     .trim();
 }
 
+// ONE parenthesis-depth pass, and the only one in this file. Returns a copy of `text`
+// of exactly the same length in which every character strictly inside parentheses is
+// replaced by MASKED, so an index into the mask is an index into the original, and a
+// needle found in the mask is a needle at depth 0. The parentheses themselves are kept,
+// so `:is(...)` stays visible as text without its contents being searchable.
+//
+// Everything below that has to tell "at the top level of this selector" from "inside a
+// functional pseudo-class" goes through here. Having one check that knew about depth
+// and another that did not is exactly what F1 was, so there is deliberately no second
+// way to ask this question.
+function maskNested(text: string): string {
+  let depth = 0;
+  let masked = "";
+  for (let index = 0; index < text.length; index += 1) {
+    const ch = text.charAt(index);
+    if (ch === "(") {
+      depth += 1;
+      masked += ch;
+    } else if (ch === ")") {
+      depth = Math.max(0, depth - 1);
+      masked += ch;
+    } else {
+      masked += depth === 0 ? ch : MASKED;
+    }
+  }
+  return masked;
+}
+
 // Criterion 5 is about individual compound selectors, not selector lists: a rule is
 // widened back into the sidebar by adding one comma-separated compound next to the
 // modal-anchored one, and a check that only asks whether the whole list mentions the
-// anchor cannot see that. Depth-aware because the commas in :is(a, b) / :has(a, b) are
-// not list separators. No functional pseudo-class in the tree contains a comma today,
-// so this costs nothing now and cannot silently mangle a compound later.
+// anchor cannot see that. Split on the mask rather than on the raw text, because the
+// commas in :is(a, b) / :has(a, b) are not list separators. No functional pseudo-class
+// in the tree contains a comma today, so this costs nothing now and cannot silently
+// mangle a compound later. The compounds themselves are sliced out of the ORIGINAL, so
+// nothing downstream ever sees a masked character.
 function splitSelectorList(selectorList: string): string[] {
+  const mask = maskNested(selectorList);
   const compounds: string[] = [];
-  let depth = 0;
-  let current = "";
-  for (const ch of selectorList) {
-    if (ch === "(") depth += 1;
-    else if (ch === ")") depth = Math.max(0, depth - 1);
-    if (ch === "," && depth === 0) {
-      compounds.push(current);
-      current = "";
-      continue;
-    }
-    current += ch;
+  let start = 0;
+  for (let index = 0; index < mask.length; index += 1) {
+    if (mask.charAt(index) !== ",") continue;
+    compounds.push(selectorList.slice(start, index));
+    start = index + 1;
   }
-  compounds.push(current);
+  compounds.push(selectorList.slice(start));
   return compounds.map(normaliseSelector).filter((compound) => compound.length > 0);
 }
 
@@ -108,14 +138,35 @@ const DATA_AGENT_COMPOUNDS = ALL_COMPOUNDS.filter((compound) =>
   compound.selector.toLowerCase().includes("[data-agent"),
 );
 
-// Scoped means the attribute selector is a DESCENDANT of the modal container: the
-// anchor must be present, be followed by a combinator, and come before the
-// [data-agent] part. `.session-item-meta [data-agent="X"]` fails, and so does
+// Scoped means the attribute selector is a DESCENDANT of the modal container, with BOTH
+// halves at parenthesis depth 0: the anchor must be present at the top level, be
+// followed by a combinator, and come before a [data-agent] part that is also at the top
+// level. `.session-item-meta [data-agent="X"]` fails, and so does
 // `[data-agent="X"] .agent-modal-item-badges`.
+//
+// Searching the mask instead of the raw selector is what closes F1. This check used to
+// locate the anchor with a plain indexOf, so wrapping it in a functional pseudo-class
+// satisfied both halves and the whole guard stayed green on three real violations:
+// `:is(.agent-modal-item-badges *, .session-item-meta *) [data-agent="Claude"]`, which
+// is the criterion-5 comma-list widening rewritten with :is() and whose second branch
+// reaches sidebar rows; `:not(.agent-modal-item-badges *) [data-agent="Claude"]`, which
+// is the violation stated as a selector; and
+// `.session-item:has(.agent-modal-item-badges .chip) [data-agent="Claude"]`. All three
+// are in-place rewrites of one of the four existing rules, so the count of 4 does not
+// move and cannot catch them. In the mask the anchor inside those parentheses is simply
+// not there, so indexOf returns -1 and the compound is reported as escaped.
+//
+// Conservative on purpose, in the safe direction: a [data-agent] part nested inside a
+// functional pseudo-class that is itself a descendant of the anchor - say
+// `.agent-modal-item-badges :is([data-agent="Claude"], .chip)` - is genuinely scoped and
+// is still rejected here, because the mask hides its needle too. No rule in the tree has
+// that shape, the failure is red rather than green, and adding a fifth [data-agent] rule
+// already needs a plan revision because of the count pin below.
 function isModalScoped(selector: string): boolean {
-  const at = selector.indexOf(MODAL_ANCHOR);
+  const mask = maskNested(selector);
+  const at = mask.indexOf(MODAL_ANCHOR);
   if (at === -1) return false;
-  const afterAnchor = selector.slice(at + MODAL_ANCHOR.length);
+  const afterAnchor = mask.slice(at + MODAL_ANCHOR.length);
   return /^[\s>+~]/.test(afterAnchor) && afterAnchor.toLowerCase().includes("[data-agent");
 }
 

--- a/src/sidebar/styles/agent-badge-css.test.ts
+++ b/src/sidebar/styles/agent-badge-css.test.ts
@@ -30,9 +30,11 @@ const COMMENT_RE = /\/\*[\s\S]*?\*\//g;
 const BRACE_RE = /[{}]/g;
 const MODAL_ANCHOR = ".agent-modal-item-badges";
 // Stands in for every character that sits inside parentheses. All it has to be is a
-// character that occurs in no needle and is NOT whitespace to the [\s>+~] test below.
-// A space would be wrong: it would let a masked functional pseudo-class stand in for
-// the combinator the anchor has to be followed by, which is half of what F1 was.
+// character that occurs in no needle and is outside the [\s>+~] combinator run that
+// isModalScoped scans below. A space would be wrong: it would let a masked functional
+// pseudo-class stand in for the combinator the anchor has to be followed by, which is
+// half of what F1 was. U+0000 is in no needle and in no combinator class, so a masked
+// region both fails the needles and terminates the combinator run.
 const MASKED = "\u0000";
 
 // Every rule opening in the file, not just the first one on each line. A line-anchored
@@ -140,9 +142,22 @@ const DATA_AGENT_COMPOUNDS = ALL_COMPOUNDS.filter((compound) =>
 
 // Scoped means the attribute selector is a DESCENDANT of the modal container, with BOTH
 // halves at parenthesis depth 0: the anchor must be present at the top level, be
-// followed by a combinator, and come before a [data-agent] part that is also at the top
-// level. `.session-item-meta [data-agent="X"]` fails, and so does
+// followed by a DESCENDANT-OR-CHILD combinator, and come before a [data-agent] part that
+// is also at the top level. `.session-item-meta [data-agent="X"]` fails, and so does
 // `[data-agent="X"] .agent-modal-item-badges`.
+//
+// Only the DESCENDANT and CHILD combinators are accepted, and that is B1. `+` and `~` are
+// SIBLING combinators: `.agent-modal-item-badges + [data-agent="Claude"]` matches an
+// element that is a sibling of the anchor and a descendant of none, so it does not have
+// the property this function's name claims, and the guard used to report it green. So did
+// `.agent-modal-item-badges ~ .session-item-meta [data-agent="Claude"]`, which names a
+// sidebar container in the rule. Descendant and child are the only two combinators that
+// put the matched element inside the anchor. No rule in the tree uses `+` or `~` next to
+// the anchor, so rejecting them costs nothing; `>` stays accepted (probe M19).
+//
+// Only the combinator ADJACENT to the anchor is restricted. `+` and `~` further along are
+// none of this check's business: in `.agent-modal-item-badges > .a + .b [data-agent="X"]`
+// the sibling of a child of the anchor is still inside the anchor.
 //
 // Searching the mask instead of the raw selector is what closes F1. This check used to
 // locate the anchor with a plain indexOf, so wrapping it in a functional pseudo-class
@@ -167,7 +182,15 @@ function isModalScoped(selector: string): boolean {
   const at = mask.indexOf(MODAL_ANCHOR);
   if (at === -1) return false;
   const afterAnchor = mask.slice(at + MODAL_ANCHOR.length);
-  return /^[\s>+~]/.test(afterAnchor) && afterAnchor.toLowerCase().includes("[data-agent");
+  // The WHOLE combinator run adjacent to the anchor, not just its first character. By
+  // this point the selector is whitespace-collapsed, so a sibling combinator is spelled
+  // ` + ` far more often than `+`, and a first-character test sees only the leading space
+  // and accepts it. Measured: narrowing the first-character class from [\s>+~] to [\s>]
+  // turns `.agent-modal-item-badges+[data-agent="X"]` red and leaves
+  // `.agent-modal-item-badges + [data-agent="X"]` green. Testing the run catches both.
+  const combinator = afterAnchor.match(/^[\s>+~]*/)?.[0] ?? "";
+  if (combinator.length === 0 || /[+~]/.test(combinator)) return false;
+  return afterAnchor.toLowerCase().includes("[data-agent");
 }
 
 // The declarations of the first rule whose selector list contains `wanted` as a whole

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -726,6 +726,13 @@ html, body, #root {
   gap: 4px;
   margin-top: 2px;
 }
+/* #1167 - after the sidebar coding-agent badge moved to .ac-discovery-badge.agent,
+   the ONLY consumer of .agent-badge left in the app is the Open-Agent modal's
+   repo-tooling chip (OpenAgentModal.tsx:156-167), which never sets `running`.
+   The `.running` variant that used to brighten a live session row is therefore
+   unreachable and was deleted with the migration. Per-tool colours for the modal
+   live further down, on .agent-modal-item-badges. Do not repurpose this rule for
+   a sidebar badge: that is the divergence #1167 removed. */
 .agent-badge {
   font-size: 9px;
   font-weight: 600;
@@ -735,11 +742,6 @@ html, body, #root {
   background: var(--sidebar-border);
   color: var(--sidebar-fg-dim);
   opacity: 0.4;
-}
-.agent-badge.running {
-  opacity: 1;
-  background: var(--sidebar-hover);
-  color: var(--sidebar-fg);
 }
 
 .profile-badge {
@@ -803,11 +805,13 @@ html, body, #root {
   vertical-align: middle;
 }
 
-/* #624 - spacing for the coding-agent badge inside the inline root subtitle
-   (the badge itself only carries color/size via .agent-badge).
-   text-transform:none overrides the uppercase inherited from
-   .root-agent-subtitle so the badge reads mixed-case (e.g. "Claude Code AMP"),
-   matching the session/coordinator rows. */
+/* #624 / #1167 - spacing for the coding-agent badge inside the inline root
+   subtitle. Colour and size now come from .ac-discovery-badge.agent, the same
+   pair the Coordinator rows use, so this rule carries only inline placement.
+   text-transform:none is kept deliberately, as a local guarantee against the
+   uppercase on .root-agent-subtitle: .ac-discovery-badge.agent already sets none
+   and wins on specificity, but the banner should not depend on a rule 4800 lines
+   away to read mixed-case (e.g. "Claude Code AMP"). */
 .root-agent-badge {
   margin-left: 6px;
   vertical-align: middle;
@@ -3784,16 +3788,29 @@ html.light-theme .settings-hint-warning {
   flex-wrap: wrap;
 }
 
-/* Agent-specific badge colors (non-running only) */
-.agent-badge:not(.running)[data-agent="Claude"] { background: rgba(217, 119, 6, 0.15); color: #d97706; }
-.agent-badge:not(.running)[data-agent="Codex"] { background: rgba(16, 185, 129, 0.15); color: #10b981; }
-.agent-badge:not(.running)[data-agent="OpenCode"] { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
-.agent-badge:not(.running)[data-agent="Cursor"] { background: rgba(139, 92, 246, 0.15); color: #8b5cf6; }
-/* Running badge: brighter version of agent color */
-.agent-badge.running[data-agent="Claude"] { background: rgba(217, 119, 6, 0.3); color: #fbbf24; }
-.agent-badge.running[data-agent="Codex"] { background: rgba(16, 185, 129, 0.3); color: #34d399; }
-.agent-badge.running[data-agent="OpenCode"] { background: rgba(59, 130, 246, 0.3); color: #60a5fa; }
-.agent-badge.running[data-agent="Cursor"] { background: rgba(139, 92, 246, 0.3); color: #a78bfa; }
+/* #1167 - per-TOOL colours for the Open-Agent modal's repo chips, and ONLY those.
+   These are NOT coding-agent labels: the four values come from AGENT_DETECTORS in
+   src-tauri/src/commands/repos.rs:9-14 ("Claude", "Codex", "OpenCode", "Cursor"),
+   which reports which tooling directories a repo contains. That vocabulary is
+   closed and exhaustive, so every chip the modal renders is coloured here and none
+   falls through to the grey .agent-badge base.
+
+   Anchored on .agent-modal-item-badges, which occurs exactly once in the repo
+   (OpenAgentModal.tsx:156), so these rules cannot reach a sidebar row. Before
+   #1167 they were written as `.agent-badge:not(.running)[data-agent=...]` and were
+   shared with the sidebar badge, which is what produced the divergence the issue
+   fixes; the sidebar badge no longer emits data-agent at all.
+
+   Specificity: (0,2,0), still above the .agent-badge base (0,1,0) for background
+   and color, while opacity: 0.4 keeps coming from that base exactly as before. The
+   rendered chip is unchanged.
+
+   The four `.running` variants that used to follow were deleted: nothing in the app
+   emits `running` on an .agent-badge any more. */
+.agent-modal-item-badges [data-agent="Claude"] { background: rgba(217, 119, 6, 0.15); color: #d97706; }
+.agent-modal-item-badges [data-agent="Codex"] { background: rgba(16, 185, 129, 0.15); color: #10b981; }
+.agent-modal-item-badges [data-agent="OpenCode"] { background: rgba(59, 130, 246, 0.15); color: #3b82f6; }
+.agent-modal-item-badges [data-agent="Cursor"] { background: rgba(139, 92, 246, 0.15); color: #8b5cf6; }
 
 /* Agent choice (after repo selected) */
 .agent-choice {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,3 +4,15 @@ declare module "*.png" {
   const src: string;
   export default src;
 }
+
+/* #1167 - node:fs for static source guards ONLY (today: the one in
+   src/sidebar/styles/agent-badge-css.test.ts, which has to read real stylesheet
+   bytes because Vitest replaces every CSS module with `export default ""` unless
+   test.css is enabled). @types/node is deliberately not a dependency of this
+   frontend, so the single function that guard needs is declared here, next to the
+   other ambient module declarations. It is narrowed to a URL argument on purpose.
+   Do NOT import node:fs from application code: there is no fs in the Tauri
+   webview, and this declaration is not permission to pretend otherwise. */
+declare module "node:fs" {
+  export function readFileSync(path: URL, encoding: "utf8"): string;
+}


### PR DESCRIPTION
Closes #1167.

## What changed

The coding-agent badge (`Codex`, `Isolated Claude`, `Claude Code`, ...) was rendered by two independent implementations, so the same label appeared **emerald in a Coordinator row** and **grey in the ROOT AGENT banner and origin-agent rows**. The user asked for one appearance everywhere: the one Coordinator rows already have.

`SessionItem.tsx` and `RootAgentBanner.tsx` now emit the exact class pair the Coordinator rows already emit — `ac-discovery-badge agent` — so all sidebar rows resolve through the single rule at `sidebar.css:5620`. `ProjectPanel.tsx` is **not touched**, so the reference appearance cannot regress. `data-agent` and `.running` are no longer emitted on the badge, so no future `[data-agent=...]` rule can resurrect the divergence.

The four per-agent colour rules were **relocated**, not deleted, to `.agent-modal-item-badges [data-agent="..."]`. They are not dead code: their dominant consumer is the Open-Agent modal, whose `data-agent` values come from `AGENT_DETECTORS` (`src-tauri/src/commands/repos.rs:9-14`) and are exactly `Claude`, `Codex`, `OpenCode`, `Cursor`. Deleting them would have repainted every modal chip grey. The anchor occurs exactly once in the repo, so the rules can no longer reach a sidebar row, and the modal renders byte-identically — specificity drops (0,3,0) → (0,2,0), still above the `.agent-badge` base (0,1,0), with `opacity` still inherited from it.

### Accepted side effects, both declared in the issue

- Origin-agent rows and the ROOT AGENT banner lose the `opacity: 0.4` dimming for a badge without a live PTY. Coordinator rows never had it; matching them is the requested outcome. Liveness is still conveyed by the row status dot and `.session-item.inactive-member`.
- Those badges shift from `font-size: 9px` / `letter-spacing: 0.5px` to `8px` / `0.3px`, and pick up `[data-sidebar-style="deep-space"] .ac-discovery-badge { opacity: 0.95 }`.

## Files

Seven paths: `SessionItem.tsx`, `RootAgentBanner.tsx`, `sidebar.css`, `SessionItem.test.tsx`, `vite-env.d.ts` (modified); `RootAgentBanner.agent-badge.test.tsx`, `agent-badge-css.test.ts` (added).

`ProjectPanel.tsx`, `OpenAgentModal.tsx`, `src-tauri/`, `vitest.config.ts`, `tsconfig.json`, `package.json` and `package-lock.json` are untouched — verified by empty diff.

## Review

Architect-planned and certified over five revisions; each revision was rejected by adversarial review and re-planned rather than patched at implementation time. Four of the five revisions concerned the static CSS guard, not the production change, which passed review on the first pass and did not move afterwards.

The guard went through: a version that read no stylesheet at all (Vitest stubs CSS modules to `""`; one assertion passed **vacuously**), a line-anchored scanner blind to a second rule on the same line and to minified CSS, a scope check with no parenthesis-depth awareness (`:is(anchor *, .session-item-meta *)` passed green), and a combinator set that accepted `+`/`~` — sibling combinators — while its own comment promised DESCENDANT.

The final version was adjudicated against **jsdom's `querySelectorAll`** rather than by argument, over a 68-compound combinator × qualifier space: **0 false accepts**, **0 accepts that the prior revision rejected** (a strict narrowing), and 16 confirmed fixes.

Verification: `npm run typecheck`, `npm test` (141 files / 1323 tests), `npm run test:debt` all green, plus **8 mandatory mutation reproductions that must fail** and **2 that must pass** — each planted alone against the real tree with the harness asserting the mutation actually changed the bytes, after silent no-op probes produced false green results twice during development.

### Known limits, documented in the guard itself

The guard is a textual scanner, not a CSS tokenizer. Six residuals are named in the file (comment stripper and brace/paren/quote handling are not string-aware; CSS escapes and namespace-qualified attribute selectors are invisible to the needles), all verified absent from the tree. Follow-up issue filed for the remaining refinements.

`plans/` is gitignored, so the certified plan is not part of this diff.
