### PR TITLE
feat(pty): generic regex pattern watchers over PTY output, with activity window (refs #1171)

### DIFF
--- a/plans/1171-pty-pattern-watchers.md
+++ b/plans/1171-pty-pattern-watchers.md
@@ -1,0 +1,1403 @@
+# Plan #1171: Generic regex pattern watchers over PTY output, with activity window
+
+Author: architect, wg-19. Revision 3 certified against `main` on 2026-07-31 UTC, after three rounds of adversarial and implementer review of the amendment (11.5 to 11.9).
+
+Status: READY_FOR_IMPLEMENTATION
+
+Revision 2's certification was invalidated on 2026-07-31, because two of its contracts could not carry the UI this same document specifies (11.5). The digest `3DF57D8E2F4B08BB6F3D81F4A2C827FBBE61189EBC5EEC95581A01BD589B9736` is void and must not be accepted by any verification step.
+
+Issue: [mblua/AgentsCommander#1171](https://github.com/mblua/AgentsCommander/issues/1171), `feat(pty): generic regex pattern watchers over PTY output, with activity window`.
+
+Branch: `feature/1171-pty-pattern-watchers`. Base: `main` at `33a4a7962c1a6bf710dc40ee9b3b4119dc18d944`.
+
+Every `path:line` reference in this document was read against `33a4a79`. This is revision 3, produced after revision 2's implementation was reviewed and two of its IPC contracts were found unable to carry the UI this same plan specifies. Section 11 records both revisions, what changed in each and what was deliberately not taken.
+
+**Revision 3 is confined to three surfaces**: the watcher reach preview (4.9, 4.12), the Settings editor's row lifecycle and validity predicate (4.12), and the activity window's scope handover and content guard (4.12). The engine, the read seam, the frame diff, the modes, the dedupe layers, the caps, the `watcher_matches` event, the history buffer and its purge helper, `get_watcher_activity`, `preview_watcher_pattern` and the settings schema are unchanged from revision 2. Nothing already implemented against those contracts is invalidated by this revision.
+
+`plans/` is ignored by the repository `.gitignore` (`.gitignore:11`). The four existing plans are tracked, so this file must be added with `git add -f plans/1171-pty-pattern-watchers.md`. Do not weaken the ignore rule.
+
+---
+
+## 1. Issue and objective
+
+Build a generic, user-configured engine that runs regular expressions over the plain de-ANSI'd rows of the vt100 screen mirror AgentsCommander already keeps for every session, and surface the matches in a detached activity window.
+
+Today the mirror is scraped for exactly one hardcoded purpose: the per-agent `contextRegex` that produces `contextPercent`, sampled every 5 seconds by `ContextScraper` (`src-tauri/src/pty/context_scrape/mod.rs:26`). There is no mechanism to detect anything else on a coding agent's screen, and the configuration shape (`context_regex` as a scalar field on `AgentConfig`, `src-tauri/src/config/settings.rs:80-81`) cannot express a pattern that applies to every agent.
+
+The objective is a second, independent engine that:
+
+1. Evaluates any number of user-configured patterns, with applicability selected by the agent command's executable stem rather than by agent entry.
+2. Distinguishes a `state` reading (idempotent, gated) from an `occurrence` (each match is an event).
+3. Samples fast enough to catch rows in transit (200 ms rather than 5 s) and reports its own sampling loss instead of hiding it.
+4. Feeds a per-session in-RAM history buffer and a singleton Tauri window that lists activations with filters.
+
+The engine is a best-effort indicator and not an audit log. That limitation is a property of the PTY channel, is already established, and must be stated in the UI.
+
+---
+
+## 2. Evidence and current state
+
+Every fact below was read from the tree at `33a4a79`.
+
+### 2.1 The output pipeline and the shared mirror
+
+- `SessionIoFanout::handle_output` (`src-tauri/src/pty/output.rs:118-179`) is the single point every PTY byte passes through. It feeds the vt100 mirror at `output.rs:157-167`, incrementing `ScreenReplayState::output_sequence` once per **chunk** (`output.rs:160`), including chunks that change no character (cursor show/hide, colour changes, repositioning).
+- The mirror is created with **zero scrollback**: `vt100::Parser::new(rows, cols, 0)` (`output.rs:112`). Only the current view exists; rows that scroll off are gone for every backend consumer.
+- `SessionIoFanout::get_screen_rows` (`output.rs:295-301`) clones the live grid as plain text rows, releasing the `screen_parsers` guard at the return.
+- `SessionIoFanout::resize_screen_and_broadcast` (`output.rs:202-224`) calls `parser.set_size` and refuses a zero dimension (#973). It does **not** bump `output_sequence`.
+- `SessionIoFanout::register_session` (`output.rs:109-116`) inserts a fresh parser with `output_sequence: 0`.
+- `SessionIoFanout::remove_session` (`output.rs:226-236`) drops the parser.
+- **There is more than one screen mirror map.** `screen_parsers` is created inside `SessionIoFanout::new` (`output.rs:105`), and two fanouts exist: one built by `LocalProcessBackend::new` (`local_backend.rs:678`) and one by `ContainerTransportBackend::new` (`container_backend.rs:1473`). Local and container sessions do not share that mutex.
+- Relevant vt100 0.15.2 API, all public and all reachable under the same guard: `Screen::rows(start, width)` (`screen.rs:163-173`), `Screen::cursor_position() -> (u16, u16)` (`screen.rs:557`), `Screen::row_wrapped(row) -> bool` (`screen.rs:604-611`, documented as "whether the text in row `row` should wrap to the next line"), `Screen::size()`.
+
+### 2.2 The existing scraper, which this plan does not modify
+
+- `ContextScraper` (`src-tauri/src/pty/context_scrape/mod.rs:163-182`) holds five narrow trait objects and no `AppHandle` and no `PtyManager`. That is its documented capability boundary (`mod.rs:5-8`, `:158-162`).
+- Registration chokepoint: `commands/session.rs:2268-2274`, after a successful spawn, only for sessions that have an `agent_id`.
+- Retirement: `retire_session` (`mod.rs:248-251`), reached from `context_alerts.rs:1143-1147` and from the tick itself on `SessionOver` (`mod.rs:404-412`).
+- Equality gate and coalesced persist: `mod.rs:414-432` and `mod.rs:435-442`. Empty-registry early exit: `mod.rs:322-330`, which takes the `registered` mutex to ask.
+- Pattern resolution with a sticky compile failure: `mod.rs:296-319`.
+- `pattern::compile` (`context_scrape/pattern.rs:36-54`) sets `size_limit(1 MiB)` and **rejects any pattern without capture group 1** (`pattern.rs:44-48`, test at `:68-75`).
+- `rows::extract` scans bottom-up with `.rev()` (`context_scrape/rows.rs:19-26`), pinned by `the_lowest_matching_row_wins` (`rows.rs:125-130`).
+- Adapters in `lib.rs`: `ScraperRows` (`lib.rs:531-572`), `ScraperPatterns` (`lib.rs:576-606`), `ScraperSink` (`lib.rs:610-618`), `ScraperSamples` (`lib.rs:622-668`), `ScraperPersist` (`lib.rs:675-699`). Construction and `app.manage` at `lib.rs:1051-1073`.
+- **The existing rows read path is four locks deep and includes a child liveness syscall.** `ScraperRows::get_screen_rows` takes the `PtyManager` mutex (`lib.rs:540`); `PtyManager::get_screen_rows` (`manager.rs:575-580`) takes the `registry` mutex inside `kind_for_session` (`manager.rs:362-370`); the local backend then reaches `screen_rows_if_child_alive` (`local_backend.rs:1089-1109`), which probes the child under the `ptys` mutex; and finally `screen_parsers` is taken (`output.rs:296`). The container backend has no liveness gate and reads the mirror directly, mapping parser-absent to `SessionOver` with the comment "Parser-absent IS the container's liveness oracle" (`container_backend.rs:3171-3179`).
+- `PtyManager::backend_for_kind` is `pub` and returns a cloned `Arc<dyn PtyBackend>` (`manager.rs:192-197`). The two backends are process singletons built once in `PtyManager::new`.
+- The only measured cost number in the repository: "A full sample is ~200 us at AC's default 30x120, so fifty sessions at 5s is ~0.2% of one core, and the liveness gate adds ~0.9 us per configured session per tick" (`context_scrape/mod.rs:22-25`).
+
+### 2.3 Configuration surface
+
+- `AgentConfig` (`settings.rs:47-86`), `context_regex` at `:80-81`.
+- `AppSettings` (`settings.rs:271-538`), `agents` at `:277`, `Default` impl at `settings.rs:685-765`.
+- Root-level `BTreeMap` precedent with a global master: `auto_self_clear_enabled` (`settings.rs:525-526`) and `auto_self_clear_by_agent` (`settings.rs:530-531`).
+- **Settings deserialization is all-or-nothing.** `parse_settings_json` (`settings.rs:870-871`) performs a single `serde_json::from_value::<AppSettings>`; any error is caught at `load_settings_from_path:1661-1664` and replaced with `AppSettings::default()`, leaving one `log::error!` line. The #1077 write gate then refuses to overwrite the file (`read_disk_object_for_write`, `settings.rs:2565-2591`, validating at `:2581`), so nothing is lost on disk, but the application runs with **no agents configured** and every subsequent save from the UI fails silently.
+- Stem normalization already exists and is already composed: `command_executable_basename` (`config/coding_agents_catalog.rs:427-432`) chains `normalize_legacy_agent_command` (`config/agent_command.rs:87`) with `command_token_basename` (`settings.rs:768-774`, already `pub(crate)`). `command_executable_basename` itself is private.
+- The catalog code explicitly rejects `starts_with` matching, naming `pi` and `agent` as the reason (`coding_agents_catalog.rs:494-497`). The TypeScript `suggestedContextRegex` rule uses `starts_with` and must not be reused.
+- Window geometry: `main_geometry` is the live field, `#[serde(default)] Option<WindowGeometry>` **without** `skip_serializing_if` (`settings.rs:367-369`); `sidebar_geometry` and `terminal_geometry` are deprecated since 0.8.0 and do carry `skip_serializing_if` (`settings.rs:359-366`).
+- `initWindowGeometry` (`src/shared/window-geometry.ts:26-47`) performs a debounced read-modify-write of the **whole** `AppSettings`. The repository documents the resulting race in writing (`commands/config.rs:653-655`) and defends against it with an explicit list of fields restored from live memory (`config.rs:611-624`, `:647-655`). `set_detached_geometry` (`commands/window.rs:528-538`) is the precedent for a dedicated single-field geometry command that never touches `AppSettings`.
+
+### 2.4 Session lifetime chokepoints
+
+- Creation of the scraper registration: `commands/session.rs:2268-2274`. Its comment at `:2266-2267` states "the first sample is 5s away", which the new engine invalidates.
+- **There are three production sites that remove a session from `SessionManager`**, all funnelling into `mutations.remove(...)` and then into `apply_lifecycle_mutations` (`session/manager.rs:1737-1745`):
+
+| site | function | post-commit cleanup loop |
+|---|---|---|
+| `commands/session.rs:3104` | `execute_destroy_transaction` | `session.rs:3181-3208` |
+| `commands/session.rs:4026` | `execute_restart_transaction`, success path | `publish_restart_destroyed`, `session.rs:3758-3782`, called from `:4064` |
+| `commands/session.rs:3792` | `finalize_failed_restart` | `publish_restart_destroyed`, called from `:3807` |
+
+  (`session/manager.rs:3531` and `:4300` are test-only.)
+
+- The two cleanup loops are **parallel copies**: both call `publish_destroyed`, both destroy the `terminal-*` window, and both reset `SubstantiveInputState` (`session.rs:3199-3207` and `session.rs:3773-3781`). The per-session side-state purge pattern is therefore already duplicated in the tree.
+- Root-agent sessions with `force_destroy_root == false` are **not** removed: they go to `outcome.retained_exited_ids` (`session.rs:3096-3102`) and stay in the manager marked `Exited`. The destroy loop at `:3181-3186` iterates `destroyed_ids.chain(retained_exited_ids)`.
+- `restart_session` is a normal flow: it is in the invoke handler (`lib.rs:2255`), the mailbox calls it (`phone/mailbox.rs:9679`), and `commands/config.rs:1134` and `:1180` can restart sessions in bulk through `request.restart_sessions`.
+- `SessionManager::destroy_session` (`session/manager.rs:2040-2070`) is reachable only from `#[cfg(test)]` blocks and test-hook branches (`phone/mailbox.rs:7286`, `:7570`, `:10055`, `:14122`, `:17512`, `:17754`, `:17958`; `config/sessions_persistence.rs:3986`). The production branches of those same functions call `background_destroy_session_inner`, which routes to `execute_destroy_transaction`.
+- `rollback_pending_create` (`session/manager.rs:1416-1434`) removes a session on spawn rollback. It runs before the registration site (`commands/session.rs:2254-2258` returns before `:2268`), so a rolled-back session never acquires per-session watcher state.
+
+### 2.5 Frontend surface
+
+- `SettingsModal.tsx:96` declares `type SettingsTab = "general" | "agents" | "resources" | "integrations"`, `TABS` at `:98-103`, and `resolveSettingsSection` at `:105-110`, which **falls back silently to `"general"`** for any unrecognised string and has no `"resources"` branch. The Resource Monitor's own Settings button (`src/resource-monitor/App.tsx:422`, `emitOpenSettings("resources")`) therefore lands on General today. That is a pre-existing bug, recorded in section 11.4 and out of scope here.
+- `SettingsModal` is mounted in exactly one place, `ActionBar.tsx:388`, inside the sidebar. The chain `emitOpenSettings` (`src/shared/ipc.ts:1014-1019`) to `onOpenSettings` (`ActionBar.tsx:77-80`) to `<SettingsModal section={pendingSection()}>` (`:387-392`) is otherwise intact. `WindowAPI.focusMain()` exists (`src/shared/ipc.ts:474`).
+- `formatTimestamp` (`src/resource-monitor/App.tsx:62-71`) is a module-local `const`, **not exported**, and returns `toLocaleTimeString(...)`, not `HH:MM:SS`.
+- `.workgroup-task-text` (`src/terminal/styles/terminal.css:227-236`) uses `white-space: pre-wrap` with `word-break: break-word`, that is containment by wrapping, not by scrolling.
+- `.status-bar-btn` already exists (`src/terminal/styles/terminal.css:631-660`).
+- `src/browser/App.tsx:2` imports and renders `TerminalApp`, so the StatusBar exists in the web client. `src-tauri/src/web/commands.rs` has a window-command no-op list at `:625-639` and a catch-all `_ => Err(format!("Unknown command: {}", cmd))` at `:702`. `isTauri` is exported from `src/shared/platform.ts:3-4`.
+- `src/shared/stores/settings.ts` does **not** autoload: `settingsStore.current` is `null` until someone calls `load()`.
+- There is **no cross-window event for a generic settings change.** `emit_settings_draft_update_events` (`commands/config.rs:747-769`) emits only `coding_agent_profiles_updated` and `coding_agent_env_settings_updated`; `coding_agent_settings_updated` is emitted exclusively from `phone/mailbox.rs:10812`.
+- Polling precedent with written cadence: `resourceMonitorStore.startPolling({ activeIntervalMs: 10_000, idleIntervalMs: 15_000, backoffIntervalMs: 20_000 })` (`ActionBar.tsx:81-87`).
+- `emit_to` is already used in the tree (`testability/ui_automation.rs:631`).
+
+### 2.6 The gap
+
+There is no second pattern, no applicability selector, no occurrence semantics, no sub-second sampling, no history buffer, no activity window, and no way to configure a pattern that reaches every agent.
+
+---
+
+## 3. Scope
+
+### 3.1 In scope
+
+1. A new backend module `src-tauri/src/pty/watchers/` containing the engine, the pattern compiler, the frame diff, the dedupe layers and the history buffer type.
+2. A new read seam on `SessionIoFanout` and `PtyBackend` that returns "unchanged" without cloning rows, and that carries wrap flags and the cursor row.
+3. A root-level `watchers` map in `AppSettings` with the `commands` selector, deserialized entry by entry so one bad entry cannot take the file down.
+4. The `watcher_matches` Tauri event, delivered to the activity window, and its TypeScript mirror and listener.
+5. The `get_watcher_activity` command, the per-session ring buffer, and the loss signals.
+6. `open_watchers_window`, `get_watchers_scope` and `set_watchers_geometry`, and the singleton `watchers` window with persisted geometry and a scope handover that survives being opened again while it is still loading.
+7. The activity window itself: table, scope selector, filters by watcher, agent and workgroup, free text over captures, three empty states, snapshot polling, best-effort footer.
+8. A StatusBar button that opens or focuses the window and sets its scope, hidden outside Tauri.
+9. A Watchers section in the Settings modal that edits the root map, including the `resolveSettingsSection` branch that makes its entry point work.
+10. `preview_watcher_pattern` and `preview_watcher_reach`, the two commands the Settings section needs to validate a pattern and to show the reach and the budget of the **whole draft** without porting either the stem rule or the budget rule to TypeScript.
+
+### 3.2 Out of scope
+
+1. **Actions triggered by a match.** The engine holds no `AppHandle` and no `PtyManager` for the same structural reason `ContextScraper` does not (`context_scrape/mod.rs:5-8`). Injection capability plus a loose pattern is a feedback loop: inject, printed to the PTY, matches its own injection, inject again. Any action layer must consume the events from outside the engine, with its own rate limiting, a dry-run mode, and a whitelist that excludes injecting into the session that produced the match.
+2. **Migrating `context_regex` into the new map.** It keeps its field, its semantics, its tests and its path to `sessions.json` and `list-peers-lean`.
+3. **Unifying `CodingAgentKind` (`session/profile.rs`) with the preset catalog.**
+4. **A global cross-session history buffer.** `get_watcher_activity` is per session; the "All sessions" view is composed in the frontend with N calls.
+5. **Filtering by workgroup replica ("Role").** `extractAgentName` (`src/shared/path-extractors.ts:28-36`) already exists and it would be cheap, but it was not requested.
+6. **`RegexSet`.** Decided out; the arithmetic is in section 7.3.
+7. **Persisting a per-watcher summary into `sessions.json`.** Decided out; the reasoning and the flag are in section 3.3.
+8. **Seeding default watcher patterns from `agents.default.json`.** No pattern for any watcher use case is captured anywhere in the repository or in any log on the development machine. Shipping an unvalidated default would be shipping a guess as a product default. Every watcher in this issue is user-authored.
+9. **Changing `waiting_for_input` to be driven by a state watcher** (`session/manager.rs:506`, `:554`).
+10. **Fixing the missing `"resources"` branch in `resolveSettingsSection`.** Pre-existing, unrelated, recorded in 11.4.
+
+### 3.3 One scope call that touches an issue-body bullet, stated explicitly
+
+The issue body says, under "IPC contract": *"What is persisted to `sessions.json` stays a bounded per-watcher summary, never a list of occurrences."*
+
+That sentence is a guardrail on the shape of persistence, not a commitment that persistence ships. **This plan ships no watcher persistence at all**, so the guardrail holds vacuously.
+
+Two reasons. First, nothing in #1171 consumes it: the activity window reads the in-RAM ring buffer plus the live event, and neither path touches `sessions.json`. Adding the summary would mean a new field on `Session`, on `SessionInfo`, in `config/sessions_persistence.rs`, in the `Session` TypeScript type and in the CLI peer row.
+
+Second, and stronger: `get_watcher_activity` is served from a per-session mutex, synchronously (section 4.10). A per-watcher summary on `Session` would put a write against the `SessionManager` async `RwLock` on the engine's hot path, once per match, on top of the coalesced persist `ScraperPersist` already performs (`lib.rs:679-699`). The cut does not merely lose nothing; it keeps the engine out of the session lock.
+
+This is the one place where the plan narrows something an issue-body sentence could be read as requiring.
+
+---
+
+## 4. The decided solution
+
+### 4.1 Shape: a sibling engine, not an extension of `ContextScraper`
+
+`src-tauri/src/pty/watchers/` is a new module with its own thread, its own runtime and its own shutdown token, following the shape `ContextScraper::start` already uses (`context_scrape/mod.rs:207-227`).
+
+`ContextScraper` is not modified. It keeps its 5 second interval, its single pattern per agent, its five sinks and its two shipped issues (#1032, #1088). The two engines share only the read seam on `SessionIoFanout`, which is already a public read boundary.
+
+Reason: the new engine differs in interval (200 ms against 5 s), in modes, in dedupe, in the frame diff, in rate limiting and in owning a history buffer. Folding all of that into `ContextScraper` would put #1032 and #1088 at risk for no gain.
+
+### 4.2 The read seam
+
+Types live in `src-tauri/src/pty/watchers/mod.rs`, mirroring the existing arrangement in which `ScreenRowsRead` lives in its consumer module (`context_scrape/mod.rs:46-54`) and `backend.rs` imports it from there.
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameStamp {
+    /// `ScreenReplayState::output_sequence` (`output.rs:160`).
+    pub sequence: u64,
+    pub rows: u16,
+    pub cols: u16,
+}
+
+pub struct ScreenFrame {
+    /// One entry per physical row, from `Screen::rows(0, cols)`.
+    pub rows: Vec<String>,
+    /// `Screen::row_wrapped(i)` for each i: does this physical row continue
+    /// into the next one. Same length as `rows`.
+    pub wrapped: Vec<bool>,
+    /// `Screen::cursor_position().0`. The row currently being written.
+    pub cursor_row: u16,
+    /// `None` only from the default trait implementation, which has no
+    /// sequence to report. `None` means "treat as changed".
+    pub stamp: Option<FrameStamp>,
+}
+
+pub enum ScreenRowsSince {
+    /// The stamp matched. NO rows were cloned and no allocation was made.
+    Unchanged,
+    Frame(ScreenFrame),
+    /// No parser for this id. Says NOTHING about whether the session is over,
+    /// exactly like `get_screen_rows` returning `None` (`output.rs:287-294`).
+    Missing,
+    /// This backend has no session behind this id. Retire it now.
+    Gone,
+}
+
+impl SessionIoFanout {
+    pub fn get_screen_rows_since(&self, id: Uuid, seen: Option<FrameStamp>) -> ScreenRowsSince;
+}
+```
+
+Four decisions embedded here, each with its reason:
+
+- **The size is part of the stamp** because `resize_screen_and_broadcast` reflows the grid without bumping `output_sequence` (`output.rs:202-212`). Comparing the sequence alone would miss a reflow. `output_sequence` itself is **not** modified, because it is also the replay ordering key `get_screen_snapshot` hands the frontend (`output.rs:274-285`, #955), and changing when it advances would change that contract. The seam only reads it.
+- **`stamp` is `Option`** because the defaulted trait method has no sequence available: `get_screen_rows` returns `ScreenRowsRead` (`context_scrape/mod.rs:46-54`), which carries neither a sequence nor a size, and fabricating one would put an invented value into engine state. `None` reads as "changed", so the property "the default never reports `Unchanged`" falls out of the type.
+- **`Gone` exists** so the container backend keeps the liveness oracle it documents in writing ("Parser-absent IS the container's liveness oracle", `container_backend.rs:3171-3179`). The local backend, whose parser-absence is not conclusive, returns `Missing`. The engine retires immediately on `Gone` and keeps sampling on `Missing`. The `Unavailable` and `SessionOver` distinction that `ScreenRowsRead` argues for at length (`context_scrape/mod.rs:39-45`) is preserved by exactly this split.
+- **`wrapped` and `cursor_row` are read under the same guard** the row clone already takes, at O(1) each. They are what sections 4.3 and 4.4 need, and fetching them separately would mean a second lock acquisition on a possibly different frame.
+
+`FrameStamp.sequence` is monotonic only within one parser instance: `SessionIoFanout::register_session` (`output.rs:109-116`) inserts a fresh parser at `output_sequence: 0`. That is safe here only because session ids are minted per spawn and never reused (`context_scrape/mod.rs:232-233`). This must be stated in the seam's doc comment, because #955's replay tolerates a reset and this engine does not: if a future "reattach in place" ever reuses an id, the stamp would move backwards and the engine could report `Unchanged` over a completely different screen.
+
+**Routing.**
+
+- `PtyBackend::screen_rows_since(&self, id, seen: Option<FrameStamp>) -> ScreenRowsSince` is added as a **defaulted** trait method on `pty/backend.rs` (the trait is at `:127`; `context_session_liveness` at `:148-154` is the precedent). The default delegates to `get_screen_rows`, mapping `Rows` to `Frame` with `stamp: None`, `wrapped` all false, `cursor_row: 0`, and everything else to `Missing`. The two `PtyBackend` test fakes (`pty/manager.rs:926`, `:1025`) keep compiling untouched.
+- `LocalProcessBackend` and `ContainerBackend` override it with a direct `self.fanout.get_screen_rows_since(id, seen)`, **with no child liveness probe**. The container override returns `Gone` where its `get_screen_rows` returns `SessionOver`.
+- `PtyManager::screen_rows_since(id, seen)` is added for completeness, mirroring `manager.rs:575-580`, and returns `Gone` when `kind_for_session` finds no route, preserving that function's documented reading ("A missing route is not 'we could not read'"). **The engine does not use it in the tick**; see 4.2.1.
+
+#### 4.2.1 The engine holds the backend directly, so the tick takes one lock
+
+At registration the engine resolves the session's `Arc<dyn PtyBackend>` once, through `PtyManager::backend_for_kind` (`manager.rs:192-197`, `pub`, returns a cloned `Arc`, backends are process singletons), and stores it with the session. Every tick then calls `backend.screen_rows_since(id, seen)` directly.
+
+Consequence: the `PtyManager` mutex, "the one every terminal write, resize and kill locks on" (`local_backend.rs:1116-1117`), and the `registry` mutex inside `kind_for_session` are **out of the tick entirely**. What remains is one `screen_parsers` acquisition per session per tick, and that map is per backend (2.1), so local and container sessions do not even contend with each other.
+
+If a read returns `Missing` or `Gone`, the engine re-resolves the `Arc` once through `PtyManager` before acting on it, which covers a session that changed route.
+
+The liveness probe stays on `PtyManager::context_session_liveness` (`manager.rs:506-511`) and runs once every **25th tick**, that is once per 5 seconds per session, exactly today's rate. A session whose child exited is retired within 5 seconds, or immediately if a read returns `Gone`.
+
+This makes the engine strictly better than the status quo on both axes rather than better at rest and worse under load. Section 7.3 has the arithmetic.
+
+### 4.3 Frame diff by best-shift alignment
+
+Per session the engine keeps:
+
+- `prev_hashes: Vec<u64>`, one 64-bit hash per physical row of the previous frame.
+- `dirty: Vec<bool>`, one flag per row position.
+- `stamp: Option<FrameStamp>`, `evaluated_since_reseed: bool`, `possibly_missed_frames: u64`.
+
+The previous frame's **text is never kept**: hashes suffice for alignment and change detection, at 8 bytes per row instead of up to 120 (240 bytes per session instead of about 3.6 KB). Hashing uses `std::collections::hash_map::DefaultHasher`, which needs no new dependency. A 64-bit collision costs one missed evaluation, which is the fail-closed direction the module already takes (`context_scrape/rows.rs:107-124`).
+
+**Alignment is a best-shift search, not slice equality.** Revision 1 defined `k` as the smallest shift for which `prev_hashes[k..] == curr_hashes[..R-k]` and then branched, inside that same range, on rows that differ. Those two statements cannot both hold: exact equality of the overlap makes the differing branch unreachable, and with any statusline repainting no `k` ever satisfies it, so every tick would have fallen through to a full re-render. The alignment is therefore:
+
+```
+for k in 0..R:
+    overlap(k) = R - k
+    agree(k)   = |{ i in 0..overlap(k) : prev_hashes[i + k] == curr_hashes[i] }|
+
+best_k = argmax agree(k), ties broken by the SMALLEST k
+```
+
+Cost: at most `R * (R + 1) / 2` u64 comparisons, 465 for R = 30, per changed session per tick. The smallest-k tie-break declares the fewest new rows, so ambiguity under-counts.
+
+Per tick, given the frame and `curr_hashes`:
+
+1. **First tick after registration** (`prev_hashes` empty): seed, clear `dirty`, set `evaluated_since_reseed = false`, evaluate **nothing**, and do **not** increment `possibly_missed_frames`. There was no sampling gap; reporting the whole starting screen as fresh activity would be wrong.
+2. **Size change** (`stamp.rows` or `stamp.cols` differ, or the previous stamp was `None`): reseed as in step 1 and evaluate nothing, because a reflow re-lays every row at a new width. Increment `possibly_missed_frames` **only if `evaluated_since_reseed` is true**. The frontend fits xterm shortly after spawn, so the first resize is near universal; counting it would light the "Some screen output was not sampled" line on nearly every session from birth, which is exactly what separating that line from the `truncated` banner exists to avoid.
+3. **Compute `best_k`.** Increment `possibly_missed_frames` when `2 * agree(best_k) < overlap(best_k)`, that is when less than half the overlap agreed. That is the honest meaning of "the sampler could not follow the screen": a `clear`, an alternate-screen switch, a full repaint, or a scroll burst larger than the screen.
+4. **New by scroll**, positions `R - best_k .. R` when `best_k >= 1`, **excluding `cursor_row`**: evaluate immediately. These rows arrived complete from below and need no stabilization. Set their `dirty` to false. The cursor row is excluded because a terminal that prints a newline lands the cursor on an empty bottom row and only then writes it: at a 200 ms cadence, against 4096-byte read chunks (`local_backend.rs:946`), landing mid-write is routine, and evaluating it would emit one event with a truncated capture (`Read /path/to/fi`) followed by a second with the complete one. No `dedupe` setting can merge those two, because both the row and the captures differ. The cursor row is instead treated as in-place, so it is evaluated once, complete, one tick later.
+5. **In place**, positions `0 .. R - best_k`, plus `cursor_row` whenever it falls in the new-by-scroll range, comparing `curr_hashes[i]` against the shifted previous hash:
+   - different: set `dirty[i] = true`, do **not** evaluate.
+   - equal and `dirty` carried over: the row has been stable for one full tick. **Evaluate** it and clear `dirty[i]`.
+   - equal and not dirty: nothing.
+6. **Shift the dirty flags** before step 5 uses them. This is a named operation, `shift_dirty(dirty, k)`, defined as `new[i] = old[i + k]` for `i` in `0 .. R - k` and `false` for `R - k .. R`. It is the step most easily implemented wrong and is tested on its own.
+7. Rows that scrolled off the top while still dirty are lost. In practice this is rare (in-place writes happen at the cursor, which is near the bottom, and a scroll moves the cursor row up rather than off) and the engine cannot evaluate them because it never kept their text. It is a documented loss and it does **not** increment `possibly_missed_frames`, so that counter keeps exactly one meaning.
+8. Store `curr_hashes`, the new stamp, and set `evaluated_since_reseed` if anything was evaluated.
+
+There is **no separate "re-render, evaluate every row now" path**. A repaint produces a low-agreement alignment whose differing rows all land in `dirty`, and they are evaluated one tick later if the new screen is stable, which it is. That is one evaluation per row, in order, with no burst and with no reliance on the TTL dedupe layer. Removing that path is what makes layer 1 the layer that does the work, as the design always claimed.
+
+**Known imprecision, stated rather than hidden.** When a TUI uses a scroll region, the rows at the bottom of the physical screen are the statusline and do not scroll with the transcript, yet they fall inside `R - best_k .. R` and are evaluated as new on each scrolling tick. A row that does not match costs one regex execution; a row that does match is suppressed by layer 2 while its text is unchanged. Watchers on statusline content belong in `state` mode, which does not use this path at all.
+
+**A deliberate non-guard.** The engine does not skip a scrolled-in row whose hash equals the hash previously at that same position. Such a guard would remove the statusline imprecision above, but it would also drop the second of two consecutive identical rows, and edge case 39 requires identical rows to count twice. The requirement wins.
+
+`state` mode does not use the diff: it evaluates the whole frame, which the engine already holds whenever the stamp changed. The diff state is maintained for every session regardless of configured modes, so switching a watcher's mode at runtime needs no reseed.
+
+#### 4.3.1 Logical rows: wrapped rows are joined before evaluation
+
+`Screen::rows` returns **physical** rows, so a line longer than the terminal width occupies two or more of them and no pattern can match across the break. At 120 columns that is precisely what an absolute file path does, which is the issue's primary use case.
+
+The diff stays on physical rows, because physical arrival is what the alignment measures. Evaluation is on logical rows:
+
+- A physical row `i` is a **continuation** when `wrapped[i - 1]` is true. A continuation is never evaluated on its own.
+- When a non-continuation row `i` is selected for evaluation, the text handed to the patterns is `rows[i]` concatenated with `rows[i + 1]`, `rows[i + 2]` and so on while `wrapped` of the preceding row is true. There is no separator: `write_contents` emits no trailing padding (`vt100 row.rs:122-133`), so the concatenation reconstitutes the original line.
+- A continuation whose start is above the top of the screen has lost its beginning and is **skipped**, never evaluated as a fragment. Fail-closed.
+- The `row` field of the payload carries the logical row, truncated to 256 bytes on a char boundary with `rowTruncated` set, exactly as before.
+- If a continuation row is selected for evaluation by step 4 or step 5 while its start row is not, the engine evaluates the **logical row starting at that start row**, once. Selection is therefore mapped from physical to logical before evaluation, and a logical row is evaluated at most once per tick.
+
+`Row::resize` clears the wrap flag (`vt100 row.rs:73-76`), which is consistent: a resize reseeds anyway.
+
+### 4.4 Modes
+
+**`state`**: over the full frame, take the **lowest** matching logical row, mirroring `rows::extract` (`context_scrape/rows.rs:19-26`), because a statusline always sits below the transcript.
+
+The gate is not `(captures, row)` alone. Revision 1 kept only that pair and cleared it when nothing matched, which means a second instance of a condition appearing while the first is still visible never emits: the lowest match still reads the same text, so the tuple never changes. That is the failure mode of the permission-prompt watcher, which is the strongest argument for the engine existing.
+
+The gate is `(captures, row, generation)`, where `generation` is a per `(session, watcher)` counter incremented whenever the number of matching logical rows **rises** from the previous tick. Walking the cases:
+
+| transition | count | generation | emits |
+|---|---|---|---|
+| condition appears | 0 to 1 | +1 | yes |
+| screen scrolls, condition still visible | 1 to 1 | same | no |
+| second instance appears while the first is visible | 1 to 2 | +1 | **yes** |
+| first instance scrolls off | 2 to 1 | same | no |
+| everything scrolls off | 1 to 0 | same, gate cleared | no |
+| condition reappears later | 0 to 1 | +1 | yes |
+| instance A scrolls off and B appears in the same tick, different text | 1 to 1 | same | yes, the text changed |
+
+Incrementing only on a rise is what makes the gate scroll-stable: the count of a persistent condition does not change as the screen moves.
+
+A transition to "no match" **clears the gate and emits nothing.** The only consumer in this issue is an activity log, and "the prompt disappeared" is not a log entry. Clearing is what lets an identical re-appearance emit again. This is deliberate and is why the payload needs no `present` or `cleared` field. The window compensates by marking state rows visually and by wording them as "first seen at", not "currently true" (4.12).
+
+**`occurrence`**: every logical row the diff declares evaluable is matched; every match that survives the dedupe layer and the rate limit is an event. There is no equality gate, by definition.
+
+### 4.5 Deduplication, three layers in this order
+
+**Layer 1, best-shift alignment.** Structural, and it does the work: a logical row is evaluated on the one tick it becomes final, either by arriving from below or by holding still for a tick. The same text appearing twice in a transcript is two rows at two times and counts twice; a row shifted up by a scroll is not re-evaluated.
+
+**Layer 2, key suppression with a TTL.** For the residual cases layer 1 cannot separate: differently truncated repeats of the same content, and the scroll-region statusline of 4.3. Per watcher:
+
+- `dedupe: "row"` (default): the key is the matched logical row text.
+- `dedupe: "capture"`: the key is the joined capture groups. Two rows truncated differently that capture the same path are one event.
+- `dedupe: "none"`: every match counts.
+- `dedupeWindowMs`, default `2000`, **clamped to `60_000`** on read, with one log line when a larger value is clamped.
+
+Applies to `occurrence` only; `state` has its gate.
+
+**The dedupe map is bounded.** Per `(watcher, session)` at most **256** keys, oldest-inserted evicted first. Expired keys are pruned once per tick for the sessions evaluated that tick. Without both bounds a large `dedupeWindowMs` and a `row` key would grow the key set to every distinct row seen in the window, which at 8 watchers and 20 sessions is hundreds of megabytes.
+
+**Layer 3, `possiblyMissedFrames`.** Not deduplication. It declares uncertainty instead of hiding it: above zero means "something may have been missed", never "N things were missed". Per session, because sampling is per session.
+
+### 4.6 Rate limiting, applied before both the event and the buffer
+
+Two caps, both per tick:
+
+- **8 matches per `(watcher, session)`.**
+- **16 matches per session** across all watchers.
+
+On exceeding either cap the engine counts the overflow, emits nothing further for that key this tick, logs once per `(watcher, session)` while degraded, and sets `degraded` on that watcher's counter in the snapshot. The recover-and-log-once shape follows `ScraperSamples` (`lib.rs:629-667`).
+
+**The caps bound the rate but not the duration**, so a watcher that stays saturated would emit 40 events per second forever and turn the 500-entry ring over in 0.31 seconds, making `truncated` true and useless. Therefore: after **25 consecutive degraded ticks** (5 seconds) a `(watcher, session)` pair is **suspended for 5 seconds**, keeping `degraded` true and logging one line, then retried. This adds no new state, since the degradation counter already exists for the marker, and it does not touch the event contract.
+
+The caps live **inside the engine loop**, immediately before the sink call, exactly where `ContextScraper`'s equality gate lives (`context_scrape/mod.rs:414-432`). The ring buffer lives in the concrete sink implementation. Consequence: everything that passes the caps reaches both the event and the buffer, and nothing else reaches either. The ordering requirement is a property of where each piece lives.
+
+With the event coalesced and directed (4.9), the caps no longer carry the IPC load on their own: at 50 saturated sessions the delivered event rate is 250 per second when the window is open and zero when it is closed, regardless of match count. What the caps still bound is the per-tick batch size and the rate at which the ring turns over, which is what they should bound.
+
+### 4.7 The pattern compiler
+
+A new `pty/watchers/pattern.rs`, **not** a reuse of `context_scrape/pattern.rs`, because that compiler rejects any pattern without capture group 1 (`pattern.rs:44-48`, pinned by its own test at `:68-75`) and a watcher pattern legitimately has zero groups.
+
+Everything else is identical:
+
+- `RegexBuilder::new(source).size_limit(1024 * 1024).build()`, with the same rationale: `regex` 1.x has no backtracking and is linear time by construction, so a hostile pattern cannot burn CPU; the size limit is the bound that matters, and past it compilation fails rather than allocating (`context_scrape/pattern.rs:27-30`).
+- The source string is kept beside the compiled regex so a recompile is decided by a changed string.
+- Compile failure is **sticky** per watcher id, following `Cached::Failed` (`context_scrape/mod.rs:133-140`, `:296-319`): logged once per change, never once per tick.
+- The user's pattern is handed over **verbatim**, never trimmed. Leading spaces are anchors, and the pattern is the only defence the feature has (`lib.rs:589-601`).
+
+No matching timeout is added, because there is nothing to time out.
+
+### 4.8 Configuration
+
+In `AppSettings` (`settings.rs:271-538`), two siblings of `agents`:
+
+```rust
+/// #1171 - root-level watcher patterns, keyed by watcher id. `AgentConfig` gains no
+/// field, so the 20+ struct-construction sites that already had to write
+/// `context_regex: None` are untouched. Same shape as `auto_self_clear_by_agent`
+/// (`settings.rs:530-531`). `BTreeMap` for stable on-disk order and clean diffs.
+#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+pub watchers: std::collections::BTreeMap<String, WatcherEntry>,
+
+/// #1171 - geometry of the activity window. `skip_serializing_if` and NOT a literal
+/// copy of `main_geometry` (`settings.rs:367-369`), which lacks it: without the skip,
+/// `"watchersGeometry": null` would appear in every user's file on the next save,
+/// contradicting section 7.1's promise that configuring nothing leaves no trace.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub watchers_geometry: Option<WindowGeometry>,
+```
+
+**A malformed watcher must not destroy the file.** `parse_settings_json` deserializes `AppSettings` in one shot and any failure yields `AppSettings::default()` (2.3). A hand-written `"mode": "State"`, `"commands": "claude"` or `"dedupeWindowMs": "2000"` would therefore start AgentsCommander with **no agents configured**, leaving one log line, and every later save would be refused by the #1077 gate. The map is consequently deserialized entry by entry:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WatcherEntry {
+    Valid(WatcherConfig),
+    /// Anything that did not deserialize as a `WatcherConfig`. Kept verbatim so a
+    /// save round-trips the user's bytes instead of deleting what it could not read,
+    /// skipped by resolution, and logged once per changed value.
+    Invalid(serde_json::Value),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub mode: WatcherMode,
+    pub pattern: String,
+    /// Absent or null: reaches every configured agent. Present: only entries whose
+    /// `command` executable stem matches EXACTLY. Present and empty: reaches none.
+    /// `Option` and not `#[serde(default)] Vec`, because absent and `[]` are opposites
+    /// and only `Option` lets serde tell them apart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commands: Option<Vec<String>>,
+    #[serde(default)]
+    pub dedupe: WatcherDedupe,
+    #[serde(default = "default_dedupe_window_ms")]
+    pub dedupe_window_ms: u64,
+    /// Free text, e.g. "claude 2.1.212". Never validated, never parsed. It exists
+    /// because `context_scrape/rows.rs:183-186` documents that a TUI format already
+    /// had to be re-captured, and that fact currently lives in a Rust comment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_against: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WatcherMode { State, Occurrence }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WatcherDedupe { #[default] Row, Capture, None }
+```
+
+`mode` and `pattern` stay required: a watcher without either is not a watcher, and with the wrapper the consequence is one skipped entry rather than a lost configuration. `default_dedupe_window_ms()` returns `2000`. `default_true` already exists (`settings.rs:540-542`). `AppSettings::default()` (`settings.rs:685-765`) gains two lines.
+
+**Applicability.**
+
+```
+reaches(w, agent) = w.enabled && match &w.commands {
+    None       => true,
+    Some(list) => list.iter().any(|s| stem(s) == stem(&agent.command)),
+}
+```
+
+`stem` is `command_executable_basename` (`coding_agents_catalog.rs:427-432`), promoted from `fn` to `pub(crate) fn`. **A second stem function must not be written, in Rust or in TypeScript**, and the TypeScript `starts_with` rule in `suggestedContextRegex` must not be ported: the catalog code rejects it in writing, naming `pi` and `agent` as the false-match risk (`coding_agents_catalog.rs:494-497`). The Settings UI obtains reach through the `preview_watcher_reach` command (4.9) rather than reimplementing the rule.
+
+| input | stem | effect |
+|---|---|---|
+| `claude` | `claude` | reached by `["claude"]` |
+| `C:\...\claude-sandbox-runtime\claude.cmd` | `claude` | reached by `["claude"]` |
+| `pi --provider claude` | `pi` | not reached by `["claude"]`, correctly: the TUI rendering is Pi's |
+| `cmd /c claude` | `cmd` | not reached by `["claude"]`. The user adds `"cmd"` or drops the selector |
+| `CLAUDE.EXE` | `claude` | case-insensitive on every platform |
+
+- A `commands` entry that does not tokenize, or a list containing an empty string: the **whole watcher is skipped** and logged once. Never "reaches everything".
+- A stem no agent has: not an error, reaches nobody. The Settings UI shows "reaches 0 agents" so a typo is visible.
+- An agent whose own `command` does not tokenize: not reached by any watcher **with** a selector; watchers without one still reach it. `validate_agent_commands` (`settings.rs:1473-1475`) already rejects such a command on save.
+
+**Scope of "every agent".** A watcher with `commands` absent reaches every entry in `settings.agents`, which means every **agent session**. Plain shell sessions are never registered with the engine, exactly as they are never registered with `ContextScraper` (`commands/session.rs:2268-2274`). "All agents" is not "all sessions".
+
+**Precedence: none.** Two watchers reaching the same agent both run. They have distinct ids and write distinct slots. A "most specific wins" rule would silently discard a pattern the user configured. Two watchers with identical `pattern` and `mode` are two watchers and both fire.
+
+**Budget: 8 watchers per agent.** Resolution iterates the `BTreeMap` in key order and takes the first 8 that reach the agent. Because the key order is alphabetical over user-chosen ids, adding a watcher named `aaa-test` can displace the eighth. The ones dropped are logged once per resolution change **and** reported per row by `preview_watcher_reach`, so the Settings UI shows "not running on <agent> (budget)" instead of leaving the user with a log line.
+
+**The budget is a property of the whole set, and that decides the shape of its preview.** Whether a watcher is inside the first 8 cannot be answered from that watcher alone: it depends on every other watcher that reaches the same agent, on which of them are enabled, and on where their ids fall in key order. It also depends on the agents themselves, which the same modal edits in the same draft. `preview_watcher_reach` therefore receives the entire draft, watchers and agents, and not one row (4.9). Neither the key order nor the number 8 is reimplemented in TypeScript, for the same reason the stem rule is not.
+
+**Watcher ids.** Written by the user, validated against `^[a-z0-9][a-z0-9-]{0,39}$`, unique by construction as the map key. Renaming is delete plus create: the new id starts with no history and rows already in the ring keep the old id, which is the same behavior edge case 17 defines for deletion. The Settings UI states this on the rename control.
+
+**Resolution cadence.** Patterns are resolved fresh every tick, following `ScraperPatterns` (`lib.rs:576-606`), with one `SettingsState` read lock per tick for all sessions. Cost with 12 agents and 8 watchers: 96 stem comparisons and 12 command tokenizations per tick, that is 480 comparisons and 60 tokenizations per second. No cache is added.
+
+**Zero-cost when unconfigured.** The tick reads settings first and returns immediately when no `WatcherEntry::Valid` is `enabled`, **before touching any session**. Revision 1 claimed an empty-registry early exit like `ContextScraper`'s; that was wrong, because registration is per session, not per watcher, so a running agent with no watchers configured would have kept the registry non-empty. The check on the resolved watcher set is what actually delivers the promise.
+
+### 4.9 IPC contract
+
+**Event `watcher_matches`**, one batch per `(session, tick)`.
+
+```rust
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherMatchBatch {
+    pub session_id: String,
+    pub matches: Vec<WatcherMatchPayload>,
+}
+
+/// pty/watchers/mod.rs. Mould: `ContextUsagePayload` (`context_scrape/mod.rs:104-115`).
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherMatchPayload {
+    pub session_id: String,
+    /// Monotonic per session, assigned by the engine as the match passes the caps.
+    /// The SAME value the ring stores, so the window merges snapshot and stream on
+    /// `(sessionId, seq)` instead of guessing. Without it two matches from one tick
+    /// are indistinguishable, and edge case 39 requires that they be distinct.
+    pub seq: u64,
+    /// The key of the root `watchers` map. The same grouping key everywhere.
+    pub watcher_id: String,
+    pub mode: WatcherMode,
+    /// The TICK's instant, not the match's: a match has no instant of its own.
+    /// `chrono::DateTime<Utc>` serializes RFC3339, the repository convention
+    /// (`resource_monitor/types.rs:158-160`).
+    pub at: chrono::DateTime<chrono::Utc>,
+    /// Groups 1..n IN ORDER, without group 0. `Option` per element because an
+    /// optional group may not participate, and "" is not "did not capture".
+    pub captures: Vec<Option<String>>,
+    /// The logical row (4.3.1), truncated to 256 bytes on a char boundary.
+    pub row: String,
+    /// Whether `row` lost bytes to the cap. `row.length >= 256` cannot answer this
+    /// in TypeScript, because the cap is on bytes and the row is multibyte.
+    pub row_truncated: bool,
+}
+```
+
+**No `skip_serializing_if` on any field**, for the reason `ContextUsagePayload` documents in writing (`context_scrape/mod.rs:110-114`): absent must never become a third state beside null and the value. `session_id` is repeated on each match so a frontend row is self-contained once inserted.
+
+**Delivery is directed, not broadcast.** `app.emit` reaches every window, so at 50 saturated sessions an uncoalesced per-match event would deliver on the order of 16 000 payloads per second to four windows, and every detached terminal would pay to deserialize events it discards. The sink therefore:
+
+1. Emits **one** `watcher_matches` per `(session, tick)` that produced at least one match.
+2. Delivers it with `emit_to` (already used at `testability/ui_automation.rs:631`) targeting the `watchers` window label.
+3. **Emits nothing at all when that window does not exist.** The ring buffer still records, so opening the window later shows the history. The window is closed most of the time, and this makes that case free.
+
+The sink, not the engine, holds the `AppHandle` and performs the window check, exactly as `ScraperSink` does (`lib.rs:610-618`), so the engine's capability boundary is untouched. Adding a second consumer later means adding its label or falling back to broadcast, which is a one-line change in the sink.
+
+TypeScript mirror in `src/shared/types.ts`, next to `SessionContextPayload` (`types.ts:122-125`):
+
+```ts
+export type WatcherMode = "state" | "occurrence";
+
+export interface WatcherMatchPayload {
+  sessionId: string;
+  seq: number;
+  watcherId: string;
+  mode: WatcherMode;
+  at: string;                    // RFC3339 UTC
+  captures: (string | null)[];
+  row: string;
+  rowTruncated: boolean;
+}
+
+export interface WatcherMatchBatch {
+  sessionId: string;
+  matches: WatcherMatchPayload[];
+}
+```
+
+Listeners in `src/shared/ipc.ts`, the mould of `onSessionContext` (`ipc.ts:668-672`):
+
+```ts
+export function onWatcherMatches(
+  callback: (data: WatcherMatchBatch) => void
+): Promise<UnlistenFn> {
+  return transport.listen<WatcherMatchBatch>("watcher_matches", callback);
+}
+
+export function onWatchersScopeRequest(
+  callback: (data: { sessionId: string }) => void
+): Promise<UnlistenFn> {
+  return transport.listen<{ sessionId: string }>("watchers_scope_request", callback);
+}
+```
+
+**Command `get_watcher_activity`**, the mould of `get_session_context` (`commands/pty.rs:526-533`):
+
+```rust
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherActivitySnapshot {
+    /// Oldest first. `limit` trims from the NEW end: `Some(n)` returns the n most
+    /// recent, still ordered oldest to newest.
+    pub matches: Vec<WatcherMatchPayload>,
+    /// The highest `seq` ever inserted for this session. The merge fence for a
+    /// window that subscribed before it fetched.
+    pub last_seq: u64,
+    /// The ring dropped at least one entry since the session started.
+    pub truncated: bool,
+    /// Monotonic since the session started. NOT a count of lost matches.
+    pub possibly_missed_frames: u64,
+    /// False until the engine has ticked this session at least once. Without it
+    /// the window cannot tell "no watcher reaches this agent" from "the engine has
+    /// not run yet", and shows the "Configure watchers" empty state for the first
+    /// 200 ms of every session even when watchers are configured.
+    pub warmed_up: bool,
+    /// The watchers that reach this session's agent right now, with their count
+    /// since the session started. Present even when the count is 0.
+    pub active_watchers: Vec<WatcherActivityCounter>,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherActivityCounter {
+    pub watcher_id: String,
+    pub mode: WatcherMode,
+    pub count: u64,
+    /// True while this watcher is hitting a per-tick cap or is suspended (4.6).
+    pub degraded: bool,
+}
+
+#[tauri::command]
+pub fn get_watcher_activity(
+    app: AppHandle,
+    session_id: String,
+    limit: Option<usize>,
+) -> Result<WatcherActivitySnapshot, String>
+```
+
+- A `session_id` that does not parse as a UUID returns `Err`, like `get_session_context` (`commands/pty.rs:528`).
+- A session with no buffer returns an **empty snapshot**, not `None` and not an error: `{ "matches": [], "lastSeq": 0, "truncated": false, "possiblyMissedFrames": 0, "warmedUp": false, "activeWatchers": [] }`.
+- An absent `limit` returns everything in the ring, and never more than the cap. The window always passes an explicit limit (4.12), so the unbounded form exists for the CLI-shaped caller and not for the UI.
+- The command is **synchronous** and takes one per-session mutex. To make that possible the engine publishes `active_watchers`, `possibly_missed_frames` and `warmed_up` into the history structure at the end of each tick, rather than the command resolving settings and the session manager itself. `mode` rides on the counter so the empty state can say what it is waiting for without a second call.
+
+Wrapper in `src/shared/ipc.ts`, the mould of `getSessionContext` (`ipc.ts:240-241`):
+
+```ts
+getWatcherActivity: (sessionId: string, limit?: number) =>
+  transport.invoke<WatcherActivitySnapshot>("get_watcher_activity", { sessionId, limit }),
+```
+
+**Command `preview_watcher_pattern`**, for the Settings section:
+
+```rust
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherPatternPreview {
+    pub compiles: bool,
+    pub error: Option<String>,
+    /// False when no session was given, or the session had no readable frame.
+    /// Distinguishes "matched nothing" from "could not look".
+    pub sampled: bool,
+    pub matched_rows: usize,
+    pub total_rows: usize,
+    /// Up to 3 matched logical rows, each truncated to 256 bytes.
+    pub samples: Vec<String>,
+    /// True when the captures of the lowest match differed between the two samples
+    /// taken ~1s apart. A pattern that captures a clock or a token counter matches
+    /// one row of thirty and still emits five events per second in `state` mode;
+    /// `matchedRows` alone cannot say so.
+    pub captures_volatile: bool,
+}
+
+#[tauri::command]
+pub async fn preview_watcher_pattern(
+    app: AppHandle,
+    session_id: Option<String>,
+    pattern: String,
+) -> Result<WatcherPatternPreview, String>
+```
+
+- `session_id: None` compiles only and returns `sampled: false`, `matched_rows: 0`, `total_rows: 0`, `samples: []`, `captures_volatile: false`. This is the common case: a user opens Settings and writes a regex with no agent session running, and without it the only signal for a syntax error would be the absence of activations.
+- With a session id: two frames are read about 1 second apart to compute `captures_volatile`. Any read that is not a frame (`Missing`, `Gone`, or an unparseable id that still parses as a UUID but has no PTY) yields `sampled: false` with the compile result intact. A `session_id` that is not a UUID returns `Err`.
+- The command is `async` and performs the PTY reads inside `tokio::task::spawn_blocking`, because it takes the `PtyManager` and `ptys` mutexes and runs a child liveness probe (`local_backend.rs:1089-1109`) while a session may be producing heavy output. The Settings control debounces at 300 ms and never fires per keystroke.
+
+**Command `preview_watcher_reach`**, so the Settings UI reimplements neither stem normalization nor the budget rule, and never has to guess what the budget will be after Save:
+
+```rust
+/// One watcher row of the draft the Settings modal holds in memory. Only the three fields
+/// that `reaches` and the budget depend on (4.8); `pattern`, `mode`, `dedupe` and
+/// `capturedAgainst` take no part in either and are not sent.
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherDraftEntry {
+    pub id: String,
+    pub enabled: bool,
+    #[serde(default)]
+    pub commands: Option<Vec<String>>,
+}
+
+/// One agent row of the same draft. The modal edits agents and watchers in ONE store
+/// (`SettingsModal.tsx:989-1029`) and one Save writes both, so resolving against the saved
+/// agent list would answer about a state the user has already left.
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherAgentDraftEntry {
+    pub id: String,
+    pub label: String,
+    pub command: String,
+}
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherReachEntry {
+    pub agent_id: String,
+    pub agent_label: String,
+    pub command_stem: String,
+    /// Whether this row is enabled in the draft AND holds one of this agent's 8 slots once
+    /// every other ENABLED row of the draft is counted. It is the membership of the engine's
+    /// own `running` list, and NOT a promise that the watcher will produce anything: a
+    /// resolved watcher whose pattern does not compile is allocated a slot and is inert
+    /// (edge case 13). Compilability is a separate dimension, answered per row by
+    /// `preview_watcher_pattern`, and this field deliberately does not restate it. A
+    /// disabled row is always false here, and the editor, which owns `enabled`, must say
+    /// "disabled" rather than "budget" (4.12).
+    pub allocated: bool,
+}
+
+/// The reach of one draft row. Exactly one per requested row, in request order, and it
+/// carries `id` back, because the editor filters unrecognised rows out of the request and
+/// its table positions therefore do not match the response positions.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherReachRow {
+    pub id: String,
+    /// Every agent this row's SELECTOR reaches, whether or not the row is enabled. Reach is
+    /// a property of the selector alone; `allocated` is where enablement and budget land.
+    pub entries: Vec<WatcherReachEntry>,
+}
+
+#[tauri::command]
+pub async fn preview_watcher_reach(
+    watchers: Vec<WatcherDraftEntry>,
+    agents: Vec<WatcherAgentDraftEntry>,
+) -> Result<Vec<WatcherReachRow>, String>
+```
+
+**Why the whole draft and not one row.** Running is a property of the set (4.8): resolution iterates the `BTreeMap` in key order and takes the first 8 that reach the agent. A command that receives a single row can only answer it by inventing what the rest of the set is, and the only set available to it is the saved one, which is not the one the user is editing. With an empty saved map, adding nine rows before pressing Save makes all nine previews resolve `{}` plus themselves and report that they run, and then only eight do. That is a positive claim that a watcher will run, about a watcher that will not, and it is the opposite of the fail-closed direction section 6 pins everywhere else.
+
+Narrowing the claim to "as currently saved" does **not** rescue the row-level form. The command substitutes the edited row before resolving, so it already speaks about the state after Save; making it honest would mean suppressing the indicator whenever the draft differs from the saved map, which is exactly when it exists to be read. Computing the budget in TypeScript from per-row reach sets does not rescue it either: it duplicates the key order and the number 8 in a second language, `Array.prototype.sort` compares UTF-16 code units while `Ord for String` compares UTF-8 bytes (they agree for ids matching the id pattern and can disagree for a hand-written `settings.json`), and it needs the same lift of reach state out of the row component that the draft-shaped command needs, so it buys nothing.
+
+**Why the agents travel too.** The same store holds both: `updateAgent` writes `settings.data.agents` and `mutateWatchers` writes `settings.data.watchers` (`SettingsModal.tsx:986-1030`), and one Save writes both. Resolving against the saved agent list therefore answers about a state the user has already left, and two of the three agent edits **over-report**: deleting an agent leaves it named in a reach list it will not be in, and changing an agent's `command` leaves a watcher reported as reaching it under the old stem. Only adding an agent under-reports. Carrying `(id, label, command)` per agent is a few short strings on a debounced call, it makes the preview a pure function of the draft, and it removes the last question the UI would otherwise have to answer about which unsaved edits the indicator reflects.
+
+Seven points of fixed semantics, so nothing is left to decide at implementation time:
+
+1. **Both halves come from the draft and nothing comes from disk.** The command reads no settings at all: it builds a `BTreeMap<String, WatcherEntry>` from `watchers`, a `Vec<WatcherAgent>` from `agents`, and hands them to the existing `resolve_watchers`. No second resolution rule is written, and **no settings lock is taken**, so a preview can never contend with a save.
+2. **`WatcherEntry::Invalid` rows are not sent.** Resolution skips them before any budget is counted (6, edge case 14), so they consume no slot, and sending them would only produce notices. The editor keeps them verbatim for the save (4.12) and leaves them out of the request. This is only sound if the editor's validity predicate is the exact mirror of the Rust decoder; that requirement is fixed in 4.12 and is not optional, because a row the editor thinks is valid and Rust does not would be counted here and skipped by the engine, which is the same false-positive class this whole revision exists to remove.
+3. **Reach and allocation are two different questions, answered by two passes, and neither is a counterfactual budget.**
+   - **Pass A, every row forced enabled:** the reach relation. A row reaches an agent when it appears in that agent's `running` or `over_budget` list, which together hold everything whose selector matches. This pass supplies `entries` and nothing else. Reach does not depend on any other row, so forcing enablement here changes no row's answer but its own presence.
+   - **Pass B, every row at its real draft `enabled`:** the engine's own resolution. `allocated` is true when the row is in that agent's `running` list.
+
+   A disabled row therefore still shows the agents its selector reaches, which is the state where the control is needed most, and it reports `allocated: false` everywhere, which is true. **No counterfactual budget is computed and none is reported.** Revision 3's first form ran one forced-enabled pass per row and could report nine rows as running with only eight slots, because each row's pass silently displaced a different one; two passes over one draft cannot produce a set of answers that disagree with each other.
+
+   **`allocated` is slot assignment, not a guarantee of output.** The pattern does not travel, because it takes no part in either pass, and a resolved watcher whose pattern fails to compile is inert while still holding its slot (edge case 13). The field is named for what the two passes can actually establish. Carrying the pattern so the command could also report compilability was rejected: `preview_watcher_pattern` already answers exactly that, per row and with the error text, so the second dimension is already on screen next to the first, and duplicating it here would inflate every debounced payload with pattern text for an answer the row already has. Enabling and saving a watcher whose regex does not compile stays possible and stays inert-plus-logged, which is what edge case 13 already fixes.
+4. **What this deliberately does not forecast:** enabling a disabled row can push an enabled one out of budget, and no row's answer says so in advance. Nothing false is stated, and the moment the user enables the row the call re-fires and the displaced row shows its budget badge. A `displacedWatcherIds` field was considered and left out: it adds a concept to forecast a state that becomes visible and correct one click later.
+5. **Cost, stated in the right variable.** `resolve_watchers` tokenizes every selector entry once and then, for every agent, scans the stems of every usable watcher (`mod.rs:197`, `:253`, `:267`). The cost of one pass is therefore **O(A x S)**, where A is the number of agents and **S is the total number of selector entries in the payload**, not the number of rows: one row carrying ten thousand selector entries costs what ten thousand rows carrying one each cost. The call runs two passes.
+
+   The defense is not that S is small, because nothing bounds it. It is that **the engine already runs exactly this resolution over exactly this data every 200 ms** (4.8, resolution cadence), so a payload large enough to make the preview expensive is already costing five times as much per second inside the tick, and the bound that would matter belongs there and not here. Two debounced passes cannot be the worse offender. Revision 3's first form claimed "a few milliseconds, nothing to protect"; that priced only the case of one short selector per row and is withdrawn. The residual is debt item 12.
+
+   No global cap on the number of watchers or selector entries is introduced, for the reason above. The computation is moved off the async worker into `tokio::task::spawn_blocking`, following `preview_watcher_pattern` (4.9), because it is synchronous CPU over an input the caller controls and an `async fn` would otherwise hold a Tokio worker for its duration. The command owns its inputs and takes no lock, so the move is a wrapper and nothing else.
+6. **Duplicate ids in the draft:** the later row wins when the `BTreeMap` is built, and both response rows report that one resolution. **An empty id** is a legal key that sorts first and is not special-cased. Neither is reachable from the editor, whose map is keyed by id and whose renames are validated (4.12); the rule exists so the command has defined behavior, not because the UI can produce it.
+7. **Order:** exactly one response row per requested row, in request order. Within a row, `entries` keeps the order revision 2 fixed, by `agentLabel` with `agentId` as tie-break, so the list does not reshuffle between keystrokes. A row whose selector does not tokenize, or whose `commands` is `[]`, is still present, with `entries: []`.
+
+The command takes neither an `AppHandle` nor `State<SettingsState>`: revision 2's `app: AppHandle` asked for a capability it never used, and after point 1 there is nothing left to read. `WatcherDraftEntry`, `WatcherAgentDraftEntry`, `WatcherReachEntry` and `WatcherReachRow` mirror into `src/shared/types.ts`, and the `src/shared/ipc.ts` wrapper takes both halves:
+
+```ts
+previewWatcherReach: (
+  watchers: WatcherDraftEntry[],
+  agents: WatcherAgentDraftEntry[]
+) => transport.invoke<WatcherReachRow[]>("preview_watcher_reach", { watchers, agents }),
+```
+
+**Commands `open_watchers_window(app, session_id: String)`** (mould: `open_resource_monitor_window`, `commands/window.rs:686-762`), **`get_watchers_scope(scope) -> Result<Option<String>, String>`** (4.12, the durable half of the scope handover) **and `set_watchers_geometry(settings, geometry)`** (mould: `set_detached_geometry`, `commands/window.rs:528-538`).
+
+All commands are registered in the `tauri::generate_handler!` list at `lib.rs:2251`. `open_watchers_window` and `get_watchers_scope` are **not** added to the web no-op list; see 4.12.
+
+### 4.10 The history buffer and its lifetime
+
+```rust
+/// pty/watchers/history.rs. Mould: `SessionWarningBuffer` (`session/warnings.rs:39-51`).
+pub struct WatcherHistory {
+    /// Outer lock guards the map only and is released before any read of a session's
+    /// entry, so a snapshot never blocks the engine's writes to other sessions.
+    sessions: Mutex<HashMap<Uuid, Arc<Mutex<SessionHistory>>>>,
+}
+pub type WatcherHistoryState = Arc<WatcherHistory>;
+```
+
+Three deliberate differences from the precedent, plus one from revision 1:
+
+- **`VecDeque` with `pop_front`, not `Vec` with `remove(0)`.** `SessionWarningBuffer` uses the latter (`warnings.rs:48`), O(n) per insert. At its cap of 32 that is irrelevant; at 500 under a burst it is not.
+- **`snapshot(limit)`, not `drain`.** `SessionWarningBuffer::drain` consumes (`warnings.rs:53-63`), which would mean closing and reopening the window shows nothing.
+- **Cap: 500 entries per session**, hard, oldest dropped, setting `truncated` on the first drop. With `row` capped at 256 bytes the worst-case element is about 500 to 550 bytes, so 20 sessions is about 3.5 MB typical and about 5.5 MB ceiling.
+- **Per-session locks, not one global mutex.** The engine takes this structure up to 250 times per second at 50 sessions; a single mutex would serialize every snapshot against every write.
+
+Not persisted. The window never claims history across restarts.
+
+**Lifetime.**
+
+- **Created** on the session's first tick, and **only for a session the engine currently has registered**. Lazy creation without that condition would let a tick recreate the entry of a session that was purged moments earlier.
+- **Purged** through a single new helper:
+
+```rust
+/// commands/session.rs. One helper, two call sites, because the per-session
+/// side-state purge is already duplicated in this file.
+pub(crate) fn purge_session_side_state<R: tauri::Runtime>(app: &AppHandle<R>, session_id: Uuid) {
+    // 1. retire from the watcher engine FIRST, so no in-flight tick can republish
+    //    `active_watchers` and recreate the entry that step 2 removes.
+    // 2. purge WatcherHistory.
+    // 3. reset SubstantiveInputState (moved here from its two existing copies).
+}
+```
+
+  Called from **both** post-commit loops:
+
+  - `execute_destroy_transaction`, in a **new loop over `outcome.destroyed_ids` only**, placed after the existing loop at `session.rs:3181-3208`. Not inside that loop with a `contains` check: it iterates `destroyed_ids.chain(retained_exited_ids)`, so a membership test would be O(n squared) and, worse, would express a business rule as a condition inside a loop that does something else. A separate loop makes "destroyed only" structural, which is the same argument section 4.6 uses for where the caps live.
+  - `publish_restart_destroyed` (`session.rs:3758-3782`), replacing its inline `SubstantiveInputState` reset at `:3773-3781`. This covers both restart paths, `execute_restart_transaction` (`session.rs:4026`, published at `:4064`) and `finalize_failed_restart` (`:3792`, published at `:3807`).
+
+  Revision 1 claimed `execute_destroy_transaction` was the only production exit from `SessionManager`. That was **false**: there are three (2.4), and the precedent it cited was one of two parallel copies. A session restart is a normal flow, reachable from the invoke handler, the mailbox and a bulk settings save, and without this helper every restart would orphan up to 500 entries, roughly 275 KB, unreachable from the UI because the old id is gone from the session list.
+
+- **Purge only for `outcome.destroyed_ids`, never for `outcome.retained_exited_ids`.** The latter are root-agent sessions that stay in the manager marked `Exited` (`session.rs:3096-3102`); their row is still in the list, so their post-mortem view still has a place to be shown.
+- **A session that exits on its own is not destroyed.** The engine retires it from sampling on the next liveness probe, or immediately on `Gone`, and the buffer stays. This is the case that matters: an API error or a CLI crash is exactly when the evidence is worth keeping.
+- **Spawn rollback needs nothing.** `rollback_pre_created_session` returns before the registration site (`commands/session.rs:2254-2258` against `:2268`), and `rollback_pending_create` (`session/manager.rs:1416-1434`) only removes sessions that never reached that point.
+- **`SessionManager::destroy_session` needs no purge call**, being test-only (2.4).
+
+The registration comment at `commands/session.rs:2266-2267` ("the first sample is 5s away") must be updated when the engine registration is added beside the scraper's: the first watcher tick is 200 ms away. There is still no race, because `PtyManager::spawn` has already returned `Ok` at `:2252` and the parser is registered during the spawn, but the comment must not be left asserting something false next to new code.
+
+### 4.11 `chrono::DateTime<Utc>`, resolved
+
+`Cargo.toml:18` declares `chrono = { version = "0.4", features = ["serde"] }` for the single crate `agentscommander_lib`, of which `src/pty/` is part. `chrono::Utc::now()` is already called from `src-tauri/src/pty/output.rs:501`. `DateTime<Utc>` in a `#[derive(Serialize)]` struct works with the already-enabled `serde` feature and produces RFC3339, the convention `resource_monitor/types.rs:158-160` follows into `types.ts`. **No new dependency and no new feature flag.**
+
+### 4.12 Frontend
+
+**Button.** In the terminal StatusBar's `.status-bar-actions` (`src/terminal/components/StatusBar.tsx:100`), inside `<Show when={terminalStore.activeSessionId}>` (`:99`), next to the mic (`:110-125`) and clear-input (`:126-132`) buttons. Not in `.workgroup-task-actions`, because the TASK panel renders inside `<Show when={!terminalStore.activeIsRootAgent}>` (`src/terminal/App.tsx:401`) while `<StatusBar />` sits outside it at `:422`, so on root-agent sessions the TASK bar does not exist. Glyph `&#x1F4E1;`, title "Watcher activity", plus a `data-ac-testid`. It reuses the existing `.status-bar-btn` class (`terminal.css:631-660`) and adds **no new CSS**: it has no state of its own.
+
+**The button renders only under `isTauri`** (`src/shared/platform.ts:3-4`). `src/browser/App.tsx:2` renders the same `TerminalApp` in the web client, where `open_watchers_window` would fall into the catch-all `_ => Err(...)` of `web/commands.rs:702`, and where `src/main.tsx` never routes `window=watchers` anyway. A button that returns a raw error is worse than an absent button, so `web/commands.rs` is left untouched.
+
+**Window.** A singleton Tauri window, label `watchers`, URL `index.html?window=watchers&sessionId=<uuid>`, `decorations(false)`, `zoom_hotkeys_enabled(false)`, focus-if-exists. Routed in `src/main.tsx` next to the `resource-monitor` branch (`main.tsx:44-45`), rendering a new `src/watchers/App.tsx`. Its own HTML titlebar, mould `src/spec-board/components/SpecBoardTitlebar.tsx`.
+
+**Re-open with a different scope, and why an event alone cannot carry it.** If the window already exists, `open_watchers_window` focuses it and emits `watchers_scope_request { sessionId }`; the window listens through `onWatchersScopeRequest` and switches scope, leaving its filters as they are.
+
+That is not sufficient on its own. The window label exists the moment `WebviewWindowBuilder::build` returns, while the JavaScript listener exists only after the bundle loads, Solid mounts and `onWatchersScopeRequest` completes an IPC round trip. Tauri does not queue events for listeners that do not exist yet, and `emit_to` returns `Ok` either way, so the backend cannot even observe the loss. The lifecycle has **three** states, absent, created but not yet listening, and listening, and a contract that branches only on "the window exists" has no answer for the middle one: a second `open` during the load focuses a window that is not listening, emits, and the user's order is dropped in silence.
+
+The fix is the shape this plan already uses for matches, subscribe first and then reconcile with a pull, applied to the scope:
+
+1. A managed `WatchersScopeState(Mutex<Option<Uuid>>)` holds **the most recently requested scope**.
+2. `open_watchers_window` writes that state **before** anything else, then creates the window, or focuses it and emits, as above. **The whole command from the state write through both branches is one critical section**; see point 6.
+3. `get_watchers_scope()` (4.9) returns that value.
+4. The window, in `onMount`, **after** `onWatchersScopeRequest` is registered, calls `get_watchers_scope()` and adopts what it returns **unless** a `watchers_scope_request` has been handled since the call was issued. That guard is the same generation idiom `lastSeq` and the two Settings previews already use.
+5. **The query parameter stays and becomes the initial value**, so the first paint has a scope without waiting for a round trip. The pull is the authoritative one and overrides it. The parameter is still read only on first creation, since the window is a singleton and its URL does not change afterwards.
+6. **One `tokio::Mutex`, acquired after the UUID is validated and held across the state write, the existence check, and whichever branch runs, including the emit.** Not two regions. Splitting it leaves this interleaving: A writes scope A and pauses; B writes scope B, takes the build guard and creates the window with B in its URL; A then takes the guard, finds a window, and emits A. The authoritative state says B while the last event says A, so a window that is already listening lands on A and disagrees with `get_watchers_scope`. Holding one guard across the whole body makes the last write and the last emit the same call by construction. The mutex is private to this command, so it cannot deadlock against anything else, and it is contended only by a second open.
+
+Why this is durable, which is the only question that matters: the command is linearizable, the state is written before every emit and read after the subscribe, so no interleaving loses an order. An emit that raced the subscribe is recovered by the pull; an emit after the pull reaches a listener that exists; a pull whose response arrives after a newer event is discarded by the guard.
+
+**The window needs a second guard, on content, and it is not the same one.** The pull guard decides *which scope is adopted*. It says nothing about *which rows are painted*: `refresh()` captures its session ids, awaits, and then writes snapshots and rows unconditionally, and its callers do not serialize against each other. A refresh for A still in flight when the window moves to B returns last and repaints A while the selector reads B. Three rules, and they are deliberately stated over `scopeIds()` and over requests rather than over a list of callers, because every enumeration of callers so far has been short by one:
+
+- **One monotonic request counter. Every `refresh()` takes the next value on entry and commits only if it is still the highest one issued.** That covers the scope selector, the `watchers_scope_request` listener, the adoption of the pull, the mount's initial fetch and the poll, and it also covers two refreshes of the **same** scope racing each other, which a scope-keyed generation would let through: the older poll response would otherwise commit an older `lastSeq`, `warmedUp`, `degraded` and counters over the newer ones and leave the table and the counters describing two different instants.
+- **Any change of `scopeIds()` invalidates and refetches**, not any change of the selected session. In "All sessions" the scope is a set derived from the session list, and the three session listeners rewrite that list without touching the selection: creating or destroying an agent session changes what the window should show. Without this, an in-flight refresh commits with the old ids and drops the new session's streamed rows, and the new session is not queried until the next poll, up to 15 seconds later with an incomplete table and nothing saying so. Stated this way the rule is also shorter than the enumeration it replaces, because the selector, the event and the pull all change `scopeIds()` by definition, while reloading the session list under a single-session scope does not and correctly changes nothing.
+- **A scope change drops the content it invalidates, synchronously.** Snapshots are cleared and rows outside the current ids are dropped before the new selector is painted. Without this the selector changes immediately while the previous session's rows stay on screen for the whole round trip, and stay forever if the new fetch fails. "A correct selector over stale rows" is the failure this whole guard exists to prevent, and a commit-time check alone does not prevent it, because nothing has to commit for it to happen.
+
+There is **no startup carve-out**. An earlier form had the listener set scope without fetching during mount, so that an event arriving before the first fetch would not start a competing round; that left a hole where an event arriving *during* the first fetch got the old fetch discarded and no fetch of its own, and the window sat correctly scoped and empty until the poll. With one counter the competing round is harmless, the older result is discarded on arrival, and one uniform rule replaces a rule plus an exception.
+
+Two alternatives were considered and rejected, recorded so they are not rediscovered. `WebviewWindowBuilder::on_page_load(Finished)` needs no new IPC but fires before the listener registration completes, so it narrows the race rather than closing it, and a narrower race is not the standard this plan holds itself to. Treating the window's first `get_watcher_activity` call as an implicit readiness signal would also need no new IPC, but it would couple a command's meaning to a frontend ordering detail that nothing enforces.
+
+**Geometry.** `watchers_geometry` on `AppSettings`, written through the dedicated `set_watchers_geometry` command and **not** through `initWindowGeometry`. Reason: `initWindowGeometry` (`src/shared/window-geometry.ts:26-47`) performs a debounced read-modify-write of the whole `AppSettings`, a race the repository already documents (`commands/config.rs:653-655`) and defends against with an explicit list of live-memory-restored fields (`config.rs:611-624`, `:647-655`). Adding `watchers` to that list would make it six fields and would leave the window as a whole-object writer; a dedicated command follows `set_detached_geometry` (`window.rs:528-538`) and touches one field. `src/shared/window-geometry.ts` is therefore **not** modified.
+
+**Layout.** Titlebar, filter bar, scrolling table, fixed footer.
+
+Columns, newest first:
+
+1. **Time**, `at` formatted `HH:MM:SS`. `formatTimestamp` (`src/resource-monitor/App.tsx:62-71`) cannot be reused: it is a module-local `const`, not exported, and returns `toLocaleTimeString(...)`, which is `02:31:05 PM` under en-US. A new `src/shared/time-format.ts` exports `formatClockTime(value: string | null | undefined): string` producing zero-padded 24-hour `HH:MM:SS`. The Resource Monitor is **not** refactored onto it.
+2. **Watcher**, a chip carrying the watcher id, colour derived deterministically from the id, **plus a mode marker**. Rows from the two modes are otherwise visually identical, and the word "state" invites reading the last such row as the current state. The window's help text states that a state row records when a condition was **first seen**, not that it still holds.
+3. **Session**, two lines, visible only in "All sessions" scope: `session.name` on top, `agent label · workgroup` below in muted text.
+4. **Captures**, `captures[0]` in a monospace cell with **left-side ellipsis**, so a path's tail stays visible. Remaining groups as secondary chips. A per-row copy button.
+5. **Raw `row`** is **not** a column. Clicking a row expands it below, monospace, `white-space: pre-wrap` with `word-break: break-word`, following the real behavior of `.workgroup-task-text` (`terminal.css:227-236`). Revision 1 prescribed `pre` plus `overflow-x: auto` while citing that rule as precedent, which it is not; a nested horizontal scroller inside a vertically scrolling table is also worse for a 256-byte row.
+
+Scrolling: its own `overflow-y: auto`, auto-scroll only while the user is pinned at the top.
+
+Solid's `<For>` keys rows on `(sessionId, seq)`.
+
+**Scope against filters**, two zones in one bar:
+
+- **Scope**, deciding what is fetched: a session selector plus an "All sessions" toggle.
+- **Filters**, deciding what is shown: chips for `Watcher`, `Agent` and `Workgroup`, plus free text over `captures`. `Set<string>` per dimension, AND between dimensions, OR within one, and a "Clear filters" control, reusing the Resource Monitor's shape (`src/resource-monitor/App.tsx:374-406`, `:606-744`) and its CSS classes.
+
+With scope set to one session, `Agent` and `Workgroup` have one possible value each and are **not rendered**, the gesture `<Show when={workgroupOptions().length > 0}>` already uses (`App.tsx:669`). They appear on "All sessions".
+
+The scope does **not** follow the active session. Filters are **not** persisted between openings, following the Resource Monitor's plain `createSignal`s (`App.tsx:364-369`).
+
+**Fetching and staying correct.**
+
+- On mount and on every scope change: subscribe to `watcher_matches` **first**, buffer arrivals, then call `get_watcher_activity` per session in scope, then merge on `(sessionId, seq)` discarding anything at or below the snapshot's `lastSeq` that is already present. This is only possible because `seq` exists; with `at` alone, two matches from one tick are indistinguishable and edge case 39 requires that they be distinct.
+- **On mount the scope is settled before the first fetch.** The order is: subscribe to `watcher_matches`, subscribe to `watchers_scope_request`, `get_watchers_scope()`, adopt it unless the scope adoption guard says a newer event already arrived, and only then fetch. Fetching before the scope is settled would issue a round of calls for a session the window is about to leave.
+- **Every fetch, including the mount's, takes the request counter and commits only if it is still the highest issued** (see the re-scope block above). Without it the window can show the selector on one session and the table on another, which is worse than showing neither.
+- **The two guards are separate and must not be merged.** The **scope adoption guard** decides whether the pulled scope is adopted; the **request counter** decides whether a fetch may paint. They protect different things and each leaves the other's failure open.
+- Explicit limits: **500** per session in single-session scope, **100** per session in "All sessions" scope. Fifty sessions at the full ring would be 25 000 payloads on first paint.
+- **Snapshot polling**, because `truncated`, `possiblyMissedFrames`, `warmedUp`, `activeWatchers` and `degraded` exist only in the snapshot and there is no cross-window settings event to hang a refresh on (2.5). Cadence copies the Resource Monitor's written precedent (`ActionBar.tsx:81-87`): **10 s** while the window is focused, **15 s** while it is not. In "All sessions" that is N calls per period, which at 20 sessions is 2 calls per second against a per-session mutex. The number is written here rather than discovered later.
+- The poll also refreshes `settingsStore` so a watcher saved from the modal turns empty state 1 into empty state 2 without the user reopening the window.
+- The window calls `settingsStore.load()` on mount: `src/shared/stores/settings.ts` does not autoload, and the store is needed for the live agent-label fallback.
+- The window subscribes to `onSessionCreated` (`src/shared/ipc.ts:355`), `onSessionDestroyed` (`:367`) and `onSessionRenamed` (`:404`), each released in `onCleanup`. Without them a session created while the window is open never enters the scope selector and its matches arrive unlabelled.
+
+**Agent and workgroup resolution, entirely in the frontend:**
+
+- Session list from `SessionAPI.list()` (`src/shared/ipc.ts:199`), maintained by the three listeners above.
+- Agent from `session.agentId` and `session.agentLabel` (`src/shared/types.ts:36-37`), falling back to `agents.find(a => a.id === session.agentId)?.label`, the precedent being `liveAgentLabel` (`src/sidebar/components/ProjectPanel.tsx:903-908`). **Filter key is `agentId`, chip text is `label`**; on a duplicate label the chip appends a short id suffix.
+- Workgroup from `extractWorkgroupName(session.workingDirectory)` (`src/shared/path-extractors.ts:20-26`), **not** from `session.name`: the backend derives the pair from the spawn cwd and says so in writing (`commands/session.rs:2093-2098`).
+- Both are **frozen into the row when it is inserted**, so rows survive their session's death with the right label; the displayed label re-renders live from the settings store by `agentId`, with the frozen value as fallback.
+
+The `Agent` chip is named `Agent` because it is a `settings.agents` entry. A future filter by workgroup replica must be called `Role`, which is what the Resource Monitor calls that concept (`App.tsx:377`, `:390`).
+
+**Empty states, three of them, distinguished without nullability:**
+
+1. `warmedUp && activeWatchers.length === 0`: no configured watcher reaches this session's agent. Message plus a **"Configure watchers"** button. This is what everybody sees on day one.
+2. `activeWatchers` non-empty, all counts 0, `matches` empty: configured and waiting. The active watchers are listed with their `mode` and their zero counters.
+3. `matches` non-empty: the table. If `truncated`, a one-line banner: *"Older activations were dropped (buffer limit)"*.
+
+While `warmedUp` is false the window shows a neutral starting state, never state 1.
+
+`possiblyMissedFrames` above zero gets a **separate and weaker** line: *"Some screen output was not sampled"*. It must not be merged with `truncated`: one is exact knowledge that something was lost, the other is uncertainty about whether anything was.
+
+**Footer, always visible, never a tooltip:** *"Best-effort. Activations can be missed. This is not an audit log."*
+
+**The "Configure watchers" button** calls `WindowAPI.focusMain()` (`src/shared/ipc.ts:474`) and then `emitOpenSettings("watchers")`. Focusing first is required: `SettingsModal` is mounted only in the sidebar (`ActionBar.tsx:388`), so with the watchers window in front the modal would open behind it and nothing visible would happen.
+
+**Settings section.** A new "Watchers" tab in `src/sidebar/components/SettingsModal.tsx`, which needs three edits and not two:
+
+1. `"watchers"` added to the `SettingsTab` union (`:96`).
+2. An entry in `TABS` (`:98-103`).
+3. **A branch in `resolveSettingsSection` (`:105-110`).** Without it the resolver falls back silently to `"general"`, and the day-one gesture of empty state 1 would open Settings on the wrong tab with no error and no log. The one existing precedent for an auxiliary window requesting its own section is broken for exactly this reason (2.5), so it must not be copied.
+
+The section edits the root map as a list of rows: id, enabled, mode, pattern, commands, dedupe, dedupe window, captured-against. Specifics that are decisions, not implementation detail:
+
+- **`commands` is edited through a two-state control, `All agents` or `Selected`.** A plain multiselect left empty produces `[]`, which is the exact opposite of absent. `All agents` writes `null`; `Selected` writes the list, and an empty list in `Selected` is a valid state meaning "nobody", shown as "reaches 0 agents".
+- The options offered under `Selected` are the distinct **command stems**, not agent entries: five `claude` entries are one option. A free-text entry is allowed for a stem no agent currently has, which 4.8 defines as a non-error.
+- Reach and budget come from `preview_watcher_reach`, **which receives the whole draft, watchers and agents**, so both the stem rule and the budget rule stay in Rust and the indicator answers what will happen when the user presses Save rather than what is true of the file on disk.
+- **The two fields are worded differently, because they answer different questions.** `entries` is what the row's selector reaches; `allocated` is whether the row holds a slot on that agent after Save.
+  - Enabled row: "Reaches N agents", and for each entry with `allocated: false`, "not running on <agent> (budget)". An enabled row that reaches an agent and holds no slot can only be out of budget, so the badge names the one real reason.
+  - Disabled row **with a pattern**: "Would reach N agents when enabled", and **no budget badge at all**. A disabled row holds no slot because it is disabled, and presenting that as a budget outcome would name the wrong cause. Present-tense "reaches" on a disabled row is a false statement about a watcher that is doing nothing, which is the over-reporting direction section 6 forbids.
+  - Disabled row **with an empty pattern**: "Would reach N agents when enabled. Add a pattern to enable it." This is the state every user sees the instant they press Add Watcher, and the previous sentence alone offers a condition the editor refuses to let them meet. Naming the missing condition first and keeping the reach after it is the choice, rather than hiding the reach until a pattern exists: configuring the selector before the pattern is a legitimate order of work, and it is the reason the reach of a disabled row is reported at all.
+- **The reach state lives on the section, not on the row.** One debounced call at 300 ms carrying every valid row plus the draft agents; each row renders its own `entries`, indexed by `id`, because the request omits unrecognised rows and response positions therefore do not match table positions.
+- **One rule keeps that call honest, and it is keyed on the request, not on the draft.** The section computes the **fingerprint of the request it would send**, that is the serialized watcher rows plus agent rows, and:
+  - The displayed answer belongs to exactly one fingerprint. While the current fingerprint equals the displayed one, nothing is cleared and no call is made.
+  - When the current fingerprint differs from the displayed one, the displayed answer is cleared **synchronously** and a call is issued, unless a call for that same fingerprint is already in flight, in which case its answer is awaited. An answer is rendered only if its fingerprint is still the current one when it resolves. A rejected call renders an error, not the previous answer.
+
+  Keying on the request rather than on "any change to the draft" is what makes the rule consistent with itself. An earlier form paired an idempotence guard ("skip the call when the serialized request is unchanged") with a clear-on-any-change rule, and those two contradict: a `pattern` keystroke changes the draft but not the request, so the answer would be cleared and no call would ever replace it, leaving the row pending forever. Under the fingerprint rule a `pattern` keystroke changes nothing at all, which is the correct behavior, and a draft that returns to a shape it already had is re-requested rather than restored from a cache, because a cache would add an invalidation question to save one debounced call on an uncommon path.
+
+  Clearing synchronously matters because a commit-time guard stops a stale answer from being **written**, not from being **read**: on its own it leaves the old answer on screen for the debounce plus the round trip, and a user who presses Save in that gap decides against an indicator belonging to a draft that no longer exists. Save is **not** blocked while pending: the requirement is that the indicator never states something false, not that the user waits for it.
+- The **id** is user-written and validated against `^[a-z0-9][a-z0-9-]{0,39}$`. The rename control states that renaming is delete plus create and that existing history keeps the old id.
+- **A new row is born `enabled: false`, and the editor refuses to enable a row whose `pattern` is empty.** An empty pattern is a valid regex that matches every row, so a row born enabled turns Add plus an accidental Save into a watcher that matches everything on every agent, fills the caps, turns the ring over, goes degraded and can displace a useful watcher out of an agent's budget, all without the user having written a pattern or looked at the preview. This is a decision, not a preference: the birth state of a row is the same altitude as the two-state selector control and the id rule, and leaving it to implementation leaves it with no requirement and no test. The serde default for a **hand-written** file stays `default_true` (4.8), because an omitted `enabled` in a file someone wrote deliberately means on; only the editor's new-row shape changes. The Rust pattern compiler is **not** changed to reject an empty pattern: it is a legal regex, a hand-written one is bounded by the caps and the suspension rule (4.6), and the editor is where the user is.
+- **The editor's validity predicate accepts nothing the Rust decoder would reject, and the editor cannot produce a value the decoder would reject.** Today's predicate accepts any array as `commands` and any `number` as `dedupeWindowMs`, while Rust requires `Vec<String>` and `u64`, so `commands: [1]` or a typed `dedupeWindowMs: -1` is editable in the UI and `WatcherEntry::Invalid` in Rust. That gap is not cosmetic here: such a row would be sent as valid to `preview_watcher_reach`, counted against the budget, possibly push a real watcher out of it, and then be skipped by the engine after Save.
+
+  The requirement is one-directional and that direction is the point. It is **not** "the exact mirror of the decoder": the decoder accepts several fields absent, through `#[serde(default)]` on `enabled`, `dedupe`, `dedupe_window_ms`, `commands` and `captured_against`, while the predicate requires the first three present. Being stricter than the decoder is safe, because the worst it does is leave a row out of the request, which under-reports budget; and it is unreachable in practice, because the frontend never sees the file's bytes but what Rust re-serialized, and those three fields carry no `skip_serializing_if` and are therefore always written. Relaxing the predicate to accept absences that cannot arrive would weaken it for nothing. **The predicate mirrors what the serializer emits, and rejects everything the decoder would reject.**
+
+  Concretely: `commands` is absent, null, or an array **every element of which is a string**; `dedupeWindowMs` is a number that is a **non-negative safe integer**, that is `Number.isSafeInteger(n) && n >= 0`. `typeof n === "number" && n >= 0` is not sufficient and is the naive correction this rule exists to exclude: it still admits `1.5` and `1e30`, both of which serde rejects, so both would travel and consume a slot. Safe-integer is deliberately **narrower** than `u64`: JavaScript cannot represent every `u64` exactly, so a hand-written value above 2^53 is classified as unrecognised rather than silently rounded. Such a row still runs in the engine, clamped by 4.5, and the editor lists it as unrecognised instead of offering to edit a number it cannot hold.
+
+  A row that fails the predicate is treated exactly like any other unrecognised entry: preserved verbatim, not offered for editing, not sent.
+- **"Test against current session"** uses a session selector populated with sessions that have an `agentId`, preselecting `sessionsStore.activeId` (`src/sidebar/stores/sessions.ts:294-296`) when it qualifies, and allowing "no session" which exercises the compile-only path. Debounced at 300 ms.
+
+Hand-editing `settings.json` stays valid because it is the same file.
+
+---
+
+## 5. Affected surfaces, exact files and symbols
+
+### 5.1 New files
+
+| path | contents |
+|---|---|
+| `src-tauri/src/pty/watchers/mod.rs` | `WatcherEngine`, `FrameStamp`, `ScreenFrame`, `ScreenRowsSince`, `WatcherMatchPayload`, `WatcherMatchBatch`, `WatcherMode`, narrow sink traits, `start`, `tick`, `register_session`, `retire_session`, caps and suspension |
+| `src-tauri/src/pty/watchers/pattern.rs` | `WatcherPattern`, `compile` (size limit kept, group-1 requirement dropped) |
+| `src-tauri/src/pty/watchers/frame.rs` | hashing, `best_shift`, `shift_dirty`, logical-row joining, dirty and stabilization rules, `possibly_missed_frames` |
+| `src-tauri/src/pty/watchers/dedupe.rs` | key suppression with TTL, bounds and pruning |
+| `src-tauri/src/pty/watchers/history.rs` | `WatcherHistory`, `SessionHistory`, `WatcherActivitySnapshot`, `WatcherActivityCounter` |
+| `src/shared/time-format.ts` | `formatClockTime` |
+| `src/watchers/App.tsx` | the window root |
+| `src/watchers/components/*.tsx` | titlebar, filter bar, table, expandable raw row, empty states, footer |
+| `src/watchers/styles/watchers.css` | window styles |
+
+### 5.2 Modified backend files
+
+| file | change |
+|---|---|
+| `src-tauri/src/pty/mod.rs` | `pub mod watchers;` next to `pub mod input_activity;` (`:14`) |
+| `src-tauri/src/pty/output.rs` | add `SessionIoFanout::get_screen_rows_since`, next to `get_screen_rows` (`:295-301`). Nothing existing is modified |
+| `src-tauri/src/pty/backend.rs` | add **defaulted** `PtyBackend::screen_rows_since`, following `context_session_liveness` (`:148-154`) |
+| `src-tauri/src/pty/local_backend.rs` | override `screen_rows_since`, straight to the fanout, no child probe, `Missing` on absent parser |
+| `src-tauri/src/pty/container_backend.rs` | same override next to `get_screen_rows` (`:3171-3179`), `Gone` on absent parser to preserve its documented oracle |
+| `src-tauri/src/pty/manager.rs` | `PtyManager::screen_rows_since`, mirroring `get_screen_rows` (`:575-580`), `Gone` on a missing route |
+| `src-tauri/src/config/settings.rs` | `AppSettings::watchers`, `AppSettings::watchers_geometry`, `WatcherEntry`, `WatcherConfig`, `WatcherMode`, `WatcherDedupe`, `default_dedupe_window_ms`, two lines in `Default` (`:685-765`) |
+| `src-tauri/src/config/coding_agents_catalog.rs` | `command_executable_basename` from `fn` to `pub(crate) fn` (`:427`) |
+| `src-tauri/src/lib.rs` | adapters `WatcherRows`, `WatcherPatterns`, `WatcherSink` next to the scraper adapters (`:524-699`); construction, `start` and `manage` for the engine, for `WatcherHistory` and for `WatchersScopeState` next to `:1051-1073`; **six** entries in `generate_handler!` (`:2251`), the five of revision 2 plus `get_watchers_scope`. Revision 2 said seven and revision 3 repeated it; the tree registers five (`lib.rs:2548-2550`, `:2587`, `:2593`) |
+| `src-tauri/src/commands/session.rs` | register with the engine in the same block as the scraper and correct the comment (`:2266-2274`); new `purge_session_side_state` helper; a new `destroyed_ids`-only loop after `:3181-3208`; `publish_restart_destroyed` (`:3758-3782`) switched to the helper |
+| `src-tauri/src/commands/pty.rs` | `get_watcher_activity`, `preview_watcher_pattern`, `preview_watcher_reach` with `WatcherDraftEntry`, `WatcherAgentDraftEntry` and `WatcherReachRow`, next to `get_session_context` (`:526-533`). The reach command holds no state, takes no lock, and runs its two passes inside `spawn_blocking` |
+| `src-tauri/src/commands/window.rs` | `open_watchers_window` and `WATCHERS_WINDOW_LABEL`, following `open_resource_monitor_window` (`:686-762`), with **one** `tokio::Mutex` held from the scope-state write through both branches including the emit; `WatchersScopeState` and `get_watchers_scope`; `set_watchers_geometry`, following `set_detached_geometry` (`:528-538`) |
+
+### 5.3 Modified frontend files
+
+| file | change |
+|---|---|
+| `src/main.tsx` | a `windowType === "watchers"` branch next to `resource-monitor` (`:44-45`) |
+| `src/shared/types.ts` | `WatcherMode`, `WatcherMatchPayload`, `WatcherMatchBatch`, `WatcherActivitySnapshot`, `WatcherActivityCounter`, `WatcherPatternPreview`, `WatcherDraftEntry`, `WatcherAgentDraftEntry`, `WatcherReachEntry`, `WatcherReachRow`, `WatcherConfig`; `watchers` and `watchersGeometry` on `AppSettings` (`:420`) |
+| `src/sidebar/components/settings-watchers.ts` | `isWatcherConfig` tightened to the exact mirror of the Rust decoder, and `newWatcherConfig` born `enabled: false` (4.12) |
+| `src/shared/ipc.ts` | `onWatcherMatches` and `onWatchersScopeRequest` next to `onSessionContext` (`:668-672`); `getWatcherActivity`, `previewWatcherPattern`, `previewWatcherReach` taking the draft array, next to `getSessionContext` (`:240-241`); `openWatchersWindow`, `getWatchersScope` and `setWatchersGeometry` on the window API |
+| `src/terminal/components/StatusBar.tsx` | the button inside `.status-bar-actions` (`:100`), gated on `isTauri` |
+| `src/sidebar/components/SettingsModal.tsx` | `SettingsTab` union (`:96`), `TABS` (`:98-103`), **`resolveSettingsSection` branch (`:105-110`)**, and the Watchers section, whose reach state is held by the section rather than by each row (4.12) |
+
+### 5.4 Explicitly untouched
+
+`src-tauri/src/pty/context_scrape/**`, `AgentConfig` (`settings.rs:47-86`), `context_regex` and its adapters and tests, `src-tauri/resources/coding-agents/agents.default.json`, `src/shared/profile-utils.ts`, `session/profile.rs`, `telegram/bridge.rs`, `output_sequence` semantics, `session/warnings.rs`, `src/shared/window-geometry.ts`, `src/resource-monitor/App.tsx`, `src-tauri/src/web/commands.rs`, `src/terminal/styles/terminal.css`.
+
+---
+
+## 6. Required behavior, edge cases and failure behavior
+
+| # | situation | required behavior |
+|---|---|---|
+| 1 | No enabled watcher in `settings.json` | The tick reads settings and returns **before touching any session**: no `screen_parsers` lock, no allocation |
+| 2 | Session with no `agent_id` | Never registered |
+| 3 | First tick after registration | Seed the hashes, evaluate nothing, do not count a miss |
+| 4 | Frame unchanged (stamp equal) | `Unchanged`: no row clone, no allocation, no evaluation, no event |
+| 5 | Terminal resized | Reseed, evaluate nothing; count a miss **only if** something had been evaluated since the last reseed |
+| 6 | Screen scrolled by `k` rows | Rows `R-k..R` except the cursor row are evaluated with no stabilization |
+| 7 | Row written in place, or the cursor row | Evaluated on the next tick in which its hash is unchanged |
+| 8 | Repaint or `clear`: agreement below half the overlap | Count a miss; the differing rows become dirty and are evaluated one tick later, once each. There is no evaluate-everything-now path |
+| 9 | Dirty row scrolls off the top | Lost, documented, does **not** count a miss |
+| 10 | Statusline inside a scroll region | May be re-evaluated as new on each scrolling tick; suppressed by layer 2 while its text is unchanged. Statusline watchers belong in `state` mode |
+| 11 | A logical row spans several physical rows | Joined through `wrapped` before evaluation; the payload carries the joined row |
+| 12 | A continuation whose start scrolled off | Skipped, never evaluated as a fragment, **for as long as the line is still wrapping across the top edge**. Once the head is gone entirely the survivor carries no wrap flag and is not distinguishable from a line that genuinely begins at row 0; that residual is debt item 10 and is not detectable with the `vt100` API over a mirror with no scrollback |
+| 13 | Pattern does not compile | The watcher is inert for every session, logged **once** per source change through the sticky cache. Other watchers are unaffected |
+| 14 | A `watchers` entry does not deserialize | That entry becomes `WatcherEntry::Invalid`, is skipped, is logged once, and is written back verbatim on save. **Every other setting and every other watcher is unaffected** |
+| 15 | `commands` entry does not tokenize, or is empty | The whole watcher is skipped and logged once. Never "reaches everything" |
+| 16 | `commands: []` | Reaches nobody |
+| 17 | Stem that no agent has | Reaches nobody. Not an error. Settings shows "reaches 0 agents" |
+| 18 | More than 8 watchers reach one agent | The first 8 in `BTreeMap` key order run; the rest are logged once per resolution change **and** shown per row in Settings as out of budget |
+| 19 | `dedupeWindowMs` above 60000 | Clamped to 60000, logged once |
+| 20 | Dedupe keys exceed 256 for a `(watcher, session)` | Oldest key evicted. Expired keys pruned once per tick |
+| 21 | Per-tick cap exceeded | Count, stop emitting for that key this tick, log once while degraded, set `degraded`. Neither the event nor the buffer receives the overflow |
+| 22 | 25 consecutive degraded ticks | That `(watcher, session)` is suspended for 5 s, `degraded` stays true, one log line, then retried |
+| 23 | Pattern edited while running | Recompile on the changed source; clear that watcher's state gate, generation and dedupe entries for every session |
+| 24 | Watcher deleted or renamed while running | It stops resolving and stops emitting. Its buffered matches stay under the old id and it leaves `activeWatchers`. Renaming behaves as delete plus create |
+| 25 | `screen_parsers` mutex poisoned | `Missing`: no reading this tick, no claim about the session |
+| 26 | Backend reports no session behind the id | `Gone`: retire immediately |
+| 27 | Child exited | Retired on `Gone`, or on the next 5 s liveness probe. The buffer is **kept** |
+| 28 | Session destroyed | `purge_session_side_state` retires from the engine, then purges, for `destroyed_ids` only |
+| 29 | Session restarted, success or failed finalize | Same helper through `publish_restart_destroyed`. The old id's buffer is purged |
+| 30 | Root-agent session retained as exited | The buffer is **kept**; the row is still in the list |
+| 31 | Application restarted | Every buffer is empty. The window never promises history across restarts |
+| 32 | Window opened with the session already running | It shows whatever the ring holds |
+| 33 | Window not open | No event is emitted at all. The ring still records |
+| 34 | Window opened during the session's first 200 ms | `warmedUp` is false, so a neutral starting state is shown, never "Configure watchers" |
+| 35 | Session dies while the window is open | Rows keep their frozen agent and workgroup labels |
+| 36 | Two watchers with identical `pattern` and `mode` | Both run and both emit |
+| 37 | A pattern with zero capture groups | Valid. `captures` is `[]` and the UI falls back to the raw row |
+| 38 | A logical row longer than 256 bytes | Truncated on a char boundary, `rowTruncated: true` |
+| 39 | The same text appearing twice at two positions at two times | Counts twice. Distinguished in the payload by `seq` |
+| 40 | State watcher stops matching | Gate cleared, **no event**. An identical re-appearance emits again |
+| 41 | A second instance of a state condition appears while the first is visible | The match count rises, the generation advances, **it emits** |
+| 42 | State watcher whose capture is volatile (a clock) | Emits every tick by design. `preview_watcher_pattern` reports `capturesVolatile` so this is visible before saving |
+| 43 | Button pressed in browser mode | Not reachable: the button does not render outside Tauri |
+| 44 | "Configure watchers" pressed with the watchers window in front | The main window is focused first, then the modal opens on the Watchers tab |
+
+**Fail-closed direction throughout:** every ambiguous case under-reports rather than over-reports. The smallest-k tie-break, the hash collision, the missing parser, the untokenizable command, the skipped continuation and the dirty row that scrolls off all lose a detection rather than invent one, which is the direction `context_scrape/rows.rs:107-124` already pins with a test.
+
+---
+
+## 7. Compatibility, safety and cost
+
+### 7.1 Compatibility
+
+- **`settings.json`**: `watchers` and `watchers_geometry` are `#[serde(default)]` with `skip_serializing_if`, so an existing file loads unchanged and a user who configures nothing never sees either key appear. `AppSettings` has no `deny_unknown_fields`, so a file written by a newer build loads in an older one without failing.
+- **Downgrade is lossy on the next save, and this is stated rather than promised away.** `AppSettings` has no `#[serde(flatten)]` catch-all and `save_settings_value` (`settings.rs:2646-2653`) serializes the struct, so a build without this feature reads a `watchers` key, ignores it, and **drops it the next time it saves settings**. Revision 1 claimed round-trip safety; that was wrong. The honest statement is: downgrading is safe until the older build writes settings, at which point watcher configuration is lost and must be re-entered.
+- **`AgentConfig` gains no field**, so none of the 20-plus construction sites is touched.
+- **`PtyBackend` gains a defaulted method**, so the two test fakes (`pty/manager.rs:926`, `:1025`) and any out-of-tree implementor keep compiling.
+- **`ContextScraper`, `contextPercent`, `session_context` and `list-peers-lean` are untouched.**
+- **`output_sequence` semantics are untouched**, so #955 replay ordering is unaffected.
+- **`SubstantiveInputState` behavior is unchanged**; its two inline resets move into one helper called from the same two places.
+- No new crate and no new cargo feature. `chrono`, `regex`, `vt100`, `uuid` and `serde` are already declared (`Cargo.toml:9-42`).
+
+### 7.2 Safety
+
+- **ReDoS is not the risk and needs no mitigation.** `regex` 1.x has no backtracking and is linear time by construction; the size limit is the bound that matters, and past it compilation fails rather than allocating (`context_scrape/pattern.rs:27-30`, pinned at `:83-92`).
+- **The real risks are unbounded growth and unbounded emission**, and each has a structural bound: the per-tick caps plus suspension (4.6), the 500-entry ring (4.10), the 256-key dedupe bound with per-tick pruning and the 60 s window clamp (4.5), and directed coalesced delivery that emits nothing when the window is closed (4.9).
+- **A malformed configuration cannot take the application down.** The per-entry wrapper (4.8) is what turns "the whole settings file is replaced by defaults" into "one watcher is skipped".
+- **The engine cannot act.** It holds narrow sinks, no `AppHandle` and no `PtyManager` of its own. The worst a hostile or careless pattern can do is put a wrong row in a window and a wrong number in a counter.
+- **`dfa_size_limit` is left at the crate default**, as it is today (`context_scrape/pattern.rs:37-40`). With many active patterns the DFA cache can thrash and degrade to the slower engine. That is a degradation, not a denial of service, and it is bounded by the 8-watcher budget.
+- **The window shows raw PTY rows**, which can contain anything the agent printed. They are rendered as text, never as HTML, and truncated to 256 bytes.
+- **Disk writes in the worst case: zero.** The engine persists nothing and its logging is gated to log-once. This is a property to keep.
+
+### 7.3 Cost
+
+**`RegexSet` is out of scope.** The reasoning, with the arithmetic:
+
+1. This engine runs patterns over **newly evaluable logical rows**, not over the whole frame. Worst case per session per tick is 8 patterns against 30 rows, 240 regex executions. With a literal prefix `regex` resolves that as a memory scan, roughly 100 ns each, about 24 microseconds against a 200 ms tick: about 0.012 percent of a core per session, about 0.6 percent at 50 sessions, and that is a full screen of new rows every tick.
+2. `RegexSet` cannot extract capture groups, so a hit still requires running the individual regex. It only helps the no-match case, which by point 1 is already cheap.
+3. It would add a second compiled artifact per resolved watcher set whose invalidation is the cross product of the individual pattern caches.
+
+**Re-entry condition:** revisit if the per-agent budget rises above 8, or the tick drops below 200 ms, or a measured profile shows regex execution above 2 percent of a core at 20 sessions.
+
+**Lock cost, with the honest baseline.**
+
+The `Unchanged` short circuit fires less often than revision 1 assumed: `output_sequence` advances on **every chunk** (`output.rs:160`), including chunks that change no character, so a CLI with a spinner or a seconds counter moves it several times per second. `Unchanged` therefore fires for a genuinely quiet PTY, not for a visually still one. The Phase 0 measurement is taken against a session with a live spinner, not a static screen.
+
+What carries the cost argument instead is 4.2.1. Comparing sustained time held on the hot `PtyManager` mutex at 50 sessions:
+
+| | acquisitions per second | path per acquisition | sustained |
+|---|---|---|---|
+| today, scraper at 5 s | 10 | registry, ptys, liveness syscall, 30-row clone | about 2.0 ms/s |
+| revision 1 design, active sessions | 250 | same path minus the syscall | about 50 ms/s |
+| **this design** | **2** (the 25th-tick liveness probe only) | liveness only | **well under 1 ms/s** |
+
+The per-tick frame read no longer touches that mutex at all: it goes straight to the backend `Arc` and takes one `screen_parsers` lock, and that map is per backend (2.1). The engine is therefore strictly better than the status quo on both the acquisition count and the sustained hold of the mutex every terminal write contends for, instead of better at rest and worse under load.
+
+**Measurement, in Phase 0, recorded in the code.** Before the engine is wired, a co-located `#[test]` measures at the default 30x120 grid: the wall time of `get_screen_rows`, of `get_screen_rows_since` on an unchanged frame, and of `get_screen_rows_since` on a changed frame. All three numbers go into the new module's doc comment in the form `context_scrape/mod.rs:22-25` already uses. The test is `#[ignore]`d so it never becomes a flaky gate and stays in the tree so the numbers can be re-taken.
+
+**Acceptance criterion for contention:** the unchanged-frame read performs zero row allocations, enforced by the **type** (`ScreenRowsSince::Unchanged` carries no rows) rather than by a timing assertion, and the tick path takes neither the `PtyManager` mutex nor the `registry` mutex, enforced by a test that asserts the engine holds a backend `Arc` and by the absence of those calls in the tick.
+
+**Memory.** Diff state is 8 bytes per row per session, about 240 bytes, about 12 KB at 50 sessions. Dedupe is at most 256 keys per `(watcher, session)`. History is at most 500 entries per session, about 5.5 MB ceiling at 20 sessions.
+
+---
+
+## 8. Implementation order
+
+The ordering principle: **build and prove the engine on the mode that still has a gate, then remove the gate**, and put the tool that configures the engine in the hands of whoever is testing it before the hardest phase, not after.
+
+### Phase 0: the read seam and the measurement
+
+1. `FrameStamp`, `ScreenFrame`, `ScreenRowsSince` in `pty/watchers/mod.rs`; `SessionIoFanout::get_screen_rows_since` in `pty/output.rs`.
+2. Defaulted `PtyBackend::screen_rows_since`, the two backend overrides with their `Missing` and `Gone` split, and `PtyManager::screen_rows_since`.
+3. The ignored timing test and the recorded numbers.
+
+### Phase 1: configuration, resolution and geometry
+
+1. `WatcherEntry`, `WatcherConfig`, `WatcherMode`, `WatcherDedupe`, `AppSettings::watchers`, `AppSettings::watchers_geometry`, the two `Default` lines.
+2. `set_watchers_geometry`.
+3. `command_executable_basename` to `pub(crate)`.
+4. Resolution: `settings.agents` crossed with the valid watchers through `reaches`, the 8-watcher budget, the log-once rules, the clamp on `dedupeWindowMs`.
+5. `pty/watchers/pattern.rs` with the sticky compile cache.
+
+`watchers_geometry` and its command sit here rather than with the window because they are `settings.rs` changes, and grouping them touches that file once.
+
+### Phase 2: the engine on state mode only
+
+1. `pty/watchers/mod.rs`: thread, runtime, shutdown token, `register_session` resolving the backend `Arc`, `retire_session`, the tick with the settings-first early exit.
+2. The 200 ms tick reading through the Phase 0 seam, with the 25th-tick liveness probe.
+3. `state` mode: full-frame evaluation with logical-row joining, lowest match, the `(captures, row, generation)` gate.
+4. `WatcherMatchPayload`, `WatcherMatchBatch`, the directed `watcher_matches` emission, the `WatcherSink` adapter in `lib.rs`.
+5. Registration at `commands/session.rs:2268-2274`, with the comment corrected.
+6. The TypeScript types and `onWatcherMatches`.
+
+At the end of Phase 2 the engine is provable end to end with a state watcher and a listener, and it cannot flood anything.
+
+### Phase 3: the diff, occurrence mode, and the Settings editor
+
+1. `pty/watchers/frame.rs`: hashing, `best_shift`, `shift_dirty`, the cursor-row rule, logical-row joining, `possibly_missed_frames`. Written as pure functions over hash slices and unit-tested on their own, which is why the riskiest piece is also the cheapest to test.
+2. `occurrence` mode wired to the diff.
+3. `pty/watchers/dedupe.rs` with its bounds and pruning.
+4. The two per-tick caps, the degraded marker and the suspension rule.
+5. `preview_watcher_reach` in its draft-shaped form; the tightened `isWatcherConfig` and the disabled-by-default `newWatcherConfig` in `settings-watchers.ts`; and the Watchers section in `SettingsModal.tsx` including the `resolveSettingsSection` branch, the section-level reach state with its two honesty rules, and the text that distinguishes reach from running.
+
+The editor lands here and not at the end because it is the instrument used to exercise phases 2 and 3: without it the only way to configure a watcher is to hand-edit `settings.json` and restart. Occurrence mode enters here too, because this is the first point at which the gate is gone and the caps are the only thing bounding output.
+
+### Phase 4: history and the snapshot command
+
+1. `pty/watchers/history.rs`, per-session locks, the ring, `seq`, `lastSeq`, `truncated`, the counters, and the published `possibly_missed_frames`, `warmed_up` and `active_watchers`.
+2. `get_watcher_activity` and its wrapper.
+3. `purge_session_side_state` and its two call sites, with retire-before-purge.
+
+### Phase 5: the window
+
+1. `open_watchers_window` with its creation mutex, the label, the `main.tsx` route, `WatchersScopeState`, `get_watchers_scope`, `watchers_scope_request` and `onWatchersScopeRequest`. The scope state and its command land with the window rather than in Phase 1, because they exist only to make this window's handover durable and have no meaning without it.
+2. `src/shared/time-format.ts`.
+3. `src/watchers/App.tsx` and its components: table, expandable raw row, scope selector, filters, three empty states plus the warming state, the two loss banners, the footer, the subscribe-then-settle-scope-then-fetch-then-merge startup with its guard, the polling loop, `settingsStore.load()`, the three session listeners.
+4. The StatusBar button, gated on `isTauri`.
+
+### Phase 6: the pattern preview
+
+1. `preview_watcher_pattern` with its optional session, its two samples and `spawn_blocking`.
+2. The debounced "Test against current session" control with its session selector.
+
+---
+
+## 9. Tests and acceptance criteria
+
+Rust tests are co-located in the module they cover.
+
+### 9.1 Phase 0, the read seam
+
+1. An unchanged frame returns `Unchanged`, and the returned variant carries no rows.
+2. One `handle_output` chunk changes `sequence`, and the next call returns `Frame`.
+3. A `resize_screen_and_broadcast` that does not change `sequence` still returns `Frame`, because the size is in the stamp. **This is the regression a sequence-only stamp would let through.**
+4. An unknown id returns `Missing` from the local backend and `Gone` from the container backend.
+5. A poisoned `screen_parsers` returns `Missing` and not `Unchanged`.
+6. `get_screen_rows_since` on a changed frame returns the same rows, row for row, as `get_screen_rows`.
+7. `wrapped` matches `Screen::row_wrapped` for every row, and `cursor_row` matches `Screen::cursor_position().0`.
+8. The default `PtyBackend::screen_rows_since` never returns `Unchanged` and reports `stamp: None`.
+9. `PtyManager::screen_rows_since` returns `Gone` for a session with no route.
+
+### 9.2 Phase 1, configuration and resolution
+
+10. `commands` absent reaches every configured agent; `commands: []` reaches none.
+11. `commands: ["claude"]` reaches `claude`, `CLAUDE.EXE` and `C:\...\claude-sandbox-runtime\claude.cmd`, and does **not** reach `pi --provider claude`, `cmd /c claude` or `npx claude`.
+12. `commands: ["claude"]` does not reach an agent whose command is `claude-phi`. Exact equality, never a prefix.
+13. `enabled: false` reaches nobody while keeping its configuration.
+14. A `commands` entry that does not tokenize skips the whole watcher and logs once.
+15. An agent whose own command does not tokenize is reached by a selectorless watcher and by no watcher with a selector.
+16. With 12 watchers reaching one agent, exactly 8 run, they are the first 8 in `BTreeMap` key order, and the other 4 are named in exactly one log line.
+17. **A `watchers` map containing one entry with `"mode": "State"`, one with `"commands": "claude"` and one with `"dedupeWindowMs": "2000"` loads successfully: every other setting is intact, every other watcher resolves, and the three bad entries are skipped, logged once and written back verbatim on save.** This is the regression that a plain `BTreeMap<String, WatcherConfig>` would let through, and its failure mode is the whole settings file.
+18. A `settings.json` with no `watchers` key round-trips without either new key appearing.
+19. A `settings.json` with watchers round-trips byte-stable through save and load, including the absent-against-`[]` distinction for `commands`.
+20. `dedupeWindowMs` above 60000 is clamped and logged once.
+21. A pattern with zero capture groups **compiles**, which is the difference from `context_scrape::pattern::compile`.
+22. A pattern over the size limit fails to compile because of the size limit.
+23. A pattern is resolved verbatim, with leading and trailing whitespace intact.
+
+### 9.3 Phase 2, the engine on state mode
+
+24. A session with no `agent_id` is never registered.
+25. **With sessions registered but no enabled watcher, the tick takes no `screen_parsers` lock and allocates no rows.**
+26. The engine holds a backend `Arc` per session and the tick path calls neither `PtyManager::get_screen_rows` nor `kind_for_session`.
+27. A state watcher whose pattern matches emits exactly one match for a value that does not change over 5 ticks.
+28. The same watcher emits again when the matched row changes.
+29. A state watcher that stops matching emits **nothing**, and emits again when an identical row reappears.
+30. **A second identical match appearing while the first is still on screen emits**, because the match count rose and the generation advanced.
+31. A screen scroll that leaves the match count unchanged emits nothing.
+32. With several matching rows, the **lowest** one wins.
+33. A compile failure logs once across 10 ticks.
+34. A session that reports `Gone` is retired on that tick; one reporting `SessionOver` liveness is retired on the probe tick.
+35. Liveness is probed on tick 25 and not on ticks 1 through 24.
+36. No `watcher_matches` event is emitted when the `watchers` window does not exist, and the ring still records.
+37. One event carries all of a tick's matches for a session.
+
+### 9.4 Phase 3, the diff, occurrence mode and the editor
+
+38. `best_shift` on two identical frames returns `k == 0` with full agreement.
+39. `best_shift` on a frame scrolled by 3 returns `k == 3` and declares exactly the bottom 3 rows new.
+40. **`best_shift` on a frame scrolled by 3 whose bottom row also changed in place returns `k == 3`**, and that row lands in the dirty set. This is the case revision 1's slice-equality predicate made unsatisfiable, and it is the normal case for any TUI with a statusline.
+41. A frame in which only the statusline row changed returns `k == 0` with agreement `R - 1`, evaluates nothing, marks that row dirty, and does **not** increment `possiblyMissedFrames`.
+42. A row that changes on every tick is never evaluated while it keeps changing.
+43. `shift_dirty` moves flags by `k` and clears the tail.
+44. A repaint with agreement below half increments `possiblyMissedFrames`, evaluates nothing that tick, and evaluates each changed row exactly once on the following stable tick.
+45. The cursor row is not evaluated on the tick it arrives by scroll, and is evaluated once, complete, when it stabilizes. A watcher on `Read (.+)` against a row written in two chunks produces **one** event with the complete capture, not two.
+46. A logical row spanning two physical rows is matched as one string, and a pattern that only matches across the break does match.
+47. A continuation whose start is off the top of the screen is not evaluated.
+48. The first tick after registration evaluates nothing and does not increment `possiblyMissedFrames`.
+49. A resize before anything has been evaluated reseeds without incrementing `possiblyMissedFrames`; a resize after something has been evaluated does increment it.
+50. The same text appearing twice at two positions at two times counts twice and the two events carry different `seq`.
+51. The same row shifted up by a scroll is not re-evaluated.
+52. `dedupe: "capture"` collapses two differently truncated rows capturing the same path within the window and lets them through outside it; `dedupe: "none"` lets every match through.
+53. The dedupe map never exceeds 256 keys per `(watcher, session)`, and expired keys are pruned.
+54. A pattern matching every row produces at most 8 events for that watcher and at most 16 for that session in one tick, and sets `degraded`.
+55. The overflow reaches **neither** the event **nor** the buffer.
+56. 25 consecutive degraded ticks suspend that pair for 5 seconds and then retry.
+57. `possiblyMissedFrames` is monotonic.
+58a. **A draft of 9 enabled selectorless rows against one agent returns `allocated: true` for the first 8 in id order and `false` for the ninth**, with nothing on disk contributing. The fixture sends the nine rows in an order **different from lexicographic**, so an implementation that honours request order instead of `BTreeMap` key order fails it. This is the regression the row-level signature let through, and its failure mode is the UI telling the user that a watcher holds a slot it does not.
+58b. A draft that drops 5 of 9 rows returns `allocated: true` for all 4 that remain, and a row present on disk but absent from the draft contributes nothing to any agent's budget.
+58c. **Displacement fixture: `a` disabled plus 8 enabled `b` to `i`, all selectorless.** `a` returns its full `entries` with `allocated: false` everywhere; `b` to `i` return `allocated: true`. **No draft ever yields more allocated rows on one agent than that agent has slots.** This is the case revision 3's first form got wrong, where `a`'s own pass displaced `i` and every row still reported itself in budget.
+58d. Reach does not depend on enablement: the `entries` of a row are identical whether that row is enabled or disabled, all else equal.
+58e. Still required from revision 2: `commands` absent reaches every agent, `commands: []` reaches none, a selector that does not tokenize skips the whole watcher, and the reported `commandStem` is the agent's. In the two reach-nobody cases **the response row is still present, with `entries: []`**.
+58f. **Agents come from the draft:** a draft that changes an agent's `command` from `claude` to `codex` drops that agent from a `["claude"]` watcher's `entries` and adds it to a `["codex"]` one; a draft that removes an agent removes it from every `entries`; a draft that adds one includes it. Each of these is a case where resolving against the saved agent list would have answered about a state the user had already left, and two of the three would have over-reported.
+58g. **The request excludes rows the Rust decoder would reject, across the whole numeric contract.** The fixture covers `commands: [1]`, and `dedupeWindowMs` of `-1`, `1.5`, `1e30` and `Number.MAX_SAFE_INTEGER + 2`, plus `Number.MAX_SAFE_INTEGER` itself as the accepted boundary. `typeof n === "number" && n >= 0` must fail this test; `-1` alone does not exercise it. Each rejected row is classified unrecognised, is not sent, consumes no budget slot, and survives a save round trip verbatim.
+58h. Frontend, with at least three rows and fake timers, keyed on the **request fingerprint**: an edit to a row's selector fires exactly **one** call carrying every valid row plus the draft agents; adding, deleting and toggling `enabled` each fire exactly one; a `pattern` keystroke fires **none and clears nothing**, because the request is unchanged; changing a row's selector clears the displayed answer immediately and it does not reappear until the answer for that request arrives; **A to B and back to A re-requests A and settles on A, both when A had already answered and when A was still in flight**; a rejected call renders an error rather than the previous answer; and a stale response never overwrites a newer one. The permanent-pending case, cleared with no call ever issued, must fail this test.
+58i. Frontend text, all three: an enabled row reads "Reaches N agents" and shows the budget badge for entries with `allocated: false`; a disabled row with a pattern reads "Would reach N agents when enabled" and shows **no** budget badge; a disabled row with an empty pattern reads "Would reach N agents when enabled. Add a pattern to enable it."
+58l. A row with an **uncompilable pattern** that is enabled and within budget still reports `allocated: true`, and that is deliberate: allocation is slot assignment and the row's own `preview_watcher_pattern` reports `compiles: false` with its error. The two dimensions are asserted together so nobody later reads `allocated` as a promise of output.
+58j. The fixed points of 4.9 points 6 and 7, which are contract and therefore tested even though the editor cannot produce the first two: two draft rows with the same id and different selectors resolve as later-wins and both response rows report that resolution; an empty id sorts first; the response is one row per request row in request order; `entries` is ordered by `agentLabel` with `agentId` as tie-break.
+58k. `newWatcherConfig()` returns `enabled: false`, the editor refuses to enable a row whose pattern is empty, and Add followed immediately by Save produces a watcher that the engine does not run. The serde default for an omitted `enabled` in a hand-written file is still `true`.
+59. `resolveSettingsSection("watchers")` returns `"watchers"` and not `"general"`.
+
+### 9.5 Phase 4, history and the snapshot
+
+60. `snapshot` does **not** consume: two consecutive calls return the same content.
+61. The 501st match drops the oldest and sets `truncated`.
+62. `seq` is monotonic per session and is identical in the event and in the ring entry.
+63. `limit: Some(n)` returns the n most recent, still ordered oldest first; absent returns everything in the ring.
+64. A session with no buffer returns the empty snapshot with `warmedUp: false`, not `None` and not `Err`.
+65. A `session_id` that is not a UUID returns `Err`.
+66. `activeWatchers` lists the reaching watchers with their `mode` and count 0 before any match.
+67. `warmedUp` is false before the first tick and true after it.
+68. Destroying a session purges its buffer.
+69. **Restarting a session purges the old session's buffer**, through both the success path and the failed-finalize path.
+70. **A tick landing between the purge and the engine's retirement does not recreate the entry**, because the helper retires before it purges and creation requires registration.
+71. A root-agent session retained as exited **keeps** its buffer.
+72. A session whose child exits on its own **keeps** its buffer and stops being sampled.
+73. A snapshot of one session does not block the engine writing another.
+
+### 9.6 Phases 5 and 6, frontend
+
+74. The `WatcherMatchPayload` and `WatcherMatchBatch` TypeScript types match the Rust serialization field for field, asserted by a Rust test pinning the exact camelCase JSON.
+75. Every payload field is present in the JSON, including empty `captures` and `rowTruncated: false`.
+76. `at` parses with `new Date(value)` and `formatClockTime` returns zero-padded 24-hour `HH:MM:SS`.
+77. A window that subscribes, buffers, fetches and merges on `(sessionId, seq)` neither duplicates nor loses a match that arrives during the fetch.
+78. The StatusBar button renders on a root-agent session and does **not** render when `isTauri` is false.
+79a. Opening the window twice does not create a second window and does change the scope through `watchers_scope_request`.
+79b. **`open_watchers_window(A)` followed by `open_watchers_window(B)` leaves `get_watchers_scope()` at B, whether or not any listener exists.** This is the property that matters and the one a Rust-side listener cannot certify: `app.listen_any` registers in the Rust registry, which is always durable, so no reordering of a `listen_any` test can model a JavaScript listener that has not been registered yet. The revision 2 test is not wrong, it certifies that the emit is issued, and it stays alongside this one.
+79c. **Two concurrent `open_watchers_window` calls, for two different sessions, produce exactly one window, two `Ok`s and no duplicate-label failure; and the final `get_watchers_scope()` agrees with the loser's emitted event.** Counting windows and `Ok`s is not enough: the defect this test exists for is the interleaving that leaves the authoritative state at one session and the last emitted event at the other, which a count-only assertion passes. Revision 3's separate "the state is written before the creation branch returns" test is folded in here, because with one critical section it is no longer an independent property.
+79d. Frontend, two orderings of the same race, because they fail differently:
+   - Pull blocked: mounted with `?sessionId=A`, **no `get_watcher_activity` is issued at all**; a `watchers_scope_request` for C arrives; the pull then resolves to B; **only C is fetched**.
+   - Pull resolved, first fetch blocked: the pull settles on A and `get_watcher_activity(A)` is in flight when a `watchers_scope_request` for B arrives; **B is fetched and committed without waiting for the poll**, and A's result is discarded. This is the hole a startup carve-out left, and it is invisible to the first ordering.
+79e. Frontend, content guard, three assertions that fail independently:
+   - Two fetches in flight for different scopes resolving out of order leave the table and the snapshots showing the current scope only. Asserting the `<select>` value is not sufficient: the defect is precisely a correct selector over stale rows.
+   - **Before** the new fetch resolves, and again when it **rejects**, the previous scope's rows are already gone from the DOM. A test that only inspects the end state after both promises settle passes without the synchronous drop.
+   - Two refreshes of the **same** scope resolving out of order leave `lastSeq`, `warmedUp`, `degraded` and the counters from the newer one, never the older.
+79f. In "All sessions", creating and destroying an agent session while a refresh is in flight invalidates that refresh, refetches, and does **not** drop rows belonging to the newly created session. A generation keyed on the selected session, rather than on `scopeIds()`, passes every other test here and fails this one.
+80. `Agent` and `Workgroup` chips do not render in single-session scope and do render in "All sessions".
+81. The four empty and warming states are distinguished from the snapshot alone, with no nullability.
+82. The `truncated` banner and the `possiblyMissedFrames` line are separate elements with distinct text.
+83. The footer is present in every state.
+84. A row containing HTML-looking text renders as text.
+85. State rows and occurrence rows are visually distinguishable.
+86. `preview_watcher_pattern` with `session_id: None` returns the compile result with `sampled: false`; with a session it returns `matchedRows` against `totalRows`; with a session that cannot be read it returns `sampled: false` and keeps the compile result; a pattern that does not compile returns `compiles: false` with an error rather than failing.
+87. A pattern capturing a volatile value reports `capturesVolatile: true`.
+
+### 9.7 Objective acceptance criteria for the issue
+
+- **A1.** A single watcher with no `commands` reaches all 12 agent entries of a real `settings.json`, which is the configuration the issue says cannot be expressed today.
+- **A2.** With sessions running and no enabled watcher, `cargo test` passes and the tick takes no `screen_parsers` lock and allocates no rows.
+- **A3.** Every existing `context_scrape` and #1088 test passes unmodified.
+- **A4.** A state watcher on a persistent row emits once and does not re-emit while the row is unchanged over at least 25 ticks, and emits again when a second instance appears above it.
+- **A5.** An occurrence watcher on a scrolling transcript of at least 60 rows delivered in one burst reports matches and, if agreement fell below half, a non-zero `possiblyMissedFrames`, never a silent zero.
+- **A6.** With a watcher configured for `claude`, a real Claude session printing a file path longer than the terminal width produces exactly one activation carrying the **complete** path, proving both the wrapped-row join and the cursor-row rule.
+- **A7.** The activity window opens from the StatusBar on both a normal and a root-agent session, shows the ring's content for a session that was already running, and shows the best-effort footer. Its "Configure watchers" button focuses the main window and opens Settings on the Watchers tab.
+- **A8.** Destroying a session purges its buffer; restarting a session purges the old id's buffer; a session that crashes keeps it.
+- **A9.** A `settings.json` whose `watchers` map contains one malformed entry starts the application with every agent and every other watcher intact.
+- **A10.** Measured and recorded in the module doc comment: the unchanged-frame read, the changed-frame read, and the existing 200 microsecond figure, taken against a session with a live spinner.
+- **A11.** End to end through the real editor, not through the command alone: starting from a `settings.json` with no `watchers` key, adding nine watchers, giving each a compilable pattern, enabling them, and reading the indicator **before** pressing Save shows the ninth as not running for budget; pressing Save then leaves the engine resolving exactly the eight the indicator named, associated with the same rows. The same holds when the draft also edits an agent's `command`, which is the case the saved-agent list would have got wrong. **The indicator never states that a watcher holds a slot it will not hold, and never shows more allocated rows on one agent than that agent has slots.** A tenth watcher with an uncompilable pattern is allocated and inert, which the row's own pattern preview reports and this criterion does not contradict.
+- **A12.** Pressing the StatusBar button on session A and then, **while the activity window is still loading**, pressing it on session B leaves the window scoped to B **and showing B's rows**. Neither press produces an error, and only one window exists. The loading barrier is deterministic in the test rather than timing-dependent, and the assertion covers scope, content and window count together, because a window that shows the right session name over the wrong session's activations is the failure this criterion exists to catch.
+
+---
+
+## 10. Declared debt
+
+These are known, bounded and deliberately not fixed in #1171. They are stated here so they are debt and not surprise.
+
+1. **A dirty row that scrolls off the top is lost.** The engine never kept its text. Rare, because in-place writes happen near the cursor and a scroll moves that row up rather than off.
+2. **A statusline inside a scroll region may be re-evaluated as new on each scrolling tick.** Bounded by layer 2 while its text is unchanged, and by the fact that statusline watchers belong in `state` mode. Fixing it would need the engine to infer the scroll region, which the mirror does not expose.
+3. **Two consecutive identical rows arriving exactly one row apart are both counted**, which is correct, at the cost of item 2. The alternative guard was rejected because edge case 39 requires it.
+4. **`possiblyMissedFrames` cannot say how much was missed**, only that agreement fell below half at least once. That is a property of sampling.
+5. **A state watcher cannot report that a condition ended.** Correct for an activity log, which is the only consumer here. The day a state watcher drives a live indicator, the payload needs a field and section 4.4 must be reread.
+6. **No watcher state is persisted**, so history does not survive an application restart and `list-peers-lean` shows nothing about watchers.
+7. **Downgrading loses watcher configuration on the older build's next settings save** (7.1).
+8. **The 8-watcher budget is resolved by alphabetical id order.** Surfaced per row in Settings rather than fixed, because any other order would need a user-visible priority field.
+9. **8, 16, 256, 500, 25 ticks and 60 s are chosen numbers, not measured ones.** Each has its arithmetic written beside it so it can be redone rather than guessed at again.
+10. **A wrapped line whose head has already scrolled off can be evaluated as if it began at row 0.** The survivor carries no wrap flag and is not distinguishable from a line that genuinely begins there. `vt100` exposes `row_wrapped(i)`, "does row i continue **into** row i+1", and nothing that says "row i continues **from** row i-1", and the mirror is created with zero scrollback (`output.rs:112`), so the case is not detectable with the API available. It is one row of thirty, only while a wrapped line is straddling the top edge, and it self-corrects on the next scroll. This is the **one known deviation from the fail-closed direction** of section 6, which is why it is stated here and reserved in edge case 12 rather than left in a module comment.
+11. **Enabling a disabled watcher can push an enabled one out of an agent's budget, and nothing forecasts it.** Every answer the preview gives is true, and the displaced row shows its badge as soon as the toggle re-fires the call, but before the toggle no row names what it would displace. Reporting it would mean a `displacedWatcherIds` concept whose only job is to predict a state that becomes visible and correct one click later (4.9, point 4).
+12. **The reach preview's cost is unbounded in the total size of the selectors, not in the number of rows.** One pass is O(agents x total selector entries), and nothing caps how many entries a hand-written `commands` list may hold. No cap is added here because the engine already runs the same resolution over the same data every 200 ms (4.8), so any payload large enough to matter costs five times as much per second inside the tick; the bound that would fix this belongs to the engine's resolution cadence, and adding one only to the preview would leave the real cost where it is. The computation runs in `spawn_blocking` so it cannot hold a Tokio worker (4.9, point 5).
+13. **`allocated` does not know whether the pattern compiles.** A watcher that is enabled and inside the budget reports `allocated: true` even when its regex fails to compile, in which case it is resolved, inert and logged once (edge case 13). The compile result is on the same row, from `preview_watcher_pattern`, and the two are deliberately not merged (4.9, point 3).
+14. **The editor's validity predicate is narrower than `u64`.** A hand-written `dedupeWindowMs` above 2^53 is classified unrecognised, so the row is listed but not offered for editing, even though the engine runs it clamped. JavaScript cannot hold that value exactly, and rounding it silently would be worse than declining to edit it (4.12).
+
+---
+
+## 11. Revision history: what changed and what was not taken
+
+Sections 11.1 to 11.4 record revision 2, against revision 1. Sections 11.5 to 11.7 record revision 3, against revision 2.
+
+### 11.1 The three convergent findings, all accepted as facts
+
+1. **The restart paths orphan the ring buffer.** `execute_destroy_transaction` is not the only production exit from `SessionManager`; there are three (2.4), and the post-commit cleanup that revision 1 cited as precedent is one of two parallel copies. Fixed by `purge_session_side_state` called from both loops (4.10), with tests 69 and 70.
+2. **The alignment predicate was unsatisfiable.** Slice equality of the overlap makes the in-place branch unreachable, and with any repainting statusline every tick would have fallen through to a full re-render, permanently lighting the sampling-loss line and leaving the TTL layer as the only contention. Fixed by best-shift alignment with an agreement threshold, and by removing the evaluate-everything-now path entirely (4.3), with tests 40, 41 and 44.
+3. **The payload had no identity.** With `at` being the tick's instant and identical rows required to count twice, snapshot and stream could not be merged. Fixed by `seq` (4.9), with test 77.
+
+### 11.2 Other findings accepted
+
+Directed coalesced delivery and no emission with the window closed (4.9); tolerant per-entry deserialization of the `watchers` map (4.8); the state-mode generation counter (4.4); retire-before-purge and registration-gated creation (4.10); bounded and pruned dedupe with a clamped window (4.5); degraded suspension (4.6); the backend `Arc` resolved at registration (4.2.1); `stamp: Option<FrameStamp>` so the defaulted trait method is implementable (4.2); the `Gone` variant so the container backend keeps its documented oracle (4.2); the cursor-row rule (4.3); logical-row joining for wrapped lines (4.3.1); `warmedUp` (4.9); per-session history locks and explicit limits (4.10, 4.12); `preview_watcher_pattern` made async with an optional session, two samples and `capturesVolatile` (4.9); `preview_watcher_reach` so no stem rule is ported to TypeScript (4.9); the resize that no longer counts as a miss (4.3); the settings-first early exit replacing a mechanism that did not exist (4.8); `resolveSettingsSection` (4.12); the two-state `commands` control (4.12); watcher id lifecycle (4.8); `onWatchersScopeRequest` promoted from prose to contract (4.9); the button hidden outside Tauri (4.12); the dedicated geometry command (4.12); `formatClockTime` (4.12); `pre-wrap` and no new CSS (4.12); `settingsStore.load()` and the three session listeners (4.12); snapshot polling with a written cadence (4.12); the Settings editor moved to Phase 3 and `watchers_geometry` to Phase 1 (8).
+
+Factual corrections: there are two screen-mirror maps, not one (2.1); the existing read path is four locks deep, not three (2.2); `chrono` is at `Cargo.toml:18` (4.11); `formatTimestamp` is neither exported nor `HH:MM:SS` (2.5); `.workgroup-task-text` wraps rather than scrolls (2.5); the registration comment must be updated (4.10); the downgrade claim was wrong (7.1).
+
+### 11.3 Findings deliberately not taken
+
+1. **Dropping the one-tick stabilization for in-place rows that are not the cursor row.** The cursor-row rule alone fixes the defect; also removing stabilization elsewhere would let a chunk boundary land mid-repaint and emit a half-drawn row. Keeping one uniform rule costs 200 ms of latency on repaint-driven matches and removes a class of failure.
+2. **A guard that skips a scrolled-in row identical to what was previously at that position.** It would remove debt item 2 but violate edge case 39. The requirement wins.
+3. **Adding `watchers` to the protected-field list in `commands/config.rs`.** The dedicated `set_watchers_geometry` command achieves the same protection without making the list six long and without leaving the new window as a whole-object writer.
+4. **Making `mode` default rather than required.** With per-entry tolerance the failure is one skipped watcher, which is the right outcome; a defaulted mode would silently run a watcher the user did not describe.
+
+### 11.4 Recorded, out of scope
+
+`"resources"` is absent from `resolveSettingsSection` (`SettingsModal.tsx:105-110`), so the Resource Monitor's Settings button (`src/resource-monitor/App.tsx:422`) has landed on General since it shipped. Unrelated to #1171 and not fixed here.
+
+### 11.5 Revision 3: why revision 2's certification was invalidated
+
+Revision 2 was implemented and reviewed. Nine of the review's findings were code defects against a plan that was right. **Two were the plan being wrong**, and both are the same kind of wrong: a contract fixed in section 4.9 that cannot carry the user interface fixed in section 4.12.
+
+1. **`preview_watcher_reach` could not compute the budget of the draft.** `in_budget` is a property of the whole watcher set, and revision 2 exposed it through a command that receives one row. A row-level command can answer it only by inventing what the rest of the set is, and the only set it has is the saved one, which is not the one the user is editing: with an empty saved map, nine rows added before Save all report `inBudget: true` and eight then run. The decisive argument is not the arithmetic but the direction: this **over-reports**, and section 6 pins under-reporting everywhere else, so revision 2 broke its own stated invariant on the one surface where the user decides to save. A second symptom of the same root cause was that the signature carried no `enabled` although `reaches` depends on it, leaving that choice to the implementation. Fixed by the draft-shaped command and its seven points of fixed semantics (4.9), with tests 58a to 58k. The field is now called `running`; 11.8 explains why the first replacement was itself replaced.
+2. **The re-scope event was not durable during the window's creation.** The label exists when `build()` returns; the JavaScript listener exists only after the bundle loads and an IPC round trip completes; Tauri queues nothing for a listener that does not exist and `emit_to` returns `Ok` regardless. Revision 2's contract branched on "the window exists" and had no answer for the state between created and listening, so a second open during the load dropped the user's order in silence. Two concurrent opens could also both reach `build()`. Fixed by writing an authoritative scope before every emit and pulling it after the subscribe, plus a creation mutex (4.12), with tests 79a to 79e.
+
+Absorbed in the same pass, because a certification is invalidated once: the `vt100` residual behind edge case 12 now has a reservation in section 6 and debt item 10, instead of living only in a module comment.
+
+**What revision 3 does not touch**, stated so the cost of re-certification is not read as wider than it is: the engine, the read seam, the frame diff, both modes, the three dedupe layers, the caps and suspension, `watcher_matches`, `get_watcher_activity`, the history buffer and its purge helper, `preview_watcher_pattern`, the settings schema, and every test from 1 to 57 and 60 to 78. The amendment lives entirely in the configuration surface and the window-opening surface.
+
+### 11.6 Considered in revision 3 and deliberately not taken
+
+1. **Narrowing the budget indicator to "as currently saved" and keeping the row-level command.** The command already substitutes the edited row, so its answer already speaks about the state after Save; making the narrowed reading honest would mean suppressing the indicator whenever the draft differs from the saved map, which is exactly when it exists to be read.
+2. **Computing the budget in TypeScript from per-row reach sets.** It duplicates the key order and the number 8 in a second language, it diverges from `Ord for String` for ids outside the id pattern that a hand-written `settings.json` can still contain, and it needs the same lift of reach state out of the row component that the draft-shaped command needs, so it buys nothing.
+3. **`on_page_load(Finished)` as the readiness signal.** No new IPC, but it fires before listener registration completes, so it narrows the race instead of closing it.
+4. **Treating the window's first `get_watcher_activity` call as an implicit readiness signal.** Also no new IPC, but it would couple a command's meaning to a frontend ordering detail that nothing enforces.
+5. **Making the scope pull replace the query parameter.** The parameter stays as the initial value so the first paint has a scope without waiting for a round trip; the pull is authoritative, not exclusive.
+
+Revision 3's first form also rejected **carrying the draft agent list**, on the grounds that its failure under-reports. That was wrong and is reversed in 11.8: two of the three agent edits over-report.
+
+### 11.7 Sequencing noted for implementation
+
+The reach rule and the birth state of a new row are one decision, not two, and 11.8 settles both: a new row is born disabled (4.12), and reach is reported for a disabled row while running is not (4.9, point 3). Revision 3's first form left the birth state conditional on a separate review finding, which gave the implementer no requirement and no test.
+
+### 11.8 Revision 3, round 2: what the enrich changed
+
+Two reviewers took the delta. Nine findings were integrated. Two of them replaced the delta's own core rule rather than patching it.
+
+1. **The agent draft now travels, and debt item 11 is gone.** Round 1 of revision 3 claimed the agent half could stay on disk because its failure under-reports. That claim was false: the modal edits agents and watchers in one store and saves them together (`SettingsModal.tsx:986-1030`), and of the three agent edits only *adding* under-reports. Deleting an agent and changing an agent's `command` both leave the indicator naming an agent a watcher will not reach, which is the same false-positive class the whole revision exists to remove. The payload argument did not justify a positively false answer.
+2. **The per-row counterfactual budget is replaced by two passes over one draft.** The delta ran one forced-enabled pass per row, which made each row's answer true in isolation and the *set* of answers incoherent: with one disabled row and eight enabled ones, all nine reported themselves in budget, because the disabled row's own pass silently displaced the eighth. Reach and slot assignment are now separate questions with separate passes, reach from an all-enabled pass and assignment from the real one, so no counterfactual budget is computed and no set of answers can disagree with itself. `in_budget` was renamed `running` here and then narrowed to `allocated` in round 3 (11.9).
+3. **That redesign also removes the complexity objection.** N passes of an O(N x A) resolver was O(N squared x A) over an input with no bound, and it ran under the settings read guard. Two passes is linear, and after point 1 the command reads no settings at all, so it holds no lock. No cap on the number of watchers was added, because with linear cost and no lock there is nothing left for a cap to protect.
+4. **The editor's validity predicate becomes contract.** "Unrecognised rows are not sent" was not implementable against a predicate that accepts `commands: [1]` and a typed `dedupeWindowMs: -1` while `serde` rejects both. Such a row would be counted in the budget and then skipped by the engine.
+5. **A second guard, on content.** Both reviewers found it independently and one stated plainly that a frozen plan with a single guard would leave no room to invent the second. The pull guard decides which scope is adopted; it says nothing about which rows are painted, and a refresh for the old scope returning last repaints it under the new scope's selector. One scope generation, incremented on every transition, captured by every fetch. Round 3 replaced that with one monotonic request counter keyed on `scopeIds()`, for the reasons in 11.9 point 5; the current contract is the one in 4.12.
+6. **One critical section in `open_watchers_window`.** The state write and the create-or-emit branches were two regions, which permits an interleaving that leaves the authoritative scope at one session and the last emitted event at the other. The window count and the two `Ok`s that the round-1 test asserted both pass through that interleaving.
+7. **The birth state of a new row is decided, not conditional** (11.7).
+8. **The reach call fires on a changed draft, and a changed draft clears the displayed answer.** Every edit replaces the whole row object, so the field-level dependency does not by itself prevent a `pattern` keystroke from firing the call; and a commit-time guard stops a stale answer from being written without stopping it from being read, which matters because this indicator gates a Save. Round 3 found that those two halves contradicted each other and replaced them with the fingerprint rule in 4.12; see 11.9 point 2.
+9. **The handler count is six**, verified against `lib.rs:2548-2550`, `:2587`, `:2593`. Revision 2 said seven with five registered, and round 1 of revision 3 incremented the wrong number.
+
+Not taken, with reasons: a `displacedWatcherIds` field (debt item 11), a contractual cap on the number of watchers (point 3), and rejecting an empty pattern in the Rust compiler rather than in the editor (4.12).
+
+### 11.9 Revision 3, round 3: what the enrich changed, and what is certified
+
+Both reviewers confirmed the core of round 2: the two passes are coherent, `B.allocated` implies `A.entries`, enablement does not change `entries`, the agent draft removes the fail-open in all three directions, one critical section closes the open-window interleaving, and the handler count is six. Seven further findings were taken.
+
+1. **`running` is renamed `allocated` and its promise is narrowed.** The pattern does not travel, so the field cannot mean "will produce output": a watcher whose regex fails to compile is allocated a slot and is inert. The name now says what the two passes can establish, and compilability stays where it already was answered, on the row's own pattern preview. Carrying the pattern to merge the two dimensions was rejected: it would inflate every debounced payload to restate an answer already on screen.
+2. **The idempotence guard and the synchronous invalidation contradicted each other and are replaced by one fingerprint rule.** As written, a `pattern` keystroke changed the draft but not the request, so the answer was cleared and no call was ever issued: pending forever. Keying both the render and the in-flight state on the request fingerprint removes the contradiction and also fixes A to B to A, which the previous pair got wrong in both the answered and the in-flight case. No answer cache is kept; a returning shape is re-requested.
+3. **The startup carve-out is removed.** Letting the listener set scope without fetching during mount left an event arriving *during* the first fetch with its predecessor discarded and no fetch of its own, so the window sat correctly scoped and empty until the poll. One uniform rule replaces a rule plus an exception.
+4. **Scope invalidation now drops painted content synchronously.** A commit-time check stops a stale result from being written; it does not remove rows that are already on screen, which stay for the whole round trip and forever if the new fetch fails.
+5. **The scope generation becomes one monotonic request counter, and invalidation keys on `scopeIds()`.** Two independent findings converged here. A generation keyed on the selected session misses "All sessions", where the three session listeners rewrite the derived set without touching the selection, and it misses two refreshes of the same scope racing, where the older poll response commits older counters over newer ones. Stating the rule over `scopeIds()` and over requests is both wider and shorter than the enumeration of callers it replaces, which had been short by one in every version so far.
+6. **The numeric contract is written out, and "exact mirror of the decoder" is corrected to "mirror of what the serializer emits".** The naive fix, `typeof n === "number" && n >= 0`, still admits `1.5` and `1e30`. The decoder also accepts absences the predicate requires present, and being stricter there is the safe direction and practically unreachable, so relaxing it would weaken the guard for nothing.
+7. **The cost claim is withdrawn and restated in the right variable.** The work is O(agents x total selector entries), not O(rows x agents); `commands` is unbounded, so "a few milliseconds, nothing to protect" priced only the short-selector case. The defense is now that the engine already runs the same resolution over the same data five times a second, and the computation moves into `spawn_blocking`. The residual is debt item 12.
+
+Also taken: the disabled row with an empty pattern gets its own sentence, because "when enabled" alone offers a condition the editor refuses to let the user meet, and it is the first state anyone sees after Add Watcher.
+
+Two disagreements are recorded rather than resolved by agreement: no contractual cap on watchers or selector entries (debt item 12 explains where the real bound belongs), and no `displacedWatcherIds` (debt item 11). In both the finding was accepted and the proposed remedy was not.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "guide",
     "spec-board",
     "resource-monitor",
+    "watchers",
     "screenshot-overlay-*"
   ],
   "permissions": [

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -2005,7 +2005,10 @@ pub fn get_instance_label() -> String {
     crate::config::profile::instance_label().to_string()
 }
 
-async fn persist_narrow_settings_update(
+/// `pub(crate)` since #1171: `set_watchers_geometry` lives in `commands/window.rs` beside the
+/// window it belongs to, and must write its one field through this same candidate-save-publish
+/// path rather than a second one of its own.
+pub(crate) async fn persist_narrow_settings_update(
     settings: &SettingsState,
     mutate_candidate: impl FnOnce(&mut AppSettings),
 ) -> Result<(), String> {

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -532,6 +532,29 @@ pub fn get_session_context(app: AppHandle, session_id: String) -> Result<Option<
     Ok(scraper.last_reading(uuid))
 }
 
+/// #1171 - one session's watcher activity, for the window on mount and on every poll.
+///
+/// SYNCHRONOUS, and it takes exactly one per-session mutex. That is possible only because the
+/// engine publishes `activeWatchers`, `possiblyMissedFrames` and `warmedUp` into the history at
+/// the end of each tick, instead of this command resolving settings and the session manager
+/// itself - which would put a read of the session lock on the window's polling path.
+///
+/// A session with no buffer returns an EMPTY snapshot, not `None` and not an error: the window
+/// distinguishes its four states from the values here, with no nullability to reason about.
+#[tauri::command]
+pub fn get_watcher_activity<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    session_id: String,
+    limit: Option<usize>,
+) -> Result<crate::pty::watchers::history::WatcherActivitySnapshot, String> {
+    let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+    let Some(history) = app.try_state::<crate::pty::watchers::history::WatcherHistoryState>()
+    else {
+        return Ok(crate::pty::watchers::history::WatcherActivitySnapshot::empty());
+    };
+    Ok(history.snapshot(uuid, limit))
+}
+
 /// #1171 - what a pattern does, before it is saved.
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -900,6 +923,77 @@ mod watcher_preview_tests {
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("build a pty preview test app");
         (app, id)
+    }
+
+    /// 9.5.65 - a `session_id` that is not a UUID is an error, exactly like
+    /// `get_session_context`. Everything else about this command answers with values.
+    #[test]
+    fn a_session_id_that_is_not_a_uuid_is_rejected() {
+        let app = settings_app(AppSettings::default());
+
+        assert!(get_watcher_activity(app.handle().clone(), "nope".into(), None).is_err());
+    }
+
+    /// 9.5.64 - with no history managed at all - a test app, a build without the engine - the
+    /// command answers with the EMPTY snapshot rather than an error. `warmedUp: false` is what
+    /// tells the window it is looking at a session the engine has not reached, so it shows a
+    /// neutral starting state instead of "no watcher reaches this agent".
+    #[test]
+    fn an_unmanaged_history_answers_with_the_empty_snapshot() {
+        let app = settings_app(AppSettings::default());
+
+        let snapshot = get_watcher_activity(app.handle().clone(), Uuid::new_v4().to_string(), None)
+            .expect("never an error");
+
+        assert!(snapshot.matches.is_empty());
+        assert!(!snapshot.warmed_up);
+        assert!(!snapshot.truncated);
+        assert_eq!(snapshot.last_seq, 0);
+        assert_eq!(snapshot.possibly_missed_frames, 0);
+        assert!(snapshot.active_watchers.is_empty());
+    }
+
+    /// 9.5.63 - the command hands `limit` straight to the ring, which trims from the NEW end
+    /// and keeps the order.
+    #[test]
+    fn the_command_reads_the_ring_and_honours_the_limit() {
+        use crate::pty::watchers::history::{SessionStatus, WatcherHistory, WatcherHistoryState};
+        use crate::pty::watchers::WatcherMatchPayload;
+
+        let id = Uuid::new_v4();
+        let history: WatcherHistoryState = Arc::new(WatcherHistory::default());
+        history.publish(id, SessionStatus::default());
+        for seq in 1..=5u64 {
+            history.record(
+                id,
+                &[WatcherMatchPayload {
+                    session_id: id.to_string(),
+                    seq,
+                    watcher_id: "w".to_string(),
+                    mode: crate::pty::watchers::WatcherMode::Occurrence,
+                    at: chrono::Utc::now(),
+                    captures: Vec::new(),
+                    row: format!("row {seq}"),
+                    row_truncated: false,
+                }],
+            );
+        }
+        let app = tauri::test::mock_builder()
+            .manage(history)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a watcher activity test app");
+
+        let all = get_watcher_activity(app.handle().clone(), id.to_string(), None).expect("all");
+        assert_eq!(all.matches.len(), 5);
+        assert!(all.warmed_up);
+
+        let recent =
+            get_watcher_activity(app.handle().clone(), id.to_string(), Some(2)).expect("recent");
+        assert_eq!(
+            recent.matches.iter().map(|m| m.seq).collect::<Vec<_>>(),
+            vec![4, 5]
+        );
+        assert_eq!(recent.last_seq, 5);
     }
 
     /// 9.6.86 (first case) - **the common case**: a user writes a regex in Settings with no

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -1061,6 +1061,118 @@ mod watcher_preview_tests {
         );
     }
 
+    /// 9.6.87 - **the pattern that looks fine and is not.** A regex capturing a clock matches
+    /// one row of thirty, so `matchedRows` says nothing is wrong, and in `state` mode it emits
+    /// five events a second forever. The two samples a second apart are what catch it.
+    ///
+    /// Takes about a second in real time by construction: the interval between the samples IS
+    /// the measurement.
+    #[tokio::test]
+    async fn a_pattern_capturing_a_clock_is_reported_as_volatile() {
+        struct TickingClockBackend {
+            reads: std::sync::atomic::AtomicUsize,
+        }
+
+        impl PtyBackend for TickingClockBackend {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn spawn(
+                &self,
+                _spec: BackendSpawnSpec,
+            ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+                Box::pin(async { Ok(()) })
+            }
+            fn write(
+                &self,
+                _authority: &crate::pty::manager::BackendWriteAuthority,
+                _id: Uuid,
+                _data: &[u8],
+            ) -> Result<(), AppError> {
+                unreachable!("a preview must never write to a PTY")
+            }
+            fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), AppError> {
+                unreachable!("a preview must never resize a PTY")
+            }
+            fn kill(&self, _id: Uuid) -> Result<(), AppError> {
+                unreachable!("a preview must never kill a session")
+            }
+            fn has_session(&self, _id: Uuid) -> bool {
+                true
+            }
+            fn get_screen_snapshot(
+                &self,
+                _id: Uuid,
+            ) -> Option<crate::pty::output::PtyScreenSnapshot> {
+                None
+            }
+            fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+                None
+            }
+            fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+                crate::pty::context_scrape::ScreenRowsRead::Unavailable
+            }
+            fn register_response_watcher(
+                &self,
+                _session_id: Uuid,
+                _request_id: String,
+                _response_dir: std::path::PathBuf,
+            ) {
+            }
+            fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+                false
+            }
+            fn kill_all_jobs(&self) -> (usize, usize) {
+                (0, 0)
+            }
+            fn screen_rows_since(&self, _id: Uuid, _seen: Option<FrameStamp>) -> ScreenRowsSince {
+                let tick = self
+                    .reads
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let rows = vec!["idle".to_string(), format!("elapsed 00:0{tick}")];
+                ScreenRowsSince::Frame(ScreenFrame {
+                    wrapped: vec![false; rows.len()],
+                    cursor_row: 0,
+                    stamp: Some(FrameStamp {
+                        sequence: tick as u64 + 1,
+                        rows: rows.len() as u16,
+                        cols: 120,
+                    }),
+                    rows,
+                })
+            }
+        }
+
+        let backend = Arc::new(TickingClockBackend {
+            reads: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let manager = PtyManager::new_for_test(backend);
+        let id = Uuid::new_v4();
+        manager.record_route(id, SessionBackendKind::LocalProcess);
+        let app = tauri::test::mock_builder()
+            .manage(Arc::new(Mutex::new(manager)))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a clock preview test app");
+
+        let preview = preview_watcher_pattern(
+            app.handle().clone(),
+            Some(id.to_string()),
+            r"elapsed (\d\d:\d\d)".into(),
+        )
+        .await
+        .expect("preview");
+
+        assert!(preview.sampled);
+        assert_eq!(
+            preview.matched_rows, 1,
+            "one row of two: nothing looks wrong"
+        );
+        assert!(
+            preview.captures_volatile,
+            "...and yet in state mode this would emit five events a second, forever"
+        );
+    }
+
     /// 9.6.86 (third case) - a session that cannot be read reports `sampled: false` and KEEPS
     /// the compile result. "Could not look" must never read as "looked and found nothing".
     #[tokio::test]

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -700,39 +700,135 @@ async fn read_watcher_preview_frame(
     .flatten()
 }
 
-/// #1171 - which agents a watcher reaches, and which of them it is out of budget for.
+/// #1171 - one watcher row of the draft the Settings modal holds in memory.
+///
+/// Only the three fields `reaches` and the budget depend on (plan 4.8). `pattern`, `mode`,
+/// `dedupe` and `capturedAgainst` take part in neither and are deliberately not sent: the row
+/// already shows its pattern, and `preview_watcher_pattern` answers compilability separately,
+/// so carrying it here would inflate every debounced payload to restate an answer that is
+/// already on screen next to this one.
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherDraftEntry {
+    pub id: String,
+    pub enabled: bool,
+    #[serde(default)]
+    pub commands: Option<Vec<String>>,
+}
+
+/// #1171 - one agent row of the same draft.
+///
+/// The modal edits agents and watchers in ONE store and one Save writes both, so resolving
+/// against the SAVED agent list would answer about a state the user has already left. Two of
+/// the three agent edits over-report that way: deleting an agent leaves it named in a reach
+/// list it will not be in, and changing an agent's `command` leaves a watcher reported as
+/// reaching it under the old stem. Only adding an agent under-reports.
+#[derive(Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherAgentDraftEntry {
+    pub id: String,
+    pub label: String,
+    pub command: String,
+}
+
+/// #1171 - one agent that a draft row's selector reaches.
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WatcherReachEntry {
     pub agent_id: String,
     pub agent_label: String,
     pub command_stem: String,
-    /// False when this watcher reaches the agent but falls outside its 8-watcher budget.
-    pub in_budget: bool,
+    /// Whether this row is enabled in the draft AND holds one of this agent's 8 slots once
+    /// every other ENABLED row of the draft is counted. It is membership of the engine's own
+    /// `running` list, and NOT a promise that the watcher will emit anything: a resolved
+    /// watcher whose pattern does not compile is allocated a slot and is inert. Compilability
+    /// is a separate dimension, answered per row by `preview_watcher_pattern`, and this field
+    /// deliberately does not restate it. A disabled row is always false here, and the editor,
+    /// which owns `enabled`, must say "disabled" rather than "budget".
+    pub allocated: bool,
 }
 
-/// #1171 - resolve a CANDIDATE selector against the configured agents.
+/// #1171 - the reach of one draft row.
 ///
-/// This exists so the Settings UI never reimplements stem normalization. There is exactly one
-/// stem rule in the tree (`command_executable_basename`), the catalog rejects prefix matching
-/// in writing because `pi` and `agent` false-match under it, and the frontend's existing
-/// `starts_with` rule in `suggestedContextRegex` must not be ported. Asking the backend is the
-/// only way to keep that true.
+/// Exactly one per requested row, in request order. It carries `id` back because the editor
+/// filters unrecognised rows out of the request, so its table positions do not match the
+/// response positions.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherReachRow {
+    pub id: String,
+    /// Every agent this row's SELECTOR reaches, whether or not the row is enabled. Reach is a
+    /// property of the selector alone; `allocated` is where enablement and budget land.
+    pub entries: Vec<WatcherReachEntry>,
+}
+
+/// #1171 - resolve the WHOLE Settings draft, watchers and agents, and report per row which
+/// agents its selector reaches and which of those it holds a slot on.
 ///
-/// The candidate replaces the saved entry of the same id before resolving, so the budget is
-/// computed against the map the user is about to save rather than the one on disk.
+/// This exists so the Settings UI reimplements neither stem normalization nor the budget rule.
+/// There is exactly one stem rule in the tree (`command_executable_basename`), the catalog
+/// rejects prefix matching in writing because `pi` and `agent` false-match under it, and the
+/// frontend's existing `starts_with` rule in `suggestedContextRegex` must not be ported.
+/// Neither the `BTreeMap` key order nor the number 8 is written a second time in TypeScript.
+///
+/// It takes the whole draft and not one row because allocation is a property of the SET:
+/// resolution walks the map in key order and takes the first 8 that reach an agent. A command
+/// receiving a single row could only answer by inventing what the rest of the set is, and the
+/// only set available to it is the saved one, which is not the one the user is editing. With
+/// an empty saved map, adding nine rows before Save would make all nine report that they run,
+/// and then only eight would - a positive claim about a watcher that will not run, which is
+/// the opposite of the fail-closed direction this feature takes everywhere else.
+///
+/// Both halves come from the draft and nothing comes from disk: no settings are read and **no
+/// lock is taken**, so a preview can never contend with a save.
 #[tauri::command]
 pub async fn preview_watcher_reach(
-    settings: State<'_, crate::config::settings::SettingsState>,
-    watcher_id: String,
-    commands: Option<Vec<String>>,
-) -> Result<Vec<WatcherReachEntry>, String> {
+    watchers: Vec<WatcherDraftEntry>,
+    agents: Vec<WatcherAgentDraftEntry>,
+) -> Result<Vec<WatcherReachRow>, String> {
+    // Synchronous CPU over an input the caller controls: one pass is O(agents x total selector
+    // ENTRIES), and nothing bounds either, so one row carrying ten thousand selector entries
+    // costs what ten thousand rows carrying one each cost. Off the async worker, following
+    // `preview_watcher_pattern` above. No cap is introduced here on purpose: the engine
+    // already runs exactly this resolution over exactly this data every 200 ms, so a payload
+    // big enough to make two debounced passes expensive is already costing five times as much
+    // per second inside the tick, and a cap only on the preview would feel like a fix while
+    // leaving the cost where it is.
+    //
+    // The command owns its inputs and takes no lock, so the move is a wrapper and nothing else.
+    tokio::task::spawn_blocking(move || resolve_draft_reach(&watchers, &agents))
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// The two passes behind `preview_watcher_reach`, pure and off the runtime.
+///
+/// Reach and allocation are different questions, and each gets its own pass over the SAME
+/// draft, so no counterfactual budget is computed and no set of answers can disagree with
+/// itself:
+///
+/// - **Pass A, every row forced enabled**, supplies `entries`. Reach does not depend on any
+///   other row, so forcing enablement changes no row's answer but its own presence, and a
+///   disabled row still shows the agents its selector reaches - the state where the control is
+///   needed most.
+/// - **Pass B, every row at its real draft `enabled`**, is the engine's own resolution and
+///   supplies `allocated`.
+///
+/// Running one forced-enabled pass PER ROW instead would let nine rows all report a slot on an
+/// agent that has eight, because each row's own pass silently displaces a different one.
+///
+/// Fixed points that the editor cannot produce but the contract still defines: a duplicate id
+/// means the later row wins when the map is built and both response rows report that one
+/// resolution, and an empty id is a legal key that sorts first and is not special-cased.
+fn resolve_draft_reach(
+    watchers: &[WatcherDraftEntry],
+    agents: &[WatcherAgentDraftEntry],
+) -> Vec<WatcherReachRow> {
     use crate::config::settings::{WatcherConfig, WatcherEntry, WatcherMode};
     use crate::pty::watchers::{resolve_watchers, WatcherAgent};
+    use std::collections::BTreeMap;
 
-    let settings = settings.read().await;
-    let agents: Vec<WatcherAgent> = settings
-        .agents
+    let resolution_agents: Vec<WatcherAgent> = agents
         .iter()
         .map(|agent| WatcherAgent {
             id: agent.id.clone(),
@@ -740,112 +836,128 @@ pub async fn preview_watcher_reach(
         })
         .collect();
 
-    // Start from whatever the saved entry says, so mode, pattern and dedupe are the user's,
-    // and override exactly two things.
-    //
-    // `commands` is the selector being previewed, which is the whole point of the call.
-    //
-    // `enabled` is forced ON because the question this command answers is "which agents WOULD
-    // this selector reach", not "which agents does it reach right now". A disabled watcher
-    // would otherwise always answer "reaches 0 agents", which makes the reach control useless
-    // in the one editor state where the user most needs it - configuring a watcher before
-    // turning it on. Forcing it also makes the budget honest: it reports whether enabling this
-    // watcher WOULD leave it outside some agent's 8-watcher budget.
-    //
-    // Nothing here is written back: the map below is a local copy used to resolve and dropped.
-    let mut candidate = match settings.watchers.get(&watcher_id).and_then(|e| e.valid()) {
-        Some(saved) => saved.clone(),
-        None => WatcherConfig {
-            enabled: true,
-            mode: WatcherMode::Occurrence,
-            pattern: String::new(),
-            commands: None,
-            dedupe: Default::default(),
-            dedupe_window_ms: 2000,
-            captured_against: None,
-        },
+    // `mode`, `pattern`, `dedupe` and `dedupeWindowMs` take no part in resolution and do not
+    // travel, so they are placeholders here and are never read back out.
+    let draft_map = |force_enabled: bool| -> BTreeMap<String, WatcherEntry> {
+        watchers
+            .iter()
+            .map(|row| {
+                (
+                    row.id.clone(),
+                    WatcherEntry::Valid(WatcherConfig {
+                        enabled: force_enabled || row.enabled,
+                        mode: WatcherMode::Occurrence,
+                        pattern: String::new(),
+                        commands: row.commands.clone(),
+                        dedupe: Default::default(),
+                        dedupe_window_ms: 0,
+                        captured_against: None,
+                    }),
+                )
+            })
+            .collect()
     };
-    candidate.commands = commands;
-    candidate.enabled = true;
 
-    let mut watchers = settings.watchers.clone();
-    watchers.insert(watcher_id.clone(), WatcherEntry::Valid(candidate));
-    let labels: std::collections::HashMap<&str, (&str, &str)> = settings
-        .agents
-        .iter()
-        .map(|agent| {
-            (
-                agent.id.as_str(),
-                (agent.label.as_str(), agent.command.as_str()),
-            )
-        })
-        .collect();
+    let (reach_pass, _notices) = resolve_watchers(&resolution_agents, &draft_map(true));
+    let (allocation_pass, _notices) = resolve_watchers(&resolution_agents, &draft_map(false));
 
-    let (resolved, _notices) = resolve_watchers(&agents, &watchers);
+    // Keyed by agent id and not iterated straight off `agents`, so a draft that names the same
+    // agent twice produces one entry rather than two, matching the map `resolve_watchers`
+    // itself builds.
+    let mut agent_meta: BTreeMap<String, (String, String)> = BTreeMap::new();
+    for agent in agents {
+        let stem =
+            crate::config::coding_agents_catalog::command_executable_basename(&agent.command)
+                .unwrap_or_default();
+        agent_meta.insert(agent.id.clone(), (agent.label.clone(), stem));
+    }
 
-    let mut out: Vec<WatcherReachEntry> = Vec::new();
-    for (agent_id, resolution) in &resolved {
-        let running = resolution.running.iter().any(|w| w.id == watcher_id);
-        let over_budget = resolution.over_budget.iter().any(|id| id == &watcher_id);
-        if !running && !over_budget {
-            continue;
+    let mut rows = Vec::with_capacity(watchers.len());
+    for row in watchers {
+        let mut entries: Vec<WatcherReachEntry> = Vec::new();
+        for (agent_id, (label, stem)) in &agent_meta {
+            // Reach is `running` OR `over_budget`: together they hold everything whose selector
+            // matches this agent.
+            let reaches = reach_pass.get(agent_id).is_some_and(|resolution| {
+                resolution.running.iter().any(|w| w.id == row.id)
+                    || resolution.over_budget.iter().any(|id| id == &row.id)
+            });
+            if !reaches {
+                continue;
+            }
+            let allocated = allocation_pass
+                .get(agent_id)
+                .is_some_and(|resolution| resolution.running.iter().any(|w| w.id == row.id));
+            entries.push(WatcherReachEntry {
+                agent_id: agent_id.clone(),
+                agent_label: label.clone(),
+                command_stem: stem.clone(),
+                allocated,
+            });
         }
-        let (label, command) = labels.get(agent_id.as_str()).copied().unwrap_or(("", ""));
-        out.push(WatcherReachEntry {
-            agent_id: agent_id.clone(),
-            agent_label: label.to_string(),
-            command_stem: crate::config::coding_agents_catalog::command_executable_basename(
-                command,
-            )
-            .unwrap_or_default(),
-            in_budget: running,
+        // `resolve_watchers` returns a `HashMap`, so a stable order has to be imposed here
+        // rather than assumed: the Settings list must not reshuffle between keystrokes.
+        entries.sort_by(|left, right| {
+            left.agent_label
+                .cmp(&right.agent_label)
+                .then_with(|| left.agent_id.cmp(&right.agent_id))
+        });
+        rows.push(WatcherReachRow {
+            id: row.id.clone(),
+            entries,
         });
     }
-    // `resolve_watchers` returns a HashMap, so a stable order has to be imposed here rather
-    // than assumed: the Settings list must not reshuffle between keystrokes.
-    out.sort_by(|left, right| {
-        left.agent_label
-            .cmp(&right.agent_label)
-            .then_with(|| left.agent_id.cmp(&right.agent_id))
-    });
-    Ok(out)
+    rows
 }
 
 #[cfg(test)]
 mod watcher_preview_tests {
     use super::*;
-    use crate::config::settings::{
-        AgentConfig, AppSettings, SettingsState, WatcherConfig, WatcherEntry, WatcherMode,
-    };
+    use crate::config::settings::{AppSettings, SettingsState};
     use crate::errors::AppError;
     use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
     use crate::pty::watchers::{FrameStamp, ScreenFrame, ScreenRowsSince};
 
-    fn agent(id: &str, label: &str, command: &str) -> AgentConfig {
-        AgentConfig {
+    /// One watcher row of the Settings draft. `preview_watcher_reach` takes the whole draft,
+    /// so every reach test below builds a set and never a single row.
+    fn draft(id: &str, enabled: bool, commands: Option<&[&str]>) -> WatcherDraftEntry {
+        WatcherDraftEntry {
             id: id.to_string(),
-            label: label.to_string(),
-            command: command.to_string(),
-            color: "#fff".to_string(),
-            envs: Vec::new(),
-            isolated_home: false,
-            instructions_filename: None,
-            config_seed: None,
-            context_regex: None,
-            backend: Default::default(),
+            enabled,
+            commands: commands.map(|list| list.iter().map(|s| s.to_string()).collect()),
         }
     }
 
-    fn watcher(commands: Option<&[&str]>) -> WatcherEntry {
-        WatcherEntry::Valid(WatcherConfig {
-            enabled: true,
-            mode: WatcherMode::Occurrence,
-            pattern: "x".to_string(),
-            commands: commands.map(|list| list.iter().map(|s| s.to_string()).collect()),
-            dedupe: Default::default(),
-            dedupe_window_ms: 2000,
-            captured_against: None,
-        })
+    fn draft_agent(id: &str, label: &str, command: &str) -> WatcherAgentDraftEntry {
+        WatcherAgentDraftEntry {
+            id: id.to_string(),
+            label: label.to_string(),
+            command: command.to_string(),
+        }
+    }
+
+    /// The row of `id` in a reach response, which is addressed by id and never by position.
+    fn row<'a>(rows: &'a [WatcherReachRow], id: &str) -> &'a WatcherReachRow {
+        rows.iter()
+            .find(|row| row.id == id)
+            .unwrap_or_else(|| panic!("no reach row for '{id}'"))
+    }
+
+    fn allocated_on(rows: &[WatcherReachRow], id: &str, agent_id: &str) -> bool {
+        row(rows, id)
+            .entries
+            .iter()
+            .find(|entry| entry.agent_id == agent_id)
+            .unwrap_or_else(|| panic!("watcher '{id}' does not reach agent '{agent_id}'"))
+            .allocated
+    }
+
+    fn reached_agents(rows: &[WatcherReachRow], id: &str) -> Vec<String> {
+        row(rows, id)
+            .entries
+            .iter()
+            .map(|entry| entry.agent_id.clone())
+            .collect()
     }
 
     fn settings_app(settings: AppSettings) -> tauri::App<tauri::test::MockRuntime> {
@@ -1217,79 +1329,318 @@ mod watcher_preview_tests {
         .is_err());
     }
 
-    /// 9.4.58 - `preview_watcher_reach` names the agents a selector reaches, resolving stems
-    /// through the ONE rule in the tree rather than a second one written in TypeScript.
+    /// 9.4.58a - nine enabled selectorless rows against one agent: the first eight in ID order
+    /// hold a slot and the ninth does not, with nothing on disk contributing.
+    ///
+    /// The rows are sent in an order deliberately different from lexicographic, so an
+    /// implementation that honours request order instead of `BTreeMap` key order fails here.
+    /// Its failure mode is the UI telling the user that a watcher holds a slot it does not.
     #[tokio::test]
-    async fn preview_reach_reports_the_agents_a_selector_reaches() {
-        let app = settings_app(AppSettings {
-            agents: vec![
-                agent("a1", "Claude", "claude"),
-                agent("a2", "Claude Sandbox", r"C:\rt\claude.cmd"),
-                agent("a3", "Codex", "codex"),
-                agent("a4", "Pi via Claude", "pi --provider claude"),
-            ],
-            ..AppSettings::default()
-        });
-
-        let reach = preview_watcher_reach(
-            app.state(),
-            "w".to_string(),
-            Some(vec!["claude".to_string()]),
+    async fn a_draft_of_nine_rows_allocates_the_first_eight_in_id_order() {
+        let ids = ["w3", "w9", "w1", "w7", "w5", "w2", "w8", "w4", "w6"];
+        let rows = preview_watcher_reach(
+            ids.iter().map(|id| draft(id, true, None)).collect(),
+            vec![draft_agent("a1", "Claude", "claude")],
         )
         .await
         .expect("reach");
 
-        let ids: Vec<&str> = reach.iter().map(|entry| entry.agent_id.as_str()).collect();
-        assert_eq!(ids, vec!["a1", "a2"]);
-        assert!(reach.iter().all(|entry| entry.in_budget));
-        assert_eq!(reach[0].agent_label, "Claude");
-        assert_eq!(reach[1].command_stem, "claude");
-    }
-
-    /// ...and it marks a watcher that reaches an agent but falls outside its budget, so the
-    /// user sees "not running on <agent>" in the row where they made the choice instead of in
-    /// a log line they will never read.
-    #[tokio::test]
-    async fn preview_reach_marks_a_watcher_that_is_out_of_budget() {
-        let mut settings = AppSettings {
-            agents: vec![agent("a1", "Claude", "claude")],
-            ..AppSettings::default()
-        };
-        for i in 0..8 {
-            settings.watchers.insert(format!("aaa-{i}"), watcher(None));
+        assert_eq!(
+            rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            ids,
+            "one response row per request row, in request order"
+        );
+        for id in ["w1", "w2", "w3", "w4", "w5", "w6", "w7", "w8"] {
+            assert!(allocated_on(&rows, id, "a1"), "{id} is within the budget");
         }
-        let app = settings_app(settings);
-
-        let reach = preview_watcher_reach(app.state(), "zzz-mine".to_string(), None)
-            .await
-            .expect("reach");
-
-        assert_eq!(reach.len(), 1);
-        assert_eq!(reach[0].agent_id, "a1");
         assert!(
-            !reach[0].in_budget,
-            "eight watchers already run on this agent, so the ninth is configured but idle"
+            !allocated_on(&rows, "w9", "a1"),
+            "w9 sorts ninth and the agent has eight slots"
+        );
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.entries.iter().any(|entry| entry.allocated))
+                .count(),
+            crate::pty::watchers::WATCHERS_PER_AGENT_BUDGET,
+            "no draft yields more allocated rows on one agent than that agent has slots"
         );
     }
 
-    /// A selector no agent has is not an error: it simply reaches nobody, and Settings shows
-    /// "reaches 0 agents" so the typo is visible where it was made.
+    /// 9.4.58b - the draft is the whole input. A row the user deleted contributes nothing to
+    /// any agent's budget, however many rows the saved map still holds.
     #[tokio::test]
-    async fn preview_reach_of_a_stem_no_agent_has_is_empty_and_not_an_error() {
-        let app = settings_app(AppSettings {
-            agents: vec![agent("a1", "Claude", "claude")],
-            ..AppSettings::default()
-        });
-
-        let reach = preview_watcher_reach(
-            app.state(),
-            "w".to_string(),
-            Some(vec!["gemni".to_string()]),
+    async fn rows_absent_from_the_draft_consume_no_budget() {
+        let rows = preview_watcher_reach(
+            ["w1", "w2", "w3", "w4"]
+                .iter()
+                .map(|id| draft(id, true, None))
+                .collect(),
+            vec![draft_agent("a1", "Claude", "claude")],
         )
         .await
         .expect("reach");
 
-        assert!(reach.is_empty());
+        assert_eq!(rows.len(), 4);
+        for id in ["w1", "w2", "w3", "w4"] {
+            assert!(allocated_on(&rows, id, "a1"));
+        }
+    }
+
+    /// 9.4.58c - the displacement fixture: one disabled row plus eight enabled ones.
+    ///
+    /// This is the case a per-row forced-enabled pass gets wrong. There, `a`'s own pass
+    /// displaced `i` while every other row's pass displaced nobody, so all nine reported
+    /// themselves in budget on an agent with eight slots.
+    #[tokio::test]
+    async fn a_disabled_row_reaches_everything_and_allocates_nothing() {
+        let mut watchers = vec![draft("a", false, None)];
+        for id in ["b", "c", "d", "e", "f", "g", "h", "i"] {
+            watchers.push(draft(id, true, None));
+        }
+        let rows = preview_watcher_reach(watchers, vec![draft_agent("a1", "Claude", "claude")])
+            .await
+            .expect("reach");
+
+        assert_eq!(
+            reached_agents(&rows, "a"),
+            vec!["a1"],
+            "a disabled row still reports the agents its selector reaches"
+        );
+        assert!(
+            !allocated_on(&rows, "a", "a1"),
+            "a disabled row holds no slot, and the editor must call that 'disabled', not 'budget'"
+        );
+        for id in ["b", "c", "d", "e", "f", "g", "h", "i"] {
+            assert!(
+                allocated_on(&rows, id, "a1"),
+                "{id} is one of the eight enabled rows and the disabled row displaces none of them"
+            );
+        }
+        assert_eq!(
+            rows.iter()
+                .filter(|row| row.entries.iter().any(|entry| entry.allocated))
+                .count(),
+            crate::pty::watchers::WATCHERS_PER_AGENT_BUDGET
+        );
+    }
+
+    /// 9.4.58d - reach does not depend on enablement. The `entries` of a row are identical
+    /// whether it is enabled or disabled, all else equal; only `allocated` moves.
+    #[tokio::test]
+    async fn reach_does_not_depend_on_enablement() {
+        let agents = vec![
+            draft_agent("a1", "Claude", "claude"),
+            draft_agent("a2", "Codex", "codex"),
+        ];
+        let others = || {
+            vec![
+                draft("w1", true, Some(&["claude"])),
+                draft("w2", true, None),
+            ]
+        };
+
+        let mut enabled = others();
+        enabled.push(draft("w3", true, Some(&["claude", "codex"])));
+        let enabled = preview_watcher_reach(enabled, agents.clone())
+            .await
+            .expect("reach");
+
+        let mut disabled = others();
+        disabled.push(draft("w3", false, Some(&["claude", "codex"])));
+        let disabled = preview_watcher_reach(disabled, agents)
+            .await
+            .expect("reach");
+
+        assert_eq!(reached_agents(&enabled, "w3"), vec!["a1", "a2"]);
+        assert_eq!(
+            reached_agents(&disabled, "w3"),
+            reached_agents(&enabled, "w3")
+        );
+        assert!(allocated_on(&enabled, "w3", "a1"));
+        assert!(!allocated_on(&disabled, "w3", "a1"));
+        assert_eq!(
+            reached_agents(&disabled, "w1"),
+            reached_agents(&enabled, "w1"),
+            "and no other row's reach moved either"
+        );
+    }
+
+    /// 9.4.58e - the selector rules, unchanged: absent reaches every agent, `[]` reaches none,
+    /// a selector that does not tokenize skips the whole watcher, and the reported stem is the
+    /// AGENT's. In both reach-nobody cases the response row is still present, with no entries.
+    #[tokio::test]
+    async fn the_selector_rules_survive_the_draft_shape() {
+        let rows = preview_watcher_reach(
+            vec![
+                draft("all", true, None),
+                draft("none", true, Some(&[])),
+                draft("broken", true, Some(&["claude", "   "])),
+                draft("claude-only", true, Some(&["claude"])),
+                draft("typo", true, Some(&["gemni"])),
+            ],
+            vec![
+                draft_agent("a1", "Claude", "claude"),
+                draft_agent("a2", "Claude Sandbox", r"C:\rt\claude.cmd"),
+                draft_agent("a3", "Codex", "codex"),
+                draft_agent("a4", "Pi via Claude", "pi --provider claude"),
+            ],
+        )
+        .await
+        .expect("reach");
+
+        assert_eq!(reached_agents(&rows, "all"), vec!["a1", "a2", "a3", "a4"]);
+        assert!(
+            row(&rows, "none").entries.is_empty(),
+            "an empty selector reaches nobody and is the opposite of an absent one"
+        );
+        assert!(
+            row(&rows, "broken").entries.is_empty(),
+            "one unreadable selector entry skips the WHOLE watcher, never 'reaches everybody'"
+        );
+        assert!(row(&rows, "typo").entries.is_empty());
+        assert_eq!(reached_agents(&rows, "claude-only"), vec!["a1", "a2"]);
+
+        let claude_only = &row(&rows, "claude-only").entries;
+        assert_eq!(claude_only[0].agent_label, "Claude");
+        assert_eq!(
+            claude_only[1].command_stem, "claude",
+            "the stem reported is the agent's, resolved through the one rule in the tree"
+        );
+    }
+
+    /// 9.4.58f - the agents come from the draft too. Each of these three is a case where
+    /// resolving against the saved agent list would have answered about a state the user had
+    /// already left, and two of the three would have over-reported.
+    #[tokio::test]
+    async fn the_agent_half_of_the_draft_decides_the_reach() {
+        let watchers = || {
+            vec![
+                draft("on-claude", true, Some(&["claude"])),
+                draft("on-codex", true, Some(&["codex"])),
+            ]
+        };
+
+        let before = preview_watcher_reach(
+            watchers(),
+            vec![
+                draft_agent("a1", "Claude", "claude"),
+                draft_agent("a2", "Second", "claude"),
+            ],
+        )
+        .await
+        .expect("reach");
+        assert_eq!(reached_agents(&before, "on-claude"), vec!["a1", "a2"]);
+        assert!(row(&before, "on-codex").entries.is_empty());
+
+        // The command changed in the draft: the agent leaves one watcher and joins the other.
+        let retargeted = preview_watcher_reach(
+            watchers(),
+            vec![
+                draft_agent("a1", "Claude", "claude"),
+                draft_agent("a2", "Second", "codex"),
+            ],
+        )
+        .await
+        .expect("reach");
+        assert_eq!(reached_agents(&retargeted, "on-claude"), vec!["a1"]);
+        assert_eq!(reached_agents(&retargeted, "on-codex"), vec!["a2"]);
+
+        // The agent was deleted in the draft: it is named by nobody.
+        let removed = preview_watcher_reach(
+            watchers(),
+            vec![draft_agent("a1", "Claude", "claude")],
+        )
+        .await
+        .expect("reach");
+        assert_eq!(reached_agents(&removed, "on-claude"), vec!["a1"]);
+
+        // The agent was added in the draft: it is reached before it is ever saved.
+        let added = preview_watcher_reach(
+            watchers(),
+            vec![
+                draft_agent("a1", "Claude", "claude"),
+                draft_agent("a2", "Second", "claude"),
+                draft_agent("a3", "Third", "codex"),
+            ],
+        )
+        .await
+        .expect("reach");
+        assert_eq!(reached_agents(&added, "on-claude"), vec!["a1", "a2"]);
+        assert_eq!(reached_agents(&added, "on-codex"), vec!["a3"]);
+    }
+
+    /// 9.4.58j - the fixed points of the contract that the editor cannot produce but the
+    /// command still has to define: duplicate ids, an empty id, response order, entry order.
+    #[tokio::test]
+    async fn the_defined_behavior_for_drafts_the_editor_cannot_produce() {
+        let rows = preview_watcher_reach(
+            vec![
+                draft("dup", true, Some(&["codex"])),
+                draft("", true, None),
+                draft("dup", true, Some(&["claude"])),
+            ],
+            vec![
+                // Labels out of alphabetical order and one pair sharing a label, so the
+                // entry sort is exercised on both keys.
+                draft_agent("a2", "Zed", "claude"),
+                draft_agent("a3", "Alpha", "claude"),
+                draft_agent("a1", "Alpha", "claude"),
+            ],
+        )
+        .await
+        .expect("reach");
+
+        assert_eq!(
+            rows.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+            vec!["dup", "", "dup"],
+            "one response row per request row, in request order, id carried back"
+        );
+        assert_eq!(
+            reached_agents(&rows, "dup"),
+            vec!["a1", "a3", "a2"],
+            "entries sort by label with the agent id as tie-break"
+        );
+        assert_eq!(
+            rows[0].entries.len(),
+            rows[2].entries.len(),
+            "a duplicate id is later-wins in the map and BOTH response rows report that one \
+             resolution"
+        );
+        assert_eq!(reached_agents(&rows, ""), vec!["a1", "a3", "a2"]);
+        assert!(
+            allocated_on(&rows, "", "a1"),
+            "an empty id is a legal key that sorts first, and is not special-cased"
+        );
+    }
+
+    /// 9.4.58l - allocation is slot assignment and not a promise of output.
+    ///
+    /// The pattern does not travel to the reach command at all, so a row whose regex does not
+    /// compile is allocated a slot and is inert. The two dimensions are asserted together, so
+    /// nobody later reads `allocated` as a promise that the watcher will emit.
+    #[tokio::test]
+    async fn an_uncompilable_pattern_is_allocated_and_inert() {
+        let app = settings_app(AppSettings::default());
+
+        let rows = preview_watcher_reach(
+            vec![draft("broken-regex", true, None)],
+            vec![draft_agent("a1", "Claude", "claude")],
+        )
+        .await
+        .expect("reach");
+        assert!(
+            allocated_on(&rows, "broken-regex", "a1"),
+            "an enabled row within budget holds its slot whatever its pattern is"
+        );
+
+        let compile = preview_watcher_pattern(app.handle().clone(), None, "Read (".to_string())
+            .await
+            .expect("preview");
+        assert!(
+            !compile.compiles,
+            "and the other dimension is answered next to it, by the row's own pattern preview"
+        );
+        assert!(compile.error.is_some());
     }
 }
 

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -1546,12 +1546,10 @@ mod watcher_preview_tests {
         assert_eq!(reached_agents(&retargeted, "on-codex"), vec!["a2"]);
 
         // The agent was deleted in the draft: it is named by nobody.
-        let removed = preview_watcher_reach(
-            watchers(),
-            vec![draft_agent("a1", "Claude", "claude")],
-        )
-        .await
-        .expect("reach");
+        let removed =
+            preview_watcher_reach(watchers(), vec![draft_agent("a1", "Claude", "claude")])
+                .await
+                .expect("reach");
         assert_eq!(reached_agents(&removed, "on-claude"), vec!["a1"]);
 
         // The agent was added in the draft: it is reached before it is ever saved.

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -532,6 +532,548 @@ pub fn get_session_context(app: AppHandle, session_id: String) -> Result<Option<
     Ok(scraper.last_reading(uuid))
 }
 
+/// #1171 - what a pattern does, before it is saved.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherPatternPreview {
+    pub compiles: bool,
+    pub error: Option<String>,
+    /// False when no session was given, or the session had no readable frame. This is what
+    /// distinguishes "matched nothing" from "could not look".
+    pub sampled: bool,
+    pub matched_rows: usize,
+    pub total_rows: usize,
+    /// Up to 3 matched logical rows, each truncated to 256 bytes.
+    pub samples: Vec<String>,
+    /// True when the captures of the lowest match differed between the two samples taken about
+    /// a second apart. A pattern that captures a clock or a token counter matches one row of
+    /// thirty and still emits five events a second in `state` mode, and `matchedRows` alone
+    /// cannot say so.
+    pub captures_volatile: bool,
+}
+
+/// How many matched rows the preview shows.
+const WATCHER_PREVIEW_SAMPLES: usize = 3;
+
+/// #1171 - compile a candidate pattern and, optionally, run it against a live session.
+///
+/// `session_id: None` compiles only. That is the COMMON case: a user opens Settings and writes
+/// a regex with no agent session running, and without this the only signal for a syntax error
+/// would be the absence of activations.
+///
+/// `async` and doing the PTY reads inside `spawn_blocking`, because this path deliberately
+/// goes through `PtyManager::screen_rows_since` - taking the manager mutex, the route registry
+/// and, on the local backend, a child liveness probe - while a session may be producing heavy
+/// output. The engine's own tick avoids all of that; a debounced preview can afford it, and
+/// blocking the async runtime on it could not.
+#[tauri::command]
+pub async fn preview_watcher_pattern<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    session_id: Option<String>,
+    pattern: String,
+) -> Result<WatcherPatternPreview, String> {
+    let compiled = match crate::pty::watchers::pattern::compile(&pattern) {
+        Ok(compiled) => compiled,
+        Err(error) => {
+            // A pattern that does not compile is a RESULT, not a command failure: the Settings
+            // control needs the message to show, not an exception to swallow.
+            return Ok(WatcherPatternPreview {
+                compiles: false,
+                error: Some(error),
+                sampled: false,
+                matched_rows: 0,
+                total_rows: 0,
+                samples: Vec::new(),
+                captures_volatile: false,
+            });
+        }
+    };
+
+    let mut preview = WatcherPatternPreview {
+        compiles: true,
+        error: None,
+        sampled: false,
+        matched_rows: 0,
+        total_rows: 0,
+        samples: Vec::new(),
+        captures_volatile: false,
+    };
+
+    let Some(session_id) = session_id else {
+        return Ok(preview);
+    };
+    let uuid = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+    let Some(pty_mgr) = app.try_state::<Arc<Mutex<PtyManager>>>() else {
+        return Ok(preview);
+    };
+    let pty_mgr = Arc::clone(pty_mgr.inner());
+
+    let first = read_watcher_preview_frame(Arc::clone(&pty_mgr), uuid).await;
+    let Some(first) = first else {
+        return Ok(preview);
+    };
+
+    let logical = crate::pty::watchers::frame::logical_rows(&first);
+    let regex = compiled.regex();
+    let matched: Vec<&crate::pty::watchers::frame::LogicalRow> = logical
+        .iter()
+        .filter(|row| regex.is_match(&row.text))
+        .collect();
+
+    preview.sampled = true;
+    preview.total_rows = logical.len();
+    preview.matched_rows = matched.len();
+    preview.samples = matched
+        .iter()
+        .take(WATCHER_PREVIEW_SAMPLES)
+        .map(|row| crate::pty::watchers::truncate_row(&row.text).0)
+        .collect();
+
+    let lowest_captures = |rows: &[&crate::pty::watchers::frame::LogicalRow]| {
+        rows.last()
+            .and_then(|row| regex.captures(&row.text))
+            .map(|found| {
+                found
+                    .iter()
+                    .skip(1)
+                    .map(|group| group.map(|m| m.as_str().to_string()))
+                    .collect::<Vec<_>>()
+            })
+    };
+    let before = lowest_captures(&matched);
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    if let Some(second) = read_watcher_preview_frame(pty_mgr, uuid).await {
+        let logical = crate::pty::watchers::frame::logical_rows(&second);
+        let matched: Vec<&crate::pty::watchers::frame::LogicalRow> = logical
+            .iter()
+            .filter(|row| regex.is_match(&row.text))
+            .collect();
+        let after = lowest_captures(&matched);
+        preview.captures_volatile = before.is_some() && after.is_some() && before != after;
+    }
+
+    Ok(preview)
+}
+
+/// Read one session's frame off the async runtime.
+///
+/// `seen: None` on purpose: the preview always wants the rows, never an `Unchanged`.
+async fn read_watcher_preview_frame(
+    pty_mgr: Arc<Mutex<PtyManager>>,
+    id: Uuid,
+) -> Option<crate::pty::watchers::ScreenFrame> {
+    tokio::task::spawn_blocking(move || {
+        let mgr = pty_mgr.lock().ok()?;
+        match mgr.screen_rows_since(id, None) {
+            crate::pty::watchers::ScreenRowsSince::Frame(frame) => Some(frame),
+            _ => None,
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+/// #1171 - which agents a watcher reaches, and which of them it is out of budget for.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherReachEntry {
+    pub agent_id: String,
+    pub agent_label: String,
+    pub command_stem: String,
+    /// False when this watcher reaches the agent but falls outside its 8-watcher budget.
+    pub in_budget: bool,
+}
+
+/// #1171 - resolve a CANDIDATE selector against the configured agents.
+///
+/// This exists so the Settings UI never reimplements stem normalization. There is exactly one
+/// stem rule in the tree (`command_executable_basename`), the catalog rejects prefix matching
+/// in writing because `pi` and `agent` false-match under it, and the frontend's existing
+/// `starts_with` rule in `suggestedContextRegex` must not be ported. Asking the backend is the
+/// only way to keep that true.
+///
+/// The candidate replaces the saved entry of the same id before resolving, so the budget is
+/// computed against the map the user is about to save rather than the one on disk.
+#[tauri::command]
+pub async fn preview_watcher_reach(
+    settings: State<'_, crate::config::settings::SettingsState>,
+    watcher_id: String,
+    commands: Option<Vec<String>>,
+) -> Result<Vec<WatcherReachEntry>, String> {
+    use crate::config::settings::{WatcherConfig, WatcherEntry, WatcherMode};
+    use crate::pty::watchers::{resolve_watchers, WatcherAgent};
+
+    let settings = settings.read().await;
+    let agents: Vec<WatcherAgent> = settings
+        .agents
+        .iter()
+        .map(|agent| WatcherAgent {
+            id: agent.id.clone(),
+            command: agent.command.clone(),
+        })
+        .collect();
+
+    // Keep whatever the saved entry already says, and override only the selector: a preview
+    // must not silently re-enable a disabled watcher or change its mode.
+    let mut candidate = match settings.watchers.get(&watcher_id).and_then(|e| e.valid()) {
+        Some(saved) => saved.clone(),
+        None => WatcherConfig {
+            enabled: true,
+            mode: WatcherMode::Occurrence,
+            pattern: String::new(),
+            commands: None,
+            dedupe: Default::default(),
+            dedupe_window_ms: 2000,
+            captured_against: None,
+        },
+    };
+    candidate.commands = commands;
+    candidate.enabled = true;
+
+    let mut watchers = settings.watchers.clone();
+    watchers.insert(watcher_id.clone(), WatcherEntry::Valid(candidate));
+    let labels: std::collections::HashMap<&str, (&str, &str)> = settings
+        .agents
+        .iter()
+        .map(|agent| {
+            (
+                agent.id.as_str(),
+                (agent.label.as_str(), agent.command.as_str()),
+            )
+        })
+        .collect();
+
+    let (resolved, _notices) = resolve_watchers(&agents, &watchers);
+
+    let mut out: Vec<WatcherReachEntry> = Vec::new();
+    for (agent_id, resolution) in &resolved {
+        let running = resolution.running.iter().any(|w| w.id == watcher_id);
+        let over_budget = resolution.over_budget.iter().any(|id| id == &watcher_id);
+        if !running && !over_budget {
+            continue;
+        }
+        let (label, command) = labels.get(agent_id.as_str()).copied().unwrap_or(("", ""));
+        out.push(WatcherReachEntry {
+            agent_id: agent_id.clone(),
+            agent_label: label.to_string(),
+            command_stem: crate::config::coding_agents_catalog::command_executable_basename(
+                command,
+            )
+            .unwrap_or_default(),
+            in_budget: running,
+        });
+    }
+    // `resolve_watchers` returns a HashMap, so a stable order has to be imposed here rather
+    // than assumed: the Settings list must not reshuffle between keystrokes.
+    out.sort_by(|left, right| {
+        left.agent_label
+            .cmp(&right.agent_label)
+            .then_with(|| left.agent_id.cmp(&right.agent_id))
+    });
+    Ok(out)
+}
+
+#[cfg(test)]
+mod watcher_preview_tests {
+    use super::*;
+    use crate::config::settings::{
+        AgentConfig, AppSettings, SettingsState, WatcherConfig, WatcherEntry, WatcherMode,
+    };
+    use crate::errors::AppError;
+    use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
+    use crate::pty::watchers::{FrameStamp, ScreenFrame, ScreenRowsSince};
+
+    fn agent(id: &str, label: &str, command: &str) -> AgentConfig {
+        AgentConfig {
+            id: id.to_string(),
+            label: label.to_string(),
+            command: command.to_string(),
+            color: "#fff".to_string(),
+            envs: Vec::new(),
+            isolated_home: false,
+            instructions_filename: None,
+            config_seed: None,
+            context_regex: None,
+            backend: Default::default(),
+        }
+    }
+
+    fn watcher(commands: Option<&[&str]>) -> WatcherEntry {
+        WatcherEntry::Valid(WatcherConfig {
+            enabled: true,
+            mode: WatcherMode::Occurrence,
+            pattern: "x".to_string(),
+            commands: commands.map(|list| list.iter().map(|s| s.to_string()).collect()),
+            dedupe: Default::default(),
+            dedupe_window_ms: 2000,
+            captured_against: None,
+        })
+    }
+
+    fn settings_app(settings: AppSettings) -> tauri::App<tauri::test::MockRuntime> {
+        let state: SettingsState = Arc::new(tokio::sync::RwLock::new(settings));
+        tauri::test::mock_builder()
+            .manage(state)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a watcher preview test app")
+    }
+
+    /// A backend that paints one fixed screen and refuses everything else.
+    struct FixedScreenBackend {
+        rows: Vec<String>,
+    }
+
+    impl PtyBackend for FixedScreenBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn spawn(
+            &self,
+            _spec: BackendSpawnSpec,
+        ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn write(
+            &self,
+            _authority: &crate::pty::manager::BackendWriteAuthority,
+            _id: Uuid,
+            _data: &[u8],
+        ) -> Result<(), AppError> {
+            unreachable!("a preview must never write to a PTY")
+        }
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), AppError> {
+            unreachable!("a preview must never resize a PTY")
+        }
+        fn kill(&self, _id: Uuid) -> Result<(), AppError> {
+            unreachable!("a preview must never kill a session")
+        }
+        fn has_session(&self, _id: Uuid) -> bool {
+            true
+        }
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            crate::pty::context_scrape::ScreenRowsRead::Unavailable
+        }
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+        fn screen_rows_since(&self, _id: Uuid, _seen: Option<FrameStamp>) -> ScreenRowsSince {
+            ScreenRowsSince::Frame(ScreenFrame {
+                rows: self.rows.clone(),
+                wrapped: vec![false; self.rows.len()],
+                cursor_row: 0,
+                stamp: Some(FrameStamp {
+                    sequence: 1,
+                    rows: self.rows.len() as u16,
+                    cols: 120,
+                }),
+            })
+        }
+    }
+
+    fn pty_app(rows: &[&str]) -> (tauri::App<tauri::test::MockRuntime>, Uuid) {
+        let backend = Arc::new(FixedScreenBackend {
+            rows: rows.iter().map(|r| r.to_string()).collect(),
+        });
+        let manager = PtyManager::new_for_test(backend);
+        let id = Uuid::new_v4();
+        manager.record_route(id, SessionBackendKind::LocalProcess);
+        let app = tauri::test::mock_builder()
+            .manage(Arc::new(Mutex::new(manager)))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a pty preview test app");
+        (app, id)
+    }
+
+    /// 9.6.86 (first case) - **the common case**: a user writes a regex in Settings with no
+    /// agent session running. It compiles and says so, and says explicitly that it did not
+    /// look at anything - which is not the same as having looked and found nothing.
+    #[tokio::test]
+    async fn a_compile_only_preview_reports_compiles_without_sampling() {
+        let app = settings_app(AppSettings::default());
+
+        let preview = preview_watcher_pattern(app.handle().clone(), None, r"Read \((.+)\)".into())
+            .await
+            .expect("compile-only preview never fails");
+
+        assert!(preview.compiles);
+        assert!(preview.error.is_none());
+        assert!(!preview.sampled);
+        assert_eq!((preview.matched_rows, preview.total_rows), (0, 0));
+        assert!(preview.samples.is_empty());
+        assert!(!preview.captures_volatile);
+    }
+
+    /// 9.6.86 (fourth case) - a pattern that does not compile is a RESULT, not a command
+    /// failure. The Settings control needs the message to show the user.
+    #[tokio::test]
+    async fn an_uncompilable_pattern_returns_a_result_rather_than_an_error() {
+        let app = settings_app(AppSettings::default());
+
+        let preview = preview_watcher_pattern(app.handle().clone(), None, r"Read \((.+".into())
+            .await
+            .expect("a bad pattern must not fail the command");
+
+        assert!(!preview.compiles);
+        assert!(preview.error.is_some());
+        assert!(!preview.sampled);
+    }
+
+    /// 9.6.86 (second case) - with a live session, the preview reports matched rows against
+    /// total LOGICAL rows and shows at most three of them.
+    #[tokio::test]
+    async fn a_preview_against_a_live_session_reports_matches_against_total_rows() {
+        let (app, id) = pty_app(&[
+            "Read (a.rs)",
+            "idle",
+            "Read (b.rs)",
+            "Read (c.rs)",
+            "Read (d.rs)",
+        ]);
+
+        let preview = preview_watcher_pattern(
+            app.handle().clone(),
+            Some(id.to_string()),
+            r"Read \((.+)\)".into(),
+        )
+        .await
+        .expect("preview");
+
+        assert!(preview.sampled);
+        assert_eq!(preview.total_rows, 5);
+        assert_eq!(preview.matched_rows, 4);
+        assert_eq!(preview.samples.len(), WATCHER_PREVIEW_SAMPLES);
+        assert_eq!(preview.samples[0], "Read (a.rs)");
+        assert!(
+            !preview.captures_volatile,
+            "the same screen twice cannot be volatile"
+        );
+    }
+
+    /// 9.6.86 (third case) - a session that cannot be read reports `sampled: false` and KEEPS
+    /// the compile result. "Could not look" must never read as "looked and found nothing".
+    #[tokio::test]
+    async fn a_session_that_cannot_be_read_keeps_the_compile_result_and_does_not_claim_a_sample() {
+        let app = settings_app(AppSettings::default());
+
+        let preview = preview_watcher_pattern(
+            app.handle().clone(),
+            Some(Uuid::new_v4().to_string()),
+            "Read".into(),
+        )
+        .await
+        .expect("preview");
+
+        assert!(preview.compiles);
+        assert!(!preview.sampled);
+    }
+
+    #[tokio::test]
+    async fn a_session_id_that_is_not_a_uuid_is_an_error() {
+        let app = settings_app(AppSettings::default());
+
+        assert!(preview_watcher_pattern(
+            app.handle().clone(),
+            Some("not-a-uuid".into()),
+            "x".into()
+        )
+        .await
+        .is_err());
+    }
+
+    /// 9.4.58 - `preview_watcher_reach` names the agents a selector reaches, resolving stems
+    /// through the ONE rule in the tree rather than a second one written in TypeScript.
+    #[tokio::test]
+    async fn preview_reach_reports_the_agents_a_selector_reaches() {
+        let app = settings_app(AppSettings {
+            agents: vec![
+                agent("a1", "Claude", "claude"),
+                agent("a2", "Claude Sandbox", r"C:\rt\claude.cmd"),
+                agent("a3", "Codex", "codex"),
+                agent("a4", "Pi via Claude", "pi --provider claude"),
+            ],
+            ..AppSettings::default()
+        });
+
+        let reach = preview_watcher_reach(
+            app.state(),
+            "w".to_string(),
+            Some(vec!["claude".to_string()]),
+        )
+        .await
+        .expect("reach");
+
+        let ids: Vec<&str> = reach.iter().map(|entry| entry.agent_id.as_str()).collect();
+        assert_eq!(ids, vec!["a1", "a2"]);
+        assert!(reach.iter().all(|entry| entry.in_budget));
+        assert_eq!(reach[0].agent_label, "Claude");
+        assert_eq!(reach[1].command_stem, "claude");
+    }
+
+    /// ...and it marks a watcher that reaches an agent but falls outside its budget, so the
+    /// user sees "not running on <agent>" in the row where they made the choice instead of in
+    /// a log line they will never read.
+    #[tokio::test]
+    async fn preview_reach_marks_a_watcher_that_is_out_of_budget() {
+        let mut settings = AppSettings {
+            agents: vec![agent("a1", "Claude", "claude")],
+            ..AppSettings::default()
+        };
+        for i in 0..8 {
+            settings.watchers.insert(format!("aaa-{i}"), watcher(None));
+        }
+        let app = settings_app(settings);
+
+        let reach = preview_watcher_reach(app.state(), "zzz-mine".to_string(), None)
+            .await
+            .expect("reach");
+
+        assert_eq!(reach.len(), 1);
+        assert_eq!(reach[0].agent_id, "a1");
+        assert!(
+            !reach[0].in_budget,
+            "eight watchers already run on this agent, so the ninth is configured but idle"
+        );
+    }
+
+    /// A selector no agent has is not an error: it simply reaches nobody, and Settings shows
+    /// "reaches 0 agents" so the typo is visible where it was made.
+    #[tokio::test]
+    async fn preview_reach_of_a_stem_no_agent_has_is_empty_and_not_an_error() {
+        let app = settings_app(AppSettings {
+            agents: vec![agent("a1", "Claude", "claude")],
+            ..AppSettings::default()
+        });
+
+        let reach = preview_watcher_reach(
+            app.state(),
+            "w".to_string(),
+            Some(vec!["gemni".to_string()]),
+        )
+        .await
+        .expect("reach");
+
+        assert!(reach.is_empty());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/pty.rs
+++ b/src-tauri/src/commands/pty.rs
@@ -584,11 +584,13 @@ const WATCHER_PREVIEW_SAMPLES: usize = 3;
 /// a regex with no agent session running, and without this the only signal for a syntax error
 /// would be the absence of activations.
 ///
-/// `async` and doing the PTY reads inside `spawn_blocking`, because this path deliberately
-/// goes through `PtyManager::screen_rows_since` - taking the manager mutex, the route registry
-/// and, on the local backend, a child liveness probe - while a session may be producing heavy
-/// output. The engine's own tick avoids all of that; a debounced preview can afford it, and
-/// blocking the async runtime on it could not.
+/// `async` and doing the PTY reads inside `spawn_blocking`, because this path goes through
+/// `PtyManager::screen_rows_since` and therefore takes the manager mutex and the route
+/// registry - "the one every terminal write, resize and kill locks on" - while a session may
+/// be producing heavy output. The engine's own tick avoids both by holding its backend `Arc`;
+/// a preview debounced at 300 ms can afford them, and blocking the async runtime on them could
+/// not. (No child liveness probe is involved: the watcher seam deliberately has none, see
+/// `local_backend.rs`'s `screen_rows_since`.)
 #[tauri::command]
 pub async fn preview_watcher_pattern<R: tauri::Runtime>(
     app: AppHandle<R>,
@@ -738,8 +740,19 @@ pub async fn preview_watcher_reach(
         })
         .collect();
 
-    // Keep whatever the saved entry already says, and override only the selector: a preview
-    // must not silently re-enable a disabled watcher or change its mode.
+    // Start from whatever the saved entry says, so mode, pattern and dedupe are the user's,
+    // and override exactly two things.
+    //
+    // `commands` is the selector being previewed, which is the whole point of the call.
+    //
+    // `enabled` is forced ON because the question this command answers is "which agents WOULD
+    // this selector reach", not "which agents does it reach right now". A disabled watcher
+    // would otherwise always answer "reaches 0 agents", which makes the reach control useless
+    // in the one editor state where the user most needs it - configuring a watcher before
+    // turning it on. Forcing it also makes the budget honest: it reports whether enabling this
+    // watcher WOULD leave it outside some agent's 8-watcher budget.
+    //
+    // Nothing here is written back: the map below is a local copy used to resolve and dropped.
     let mut candidate = match settings.watchers.get(&watcher_id).and_then(|e| e.valid()) {
         Some(saved) => saved.clone(),
         None => WatcherConfig {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -80,6 +80,48 @@ pub(crate) fn register_session_samplers<R: tauri::Runtime>(
     }
 }
 
+/// #1171 - purge every per-session side structure a DESTROYED session leaves behind.
+///
+/// One helper with two call sites, because the per-session side-state purge is already
+/// duplicated in this file: the destroy loop and `publish_restart_destroyed` are parallel
+/// copies of each other, and adding a third thing to purge to only one of them is how a leak
+/// gets written.
+///
+/// **The order is load-bearing.** The engine is retired FIRST, so no tick still in flight can
+/// republish this session's status and recreate the entry step 2 removes. `WatcherHistory`
+/// creates entries only from the engine's publish, and the engine publishes only while holding
+/// its registration lock, so once `retire_session` returns nothing can bring the entry back.
+///
+/// **Destroyed sessions only.** A session that exits on its own is NOT destroyed: the engine
+/// stops sampling it and its buffer stays, which is the case that matters - an API error or a
+/// CLI crash is exactly when the evidence is worth keeping. Root-agent sessions retained as
+/// `Exited` keep theirs too, because their row is still in the list.
+pub(crate) fn purge_session_side_state<R: tauri::Runtime>(app: &AppHandle<R>, session_id: Uuid) {
+    if let Some(watchers) = app.try_state::<Arc<crate::pty::watchers::WatcherEngine>>() {
+        watchers.retire_session(session_id);
+    }
+    if let Some(history) = app.try_state::<crate::pty::watchers::history::WatcherHistoryState>() {
+        history.purge(session_id);
+    }
+    reset_substantive_input(app, session_id);
+}
+
+/// #871 - clear a session's substantive-input marker.
+///
+/// Extracted by #1171 so it has ONE definition rather than the two inline copies the destroy
+/// and restart cleanups each carried. It is a map removal, so calling it twice for the same
+/// session is a no-op and not a second effect - which is what lets the destroy path keep
+/// resetting every id it publishes, retained-exited ones included, while the destroyed-only
+/// purge below also resets the ones it owns.
+fn reset_substantive_input<R: tauri::Runtime>(app: &AppHandle<R>, session_id: Uuid) {
+    if let Some(activity) = app.try_state::<crate::pty::input_activity::SubstantiveInputState>() {
+        activity
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .reset(session_id);
+    }
+}
+
 async fn rollback_pre_created_session<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     _session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
@@ -3210,16 +3252,22 @@ pub(crate) async fn execute_destroy_transaction<R: tauri::Runtime>(
                 );
             }
         }
-        if let Some(activity) = transaction
-            .app()
-            .try_state::<crate::pty::input_activity::SubstantiveInputState>()
-        {
-            activity
-                .lock()
-                .unwrap_or_else(|error| error.into_inner())
-                .reset(session_id);
-        }
+        reset_substantive_input(transaction.app(), session_id);
     }
+
+    // #1171 - a SEPARATE loop over `destroyed_ids` only, rather than a membership test inside
+    // the loop above. That loop iterates `destroyed_ids.chain(retained_exited_ids)`, so a
+    // `contains` check would be O(n squared) and, worse, would express a business rule as a
+    // condition inside a loop that does something else. A separate loop makes "destroyed only"
+    // structural.
+    //
+    // Root-agent sessions retained as `Exited` are deliberately NOT purged: they stay in the
+    // manager and their row is still in the list, so their post-mortem view still has a place
+    // to be shown.
+    for session_id in outcome.destroyed_ids.iter().copied() {
+        purge_session_side_state(transaction.app(), session_id);
+    }
+
     for row in committed.changed_rows.iter().filter(|row| {
         Uuid::parse_str(&row.id)
             .ok()
@@ -3769,6 +3817,11 @@ async fn teardown_old_for_restart<R: tauri::Runtime>(
     Ok(true)
 }
 
+/// #1171 - this covers BOTH restart paths: `execute_restart_transaction`'s success path and
+/// `finalize_failed_restart`. A restart is a normal flow - it is in the invoke handler, the
+/// mailbox calls it, and a bulk settings save can restart sessions - so without the purge here
+/// every restart would orphan up to 500 ring entries under an id that is already gone from the
+/// session list, unreachable from the UI.
 fn publish_restart_destroyed<R: tauri::Runtime>(
     transaction: &SelectionTransaction<R>,
     session_id: Uuid,
@@ -3784,15 +3837,7 @@ fn publish_restart_destroyed<R: tauri::Runtime>(
             );
         }
     }
-    if let Some(activity) = transaction
-        .app()
-        .try_state::<crate::pty::input_activity::SubstantiveInputState>()
-    {
-        activity
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .reset(session_id);
-    }
+    purge_session_side_state(transaction.app(), session_id);
 }
 
 async fn finalize_failed_restart<R: tauri::Runtime>(

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -53,6 +53,33 @@ fn classify_existing_root(status: &SessionStatus, has_pty: bool) -> ExistingRoot
     }
 }
 
+/// #1032 + #1171 - start sampling a freshly spawned session, with both engines.
+///
+/// **Sessions with no agent are never registered**, and that rule lives HERE, once, for both:
+/// a plain shell costs neither engine anything, ever. `try_state` and not `state`, because
+/// `state` panics when unmanaged and a test app manages neither engine - an absent engine is
+/// simply the feature being off.
+///
+/// There is no race with the screen parser: `PtyManager::spawn` has already returned `Ok` at
+/// the call site and the parser is registered during the spawn. The scraper's first sample is
+/// 5 s away and the first watcher tick is 200 ms away, and neither can arrive before the
+/// parser exists.
+pub(crate) fn register_session_samplers<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    id: Uuid,
+    agent_id: Option<String>,
+) {
+    let Some(agent_id) = agent_id else {
+        return;
+    };
+    if let Some(scraper) = app.try_state::<Arc<crate::pty::context_scrape::ContextScraper>>() {
+        scraper.register_session(id, agent_id.clone());
+    }
+    if let Some(watchers) = app.try_state::<Arc<crate::pty::watchers::WatcherEngine>>() {
+        watchers.register_session(id, agent_id);
+    }
+}
+
 async fn rollback_pre_created_session<R: tauri::Runtime>(
     _app: &AppHandle<R>,
     _session_mgr: &Arc<tokio::sync::RwLock<SessionManager>>,
@@ -2258,20 +2285,7 @@ async fn create_session_inner_impl<R: tauri::Runtime>(
             return Err(err);
         }
 
-        // #1032 - start sampling this session's context reading. This sits above the backend
-        // split and covers local and container alike, with no backend plumbing. `try_state`,
-        // not `state`: `state` panics when unmanaged, and test apps do not manage the scraper.
-        // An absent scraper is simply the feature being off.
-        //
-        // Sessions with no agent are never registered, so a plain shell costs nothing. There is
-        // no race with the parser here: the first sample is 5s away.
-        if let Some(agent_id) = agent_id.clone() {
-            if let Some(scraper) =
-                app.try_state::<Arc<crate::pty::context_scrape::ContextScraper>>()
-            {
-                scraper.register_session(id, agent_id);
-            }
-        }
+        register_session_samplers(app, id, agent_id.clone());
 
         // Auto-inject optional non-credential bootstrap text for agent sessions
         // after PTY spawn. Credentials are already present in child environment

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -32,6 +32,12 @@ impl WindowDestroyAudit {
 
 const MAIN_WINDOW_LABEL: &str = "main";
 const RESOURCE_MONITOR_WINDOW_LABEL: &str = "resource-monitor";
+/// #1171 - the singleton watcher activity window.
+///
+/// `pub(crate)` because the watcher sink checks for this window before emitting: when it does
+/// not exist, no `watcher_matches` event is produced at all, which is the case that holds
+/// most of the time.
+pub(crate) const WATCHERS_WINDOW_LABEL: &str = "watchers";
 const RESOURCE_MONITOR_FLOATING_WIDTH: u32 = 760;
 const RESOURCE_MONITOR_FLOATING_HEIGHT: u32 = 560;
 const RESOURCE_MONITOR_DOCK_WIDTH: u32 = 420;

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -43,6 +43,13 @@ const RESOURCE_MONITOR_FLOATING_HEIGHT: u32 = 560;
 const RESOURCE_MONITOR_DOCK_WIDTH: u32 = 420;
 const RESOURCE_MONITOR_MIN_WIDTH: u32 = 520;
 const RESOURCE_MONITOR_MIN_HEIGHT: u32 = 420;
+/// #1171 - the size the activity window opens at when no geometry was ever saved. Wider
+/// than tall because the table is four columns (time, watcher, session, captures) and the
+/// captures cell is the one that must not be cramped.
+const WATCHERS_DEFAULT_WIDTH: f64 = 980.0;
+const WATCHERS_DEFAULT_HEIGHT: f64 = 640.0;
+const WATCHERS_MIN_WIDTH: f64 = 640.0;
+const WATCHERS_MIN_HEIGHT: f64 = 420.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct PhysicalWindowRect {
@@ -829,11 +836,88 @@ pub async fn dock_resource_monitor_window(app: AppHandle) -> Result<(), String> 
     Ok(())
 }
 
+/// #1171 - open the singleton watcher activity window, or focus it and re-scope it to
+/// `session_id`.
+///
+/// Mould: `open_resource_monitor_window` above, minus the main-window-relative placement,
+/// which exists for the Resource Monitor's dock gesture and has no counterpart here.
+///
+/// Focus-if-exists is not the whole behavior for this window, because every caller names a
+/// session: an already-open window is ALSO told to re-scope, through `watchers_scope_request`
+/// (plan 4.12). The query parameter is read only on first creation, since the label is a
+/// singleton and its URL never changes afterwards.
+///
+/// Generic over the runtime like its #1171 sibling `get_watcher_activity`
+/// (`commands/pty.rs:545`) and `kill_resource_group` (`commands/resource_monitor.rs:45`), so
+/// the singleton and re-scope halves are reachable from a `MockRuntime` test.
+#[tauri::command]
+pub async fn open_watchers_window<R: tauri::Runtime>(
+    app: AppHandle<R>,
+    session_id: String,
+) -> Result<(), String> {
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+
+    // Parsed and re-rendered rather than interpolated as received: the value lands in a URL
+    // query string, and the canonical hyphenated form cannot carry an `&` or a `#`. Rejecting
+    // a non-UUID also matches `get_watcher_activity` (`commands/pty.rs:550`).
+    let session_id = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    if let Some(existing) = app.get_webview_window(WATCHERS_WINDOW_LABEL) {
+        // A focus that fails must not swallow the re-scope, which is the substantive half of
+        // this call and the only one the user can see go wrong.
+        if let Err(error) = existing.set_focus() {
+            log::warn!("[watchers] focusing the activity window failed: {}", error);
+        }
+        app.emit_to(
+            WATCHERS_WINDOW_LABEL,
+            "watchers_scope_request",
+            serde_json::json!({ "sessionId": session_id.to_string() }),
+        )
+        .map_err(|e| e.to_string())?;
+        return Ok(());
+    }
+
+    // Geometry is restored here rather than by `initWindowGeometry`, which this window stays
+    // away from (plan 4.12); `focus_main_window` (`:635-641`) is the precedent for reading a
+    // persisted rect straight into the builder.
+    let saved = crate::config::settings::load_settings();
+
+    let icon = tauri::image::Image::from_bytes(include_bytes!("../../icons/icon.png"))
+        .expect("Failed to load app icon");
+
+    let mut builder = WebviewWindowBuilder::new(
+        &app,
+        WATCHERS_WINDOW_LABEL,
+        WebviewUrl::App(format!("index.html?window=watchers&sessionId={}", session_id).into()),
+    )
+    .title(format!(
+        "Watcher Activity - {}",
+        crate::config::profile::app_title_suffix()
+    ))
+    .icon(icon)
+    .map_err(|e| e.to_string())?
+    .min_inner_size(WATCHERS_MIN_WIDTH, WATCHERS_MIN_HEIGHT)
+    .decorations(false)
+    .zoom_hotkeys_enabled(false);
+
+    if let Some(geo) = &saved.watchers_geometry {
+        builder = builder
+            .inner_size(geo.width, geo.height)
+            .position(geo.x, geo.y);
+    } else {
+        builder = builder.inner_size(WATCHERS_DEFAULT_WIDTH, WATCHERS_DEFAULT_HEIGHT);
+    }
+
+    builder.build().map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        resource_monitor_placement_for_main, PhysicalWindowRect, WindowDestroyAudit,
-        RESOURCE_MONITOR_DOCK_WIDTH,
+        open_watchers_window, resource_monitor_placement_for_main, PhysicalWindowRect,
+        WindowDestroyAudit, RESOURCE_MONITOR_DOCK_WIDTH, WATCHERS_WINDOW_LABEL,
     };
     use crate::config::settings::WindowGeometry;
     use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
@@ -1190,5 +1274,57 @@ mod tests {
         );
         assert!(events_rx.try_recv().is_err());
         coordinator.close_and_join().await;
+    }
+
+    /// #1171, criterion 79 (backend half): a second open does not build a second window, and
+    /// it does re-scope the one that is already there.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reopening_the_watchers_window_re_scopes_it_instead_of_building_a_second_one() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build watchers re-scope app");
+        WebviewWindowBuilder::new(
+            app.handle(),
+            WATCHERS_WINDOW_LABEL,
+            WebviewUrl::App("index.html?window=watchers".into()),
+        )
+        .build()
+        .unwrap();
+
+        let (payloads_tx, payloads_rx) = std::sync::mpsc::channel();
+        app.listen_any("watchers_scope_request", move |event| {
+            let _ = payloads_tx.send(event.payload().to_string());
+        });
+
+        let session_id = Uuid::new_v4();
+        open_watchers_window(app.handle().clone(), session_id.to_string())
+            .await
+            .unwrap();
+
+        let windows = app.webview_windows();
+        assert_eq!(windows.len(), 1);
+        assert!(windows.contains_key(WATCHERS_WINDOW_LABEL));
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&payloads_rx.recv_timeout(Duration::from_secs(1)).unwrap())
+                .unwrap();
+        assert_eq!(payload["sessionId"], session_id.to_string());
+        assert!(payloads_rx.try_recv().is_err());
+    }
+
+    /// The session id is interpolated into the window URL, so anything that is not a UUID is
+    /// refused before a window exists to carry it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn open_watchers_window_refuses_a_session_id_that_is_not_a_uuid() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build watchers rejection app");
+
+        assert!(
+            open_watchers_window(app.handle().clone(), "not-a-uuid&window=main".to_string())
+                .await
+                .is_err()
+        );
+        assert!(app.webview_windows().is_empty());
     }
 }

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -836,6 +836,42 @@ pub async fn dock_resource_monitor_window(app: AppHandle) -> Result<(), String> 
     Ok(())
 }
 
+/// #1171 - the most recently requested scope of the watcher activity window, and the one
+/// critical section that keeps it and the last emitted `watchers_scope_request` in agreement.
+///
+/// An event alone cannot carry a re-scope. The window label exists the moment
+/// `WebviewWindowBuilder::build` returns, while the JavaScript listener exists only after the
+/// bundle loads, Solid mounts and the subscription completes an IPC round trip. Tauri queues
+/// nothing for a listener that does not exist yet and `emit_to` returns `Ok` either way, so
+/// the backend cannot even observe the loss: a second open during the load focuses a window
+/// that is not listening, emits, and the user's order is dropped in silence.
+///
+/// The fix is the shape the matches already use, subscribe first and then reconcile with a
+/// pull, applied to the scope: this state holds the authoritative value, it is written before
+/// every emit, and `get_watchers_scope` lets the window read it after its subscribe.
+///
+/// The mutex is `tokio`'s and is private to this module, so it can be held across the whole
+/// body of `open_watchers_window` and cannot deadlock against anything else. It is contended
+/// only by a second open.
+#[derive(Default)]
+pub struct WatchersScopeState {
+    scope: tokio::sync::Mutex<Option<Uuid>>,
+}
+
+/// #1171 - the durable half of the scope handover: what `open_watchers_window` last asked for.
+///
+/// The window calls this in `onMount`, AFTER registering its `watchers_scope_request`
+/// listener, and adopts the answer unless an event has been handled since the call was issued.
+/// An emit that raced the subscribe is recovered here; an emit after this call reaches a
+/// listener that exists.
+#[tauri::command]
+pub async fn get_watchers_scope(
+    scope: State<'_, WatchersScopeState>,
+) -> Result<Option<String>, String> {
+    let scope = scope.scope.lock().await;
+    Ok(scope.as_ref().map(|id| id.to_string()))
+}
+
 /// #1171 - open the singleton watcher activity window, or focus it and re-scope it to
 /// `session_id`.
 ///
@@ -845,7 +881,8 @@ pub async fn dock_resource_monitor_window(app: AppHandle) -> Result<(), String> 
 /// Focus-if-exists is not the whole behavior for this window, because every caller names a
 /// session: an already-open window is ALSO told to re-scope, through `watchers_scope_request`
 /// (plan 4.12). The query parameter is read only on first creation, since the label is a
-/// singleton and its URL never changes afterwards.
+/// singleton and its URL never changes afterwards, and it is the window's INITIAL scope only -
+/// `get_watchers_scope` is the authoritative one.
 ///
 /// Generic over the runtime like its #1171 sibling `get_watcher_activity`
 /// (`commands/pty.rs:545`) and `kill_resource_group` (`commands/resource_monitor.rs:45`), so
@@ -853,14 +890,27 @@ pub async fn dock_resource_monitor_window(app: AppHandle) -> Result<(), String> 
 #[tauri::command]
 pub async fn open_watchers_window<R: tauri::Runtime>(
     app: AppHandle<R>,
+    scope: State<'_, WatchersScopeState>,
     session_id: String,
 ) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
 
     // Parsed and re-rendered rather than interpolated as received: the value lands in a URL
     // query string, and the canonical hyphenated form cannot carry an `&` or a `#`. Rejecting
-    // a non-UUID also matches `get_watcher_activity` (`commands/pty.rs:550`).
+    // a non-UUID also matches `get_watcher_activity` (`commands/pty.rs:550`). It happens
+    // before the guard is taken, so a rejected id contends with nothing and leaves the
+    // authoritative scope alone.
     let session_id = Uuid::parse_str(&session_id).map_err(|e| e.to_string())?;
+
+    // ONE critical section, from the state write through the existence check and whichever
+    // branch runs, including the emit. Not two regions: splitting it leaves this interleaving.
+    // A writes scope A and pauses; B writes scope B, creates the window with B in its URL; A
+    // resumes, finds a window, and emits A. The authoritative state then says B while the last
+    // event says A, so a window that is already listening lands on A and disagrees with
+    // `get_watchers_scope`. Holding one guard across the whole body makes the last write and
+    // the last emit the same call by construction.
+    let mut scope = scope.scope.lock().await;
+    *scope = Some(session_id);
 
     if let Some(existing) = app.get_webview_window(WATCHERS_WINDOW_LABEL) {
         // A focus that fails must not swallow the re-scope, which is the substantive half of
@@ -916,8 +966,9 @@ pub async fn open_watchers_window<R: tauri::Runtime>(
 #[cfg(test)]
 mod tests {
     use super::{
-        open_watchers_window, resource_monitor_placement_for_main, PhysicalWindowRect,
-        WindowDestroyAudit, RESOURCE_MONITOR_DOCK_WIDTH, WATCHERS_WINDOW_LABEL,
+        get_watchers_scope, open_watchers_window, resource_monitor_placement_for_main,
+        PhysicalWindowRect, WatchersScopeState, WindowDestroyAudit, RESOURCE_MONITOR_DOCK_WIDTH,
+        WATCHERS_WINDOW_LABEL,
     };
     use crate::config::settings::WindowGeometry;
     use crate::pty::backend::{BackendSpawnSpec, PtyBackend, SessionBackendKind};
@@ -1276,13 +1327,19 @@ mod tests {
         coordinator.close_and_join().await;
     }
 
-    /// #1171, criterion 79 (backend half): a second open does not build a second window, and
-    /// it does re-scope the one that is already there.
+    /// An app that manages the scope state, which every `open_watchers_window` call needs.
+    fn watchers_app(label: &str) -> tauri::App<tauri::test::MockRuntime> {
+        tauri::test::mock_builder()
+            .manage(WatchersScopeState::default())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap_or_else(|_| panic!("build {label} app"))
+    }
+
+    /// #1171, test 79a: a second open does not build a second window, and it does re-scope the
+    /// one that is already there.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reopening_the_watchers_window_re_scopes_it_instead_of_building_a_second_one() {
-        let app = tauri::test::mock_builder()
-            .build(tauri::test::mock_context(tauri::test::noop_assets()))
-            .expect("build watchers re-scope app");
+        let app = watchers_app("watchers re-scope");
         WebviewWindowBuilder::new(
             app.handle(),
             WATCHERS_WINDOW_LABEL,
@@ -1297,7 +1354,7 @@ mod tests {
         });
 
         let session_id = Uuid::new_v4();
-        open_watchers_window(app.handle().clone(), session_id.to_string())
+        open_watchers_window(app.handle().clone(), app.state(), session_id.to_string())
             .await
             .unwrap();
 
@@ -1312,19 +1369,121 @@ mod tests {
         assert!(payloads_rx.try_recv().is_err());
     }
 
+    /// #1171, test 79b: two opens leave the authoritative scope at the SECOND one, whether or
+    /// not any listener exists.
+    ///
+    /// This is the property a Rust-side listener cannot certify. `app.listen_any` registers in
+    /// the Rust registry, which is always durable, so no reordering of a `listen_any` test can
+    /// model a JavaScript listener that has not been registered yet. Test 79a certifies that
+    /// the emit is issued; this one certifies that the pull recovers it when it was not heard.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_last_open_wins_the_scope_with_no_listener_and_with_one() {
+        let app = watchers_app("watchers scope pull");
+        WebviewWindowBuilder::new(
+            app.handle(),
+            WATCHERS_WINDOW_LABEL,
+            WebviewUrl::App("index.html?window=watchers".into()),
+        )
+        .build()
+        .unwrap();
+
+        assert_eq!(
+            get_watchers_scope(app.state()).await.unwrap(),
+            None,
+            "nothing has been requested yet"
+        );
+
+        // No listener at all: the emits go nowhere, exactly as they do while the bundle loads.
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        open_watchers_window(app.handle().clone(), app.state(), first.to_string())
+            .await
+            .unwrap();
+        open_watchers_window(app.handle().clone(), app.state(), second.to_string())
+            .await
+            .unwrap();
+        assert_eq!(
+            get_watchers_scope(app.state()).await.unwrap(),
+            Some(second.to_string()),
+            "the window that subscribes late still pulls the LAST order, not the first"
+        );
+
+        // And with a listener the two halves agree: the pull returns what the last emit said.
+        let (payloads_tx, payloads_rx) = std::sync::mpsc::channel();
+        app.listen_any("watchers_scope_request", move |event| {
+            let _ = payloads_tx.send(event.payload().to_string());
+        });
+        let third = Uuid::new_v4();
+        open_watchers_window(app.handle().clone(), app.state(), third.to_string())
+            .await
+            .unwrap();
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&payloads_rx.recv_timeout(Duration::from_secs(1)).unwrap())
+                .unwrap();
+        assert_eq!(payload["sessionId"], third.to_string());
+        assert_eq!(
+            get_watchers_scope(app.state()).await.unwrap(),
+            Some(third.to_string())
+        );
+    }
+
+    /// #1171, test 79c: two concurrent opens for two different sessions produce exactly one
+    /// window, two `Ok`s and no duplicate-label failure, AND the authoritative scope agrees
+    /// with the event the loser emitted.
+    ///
+    /// Counting windows and `Ok`s is not enough. The defect this test exists for is the
+    /// interleaving that leaves the state at one session and the last emitted event at the
+    /// other, and a count-only assertion passes straight through it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn two_concurrent_opens_build_one_window_and_agree_on_the_scope() {
+        let app = watchers_app("watchers concurrent open");
+
+        let (payloads_tx, payloads_rx) = std::sync::mpsc::channel();
+        app.listen_any("watchers_scope_request", move |event| {
+            let _ = payloads_tx.send(event.payload().to_string());
+        });
+
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let (left, right) = tokio::join!(
+            open_watchers_window(app.handle().clone(), app.state(), first.to_string()),
+            open_watchers_window(app.handle().clone(), app.state(), second.to_string()),
+        );
+        assert!(left.is_ok(), "the losing call must not fail on the label");
+        assert!(right.is_ok());
+
+        let windows = app.webview_windows();
+        assert_eq!(windows.len(), 1);
+        assert!(windows.contains_key(WATCHERS_WINDOW_LABEL));
+
+        // Exactly one of the two built the window; the other found it and emitted. Whichever
+        // that was, it ran second under the one guard, so it is also the last state write.
+        let emitted: serde_json::Value =
+            serde_json::from_str(&payloads_rx.recv_timeout(Duration::from_secs(1)).unwrap())
+                .unwrap();
+        assert!(payloads_rx.try_recv().is_err(), "the builder emits nothing");
+        assert_eq!(
+            get_watchers_scope(app.state()).await.unwrap(),
+            Some(emitted["sessionId"].as_str().unwrap().to_string()),
+            "the authoritative scope and the last emitted event are the same call"
+        );
+    }
+
     /// The session id is interpolated into the window URL, so anything that is not a UUID is
-    /// refused before a window exists to carry it.
+    /// refused before a window exists to carry it, and before the scope state is touched.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn open_watchers_window_refuses_a_session_id_that_is_not_a_uuid() {
-        let app = tauri::test::mock_builder()
-            .build(tauri::test::mock_context(tauri::test::noop_assets()))
-            .expect("build watchers rejection app");
+        let app = watchers_app("watchers rejection");
 
-        assert!(
-            open_watchers_window(app.handle().clone(), "not-a-uuid&window=main".to_string())
-                .await
-                .is_err()
-        );
+        assert!(open_watchers_window(
+            app.handle().clone(),
+            app.state(),
+            "not-a-uuid&window=main".to_string()
+        )
+        .await
+        .is_err());
         assert!(app.webview_windows().is_empty());
+        assert_eq!(get_watchers_scope(app.state()).await.unwrap(), None);
     }
 }

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -537,6 +537,26 @@ pub async fn set_detached_geometry(
     Ok(())
 }
 
+/// #1171 - record the geometry of the watcher activity window.
+///
+/// A DEDICATED single-field command, following `set_detached_geometry` above, and
+/// deliberately not `initWindowGeometry` (`src/shared/window-geometry.ts:26-47`), which
+/// performs a debounced read-modify-write of the WHOLE `AppSettings`. That race is already
+/// documented in this repository (`commands/config.rs:653-655`) and defended against with an
+/// explicit list of fields restored from live memory (`config.rs:611-624`, `:647-655`);
+/// adding `watchers` to that list would make it six fields long and would leave the new
+/// window as a whole-object writer. This touches one field and cannot clobber another.
+#[tauri::command]
+pub async fn set_watchers_geometry(
+    settings: State<'_, crate::config::settings::SettingsState>,
+    geometry: WindowGeometry,
+) -> Result<(), String> {
+    crate::commands::config::persist_narrow_settings_update(settings.inner(), |candidate| {
+        candidate.watchers_geometry = Some(geometry);
+    })
+    .await
+}
+
 /// Open a path in the system file explorer (Explorer, Finder, xdg-open).
 #[tauri::command]
 pub fn open_in_explorer(path: String) -> Result<(), String> {

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -424,7 +424,14 @@ pub fn reseedable_command_basenames() -> Vec<String> {
 
 /// Reduce a coding-agent command to its executable basename (lowercase), mirroring
 /// the settings save path. `None` if the command does not tokenize.
-fn command_executable_basename(command: &str) -> Option<String> {
+///
+/// #1171 promoted this from private to `pub(crate)`. It is now the ONLY stem rule in the
+/// tree and a second one must not be written, in Rust or in TypeScript: the `starts_with`
+/// rule in the frontend's `suggestedContextRegex` must not be ported here or reused, for the
+/// reason `reseed_master_for_command` states below - `pi` and `agent` false-match under a
+/// prefix rule. The watcher Settings UI gets its reach from `preview_watcher_reach` rather
+/// than reimplementing this.
+pub(crate) fn command_executable_basename(command: &str) -> Option<String> {
     let normalized = crate::config::agent_command::normalize_legacy_agent_command(command).ok()?;
     Some(crate::config::settings::command_token_basename(
         &normalized.shell,

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -535,6 +535,114 @@ pub struct AppSettings {
     /// themselves (e.g. a CLAUDE_CODE_OAUTH_TOKEN env row).
     #[serde(default = "default_true")]
     pub container_credentials_from_host: bool,
+    /// #1171 - root-level watcher patterns, keyed by watcher id.
+    ///
+    /// Root-level and not a field on `AgentConfig`, so the 20-plus struct-construction sites
+    /// that already had to write `context_regex: None` are untouched, AND so a pattern can
+    /// apply to every agent - which is exactly what the per-agent shape cannot express. Same
+    /// shape as `auto_self_clear_by_agent` (`:530-531`). `BTreeMap` for a stable on-disk
+    /// order and clean diffs, and because the 8-watcher budget resolves in key order.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub watchers: BTreeMap<String, WatcherEntry>,
+    /// #1171 - geometry of the watcher activity window.
+    ///
+    /// `skip_serializing_if` and deliberately NOT a copy of `main_geometry` (`:367-369`),
+    /// which lacks it: without the skip, `"watchersGeometry": null` would appear in every
+    /// user's file on the next save, so configuring nothing would still leave a trace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watchers_geometry: Option<WindowGeometry>,
+}
+
+/// #1171 - one entry of the root `watchers` map, or whatever the user wrote there.
+///
+/// **This wrapper is what stops a malformed watcher from destroying the settings file.**
+/// `parse_settings_json` (`:870-871`) deserializes `AppSettings` in ONE shot and
+/// `load_settings_from_path` (`:1661-1664`) replaces any failure with
+/// `AppSettings::default()`, leaving one log line. A hand-written `"mode": "State"`,
+/// `"commands": "claude"` or `"dedupeWindowMs": "2000"` would therefore start
+/// AgentsCommander with NO AGENTS CONFIGURED, and every later save would be refused by the
+/// #1077 write gate (`read_disk_object_for_write`, `:2565-2591`). With the wrapper the
+/// consequence is one skipped watcher.
+///
+/// `untagged` tries `Valid` first, so `Invalid` only ever catches what `WatcherConfig`
+/// rejected. The value is kept verbatim so a save round-trips the user's bytes instead of
+/// deleting what it could not read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum WatcherEntry {
+    Valid(WatcherConfig),
+    /// Anything that did not deserialize as a `WatcherConfig`. Skipped by resolution and
+    /// logged once per changed value.
+    Invalid(serde_json::Value),
+}
+
+impl WatcherEntry {
+    pub fn valid(&self) -> Option<&WatcherConfig> {
+        match self {
+            WatcherEntry::Valid(config) => Some(config),
+            WatcherEntry::Invalid(_) => None,
+        }
+    }
+}
+
+/// #1171 - one user-configured watcher.
+///
+/// `mode` and `pattern` stay REQUIRED. A watcher without either is not a watcher, and with
+/// the wrapper above the consequence of omitting one is a single skipped entry rather than a
+/// lost configuration. A defaulted `mode` would silently run a watcher the user never
+/// described.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub mode: WatcherMode,
+    pub pattern: String,
+    /// Absent or null: reaches every configured agent. Present: only entries whose `command`
+    /// executable stem matches EXACTLY. Present and empty: reaches none.
+    ///
+    /// `Option` and not `#[serde(default)] Vec`, because absent and `[]` are opposites here
+    /// and only `Option` lets serde tell them apart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commands: Option<Vec<String>>,
+    #[serde(default)]
+    pub dedupe: WatcherDedupe,
+    #[serde(default = "default_dedupe_window_ms")]
+    pub dedupe_window_ms: u64,
+    /// Free text, e.g. "claude 2.1.212". Never validated, never parsed. It exists because
+    /// `context_scrape/rows.rs:183-186` documents that a TUI format already had to be
+    /// re-captured once, and that fact currently lives only in a Rust comment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub captured_against: Option<String>,
+}
+
+/// #1171 - what a match means.
+///
+/// `state` is a reading: idempotent, gated, taken over the whole frame. `occurrence` is an
+/// event: every match the frame diff declares evaluable counts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WatcherMode {
+    State,
+    Occurrence,
+}
+
+/// #1171 - what makes two `occurrence` matches "the same one" inside the dedupe window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WatcherDedupe {
+    /// The matched logical row text.
+    #[default]
+    Row,
+    /// The joined capture groups: two rows truncated differently that capture the same path
+    /// are one event.
+    Capture,
+    /// Every match counts.
+    None,
+}
+
+fn default_dedupe_window_ms() -> u64 {
+    2000
 }
 
 fn default_true() -> bool {
@@ -761,6 +869,8 @@ impl Default for AppSettings {
             auto_self_clear_enabled: true,
             auto_self_clear_by_agent: std::collections::BTreeMap::new(),
             container_credentials_from_host: true,
+            watchers: BTreeMap::new(),
+            watchers_geometry: None,
         }
     }
 }
@@ -5063,6 +5173,157 @@ mod tests {
 
         let lists = super::read_project_paths_from_disk(&path).unwrap().unwrap();
         assert_eq!(lists.project_paths, vec![a, b]);
+    }
+
+    /// #1171, 9.2.17 - **the regression a plain `BTreeMap<String, WatcherConfig>` would let
+    /// through, and whose failure mode is the whole settings file.**
+    ///
+    /// Three hand-written mistakes, one per entry: a capitalized enum variant, a scalar where
+    /// a list belongs, and a quoted number. Without the per-entry wrapper, ONE of them makes
+    /// `serde_json::from_value::<AppSettings>` fail, `load_settings_from_path` replaces
+    /// everything with `AppSettings::default()`, and AgentsCommander starts with no agents
+    /// configured and one log line - after which every save is refused by the #1077 gate.
+    #[test]
+    fn one_malformed_watcher_does_not_take_the_settings_file_down() {
+        let contents = serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": ["-NoLogo"],
+            "agents": [
+                { "id": "a1", "label": "Claude", "command": "claude", "color": "#fff" },
+                { "id": "a2", "label": "Codex", "command": "codex", "color": "#000" }
+            ],
+            "watchers": {
+                "bad-mode": { "mode": "State", "pattern": "x" },
+                "bad-commands": { "mode": "occurrence", "pattern": "x", "commands": "claude" },
+                "bad-window": { "mode": "occurrence", "pattern": "x", "dedupeWindowMs": "2000" },
+                "good": { "mode": "state", "pattern": "Permission required" }
+            }
+        })
+        .to_string();
+
+        let (settings, _) = super::parse_settings_json(&contents, "test").expect(
+            "a malformed watcher must never fail the whole file: that is what the wrapper is for",
+        );
+
+        // Every OTHER setting survived.
+        assert_eq!(settings.agents.len(), 2);
+        assert_eq!(settings.default_shell, "powershell.exe");
+
+        // Every entry is still there, and exactly one of them resolved.
+        assert_eq!(settings.watchers.len(), 4);
+        let valid: Vec<&str> = settings
+            .watchers
+            .iter()
+            .filter(|(_, entry)| entry.valid().is_some())
+            .map(|(id, _)| id.as_str())
+            .collect();
+        assert_eq!(valid, vec!["good"]);
+
+        // ...and the three bad ones are kept VERBATIM, so a save writes back the user's bytes
+        // instead of deleting what it could not read.
+        let round_tripped = serde_json::to_value(&settings.watchers).expect("serializes");
+        assert_eq!(
+            round_tripped["bad-mode"],
+            serde_json::json!({ "mode": "State", "pattern": "x" })
+        );
+        assert_eq!(
+            round_tripped["bad-commands"],
+            serde_json::json!({ "mode": "occurrence", "pattern": "x", "commands": "claude" })
+        );
+        assert_eq!(
+            round_tripped["bad-window"],
+            serde_json::json!({ "mode": "occurrence", "pattern": "x", "dedupeWindowMs": "2000" })
+        );
+    }
+
+    /// #1171, 9.2.18 - a user who configures nothing never sees either new key appear.
+    #[test]
+    fn a_settings_file_with_no_watchers_round_trips_without_the_new_keys() {
+        let contents = serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": []
+        })
+        .to_string();
+
+        let (settings, _) = super::parse_settings_json(&contents, "test").expect("parses");
+        assert!(settings.watchers.is_empty());
+        assert!(settings.watchers_geometry.is_none());
+
+        let written = serde_json::to_value(&settings).expect("serializes");
+        let root = written.as_object().expect("object");
+        assert!(
+            !root.contains_key("watchers"),
+            "an empty map must not appear"
+        );
+        assert!(
+            !root.contains_key("watchersGeometry"),
+            "this is why watchersGeometry carries skip_serializing_if and mainGeometry does not"
+        );
+    }
+
+    /// #1171, 9.2.19 - a configured watcher round-trips value for value, INCLUDING the
+    /// absent-against-`[]` distinction for `commands`, which is the one place where the two
+    /// are opposites: absent reaches every agent, `[]` reaches none.
+    #[test]
+    fn watchers_round_trip_through_save_and_load_including_absent_versus_empty() {
+        let contents = serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [],
+            "watchers": {
+                "all-agents": { "mode": "state", "pattern": "  Permission" },
+                "nobody": { "mode": "occurrence", "pattern": "Read", "commands": [] },
+                "claude-only": {
+                    "enabled": false,
+                    "mode": "occurrence",
+                    "pattern": "Read \\((.+)\\)",
+                    "commands": ["claude"],
+                    "dedupe": "capture",
+                    "dedupeWindowMs": 5000,
+                    "capturedAgainst": "claude 2.1.212"
+                }
+            }
+        })
+        .to_string();
+
+        let (settings, _) = super::parse_settings_json(&contents, "test").expect("parses");
+
+        let all = settings.watchers["all-agents"].valid().expect("valid");
+        assert!(all.enabled, "enabled defaults to true");
+        assert_eq!(all.mode, super::WatcherMode::State);
+        assert_eq!(all.pattern, "  Permission");
+        assert!(all.commands.is_none(), "absent means every agent");
+        assert_eq!(all.dedupe, super::WatcherDedupe::Row);
+        assert_eq!(all.dedupe_window_ms, 2000);
+
+        let nobody = settings.watchers["nobody"].valid().expect("valid");
+        assert_eq!(
+            nobody.commands.as_deref(),
+            Some(&[] as &[String]),
+            "`[]` must survive as `[]` and never collapse into absent"
+        );
+
+        let claude = settings.watchers["claude-only"].valid().expect("valid");
+        assert!(!claude.enabled);
+        assert_eq!(claude.mode, super::WatcherMode::Occurrence);
+        assert_eq!(claude.dedupe, super::WatcherDedupe::Capture);
+        assert_eq!(claude.dedupe_window_ms, 5000);
+        assert_eq!(claude.captured_against.as_deref(), Some("claude 2.1.212"));
+
+        // Byte-stable: what comes back out is what went in, key for key.
+        let written = serde_json::to_value(&settings.watchers).expect("serializes");
+        let original: serde_json::Value = serde_json::from_str(&contents).expect("parses");
+        let mut expected = original["watchers"].clone();
+        // The two defaulted fields the input omitted are written explicitly, since neither
+        // carries `skip_serializing_if`: they are settings with a value, not absent ones.
+        expected["all-agents"]["enabled"] = serde_json::json!(true);
+        expected["all-agents"]["dedupe"] = serde_json::json!("row");
+        expected["all-agents"]["dedupeWindowMs"] = serde_json::json!(2000);
+        expected["nobody"]["enabled"] = serde_json::json!(true);
+        expected["nobody"]["dedupe"] = serde_json::json!("row");
+        expected["nobody"]["dedupeWindowMs"] = serde_json::json!(2000);
+        assert_eq!(written, expected);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1348,6 +1348,10 @@ pub fn run(
             watcher_engine.start(shutdown_for_setup.clone());
             app.manage(Arc::clone(&watcher_engine));
             app.manage(watcher_history);
+            // The authoritative scope of the activity window. `open_watchers_window` writes it
+            // before every emit and the window pulls it after subscribing, so a re-scope that
+            // races the window's own load is recovered instead of dropped in silence.
+            app.manage(commands::window::WatchersScopeState::default());
 
             // Start web server if enabled in settings
             {
@@ -2591,6 +2595,7 @@ pub fn run(
             commands::window::open_resource_monitor_window,
             commands::window::dock_resource_monitor_window,
             commands::window::open_watchers_window,
+            commands::window::get_watchers_scope,
             commands::window::open_external_url,
             commands::window::focus_main_window,
             commands::spec_board::spec_board_new,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2478,6 +2478,8 @@ pub fn run(
             commands::pty::pty_resize,
             commands::pty::get_screen_snapshot,
             commands::pty::get_session_context,
+            commands::pty::preview_watcher_pattern,
+            commands::pty::preview_watcher_reach,
             commands::config::get_settings,
             commands::config::get_coding_agent_catalog,
             commands::config::list_reseedable_agent_commands,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -830,17 +830,29 @@ impl WatcherDelivery {
     }
 }
 
-/// Where a tick's matches go.
+/// Where a tick's matches go: into the ring ALWAYS, and out to the window only when there is
+/// one.
 ///
-/// The window check lives HERE and not in the engine, exactly as `ScraperSink` holds the
-/// `AppHandle` the scraper is not allowed to have. Adding a second consumer later means
-/// adding its label or falling back to broadcast, which is a one-line change in this type.
+/// The ring lives here, in the concrete sink, and the caps live in the engine loop immediately
+/// before the call that reaches this type. Consequence: everything that passes the caps
+/// reaches both the event and the buffer, and nothing else reaches either - and that ordering
+/// is a property of WHERE each piece lives rather than a rule someone has to maintain.
+///
+/// The window check lives here too, and not in the engine, exactly as `ScraperSink` holds the
+/// `AppHandle` the scraper is not allowed to have. Adding a second consumer later means adding
+/// its label or falling back to broadcast, which is a one-line change in this type.
 struct WatcherSink {
+    history: crate::pty::watchers::history::WatcherHistoryState,
     delivery: WatcherDelivery,
 }
 
 impl WatcherEventSink for WatcherSink {
     fn emit(&self, batch: crate::pty::watchers::WatcherMatchBatch) {
+        if let Ok(id) = uuid::Uuid::parse_str(&batch.session_id) {
+            // Recorded whether or not anyone is listening, so opening the window later shows
+            // the history rather than starting from nothing.
+            self.history.record(id, &batch.matches);
+        }
         self.delivery.deliver(batch);
     }
 }
@@ -851,41 +863,74 @@ mod watcher_sink_tests {
     use crate::pty::watchers::WatcherMatchBatch;
     use std::sync::Mutex as StdMutex;
 
-    fn recording(present: bool) -> (WatcherSink, Arc<StdMutex<Vec<WatcherMatchBatch>>>) {
+    use crate::pty::watchers::history::{SessionStatus, WatcherHistory};
+    use crate::pty::watchers::{WatcherMatchPayload, WatcherMode};
+
+    type Recorded = (
+        WatcherSink,
+        Arc<StdMutex<Vec<WatcherMatchBatch>>>,
+        crate::pty::watchers::history::WatcherHistoryState,
+    );
+
+    fn recording(present: bool) -> Recorded {
         let delivered = Arc::new(StdMutex::new(Vec::new()));
         let sink_delivered = Arc::clone(&delivered);
+        let history: crate::pty::watchers::history::WatcherHistoryState =
+            Arc::new(WatcherHistory::default());
         (
             WatcherSink {
+                history: Arc::clone(&history),
                 delivery: WatcherDelivery {
                     window_present: Arc::new(move || present),
                     emit: Arc::new(move |batch| sink_delivered.lock().unwrap().push(batch)),
                 },
             },
             delivered,
+            history,
         )
     }
 
-    fn batch() -> WatcherMatchBatch {
+    fn batch(session_id: uuid::Uuid) -> WatcherMatchBatch {
         WatcherMatchBatch {
-            session_id: "s".to_string(),
-            matches: Vec::new(),
+            session_id: session_id.to_string(),
+            matches: vec![WatcherMatchPayload {
+                session_id: session_id.to_string(),
+                seq: 1,
+                watcher_id: "w".to_string(),
+                mode: WatcherMode::Occurrence,
+                at: chrono::Utc::now(),
+                captures: Vec::new(),
+                row: "hit".to_string(),
+                row_truncated: false,
+            }],
         }
     }
 
-    /// #1171, 9.3.36 - with the activity window closed, NOTHING is emitted. Not a broadcast
-    /// nobody reads, not an emit to a label that does not exist: nothing.
+    /// #1171, 9.3.36 - with the activity window closed, NOTHING is emitted - not a broadcast
+    /// nobody reads, not an emit to a label that does not exist - **and the ring still
+    /// records**, so opening the window later shows the history.
     #[test]
-    fn no_event_is_emitted_when_the_watchers_window_does_not_exist() {
-        let (sink, delivered) = recording(false);
-        sink.emit(batch());
+    fn no_event_is_emitted_when_the_window_is_closed_and_the_ring_still_records() {
+        let id = uuid::Uuid::new_v4();
+        let (sink, delivered, history) = recording(false);
+        history.publish(id, SessionStatus::default());
+
+        sink.emit(batch(id));
+
         assert!(delivered.lock().unwrap().is_empty());
+        assert_eq!(history.snapshot(id, None).matches.len(), 1);
     }
 
     #[test]
-    fn the_batch_is_delivered_when_the_window_is_open() {
-        let (sink, delivered) = recording(true);
-        sink.emit(batch());
+    fn the_batch_is_delivered_and_recorded_when_the_window_is_open() {
+        let id = uuid::Uuid::new_v4();
+        let (sink, delivered, history) = recording(true);
+        history.publish(id, SessionStatus::default());
+
+        sink.emit(batch(id));
+
         assert_eq!(delivered.lock().unwrap().len(), 1);
+        assert_eq!(history.snapshot(id, None).matches.len(), 1);
     }
 }
 
@@ -1266,6 +1311,8 @@ pub fn run(
             // #1171 watcher engine. A SIBLING of the scraper above, not an extension of it:
             // different interval, different modes, its own history. Same construction shape,
             // and for the same reason it must come after `.manage(settings)`.
+            let watcher_history: crate::pty::watchers::history::WatcherHistoryState =
+                Arc::new(crate::pty::watchers::history::WatcherHistory::default());
             let watcher_engine = WatcherEngine::new(
                 Arc::new(WatcherBackends {
                     pty_mgr: pty_mgr.clone(),
@@ -1276,11 +1323,14 @@ pub fn run(
                     log: Default::default(),
                 }),
                 Arc::new(WatcherSink {
+                    history: Arc::clone(&watcher_history),
                     delivery: WatcherDelivery::to_watchers_window(app.handle().clone()),
                 }),
+                Arc::clone(&watcher_history),
             );
             watcher_engine.start(shutdown_for_setup.clone());
             app.manage(Arc::clone(&watcher_engine));
+            app.manage(watcher_history);
 
             // Start web server if enabled in settings
             {
@@ -2478,6 +2528,7 @@ pub fn run(
             commands::pty::pty_resize,
             commands::pty::get_screen_snapshot,
             commands::pty::get_session_context,
+            commands::pty::get_watcher_activity,
             commands::pty::preview_watcher_pattern,
             commands::pty::preview_watcher_reach,
             commands::config::get_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2590,6 +2590,7 @@ pub fn run(
             commands::window::open_spec_board_window,
             commands::window::open_resource_monitor_window,
             commands::window::dock_resource_monitor_window,
+            commands::window::open_watchers_window,
             commands::window::open_external_url,
             commands::window::focus_main_window,
             commands::spec_board::spec_board_new,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2304,6 +2304,7 @@ pub fn run(
             commands::window::attach_terminal,
             commands::window::list_detached_sessions,
             commands::window::set_detached_geometry,
+            commands::window::set_watchers_geometry,
             commands::window::open_in_explorer,
             commands::window::open_guide_window,
             commands::window::open_spec_board_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,9 @@ use pty::context_scrape::{
 use pty::git_watcher::GitWatcher;
 use pty::idle_detector::IdleDetector;
 use pty::manager::PtyManager;
+use pty::watchers::{
+    SessionFrameReader, WatcherBackendSource, WatcherEngine, WatcherEventSink, WatcherPatternSource,
+};
 use session::manager::SessionManager;
 use shutdown::ShutdownSignal;
 use tauri::{Emitter, Manager};
@@ -698,6 +701,194 @@ impl ContextPersistSink for ScraperPersist {
     }
 }
 
+// ---- #1171: the three narrow watcher adapters -------------------------------------------
+//
+// The same capability boundary the scrape adapters draw. The engine can read one session's
+// screen through a narrowed reader, ask for its lightweight liveness, read the resolved
+// watcher set, and hand a batch to a sink. It holds no `AppHandle` and no `PtyManager`.
+
+/// The per-session frame reader and the lightweight liveness, via the routed backend.
+///
+/// `reader_for` is called ONCE per session at registration, and again only when a read comes
+/// back `Missing` or `Gone`. That is what keeps the `PtyManager` mutex out of a 200 ms loop:
+/// the tick calls the backend directly through the `Arc` this handed over.
+struct WatcherBackends {
+    pty_mgr: Arc<Mutex<PtyManager>>,
+    /// A poisoned `PtyManager` is app-wide and permanent, so the warning is worth exactly one
+    /// line, not one per registered session five times a second.
+    poison_logged: AtomicBool,
+}
+
+impl WatcherBackends {
+    fn warn_poisoned_once(&self, what: &str) {
+        if !self
+            .poison_logged
+            .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            log::warn!("[watchers] PtyManager lock is poisoned; {what} is unavailable");
+        }
+    }
+}
+
+impl WatcherBackendSource for WatcherBackends {
+    fn reader_for(&self, id: uuid::Uuid) -> Option<SessionFrameReader> {
+        match self.pty_mgr.lock() {
+            Ok(mgr) => {
+                let kind = mgr.backend_kind(id)?;
+                Some(SessionFrameReader::new(mgr.backend_for_kind(kind)))
+            }
+            Err(_) => {
+                self.warn_poisoned_once("watcher sampling");
+                None
+            }
+        }
+    }
+
+    fn liveness(&self, id: uuid::Uuid) -> ContextSessionLiveness {
+        match self.pty_mgr.lock() {
+            Ok(mgr) => mgr.context_session_liveness(id),
+            Err(_) => {
+                self.warn_poisoned_once("watcher liveness");
+                ContextSessionLiveness::Unavailable
+            }
+        }
+    }
+}
+
+/// The configured watchers crossed with the configured agents, read fresh each tick. One
+/// `RwLock` read per tick for all sessions, not one per session.
+struct WatcherPatterns {
+    settings: SettingsState,
+    /// Log-once bookkeeping for the resolution notices, so a configuration that stays wrong
+    /// costs one line rather than five per second.
+    log: crate::pty::watchers::ResolutionLog,
+}
+
+impl WatcherPatternSource for WatcherPatterns {
+    fn resolve(
+        &self,
+    ) -> futures::future::BoxFuture<'_, HashMap<String, crate::pty::watchers::AgentResolution>>
+    {
+        Box::pin(async move {
+            let settings = self.settings.read().await;
+            let agents: Vec<crate::pty::watchers::WatcherAgent> = settings
+                .agents
+                .iter()
+                .map(|agent| crate::pty::watchers::WatcherAgent {
+                    id: agent.id.clone(),
+                    command: agent.command.clone(),
+                })
+                .collect();
+            let (resolved, notices) =
+                crate::pty::watchers::resolve_watchers(&agents, &settings.watchers);
+            drop(settings);
+            self.log.publish(notices);
+            resolved
+        })
+    }
+}
+
+/// Delivery of one coalesced batch, behind two plain `Fn`s.
+///
+/// Mould: `PtyOutputTarget` (`output.rs:58-92`), which wraps an `AppHandle` the same way and
+/// for the same reason - the DECISION is testable, an `AppHandle` is not.
+///
+/// **Directed, and silent when nobody is listening.** `app.emit` reaches every window, so at
+/// 50 saturated sessions a broadcast would deliver thousands of payloads per second to four
+/// windows and make every detached terminal pay to deserialize events it discards. The
+/// activity window is closed most of the time, and this makes that case cost nothing at all.
+#[derive(Clone)]
+struct WatcherDelivery {
+    window_present: Arc<dyn Fn() -> bool + Send + Sync>,
+    emit: Arc<dyn Fn(crate::pty::watchers::WatcherMatchBatch) + Send + Sync>,
+}
+
+impl WatcherDelivery {
+    fn to_watchers_window(app_handle: tauri::AppHandle) -> Self {
+        let present = app_handle.clone();
+        Self {
+            window_present: Arc::new(move || {
+                present
+                    .get_webview_window(commands::window::WATCHERS_WINDOW_LABEL)
+                    .is_some()
+            }),
+            emit: Arc::new(move |batch| {
+                let _ = app_handle.emit_to(
+                    commands::window::WATCHERS_WINDOW_LABEL,
+                    "watcher_matches",
+                    batch,
+                );
+            }),
+        }
+    }
+
+    fn deliver(&self, batch: crate::pty::watchers::WatcherMatchBatch) {
+        if !(self.window_present)() {
+            return;
+        }
+        (self.emit)(batch);
+    }
+}
+
+/// Where a tick's matches go.
+///
+/// The window check lives HERE and not in the engine, exactly as `ScraperSink` holds the
+/// `AppHandle` the scraper is not allowed to have. Adding a second consumer later means
+/// adding its label or falling back to broadcast, which is a one-line change in this type.
+struct WatcherSink {
+    delivery: WatcherDelivery,
+}
+
+impl WatcherEventSink for WatcherSink {
+    fn emit(&self, batch: crate::pty::watchers::WatcherMatchBatch) {
+        self.delivery.deliver(batch);
+    }
+}
+
+#[cfg(test)]
+mod watcher_sink_tests {
+    use super::*;
+    use crate::pty::watchers::WatcherMatchBatch;
+    use std::sync::Mutex as StdMutex;
+
+    fn recording(present: bool) -> (WatcherSink, Arc<StdMutex<Vec<WatcherMatchBatch>>>) {
+        let delivered = Arc::new(StdMutex::new(Vec::new()));
+        let sink_delivered = Arc::clone(&delivered);
+        (
+            WatcherSink {
+                delivery: WatcherDelivery {
+                    window_present: Arc::new(move || present),
+                    emit: Arc::new(move |batch| sink_delivered.lock().unwrap().push(batch)),
+                },
+            },
+            delivered,
+        )
+    }
+
+    fn batch() -> WatcherMatchBatch {
+        WatcherMatchBatch {
+            session_id: "s".to_string(),
+            matches: Vec::new(),
+        }
+    }
+
+    /// #1171, 9.3.36 - with the activity window closed, NOTHING is emitted. Not a broadcast
+    /// nobody reads, not an emit to a label that does not exist: nothing.
+    #[test]
+    fn no_event_is_emitted_when_the_watchers_window_does_not_exist() {
+        let (sink, delivered) = recording(false);
+        sink.emit(batch());
+        assert!(delivered.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_batch_is_delivered_when_the_window_is_open() {
+        let (sink, delivered) = recording(true);
+        sink.emit(batch());
+        assert_eq!(delivered.lock().unwrap().len(), 1);
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run(
     test_window_placement: Option<crate::testability::window_placement::TestWindowPlacement>,
@@ -1071,6 +1262,25 @@ pub fn run(
             );
             context_scraper.start(shutdown_for_setup.clone());
             app.manage(Arc::clone(&context_scraper));
+
+            // #1171 watcher engine. A SIBLING of the scraper above, not an extension of it:
+            // different interval, different modes, its own history. Same construction shape,
+            // and for the same reason it must come after `.manage(settings)`.
+            let watcher_engine = WatcherEngine::new(
+                Arc::new(WatcherBackends {
+                    pty_mgr: pty_mgr.clone(),
+                    poison_logged: AtomicBool::new(false),
+                }),
+                Arc::new(WatcherPatterns {
+                    settings: app.state::<SettingsState>().inner().clone(),
+                    log: Default::default(),
+                }),
+                Arc::new(WatcherSink {
+                    delivery: WatcherDelivery::to_watchers_window(app.handle().clone()),
+                }),
+            );
+            watcher_engine.start(shutdown_for_setup.clone());
+            app.manage(Arc::clone(&watcher_engine));
 
             // Start web server if enabled in settings
             {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -771,14 +771,31 @@ impl WatcherPatternSource for WatcherPatterns {
     {
         Box::pin(async move {
             let settings = self.settings.read().await;
-            let agents: Vec<crate::pty::watchers::WatcherAgent> = settings
-                .agents
-                .iter()
-                .map(|agent| crate::pty::watchers::WatcherAgent {
-                    id: agent.id.clone(),
-                    command: agent.command.clone(),
-                })
-                .collect();
+
+            // The agent list is cloned only when at least one watcher could possibly use it.
+            // Otherwise this ran five times a second, forever, in every installation that
+            // never touches the feature: at twelve agents that is 24 `String` allocations per
+            // tick, 120 a second, for an answer that is always empty.
+            //
+            // Resolution is still CALLED with an empty agent slice rather than skipped, so a
+            // malformed or unreadable watcher entry keeps producing its one log line even when
+            // nothing is enabled.
+            let has_enabled_watcher = settings
+                .watchers
+                .values()
+                .any(|entry| entry.valid().is_some_and(|config| config.enabled));
+            let agents: Vec<crate::pty::watchers::WatcherAgent> = if has_enabled_watcher {
+                settings
+                    .agents
+                    .iter()
+                    .map(|agent| crate::pty::watchers::WatcherAgent {
+                        id: agent.id.clone(),
+                        command: agent.command.clone(),
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
             let (resolved, notices) =
                 crate::pty::watchers::resolve_watchers(&agents, &settings.watchers);
             drop(settings);

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 use crate::errors::AppError;
 use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot};
+use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::resource_monitor::{ResourceLaunchRegistration, ResourceLogicalAgentSlot};
 use crate::session::profile::{CodingAgentKind, IdleTuning};
 
@@ -167,6 +168,26 @@ pub trait PtyBackend: Any + Send + Sync {
     /// - `SessionOver`: there is no session here any more. Report unavailable once, then
     ///   stop sampling it.
     fn get_screen_rows(&self, id: Uuid) -> ScreenRowsRead;
+
+    /// #1171 - the session's screen, but only when it CHANGED since `seen`, plus the wrap
+    /// flags and cursor row the watcher engine's frame diff needs.
+    ///
+    /// **Defaulted**, following `context_session_liveness` above, so the two `PtyBackend` test
+    /// fakes (`pty/manager.rs:926`, `:1025`) and any out-of-tree implementor keep compiling.
+    /// The default delegates to `get_screen_rows` and reports `stamp: None`, which reads as
+    /// "changed": the property "the default never reports `Unchanged`" therefore falls out of
+    /// the type instead of out of a rule an implementor has to remember.
+    ///
+    /// - `Unchanged`: the stamp matched. No rows were cloned.
+    /// - `Frame`: the live grid.
+    /// - `Missing`: no reading this tick, and NO claim about the session. Keep sampling it.
+    /// - `Gone`: there is no session behind this id. Retire it now.
+    ///
+    /// The `Missing` / `Gone` split is the same distinction `get_screen_rows` draws between
+    /// `Unavailable` and `SessionOver`, carried on a type that can also say "nothing changed".
+    fn screen_rows_since(&self, id: Uuid, _seen: Option<FrameStamp>) -> ScreenRowsSince {
+        crate::pty::watchers::frame_from_screen_rows_read(self.get_screen_rows(id))
+    }
 
     fn register_response_watcher(
         &self,

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -24,6 +24,7 @@ use crate::pty::container_runtime::{
 };
 use crate::pty::container_tokens::{ContainerApiToken, ContainerApiTokenManager};
 use crate::pty::context_scrape::ScreenRowsRead;
+use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot, SessionIoFanout};
 use crate::resource_monitor::ResourceLogicalAgentSlot;
@@ -3178,6 +3179,21 @@ impl PtyBackend for ContainerTransportBackend {
         }
     }
 
+    /// #1171 - the same read as `get_screen_rows` above, on the seam that can also say
+    /// "nothing changed", and with the same oracle: parser-absent IS this backend's liveness
+    /// answer, so it maps to `Gone` rather than to `Missing`.
+    ///
+    /// This is the whole reason `ScreenRowsSince` has four variants instead of three. The
+    /// local backend, whose parser-absence is NOT conclusive, returns `Missing` from the same
+    /// fanout call; keeping one mapping for both backends would have forced one of them to
+    /// lie.
+    fn screen_rows_since(&self, id: Uuid, seen: Option<FrameStamp>) -> ScreenRowsSince {
+        match self.fanout.get_screen_rows_since(id, seen) {
+            ScreenRowsSince::Missing => ScreenRowsSince::Gone,
+            other => other,
+        }
+    }
+
     fn register_response_watcher(
         &self,
         session_id: Uuid,
@@ -5539,6 +5555,28 @@ mod tests {
             assert!(!backend.has_session(session.id));
             assert!(!backend.has_session(session.id));
         }
+    }
+
+    /// #1171, 9.1.4 (container half) - an id this backend has no parser for is `Gone`, not
+    /// `Missing`.
+    ///
+    /// This backend tears down on a natural exit and `close_transport` drops the parser before
+    /// anyone could read it, so parser-absent IS its liveness oracle - the same reading its
+    /// `get_screen_rows` already gives (`:3171-3179`). The local backend answers `Missing` to
+    /// the identical question, which is the whole reason `ScreenRowsSince` has four variants.
+    #[test]
+    fn screen_rows_since_reports_gone_for_an_unknown_id() {
+        let backend = ContainerTransportBackend::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            IdleDetector::new(|_| {}, |_| {}),
+            None,
+            None,
+        );
+
+        assert!(matches!(
+            backend.screen_rows_since(Uuid::new_v4(), None),
+            ScreenRowsSince::Gone
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -24,9 +24,9 @@ use crate::pty::container_runtime::{
 };
 use crate::pty::container_tokens::{ContainerApiToken, ContainerApiTokenManager};
 use crate::pty::context_scrape::ScreenRowsRead;
-use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyOutputTarget, PtyScreenSnapshot, SessionIoFanout};
+use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::resource_monitor::ResourceLogicalAgentSlot;
 use crate::session::selection::ContainerLifecycleSender;
 use crate::telegram::manager::OutputSenderMap;

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
+use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
@@ -1472,6 +1473,23 @@ impl PtyBackend for LocalProcessBackend {
         screen_rows_if_child_alive(&self.ptys, &self.fanout, id)
     }
 
+    /// #1171 - straight to the fanout, with **no child liveness probe**.
+    ///
+    /// `get_screen_rows` above probes the child under the `ptys` guard, "the one every
+    /// terminal write, resize and kill locks on" (`:1116-1117`). At 200 ms that probe would be
+    /// taken 25x more often than the 5 s scraper takes it, on the hottest lock in the PTY
+    /// layer, for a question the watcher engine does not ask on this path: it runs its own
+    /// liveness probe once every 25th tick, that is once per 5 s per session, exactly today's
+    /// rate. What remains here is one `screen_parsers` acquisition, and that map is per
+    /// backend rather than per process.
+    ///
+    /// An absent parser is `Missing` and not `Gone`: for a local process, parser-absence is a
+    /// desync or a poisoned lock, never a statement about the child. Only the 5 s probe, or
+    /// the child oracle behind `get_screen_rows`, may retire a local session.
+    fn screen_rows_since(&self, id: Uuid, seen: Option<FrameStamp>) -> ScreenRowsSince {
+        self.fanout.get_screen_rows_since(id, seen)
+    }
+
     fn register_response_watcher(
         &self,
         session_id: Uuid,
@@ -2162,6 +2180,28 @@ mod context_gate_tests {
                 ScreenRowsRead::Unavailable
             ),
             "the child is alive, so nothing here may claim the session is over"
+        );
+    }
+
+    /// #1171, 9.1.4 (local half) - an unknown id is `Missing` here, where the container
+    /// backend answers `Gone` to the identical question.
+    ///
+    /// Asserted against the fanout call the `screen_rows_since` override delegates to, and not
+    /// against a `LocalProcessBackend`, because that type cannot be built in a unit test: its
+    /// `GitWatcher` needs a Tauri `AppHandle` (`:95-96`), which is the same reason
+    /// `screen_rows_if_child_alive` above is a free function. The override adds nothing to
+    /// this call on purpose - **no child liveness probe** - so this is the whole of its
+    /// behavior for an unknown id.
+    #[test]
+    fn the_watcher_seam_reports_missing_for_an_unknown_id() {
+        let fanout = fanout();
+
+        assert!(
+            matches!(
+                fanout.get_screen_rows_since(Uuid::new_v4(), None),
+                crate::pty::watchers::ScreenRowsSince::Missing
+            ),
+            "for a local process, parser-absence is a desync, never a statement about the child"
         );
     }
 }

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 use crate::errors::AppError;
 use crate::pty::backend::{BackendSpawnSpec, PtyBackend};
 use crate::pty::context_scrape::{ContextSessionLiveness, ScreenRowsRead};
-use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::pty::git_watcher::GitWatcher;
 use crate::pty::idle_detector::IdleDetector;
 use crate::pty::output::{PtyScreenSnapshot, SessionIoFanout};
 use crate::pty::spawn_diagnostics::{self, ChildLiveness, ExitCause, SpawnRecord, SpawnRecordInit};
+use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
 use crate::telegram::manager::OutputSenderMap;
 
 struct PtyInstance {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -579,6 +579,25 @@ impl PtyManager {
         self.backend_for_kind(kind).get_screen_rows(id)
     }
 
+    /// #1171 - forwards to the routed backend. A missing route is `Gone` for the same reason
+    /// it is `SessionOver` above: every route removal is preceded by parser removal, so the
+    /// session really is over.
+    ///
+    /// **The watcher engine does not call this on its tick.** It resolves the backend `Arc`
+    /// once at registration through `backend_for_kind` and calls the backend directly, which
+    /// is what keeps both this mutex and the `registry` mutex out of a 200 ms loop. This
+    /// exists for completeness and for callers that hold no `Arc` of their own.
+    pub fn screen_rows_since(
+        &self,
+        id: Uuid,
+        seen: Option<crate::pty::watchers::FrameStamp>,
+    ) -> crate::pty::watchers::ScreenRowsSince {
+        let Ok(kind) = self.kind_for_session(id) else {
+            return crate::pty::watchers::ScreenRowsSince::Gone;
+        };
+        self.backend_for_kind(kind).screen_rows_since(id, seen)
+    }
+
     pub fn register_response_watcher(
         &self,
         session_id: Uuid,
@@ -1143,6 +1162,107 @@ mod tests {
             manager.context_session_liveness(missing_id),
             ContextSessionLiveness::SessionOver
         );
+    }
+
+    /// #1171, 9.1.9 - a session with no route is `Gone`, not `Missing`.
+    ///
+    /// Same reading `get_screen_rows` already gives a routeless id (`:573-580`): every route
+    /// removal is preceded by parser removal, so the session really is over. The engine
+    /// retires on `Gone`, which is exactly what should happen here; `Missing` would keep it
+    /// sampling an id that can never come back.
+    #[test]
+    fn screen_rows_since_reports_gone_for_a_session_with_no_route() {
+        let manager = PtyManager::new_for_test(Arc::new(RecordingBackend::default()));
+
+        assert!(matches!(
+            manager.screen_rows_since(Uuid::new_v4(), None),
+            crate::pty::watchers::ScreenRowsSince::Gone
+        ));
+    }
+
+    /// #1171, 9.1.8 - a backend that never heard of the seam keeps working through the trait
+    /// default: it reports a frame with NO stamp, and it never reports `Unchanged`, whatever
+    /// stamp it is handed. That is the property that lets `stamp` be an `Option` instead of a
+    /// fabricated value, and it is what keeps the two `PtyBackend` test fakes compiling.
+    #[test]
+    fn the_defaulted_seam_reports_no_stamp_and_never_reports_unchanged() {
+        use crate::pty::watchers::{FrameStamp, ScreenRowsSince};
+
+        struct DefaultSeamBackend;
+
+        impl PtyBackend for DefaultSeamBackend {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+            fn spawn(
+                &self,
+                _spec: BackendSpawnSpec,
+            ) -> futures::future::BoxFuture<'_, Result<(), AppError>> {
+                Box::pin(async { Ok(()) })
+            }
+            fn write(
+                &self,
+                _authority: &BackendWriteAuthority,
+                _id: Uuid,
+                _data: &[u8],
+            ) -> Result<(), AppError> {
+                Ok(())
+            }
+            fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), AppError> {
+                Ok(())
+            }
+            fn kill(&self, _id: Uuid) -> Result<(), AppError> {
+                Ok(())
+            }
+            fn has_session(&self, _id: Uuid) -> bool {
+                true
+            }
+            fn get_screen_snapshot(&self, _id: Uuid) -> Option<PtyScreenSnapshot> {
+                None
+            }
+            fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+                None
+            }
+            fn get_screen_rows(&self, _id: Uuid) -> ScreenRowsRead {
+                ScreenRowsRead::Rows(vec!["only row".to_string()])
+            }
+            fn register_response_watcher(
+                &self,
+                _session_id: Uuid,
+                _request_id: String,
+                _response_dir: std::path::PathBuf,
+            ) {
+            }
+            fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+                false
+            }
+            fn kill_all_jobs(&self) -> (usize, usize) {
+                (0, 0)
+            }
+        }
+
+        let id = Uuid::new_v4();
+        let manager = PtyManager::new_for_test(Arc::new(DefaultSeamBackend));
+        manager.record_route(id, SessionBackendKind::LocalProcess);
+
+        let first = manager.screen_rows_since(id, None);
+        let frame = first.frame().expect("the default must produce a frame");
+        assert!(frame.stamp.is_none());
+        assert_eq!(frame.rows, vec!["only row".to_string()]);
+        assert_eq!(frame.wrapped, vec![false]);
+        assert_eq!(frame.cursor_row, 0);
+
+        // Handed a stamp that would match anything, it still refuses to claim "unchanged":
+        // it has no sequence of its own to compare against.
+        let seen = FrameStamp {
+            sequence: 0,
+            rows: 1,
+            cols: 1,
+        };
+        assert!(matches!(
+            manager.screen_rows_since(id, Some(seen)),
+            ScreenRowsSince::Frame(_)
+        ));
     }
 
     #[test]

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -17,3 +17,4 @@ pub mod local_backend;
 pub mod manager;
 pub mod output;
 pub mod spawn_diagnostics; // #942 - spawn/first-output/exit evidence for hang triage
+pub mod watchers; // #1171 - generic regex pattern watchers over PTY output

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -300,10 +300,81 @@ impl SessionIoFanout {
         Some(screen.rows(0, cols).collect())
     }
 
+    /// #1171 - the same live grid `get_screen_rows` clones, but only when it CHANGED since
+    /// the caller last looked, plus the two O(1) facts the watcher engine needs from the same
+    /// guard: the per-row wrap flags and the cursor row.
+    ///
+    /// The unchanged path clones nothing and allocates nothing: `ScreenRowsSince::Unchanged`
+    /// carries no rows, so that property is enforced by the type rather than by a comment.
+    /// This is what lets a 200 ms sampler cost less than the 5 s one it sits beside.
+    ///
+    /// `seen` is compared against the WHOLE stamp, sequence and size, because
+    /// `resize_screen_and_broadcast` reflows the grid without bumping `output_sequence`
+    /// (`:202-212`) - a sequence-only comparison would report `Unchanged` over a screen that
+    /// was just re-laid at a new width. `output_sequence` is only READ here; its semantics
+    /// are #955's and are untouched.
+    ///
+    /// TWO-state on the negative side for the same reason `get_screen_rows` is: `Missing`
+    /// means "no parser for this id" and says NOTHING about whether the session is over. Only
+    /// a backend holds the liveness oracle, so only a backend can turn this into `Gone`.
+    ///
+    /// Sync, and everything is cloned out: the guard is a local and is released at the return,
+    /// so no caller can hold it across an await.
+    pub fn get_screen_rows_since(
+        &self,
+        id: Uuid,
+        seen: Option<crate::pty::watchers::FrameStamp>,
+    ) -> crate::pty::watchers::ScreenRowsSince {
+        use crate::pty::watchers::{FrameStamp, ScreenFrame, ScreenRowsSince};
+
+        let Ok(parsers) = self.screen_parsers.lock() else {
+            return ScreenRowsSince::Missing;
+        };
+        let Some(state) = parsers.get(&id) else {
+            return ScreenRowsSince::Missing;
+        };
+        let screen = state.parser.screen();
+        let (grid_rows, cols) = screen.size();
+        let stamp = FrameStamp {
+            sequence: state.output_sequence,
+            rows: grid_rows,
+            cols,
+        };
+        if seen == Some(stamp) {
+            return ScreenRowsSince::Unchanged;
+        }
+
+        let rows: Vec<String> = screen.rows(0, cols).collect();
+        // Indexed off the cloned rows and not off `size().0`, so `wrapped.len() == rows.len()`
+        // holds by construction: the frame diff indexes the two together.
+        let wrapped: Vec<bool> = (0..rows.len() as u16)
+            .map(|row| screen.row_wrapped(row))
+            .collect();
+        ScreenRowsSince::Frame(ScreenFrame {
+            rows,
+            wrapped,
+            cursor_row: screen.cursor_position().0,
+            stamp: Some(stamp),
+        })
+    }
+
     pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         let parsers = self.screen_parsers.lock().ok()?;
         let state = parsers.get(&id)?;
         Some(state.parser.screen().size())
+    }
+
+    /// #1171 - poison `screen_parsers` deterministically, so the "a lock we could not take
+    /// makes no claim about the session" arm is covered by a test rather than by reasoning.
+    /// Mould: `PtyManager::poison_route_registry_for_test` (`manager.rs:346-355`).
+    #[cfg(test)]
+    pub(crate) fn poison_screen_parsers_for_test(&self) {
+        let parsers = Arc::clone(&self.screen_parsers);
+        let result = std::panic::catch_unwind(move || {
+            let _guard = parsers.lock().unwrap();
+            panic!("poison the screen parser map for deterministic test coverage");
+        });
+        assert!(result.is_err(), "screen-parser poison fixture must panic");
     }
 
     pub fn register_response_watcher(

--- a/src-tauri/src/pty/watchers/dedupe.rs
+++ b/src-tauri/src/pty/watchers/dedupe.rs
@@ -1,0 +1,199 @@
+//! #1171 - layer 2 of the three deduplication layers: key suppression with a TTL.
+//!
+//! Layer 1 is the frame diff, and it does the work: a logical row is evaluated on the one tick
+//! it becomes final. This layer exists only for the residual cases layer 1 cannot separate -
+//! differently truncated repeats of the same content, and the statusline of a TUI using a
+//! scroll region, which falls inside the scrolled-in range on every scrolling tick.
+//!
+//! Layer 3 is `possibly_missed_frames`, which is not deduplication at all: it declares
+//! uncertainty instead of hiding it.
+//!
+//! Applies to `occurrence` only. `state` has its generation gate.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+/// At most this many keys per `(watcher, session)`, oldest-inserted evicted first.
+///
+/// Without this bound AND the 60 s clamp on the window, a `row` key would grow the key set to
+/// every distinct row seen inside the window, which at 8 watchers and 20 sessions is hundreds
+/// of megabytes.
+pub const MAX_KEYS: usize = 256;
+
+/// The keys one `(watcher, session)` pair has seen recently.
+#[derive(Default)]
+pub struct DedupeKeys {
+    /// key -> when it was last admitted.
+    seen: HashMap<String, Instant>,
+    /// Insertion order, for eviction. Only ever holds keys present in `seen`.
+    order: VecDeque<String>,
+}
+
+impl DedupeKeys {
+    /// Should this match be let through?
+    ///
+    /// The window runs from the moment a key was ADMITTED, not from the last time it was seen:
+    /// a sliding window would suppress a saturated watcher forever, where this one lets it
+    /// through again as soon as the window expires. That is what makes the window a
+    /// deduplication window rather than a mute button.
+    pub fn admit(&mut self, key: &str, now: Instant, window: Duration) -> bool {
+        if let Some(admitted) = self.seen.get(key) {
+            if now.duration_since(*admitted) < window {
+                return false;
+            }
+        } else {
+            self.order.push_back(key.to_string());
+            while self.order.len() > MAX_KEYS {
+                if let Some(evicted) = self.order.pop_front() {
+                    self.seen.remove(&evicted);
+                }
+            }
+        }
+        self.seen.insert(key.to_string(), now);
+        true
+    }
+
+    /// Drop keys whose window has passed. Called once per tick for the sessions evaluated that
+    /// tick, so a quiet session costs nothing and a busy one cannot accumulate.
+    pub fn prune(&mut self, now: Instant, window: Duration) {
+        self.seen
+            .retain(|_, admitted| now.duration_since(*admitted) < window);
+        self.order.retain(|key| self.seen.contains_key(key));
+    }
+
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn window() -> Duration {
+        Duration::from_millis(2000)
+    }
+
+    /// 9.4.52 (the layer's half) - the same key inside the window is one event, and the same
+    /// key outside it is another.
+    #[test]
+    fn a_repeated_key_is_suppressed_inside_the_window_and_admitted_outside_it() {
+        let mut keys = DedupeKeys::default();
+        let start = Instant::now();
+
+        assert!(keys.admit("C:/repo/main.rs", start, window()));
+        assert!(!keys.admit(
+            "C:/repo/main.rs",
+            start + Duration::from_millis(1),
+            window()
+        ));
+        assert!(!keys.admit(
+            "C:/repo/main.rs",
+            start + Duration::from_millis(1999),
+            window()
+        ));
+        assert!(keys.admit(
+            "C:/repo/main.rs",
+            start + Duration::from_millis(2001),
+            window()
+        ));
+    }
+
+    /// Suppression does not extend itself. A key hit repeatedly inside the window still comes
+    /// back at the end of it, rather than being muted for as long as the agent keeps printing.
+    #[test]
+    fn repeated_suppression_does_not_slide_the_window_forward() {
+        let mut keys = DedupeKeys::default();
+        let start = Instant::now();
+        assert!(keys.admit("k", start, window()));
+
+        for ms in [500, 1000, 1500, 1900] {
+            assert!(!keys.admit("k", start + Duration::from_millis(ms), window()));
+        }
+        assert!(
+            keys.admit("k", start + Duration::from_millis(2100), window()),
+            "the window runs from admission, not from the last suppressed hit"
+        );
+    }
+
+    /// Different keys do not suppress each other, which is the whole reason the key is
+    /// configurable: `capture` collapses two differently truncated rows, `row` does not.
+    #[test]
+    fn different_keys_are_independent() {
+        let mut keys = DedupeKeys::default();
+        let now = Instant::now();
+
+        assert!(keys.admit("a", now, window()));
+        assert!(keys.admit("b", now, window()));
+        assert!(!keys.admit("a", now, window()));
+        assert_eq!(keys.len(), 2);
+    }
+
+    /// 9.4.53 - the map never exceeds its bound, and the OLDEST key is the one that goes.
+    #[test]
+    fn the_key_set_is_bounded_and_evicts_the_oldest_first() {
+        let mut keys = DedupeKeys::default();
+        let now = Instant::now();
+
+        for i in 0..MAX_KEYS + 50 {
+            assert!(keys.admit(&format!("row {i}"), now, window()));
+        }
+
+        assert_eq!(keys.len(), MAX_KEYS);
+        assert!(
+            keys.admit("row 0", now, window()),
+            "the oldest key was evicted, so it is new again"
+        );
+        assert!(
+            !keys.admit(&format!("row {}", MAX_KEYS + 49), now, window()),
+            "the newest key is still remembered"
+        );
+    }
+
+    /// 9.4.53 - expired keys are pruned rather than waiting for eviction pressure, so a
+    /// session that goes quiet does not hold 256 strings for the rest of its life.
+    #[test]
+    fn pruning_drops_expired_keys_and_keeps_live_ones() {
+        let mut keys = DedupeKeys::default();
+        let start = Instant::now();
+        keys.admit("old", start, window());
+        keys.admit("new", start + Duration::from_millis(1900), window());
+
+        keys.prune(start + Duration::from_millis(2100), window());
+
+        assert_eq!(keys.len(), 1);
+        assert!(
+            !keys.admit("new", start + Duration::from_millis(2100), window()),
+            "the live key survived the prune"
+        );
+    }
+
+    /// The eviction order list must never outlive the keys it names, or the bound would be
+    /// enforced against a list full of ghosts.
+    #[test]
+    fn pruning_keeps_the_eviction_order_and_the_key_set_in_step() {
+        let mut keys = DedupeKeys::default();
+        let start = Instant::now();
+        for i in 0..10 {
+            keys.admit(&format!("k{i}"), start, window());
+        }
+
+        keys.prune(start + Duration::from_millis(3000), window());
+        assert!(keys.is_empty());
+        assert_eq!(keys.order.len(), 0);
+
+        for i in 0..MAX_KEYS + 10 {
+            keys.admit(
+                &format!("later {i}"),
+                start + Duration::from_millis(3000),
+                window(),
+            );
+        }
+        assert_eq!(keys.len(), MAX_KEYS);
+        assert_eq!(keys.order.len(), MAX_KEYS);
+    }
+}

--- a/src-tauri/src/pty/watchers/frame.rs
+++ b/src-tauri/src/pty/watchers/frame.rs
@@ -1,0 +1,176 @@
+//! #1171 - what the engine makes of one frame: logical rows now, the frame diff in the
+//! phase that needs it.
+//!
+//! `Screen::rows` returns PHYSICAL rows, so a line longer than the terminal width occupies
+//! two or more of them and no pattern can match across the break. At 120 columns that is
+//! precisely what an absolute file path does, which is this issue's primary use case, so
+//! evaluation is on logical rows even though the diff stays on physical ones.
+
+use super::ScreenFrame;
+
+/// One or more physical rows, joined across the wrap flag.
+///
+/// There is no separator in the join: `write_contents` emits no trailing padding
+/// (`vt100 row.rs:122-133`), so concatenating the segments reconstitutes the original line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalRow {
+    /// The physical row it starts at. `state` mode's "the lowest match wins" orders by this.
+    pub start: usize,
+    /// The physical row it ends at, inclusive. Equal to `start` for an unwrapped line.
+    pub end: usize,
+    pub text: String,
+}
+
+/// The logical rows of a frame, top to bottom.
+///
+/// **A logical row that starts at physical row 0 and spans more than one physical row is
+/// skipped.** The mirror is created with ZERO scrollback (`output.rs:112`), so there is
+/// nothing above row 0 to check the line's beginning against, and a line that reaches the top
+/// edge while still wrapping is exactly the shape of one whose head has just scrolled off.
+/// Evaluating it would emit a truncated capture - `/to/file.rs` for `/path/to/file.rs` - which
+/// is a WRONG answer, where skipping it is only a missed one. That is the fail-closed
+/// direction this module takes everywhere.
+///
+/// **Known residual, stated rather than hidden.** When a two-physical-row line loses its
+/// first row, the survivor is an ordinary unwrapped row 0 and is indistinguishable from a
+/// line that genuinely begins there. `vt100` exposes `row_wrapped(i)` - "does row i continue
+/// INTO row i+1" - and nothing that says "row i continues FROM row i-1", so with no
+/// scrollback that case cannot be detected at all. It is one row of thirty, only while a
+/// wrapped line is straddling the top edge, and it self-corrects on the next scroll.
+///
+/// A tail that runs off the BOTTOM edge is not skipped: the visible part is evaluated, and if
+/// the pattern needed the missing end it simply does not match until the next scroll brings
+/// it in. Nothing wrong is emitted either way.
+pub fn logical_rows(frame: &ScreenFrame) -> Vec<LogicalRow> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+
+    while start < frame.rows.len() {
+        let mut end = start;
+        while end + 1 < frame.rows.len() && frame.wrapped.get(end).copied().unwrap_or(false) {
+            end += 1;
+        }
+
+        if start == 0 && end > start {
+            start = end + 1;
+            continue;
+        }
+
+        let mut text = String::new();
+        for row in &frame.rows[start..=end] {
+            text.push_str(row);
+        }
+        out.push(LogicalRow { start, end, text });
+        start = end + 1;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pty::watchers::FrameStamp;
+
+    fn frame(rows: &[&str], wrapped: &[bool]) -> ScreenFrame {
+        ScreenFrame {
+            rows: rows.iter().map(|r| r.to_string()).collect(),
+            wrapped: wrapped.to_vec(),
+            cursor_row: 0,
+            stamp: Some(FrameStamp {
+                sequence: 1,
+                rows: rows.len() as u16,
+                cols: 120,
+            }),
+        }
+    }
+
+    /// 9.4.46 - the issue's primary use case. A path wider than the terminal occupies two
+    /// physical rows and matches only when they are joined.
+    #[test]
+    fn a_line_spanning_two_physical_rows_is_one_logical_row() {
+        let frame = frame(
+            &[
+                "idle",
+                "Read (C:/repo/very/long/pa",
+                "th/to/main.rs)",
+                "idle",
+            ],
+            &[false, true, false, false],
+        );
+
+        let logical = logical_rows(&frame);
+        assert_eq!(logical.len(), 3);
+        assert_eq!(logical[1].start, 1);
+        assert_eq!(logical[1].end, 2);
+        assert_eq!(logical[1].text, "Read (C:/repo/very/long/path/to/main.rs)");
+
+        let pattern = regex::Regex::new(r"Read \((.+)\)").expect("compiles");
+        assert_eq!(
+            &pattern.captures(&logical[1].text).expect("matches")[1],
+            "C:/repo/very/long/path/to/main.rs",
+            "the whole point: this pattern cannot match either physical row on its own"
+        );
+        assert!(!pattern.is_match(&frame.rows[1]));
+        assert!(!pattern.is_match(&frame.rows[2]));
+    }
+
+    /// A continuation is never a logical row of its own, so no fragment is ever evaluated in
+    /// the middle of the screen - and a line that wraps twice joins all three of its rows.
+    #[test]
+    fn a_continuation_never_becomes_a_logical_row_of_its_own() {
+        let frame = frame(
+            &["alone", "one", "two", "three", "last"],
+            &[false, true, true, false, false],
+        );
+
+        let logical = logical_rows(&frame);
+        let starts: Vec<usize> = logical.iter().map(|r| r.start).collect();
+        assert_eq!(starts, vec![0, 1, 4]);
+        assert_eq!(logical[1].text, "onetwothree");
+        assert_eq!((logical[1].start, logical[1].end), (1, 3));
+    }
+
+    /// 9.4.47 - a wrapped line touching the TOP edge may have lost its head, and there is no
+    /// scrollback to check. Skipped: a missed detection beats a truncated capture.
+    #[test]
+    fn a_wrapped_line_at_the_top_edge_is_skipped_rather_than_evaluated_as_a_fragment() {
+        let frame = frame(&["th/to/main.rs)", " done", "next"], &[true, false, false]);
+
+        let starts: Vec<usize> = logical_rows(&frame).iter().map(|r| r.start).collect();
+        assert_eq!(
+            starts,
+            vec![2],
+            "rows 0-1 are one logical row touching the top edge, so its beginning is unknowable \
+             and BOTH are withheld: row 1 is a continuation and was never evaluable on its own"
+        );
+    }
+
+    /// ...but an ORDINARY row 0 is still evaluated. Skipping every top row would lose one
+    /// line of every screen forever, which the fail-closed rule does not ask for.
+    #[test]
+    fn an_unwrapped_row_zero_is_still_a_logical_row() {
+        let frame = frame(&["top", "middle", "bottom"], &[false, false, false]);
+
+        let starts: Vec<usize> = logical_rows(&frame).iter().map(|r| r.start).collect();
+        assert_eq!(starts, vec![0, 1, 2]);
+    }
+
+    /// A wrap flag on the LAST row points off the bottom of the screen. The visible part is
+    /// evaluated; nothing is joined past the end and nothing panics.
+    #[test]
+    fn a_wrap_flag_on_the_last_row_does_not_run_off_the_end() {
+        let frame = frame(&["a", "b continues below"], &[false, true]);
+
+        let logical = logical_rows(&frame);
+        assert_eq!(logical.len(), 2);
+        assert_eq!(logical[1].start, 1);
+        assert_eq!(logical[1].end, 1);
+        assert_eq!(logical[1].text, "b continues below");
+    }
+
+    #[test]
+    fn an_empty_frame_yields_no_logical_rows() {
+        assert!(logical_rows(&frame(&[], &[])).is_empty());
+    }
+}

--- a/src-tauri/src/pty/watchers/frame.rs
+++ b/src-tauri/src/pty/watchers/frame.rs
@@ -224,7 +224,13 @@ impl FrameDiffState {
         // reseeds every tick and never evaluates. Only the defaulted trait method is in that
         // position, and it already cannot report `Unchanged` either.
         let first_tick = self.prev_hashes.is_empty();
-        let reflowed = size.is_none() || self.size != size;
+        // A frame whose row count disagrees with the state carried over is a reseed too, and
+        // NOT an assumption to index on. The stamp's `rows` and the actual row count agree for
+        // both real backends today, but nothing in the type says they must: a backend
+        // reporting an unchanged stamp with a different number of rows would otherwise index
+        // `dirty` out of bounds and take the whole engine down with a panic.
+        let desynced = self.prev_hashes.len() != curr.len() || self.dirty.len() != curr.len();
+        let reflowed = size.is_none() || self.size != size || desynced;
         if first_tick || reflowed {
             if !first_tick && self.evaluated_since_reseed {
                 self.possibly_missed_frames += 1;
@@ -250,10 +256,16 @@ impl FrameDiffState {
         let mut evaluate = Vec::new();
 
         for (row, hash) in curr.iter().enumerate() {
+            // `.get_mut` and not indexing: the reseed above already guarantees the lengths
+            // agree, and this is the one loop where being wrong about that would be a panic
+            // inside the engine thread rather than a missed evaluation.
+            let Some(dirty) = self.dirty.get_mut(row) else {
+                continue;
+            };
             let arrived_by_scroll = k >= 1 && row >= scrolled_in;
             if arrived_by_scroll && row != cursor_row {
                 evaluate.push(row);
-                self.dirty[row] = false;
+                *dirty = false;
                 continue;
             }
 
@@ -266,13 +278,13 @@ impl FrameDiffState {
             };
             match previous {
                 Some(previous) if previous == *hash => {
-                    if self.dirty[row] {
+                    if *dirty {
                         // Stable for one full tick: whatever was being written is finished.
                         evaluate.push(row);
-                        self.dirty[row] = false;
+                        *dirty = false;
                     }
                 }
-                _ => self.dirty[row] = true,
+                _ => *dirty = true,
             }
         }
 
@@ -655,6 +667,49 @@ mod tests {
             }),
         });
         assert_eq!(later.possibly_missed_frames(), 1);
+    }
+
+    /// A frame whose row count disagrees with the stamp it carries reseeds instead of indexing
+    /// off the end.
+    ///
+    /// Both real backends build the stamp from the same grid they clone the rows from, so this
+    /// cannot happen today - but nothing in the TYPE says so, and the cost of being wrong here
+    /// is a panic on the engine thread, which stops every session's sampling for the life of
+    /// the process. Reseeding is the fail-closed answer: lose a tick, not the engine.
+    #[test]
+    fn a_frame_whose_row_count_contradicts_its_stamp_reseeds_instead_of_panicking() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c"], 1, 0));
+        state.advance(&tick_frame(&["b", "c", "d"], 2, 0));
+
+        // Same stamp size, fewer rows than it claims.
+        let lying = ScreenFrame {
+            rows: vec!["b".into()],
+            wrapped: vec![false],
+            cursor_row: 0,
+            stamp: Some(FrameStamp {
+                sequence: 3,
+                rows: 3,
+                cols: 120,
+            }),
+        };
+        assert!(
+            state.advance(&lying).is_empty(),
+            "a reseed evaluates nothing"
+        );
+
+        // ...and the state is coherent afterwards, so the next real frame works normally.
+        let evaluated = state.advance(&ScreenFrame {
+            rows: vec!["z".into()],
+            wrapped: vec![false],
+            cursor_row: 5,
+            stamp: Some(FrameStamp {
+                sequence: 4,
+                rows: 3,
+                cols: 120,
+            }),
+        });
+        assert!(evaluated.is_empty());
     }
 
     /// 9.4.51 - a row shifted up by a scroll is not re-evaluated. It is the same row, at a new

--- a/src-tauri/src/pty/watchers/frame.rs
+++ b/src-tauri/src/pty/watchers/frame.rs
@@ -1,12 +1,24 @@
-//! #1171 - what the engine makes of one frame: logical rows now, the frame diff in the
-//! phase that needs it.
+//! #1171 - what the engine makes of one frame: which rows became evaluable, and what text
+//! they carry.
 //!
-//! `Screen::rows` returns PHYSICAL rows, so a line longer than the terminal width occupies
-//! two or more of them and no pattern can match across the break. At 120 columns that is
-//! precisely what an absolute file path does, which is this issue's primary use case, so
-//! evaluation is on logical rows even though the diff stays on physical ones.
+//! Two separate things live here, on purpose.
+//!
+//! **The diff is on PHYSICAL rows**, because physical arrival is what the alignment measures:
+//! a scroll moves physical rows, and the question "did this row just arrive" is a question
+//! about the grid.
+//!
+//! **Evaluation is on LOGICAL rows**, because `Screen::rows` returns physical ones and a line
+//! longer than the terminal width occupies two or more of them, so no pattern can match across
+//! the break. At 120 columns that is precisely what an absolute file path does, which is this
+//! issue's primary use case.
+//!
+//! Everything here is a pure function over hash slices or over a frame, with no locks and no
+//! engine state, which is why the riskiest piece of the feature is also the cheapest to test.
 
-use super::ScreenFrame;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use super::{FrameStamp, ScreenFrame};
 
 /// One or more physical rows, joined across the wrap flag.
 ///
@@ -65,6 +77,234 @@ pub fn logical_rows(frame: &ScreenFrame) -> Vec<LogicalRow> {
     }
 
     out
+}
+
+/// One 64-bit hash per physical row.
+///
+/// The previous frame's TEXT is never kept: hashes are enough for both alignment and change
+/// detection, at 8 bytes per row instead of up to 120 - about 240 bytes per session instead of
+/// about 3.6 KB. `DefaultHasher` needs no new dependency, and a 64-bit collision costs one
+/// missed evaluation, which is the fail-closed direction this module takes everywhere.
+pub fn hash_rows(rows: &[String]) -> Vec<u64> {
+    rows.iter()
+        .map(|row| {
+            let mut hasher = DefaultHasher::new();
+            row.hash(&mut hasher);
+            hasher.finish()
+        })
+        .collect()
+}
+
+/// How well the previous frame lines up with the current one at a shift of `k`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Alignment {
+    /// How far the screen appears to have scrolled: `prev[i + k]` is believed to be `curr[i]`.
+    pub k: usize,
+    /// How many of the overlapping rows agreed.
+    pub agree: usize,
+    /// How many rows overlap at this shift: `R - k`.
+    pub overlap: usize,
+}
+
+impl Alignment {
+    /// "The sampler could not follow the screen": fewer than half the overlapping rows agreed.
+    /// A `clear`, an alternate-screen switch, a full repaint, or a scroll burst larger than the
+    /// screen all land here, and all of them mean something may have gone past unsampled.
+    pub fn lost_the_screen(&self) -> bool {
+        2 * self.agree < self.overlap
+    }
+}
+
+/// Find the shift that best explains the current frame in terms of the previous one.
+///
+/// **This is a best-shift search and not slice equality.** Requiring `prev[k..] == curr[..R-k]`
+/// makes the in-place branch unreachable by construction - exact equality of the overlap leaves
+/// nothing to differ - and with any repainting statusline no `k` satisfies it at all, so every
+/// tick would fall through to a full re-render, permanently lighting the sampling-loss line.
+///
+/// Cost is at most `R * (R + 1) / 2` u64 comparisons, 465 at AC's default 30 rows, per changed
+/// session per tick.
+///
+/// Ties break to the SMALLEST k, which declares the fewest rows new: ambiguity under-counts
+/// rather than inventing arrivals.
+pub fn best_shift(prev: &[u64], curr: &[u64]) -> Alignment {
+    let rows = curr.len().min(prev.len());
+    let mut best = Alignment {
+        k: 0,
+        agree: 0,
+        overlap: rows,
+    };
+    for k in 0..rows {
+        let overlap = rows - k;
+        let agree = (0..overlap).filter(|i| prev[i + k] == curr[*i]).count();
+        if agree > best.agree {
+            best = Alignment { k, agree, overlap };
+        }
+    }
+    best
+}
+
+/// Move the dirty flags up by `k`, clearing the tail.
+///
+/// `new[i] = old[i + k]` for `i` in `0 .. R - k`, and `false` for the rows that just arrived.
+/// This is the step most easily implemented wrong, so it is a named function with a test of
+/// its own rather than three lines inside the diff.
+pub fn shift_dirty(dirty: &mut [bool], k: usize) {
+    if k == 0 {
+        return;
+    }
+    let rows = dirty.len();
+    if k >= rows {
+        dirty.fill(false);
+        return;
+    }
+    dirty.copy_within(k.., 0);
+    dirty[rows - k..].fill(false);
+}
+
+/// Everything the diff remembers about one session between ticks.
+///
+/// About 9 bytes per row: a hash and a flag. At 30 rows that is 240 bytes per session, about
+/// 12 KB at fifty sessions.
+#[derive(Default)]
+pub struct FrameDiffState {
+    prev_hashes: Vec<u64>,
+    dirty: Vec<bool>,
+    size: Option<(u16, u16)>,
+    /// Whether anything has been evaluated since the last reseed. A resize that reseeds before
+    /// anything was ever evaluated is not a sampling loss, it is a startup.
+    evaluated_since_reseed: bool,
+    /// Monotonic since the session started. Above zero means "something MAY have been missed",
+    /// never "N things were missed". That is a property of sampling, not a defect.
+    possibly_missed_frames: u64,
+}
+
+impl FrameDiffState {
+    pub fn possibly_missed_frames(&self) -> u64 {
+        self.possibly_missed_frames
+    }
+
+    /// Advance one tick and return the PHYSICAL rows that became evaluable.
+    ///
+    /// The rules, in order:
+    ///
+    /// 1. **First tick after registration.** Seed and evaluate nothing. There was no sampling
+    ///    gap, and reporting the whole starting screen as fresh activity would be wrong.
+    /// 2. **Size change.** A reflow re-lays every row at a new width, so reseed and evaluate
+    ///    nothing. This counts as a miss ONLY if something had been evaluated since the last
+    ///    reseed: the frontend fits xterm shortly after spawn, so the first resize is near
+    ///    universal, and counting it would light the sampling-loss line on nearly every session
+    ///    from birth - which is exactly what separating that line from the buffer banner exists
+    ///    to avoid.
+    /// 3. **New by scroll**, the bottom `k` rows, EXCLUDING the cursor row: evaluated at once.
+    ///    They arrived complete from below and need no stabilization.
+    /// 4. **In place**, everything else plus the cursor row: evaluated on the next tick in
+    ///    which its hash is unchanged.
+    ///
+    /// **The cursor row is excluded from step 3** because a terminal that prints a newline
+    /// lands the cursor on an empty bottom row and only THEN writes it. At a 200 ms cadence
+    /// against 4096-byte read chunks, landing mid-write is routine, and evaluating it would
+    /// emit one event with a truncated capture followed by a second with the complete one - two
+    /// events no dedupe setting can merge, because both the row and the captures differ.
+    ///
+    /// **There is no "re-render, evaluate everything now" path.** A repaint produces a
+    /// low-agreement alignment whose differing rows all land in `dirty`, and they are evaluated
+    /// one tick later if the new screen is stable, which it is: one evaluation per row, in
+    /// order, with no burst.
+    ///
+    /// A dirty row that scrolls off the top is lost - the engine never kept its text - and that
+    /// does NOT count as a miss, so `possibly_missed_frames` keeps exactly one meaning.
+    pub fn advance(&mut self, frame: &ScreenFrame) -> Vec<usize> {
+        let curr = hash_rows(&frame.rows);
+        let size = frame
+            .stamp
+            .map(|stamp: FrameStamp| (stamp.rows, stamp.cols));
+
+        // A backend with no stamp to report cannot promise the size is unchanged, so it
+        // reseeds every tick and never evaluates. Only the defaulted trait method is in that
+        // position, and it already cannot report `Unchanged` either.
+        let first_tick = self.prev_hashes.is_empty();
+        let reflowed = size.is_none() || self.size != size;
+        if first_tick || reflowed {
+            if !first_tick && self.evaluated_since_reseed {
+                self.possibly_missed_frames += 1;
+            }
+            self.prev_hashes = curr;
+            self.dirty = vec![false; frame.rows.len()];
+            self.size = size;
+            self.evaluated_since_reseed = false;
+            return Vec::new();
+        }
+
+        let alignment = best_shift(&self.prev_hashes, &curr);
+        if alignment.lost_the_screen() {
+            self.possibly_missed_frames += 1;
+        }
+
+        let rows = curr.len();
+        let k = alignment.k;
+        shift_dirty(&mut self.dirty, k);
+
+        let cursor_row = frame.cursor_row as usize;
+        let scrolled_in = rows.saturating_sub(k);
+        let mut evaluate = Vec::new();
+
+        for (row, hash) in curr.iter().enumerate() {
+            let arrived_by_scroll = k >= 1 && row >= scrolled_in;
+            if arrived_by_scroll && row != cursor_row {
+                evaluate.push(row);
+                self.dirty[row] = false;
+                continue;
+            }
+
+            // In place, and the cursor row that arrived by scroll with it: there is no shifted
+            // previous hash for the latter, which is the same thing as "it changed".
+            let previous = if arrived_by_scroll {
+                None
+            } else {
+                self.prev_hashes.get(row + k).copied()
+            };
+            match previous {
+                Some(previous) if previous == *hash => {
+                    if self.dirty[row] {
+                        // Stable for one full tick: whatever was being written is finished.
+                        evaluate.push(row);
+                        self.dirty[row] = false;
+                    }
+                }
+                _ => self.dirty[row] = true,
+            }
+        }
+
+        self.prev_hashes = curr;
+        self.size = size;
+        if !evaluate.is_empty() {
+            self.evaluated_since_reseed = true;
+        }
+        evaluate
+    }
+}
+
+/// Map the physical rows the diff selected onto the logical rows to evaluate.
+///
+/// A continuation selected while its start row was not still evaluates the LOGICAL row it
+/// belongs to, once: selection is mapped from physical to logical before evaluation, and a
+/// logical row is evaluated at most once per tick. A physical row belonging to no logical row -
+/// the withheld top-edge case - selects nothing.
+pub fn select_logical<'a>(logical: &'a [LogicalRow], physical: &[usize]) -> Vec<&'a LogicalRow> {
+    let mut selected: Vec<&LogicalRow> = Vec::new();
+    for row in physical {
+        if let Some(found) = logical
+            .iter()
+            .find(|candidate| candidate.start <= *row && *row <= candidate.end)
+        {
+            if !selected.iter().any(|already| already.start == found.start) {
+                selected.push(found);
+            }
+        }
+    }
+    selected.sort_by_key(|row| row.start);
+    selected
 }
 
 #[cfg(test)]
@@ -172,5 +412,304 @@ mod tests {
     #[test]
     fn an_empty_frame_yields_no_logical_rows() {
         assert!(logical_rows(&frame(&[], &[])).is_empty());
+    }
+
+    // ---- the frame diff ------------------------------------------------------------------
+
+    /// A frame at a given sequence, with the cursor parked where it cannot interfere.
+    fn tick_frame(rows: &[&str], sequence: u64, cursor_row: u16) -> ScreenFrame {
+        ScreenFrame {
+            rows: rows.iter().map(|r| r.to_string()).collect(),
+            wrapped: vec![false; rows.len()],
+            cursor_row,
+            stamp: Some(FrameStamp {
+                sequence,
+                rows: rows.len() as u16,
+                cols: 120,
+            }),
+        }
+    }
+
+    fn hashes(rows: &[&str]) -> Vec<u64> {
+        hash_rows(&rows.iter().map(|r| r.to_string()).collect::<Vec<_>>())
+    }
+
+    /// 9.4.38 - nothing moved: shift zero, everything agrees.
+    #[test]
+    fn best_shift_of_two_identical_frames_is_zero_with_full_agreement() {
+        let rows = hashes(&["a", "b", "c", "d", "e"]);
+
+        let alignment = best_shift(&rows, &rows);
+        assert_eq!(alignment.k, 0);
+        assert_eq!(alignment.agree, 5);
+        assert_eq!(alignment.overlap, 5);
+        assert!(!alignment.lost_the_screen());
+    }
+
+    /// 9.4.39 - a clean scroll of three rows is a shift of three, and exactly the bottom three
+    /// rows are declared new.
+    #[test]
+    fn a_frame_scrolled_by_three_declares_exactly_the_bottom_three_rows_new() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c", "d", "e"], 1, 0));
+
+        let evaluated = state.advance(&tick_frame(&["d", "e", "f", "g", "h"], 2, 0));
+
+        assert_eq!(evaluated, vec![2, 3, 4]);
+        assert_eq!(state.possibly_missed_frames(), 0);
+    }
+
+    /// 9.4.40 - **the case revision 1's slice-equality predicate made unsatisfiable, and the
+    /// normal case for any TUI with a statusline.**
+    ///
+    /// The screen scrolled by three AND the bottom row was repainted in place. Exact equality
+    /// of the overlap cannot describe that at any `k`; best-shift can, and the repainted row
+    /// lands in the dirty set instead of taking the whole tick down a re-render path.
+    #[test]
+    fn a_scroll_whose_bottom_row_also_changed_still_aligns_and_leaves_that_row_dirty() {
+        let mut state = FrameDiffState::default();
+        // Row 4 is a statusline: it repaints on every tick and never scrolls with the rest.
+        state.advance(&tick_frame(&["a", "b", "c", "d", "status 1"], 1, 0));
+
+        let alignment = best_shift(
+            &hashes(&["a", "b", "c", "d", "status 1"]),
+            &hashes(&["d", "status 1", "f", "g", "status 2"]),
+        );
+        assert_eq!(alignment.k, 3);
+        assert!(!alignment.lost_the_screen());
+
+        let evaluated = state.advance(&tick_frame(&["d", "status 1", "f", "g", "status 2"], 2, 0));
+        assert_eq!(
+            evaluated,
+            vec![2, 3, 4],
+            "the three rows that arrived from below, statusline included"
+        );
+
+        // The statusline changing again is now an in-place change: dirty, not evaluated.
+        let evaluated = state.advance(&tick_frame(&["d", "status 1", "f", "g", "status 3"], 3, 0));
+        assert!(evaluated.is_empty());
+        // ...and it IS evaluated once it holds still for a tick.
+        let evaluated = state.advance(&tick_frame(&["d", "status 1", "f", "g", "status 3"], 4, 0));
+        assert_eq!(evaluated, vec![4]);
+        assert_eq!(state.possibly_missed_frames(), 0);
+    }
+
+    /// 9.4.41 - one statusline row changing is not a lost screen. It aligns at zero with
+    /// `R - 1` agreement, evaluates nothing, marks that row dirty, and counts NO miss.
+    #[test]
+    fn a_single_changed_row_evaluates_nothing_and_counts_no_miss() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c", "d", "status 1"], 1, 0));
+
+        let alignment = best_shift(
+            &hashes(&["a", "b", "c", "d", "status 1"]),
+            &hashes(&["a", "b", "c", "d", "status 2"]),
+        );
+        assert_eq!((alignment.k, alignment.agree), (0, 4));
+        assert!(!alignment.lost_the_screen());
+
+        let evaluated = state.advance(&tick_frame(&["a", "b", "c", "d", "status 2"], 2, 0));
+        assert!(evaluated.is_empty());
+        assert_eq!(state.possibly_missed_frames(), 0);
+    }
+
+    /// 9.4.42 - a row that changes on every tick is never stable, so it is never evaluated.
+    /// This is what keeps a clock or a spinner from emitting five events a second.
+    #[test]
+    fn a_row_that_changes_every_tick_is_never_evaluated() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "spinner 0"], 1, 0));
+
+        for i in 1..10 {
+            let row = format!("spinner {i}");
+            let evaluated = state.advance(&tick_frame(&["a", "b", &row], i + 1, 0));
+            assert!(evaluated.is_empty(), "tick {i} evaluated {evaluated:?}");
+        }
+        assert_eq!(state.possibly_missed_frames(), 0);
+    }
+
+    /// 9.4.43 - the step most easily implemented wrong, on its own.
+    #[test]
+    fn shift_dirty_moves_the_flags_and_clears_the_tail() {
+        let mut dirty = vec![true, false, true, false, true];
+        shift_dirty(&mut dirty, 2);
+        assert_eq!(dirty, vec![true, false, true, false, false]);
+
+        let mut dirty = vec![true, true, true];
+        shift_dirty(&mut dirty, 0);
+        assert_eq!(
+            dirty,
+            vec![true, true, true],
+            "a shift of zero moves nothing"
+        );
+
+        let mut dirty = vec![true, true, true];
+        shift_dirty(&mut dirty, 5);
+        assert_eq!(
+            dirty,
+            vec![false, false, false],
+            "a scroll larger than the screen leaves nothing carried over"
+        );
+    }
+
+    /// 9.4.44 - a full repaint counts a miss, evaluates NOTHING that tick, and evaluates each
+    /// changed row exactly once on the next stable tick. There is deliberately no
+    /// evaluate-everything-now path: that would be a burst, in no order, relying on the TTL
+    /// layer to clean up after it.
+    #[test]
+    fn a_repaint_counts_a_miss_and_evaluates_each_row_once_on_the_next_stable_tick() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c", "d"], 1, 0));
+        // Make the seeded frame have something evaluated, so the state is past its startup.
+        state.advance(&tick_frame(&["b", "c", "d", "e"], 2, 0));
+
+        let evaluated = state.advance(&tick_frame(&["w", "x", "y", "z"], 3, 0));
+        assert!(
+            evaluated.is_empty(),
+            "a repaint emits nothing at the moment it lands"
+        );
+        assert_eq!(state.possibly_missed_frames(), 1);
+
+        let evaluated = state.advance(&tick_frame(&["w", "x", "y", "z"], 4, 0));
+        assert_eq!(evaluated, vec![0, 1, 2, 3], "once each, in order");
+
+        let evaluated = state.advance(&tick_frame(&["w", "x", "y", "z"], 5, 0));
+        assert!(
+            evaluated.is_empty(),
+            "and never again while they hold still"
+        );
+        assert_eq!(state.possibly_missed_frames(), 1, "still exactly one");
+    }
+
+    /// 9.4.45 (the diff half) - the cursor row is NOT evaluated on the tick it arrives by
+    /// scroll, and IS evaluated once, complete, when it stabilizes.
+    ///
+    /// A terminal that prints a newline lands the cursor on an empty bottom row and only then
+    /// writes it; at 200 ms against 4 KB chunks, landing mid-write is routine.
+    #[test]
+    fn the_cursor_row_is_evaluated_one_tick_later_rather_than_half_written() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c"], 1, 2));
+
+        // Scrolled by one; the cursor is on the new bottom row, which is still being written.
+        let evaluated = state.advance(&tick_frame(&["b", "c", "Read /path/to/fi"], 2, 2));
+        assert!(
+            evaluated.is_empty(),
+            "the half-written cursor row must not be evaluated with a truncated capture"
+        );
+
+        // The write finished. Still not stable, so still nothing.
+        let evaluated = state.advance(&tick_frame(&["b", "c", "Read /path/to/file.rs"], 3, 2));
+        assert!(evaluated.is_empty());
+
+        // Stable: evaluated once, complete.
+        let evaluated = state.advance(&tick_frame(&["b", "c", "Read /path/to/file.rs"], 4, 2));
+        assert_eq!(evaluated, vec![2]);
+    }
+
+    /// 9.4.48 - the first tick after registration evaluates nothing and counts no miss. There
+    /// was no sampling gap; the whole starting screen is not fresh activity.
+    #[test]
+    fn the_first_tick_evaluates_nothing_and_counts_no_miss() {
+        let mut state = FrameDiffState::default();
+
+        let evaluated = state.advance(&tick_frame(&["a", "b", "c"], 1, 0));
+
+        assert!(evaluated.is_empty());
+        assert_eq!(state.possibly_missed_frames(), 0);
+    }
+
+    /// 9.4.49 - a resize before anything was evaluated is a startup, not a loss. After
+    /// something HAS been evaluated it is a real gap and is counted.
+    ///
+    /// Without the distinction, the frontend fitting xterm shortly after spawn would light the
+    /// sampling-loss line on nearly every session from birth.
+    #[test]
+    fn a_resize_counts_a_miss_only_after_something_has_been_evaluated() {
+        let mut early = FrameDiffState::default();
+        early.advance(&tick_frame(&["a", "b", "c"], 1, 0));
+        early.advance(&ScreenFrame {
+            rows: vec!["a".into(), "b".into()],
+            wrapped: vec![false; 2],
+            cursor_row: 0,
+            stamp: Some(FrameStamp {
+                sequence: 2,
+                rows: 2,
+                cols: 100,
+            }),
+        });
+        assert_eq!(early.possibly_missed_frames(), 0);
+
+        let mut later = FrameDiffState::default();
+        later.advance(&tick_frame(&["a", "b", "c"], 1, 0));
+        later.advance(&tick_frame(&["b", "c", "d"], 2, 0));
+        assert_eq!(later.possibly_missed_frames(), 0);
+        later.advance(&ScreenFrame {
+            rows: vec!["b".into(), "c".into()],
+            wrapped: vec![false; 2],
+            cursor_row: 0,
+            stamp: Some(FrameStamp {
+                sequence: 3,
+                rows: 2,
+                cols: 100,
+            }),
+        });
+        assert_eq!(later.possibly_missed_frames(), 1);
+    }
+
+    /// 9.4.51 - a row shifted up by a scroll is not re-evaluated. It is the same row, at a new
+    /// position, and it was already counted when it arrived.
+    #[test]
+    fn a_row_shifted_up_by_a_scroll_is_not_re_evaluated() {
+        let mut state = FrameDiffState::default();
+        state.advance(&tick_frame(&["a", "b", "c", "d"], 1, 0));
+        let evaluated = state.advance(&tick_frame(&["b", "c", "d", "hit"], 2, 0));
+        assert_eq!(evaluated, vec![3]);
+
+        let evaluated = state.advance(&tick_frame(&["c", "d", "hit", "next"], 3, 0));
+        assert_eq!(
+            evaluated,
+            vec![3],
+            "only the newly arrived row: `hit` moved up and must not count twice"
+        );
+    }
+
+    /// 9.4.57 - `possibly_missed_frames` only ever grows.
+    #[test]
+    fn possibly_missed_frames_is_monotonic() {
+        let mut state = FrameDiffState::default();
+        let mut seen = 0;
+        for i in 0..30u64 {
+            let row = format!("burst {i}");
+            state.advance(&tick_frame(&[&row, "x", "y"], i + 1, 0));
+            let now = state.possibly_missed_frames();
+            assert!(now >= seen, "went backwards at tick {i}: {seen} -> {now}");
+            seen = now;
+        }
+    }
+
+    /// The physical-to-logical mapping: a continuation selected on its own evaluates the whole
+    /// logical row it belongs to, once, and a withheld top-edge row selects nothing.
+    #[test]
+    fn selection_maps_physical_rows_onto_logical_rows_without_duplicates() {
+        let top_edge = frame(&["head", "one", "two", "tail"], &[true, true, false, false]);
+        let logical = logical_rows(&top_edge);
+
+        // Rows 0-2 are the withheld top-edge logical row; row 3 is its own.
+        assert_eq!(select_logical(&logical, &[0]).len(), 0);
+        assert_eq!(select_logical(&logical, &[1, 2]).len(), 0);
+        let selected = select_logical(&logical, &[3, 3]);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].text, "tail");
+
+        let plain = frame(&["a", "b", "c"], &[false, true, false]);
+        let logical = logical_rows(&plain);
+        let selected = select_logical(&logical, &[2, 1]);
+        assert_eq!(
+            selected.len(),
+            1,
+            "row 2 is a continuation of row 1: one logical row, evaluated once"
+        );
+        assert_eq!(selected[0].text, "bc");
     }
 }

--- a/src-tauri/src/pty/watchers/history.rs
+++ b/src-tauri/src/pty/watchers/history.rs
@@ -1,0 +1,389 @@
+//! #1171 - the per-session in-RAM ring the activity window reads, and the per-session status
+//! the engine publishes beside it.
+//!
+//! Mould: `SessionWarningBuffer` (`session/warnings.rs:39-51`), with four deliberate
+//! differences, each because this buffer is bigger, hotter and read rather than drained.
+//!
+//! **Nothing here is persisted.** The window never claims history across restarts, and the
+//! engine's worst-case disk write is zero - a property worth keeping.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use uuid::Uuid;
+
+use super::{WatcherMatchPayload, WatcherMode};
+
+/// Hard cap per session, oldest dropped first.
+///
+/// With `row` capped at 256 bytes the worst-case element is about 500 to 550 bytes, so twenty
+/// sessions is about 3.5 MB typical and about 5.5 MB at the ceiling.
+pub const MAX_ENTRIES_PER_SESSION: usize = 500;
+
+/// One watcher's standing on one session, for the window's empty states and its degraded
+/// marker. Present even when the count is 0, which is what lets the window say "configured and
+/// waiting" instead of "nothing reaches this session".
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherActivityCounter {
+    pub watcher_id: String,
+    pub mode: WatcherMode,
+    pub count: u64,
+    /// True while this watcher is hitting a per-tick cap or is suspended.
+    pub degraded: bool,
+}
+
+/// Everything `get_watcher_activity` answers with, in one synchronous read.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherActivitySnapshot {
+    /// Oldest first. `limit` trims from the NEW end: `Some(n)` returns the n most recent, still
+    /// ordered oldest to newest.
+    pub matches: Vec<WatcherMatchPayload>,
+    /// The highest `seq` ever inserted for this session. The merge fence for a window that
+    /// subscribed before it fetched.
+    pub last_seq: u64,
+    /// The ring dropped at least one entry since the session started.
+    pub truncated: bool,
+    /// Monotonic since the session started. NOT a count of lost matches.
+    pub possibly_missed_frames: u64,
+    /// False until the engine has ticked this session at least once.
+    ///
+    /// Without it the window cannot tell "no watcher reaches this agent" from "the engine has
+    /// not run yet", and would show the "Configure watchers" empty state for the first 200 ms
+    /// of every session even when watchers ARE configured.
+    pub warmed_up: bool,
+    /// The watchers that reach this session's agent right now, with their count since the
+    /// session started.
+    pub active_watchers: Vec<WatcherActivityCounter>,
+}
+
+impl WatcherActivitySnapshot {
+    /// What a session with no buffer answers with: an empty snapshot, never `None` and never
+    /// an error. The window distinguishes its states from the VALUES here, with no nullability
+    /// to reason about.
+    pub fn empty() -> Self {
+        Self {
+            matches: Vec::new(),
+            last_seq: 0,
+            truncated: false,
+            possibly_missed_frames: 0,
+            warmed_up: false,
+            active_watchers: Vec::new(),
+        }
+    }
+}
+
+/// What the engine publishes at the end of each tick, so the snapshot command can be
+/// synchronous and take one per-session mutex instead of resolving settings and the session
+/// manager itself.
+#[derive(Clone, Debug, Default)]
+pub struct SessionStatus {
+    pub possibly_missed_frames: u64,
+    pub active_watchers: Vec<WatcherActivityCounter>,
+}
+
+#[derive(Default)]
+struct SessionHistory {
+    matches: VecDeque<WatcherMatchPayload>,
+    last_seq: u64,
+    truncated: bool,
+    status: SessionStatus,
+}
+
+/// The per-session rings, behind per-session locks.
+///
+/// The outer lock guards the MAP only and is released before any read or write of a session's
+/// entry, so a snapshot never blocks the engine's writes to other sessions. The engine takes
+/// this structure up to 250 times a second at fifty sessions; a single mutex would serialize
+/// every snapshot against every write.
+#[derive(Default)]
+pub struct WatcherHistory {
+    sessions: Mutex<HashMap<Uuid, Arc<Mutex<SessionHistory>>>>,
+}
+
+pub type WatcherHistoryState = Arc<WatcherHistory>;
+
+impl WatcherHistory {
+    /// Create or refresh a session's entry with what the engine knows at the end of its tick.
+    ///
+    /// **This is the only path that CREATES an entry**, and the engine calls it while still
+    /// holding its registration lock. Together with `purge_session_side_state` retiring before
+    /// it purges, that is what stops a tick in flight from resurrecting a session that was
+    /// destroyed moments earlier.
+    pub fn publish(&self, id: Uuid, status: SessionStatus) {
+        let entry = {
+            let mut sessions = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+            Arc::clone(sessions.entry(id).or_default())
+        };
+        let mut history = entry.lock().unwrap_or_else(|e| e.into_inner());
+        history.status = status;
+    }
+
+    /// Append a tick's matches to an EXISTING entry.
+    ///
+    /// Creates nothing. A batch that arrives for a session purged between the tick and the
+    /// emit is dropped, which is exactly what should happen to it.
+    pub fn record(&self, id: Uuid, matches: &[WatcherMatchPayload]) {
+        let Some(entry) = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&id)
+            .map(Arc::clone)
+        else {
+            return;
+        };
+        let mut history = entry.lock().unwrap_or_else(|e| e.into_inner());
+        for payload in matches {
+            history.last_seq = history.last_seq.max(payload.seq);
+            history.matches.push_back(payload.clone());
+            // `VecDeque::pop_front` and not `Vec::remove(0)`: at the 32-entry cap of the
+            // warning buffer that difference is irrelevant, at 500 under a burst it is not.
+            while history.matches.len() > MAX_ENTRIES_PER_SESSION {
+                history.matches.pop_front();
+                history.truncated = true;
+            }
+        }
+    }
+
+    /// Read a session's activity WITHOUT consuming it.
+    ///
+    /// `SessionWarningBuffer::drain` consumes (`warnings.rs:53-63`), which here would mean
+    /// closing and reopening the window shows nothing.
+    pub fn snapshot(&self, id: Uuid, limit: Option<usize>) -> WatcherActivitySnapshot {
+        let Some(entry) = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&id)
+            .map(Arc::clone)
+        else {
+            return WatcherActivitySnapshot::empty();
+        };
+        let history = entry.lock().unwrap_or_else(|e| e.into_inner());
+
+        let matches: Vec<WatcherMatchPayload> = match limit {
+            // Trimmed from the NEW end and still ordered oldest to newest, so the window can
+            // append to what it has instead of re-sorting.
+            Some(limit) => history
+                .matches
+                .iter()
+                .skip(history.matches.len().saturating_sub(limit))
+                .cloned()
+                .collect(),
+            None => history.matches.iter().cloned().collect(),
+        };
+
+        WatcherActivitySnapshot {
+            matches,
+            last_seq: history.last_seq,
+            truncated: history.truncated,
+            possibly_missed_frames: history.status.possibly_missed_frames,
+            // The entry exists at all only because the engine ticked this session.
+            warmed_up: true,
+            active_watchers: history.status.active_watchers.clone(),
+        }
+    }
+
+    /// Drop a session's history. Idempotent.
+    pub fn purge(&self, id: Uuid) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tracked_sessions(&self) -> usize {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload(seq: u64) -> WatcherMatchPayload {
+        WatcherMatchPayload {
+            session_id: "s".to_string(),
+            seq,
+            watcher_id: "w".to_string(),
+            mode: WatcherMode::Occurrence,
+            at: chrono::DateTime::parse_from_rfc3339("2026-07-30T00:00:00Z")
+                .expect("fixed instant")
+                .with_timezone(&chrono::Utc),
+            captures: Vec::new(),
+            row: format!("row {seq}"),
+            row_truncated: false,
+        }
+    }
+
+    fn history_with(id: Uuid, count: u64) -> WatcherHistory {
+        let history = WatcherHistory::default();
+        history.publish(id, SessionStatus::default());
+        for seq in 1..=count {
+            history.record(id, &[payload(seq)]);
+        }
+        history
+    }
+
+    /// 9.5.60 - reading is not draining. Closing and reopening the window must show the same
+    /// thing, which is the whole difference from the warning buffer this is modelled on.
+    #[test]
+    fn a_snapshot_does_not_consume() {
+        let id = Uuid::new_v4();
+        let history = history_with(id, 3);
+
+        let first = history.snapshot(id, None);
+        let second = history.snapshot(id, None);
+
+        assert_eq!(first.matches.len(), 3);
+        assert_eq!(
+            first.matches.iter().map(|m| m.seq).collect::<Vec<_>>(),
+            second.matches.iter().map(|m| m.seq).collect::<Vec<_>>()
+        );
+    }
+
+    /// 9.5.61 - the 501st entry drops the oldest and says so. `truncated` is EXACT knowledge
+    /// that something was lost, which is why the window shows it separately from the weaker
+    /// "some screen output was not sampled" line.
+    #[test]
+    fn the_ring_drops_the_oldest_entry_and_marks_itself_truncated() {
+        let id = Uuid::new_v4();
+        let history = history_with(id, MAX_ENTRIES_PER_SESSION as u64);
+        assert!(!history.snapshot(id, None).truncated);
+
+        history.record(id, &[payload(MAX_ENTRIES_PER_SESSION as u64 + 1)]);
+
+        let snapshot = history.snapshot(id, None);
+        assert!(snapshot.truncated);
+        assert_eq!(snapshot.matches.len(), MAX_ENTRIES_PER_SESSION);
+        assert_eq!(
+            snapshot.matches[0].seq, 2,
+            "the oldest went, not the newest"
+        );
+        assert_eq!(
+            snapshot.last_seq,
+            MAX_ENTRIES_PER_SESSION as u64 + 1,
+            "lastSeq counts what was INSERTED, not what is still held"
+        );
+    }
+
+    /// 9.5.63 - `limit` trims from the new end and keeps the order, so the window can append.
+    #[test]
+    fn a_limit_returns_the_most_recent_entries_still_oldest_first() {
+        let id = Uuid::new_v4();
+        let history = history_with(id, 10);
+
+        let limited = history.snapshot(id, Some(3));
+        assert_eq!(
+            limited.matches.iter().map(|m| m.seq).collect::<Vec<_>>(),
+            vec![8, 9, 10]
+        );
+
+        assert_eq!(history.snapshot(id, None).matches.len(), 10);
+        assert_eq!(
+            history.snapshot(id, Some(1000)).matches.len(),
+            10,
+            "a limit past the ring is the ring"
+        );
+    }
+
+    /// 9.5.64 - a session with no buffer is an EMPTY snapshot, never `None` and never an
+    /// error, and `warmedUp` is what tells the window it is looking at a session the engine
+    /// has not reached yet.
+    #[test]
+    fn a_session_with_no_buffer_returns_the_empty_snapshot_and_is_not_warmed_up() {
+        let history = WatcherHistory::default();
+
+        let snapshot = history.snapshot(Uuid::new_v4(), None);
+
+        assert!(snapshot.matches.is_empty());
+        assert_eq!(snapshot.last_seq, 0);
+        assert!(!snapshot.truncated);
+        assert_eq!(snapshot.possibly_missed_frames, 0);
+        assert!(!snapshot.warmed_up);
+        assert!(snapshot.active_watchers.is_empty());
+    }
+
+    /// 9.5.66 and 9.5.67 - the counters are there before any match, with their mode, and
+    /// `warmedUp` flips on the first published tick. That is the difference between "nothing
+    /// reaches this session" and "configured and waiting".
+    #[test]
+    fn the_counters_are_published_before_any_match_and_warm_the_session_up() {
+        let id = Uuid::new_v4();
+        let history = WatcherHistory::default();
+        assert!(!history.snapshot(id, None).warmed_up);
+
+        history.publish(
+            id,
+            SessionStatus {
+                possibly_missed_frames: 0,
+                active_watchers: vec![WatcherActivityCounter {
+                    watcher_id: "perm".to_string(),
+                    mode: WatcherMode::State,
+                    count: 0,
+                    degraded: false,
+                }],
+            },
+        );
+
+        let snapshot = history.snapshot(id, None);
+        assert!(snapshot.warmed_up);
+        assert!(snapshot.matches.is_empty());
+        assert_eq!(snapshot.active_watchers.len(), 1);
+        assert_eq!(snapshot.active_watchers[0].mode, WatcherMode::State);
+        assert_eq!(snapshot.active_watchers[0].count, 0);
+    }
+
+    /// 9.5.70 - **the resurrection this ordering exists to prevent.** A batch that arrives for
+    /// a purged session creates nothing: only the engine, holding its registration lock,
+    /// creates entries.
+    #[test]
+    fn recording_into_a_purged_session_does_not_recreate_it() {
+        let id = Uuid::new_v4();
+        let history = history_with(id, 2);
+        assert_eq!(history.tracked_sessions(), 1);
+
+        history.purge(id);
+        history.record(id, &[payload(3)]);
+
+        assert_eq!(history.tracked_sessions(), 0);
+        assert!(!history.snapshot(id, None).warmed_up);
+    }
+
+    /// 9.5.73 - the outer lock guards the map only, so a snapshot of one session cannot block
+    /// the engine writing another. Asserted by HOLDING one session's entry and reading the
+    /// other, which would deadlock under a single global mutex.
+    #[test]
+    fn a_snapshot_of_one_session_does_not_block_another() {
+        let held = Uuid::new_v4();
+        let other = Uuid::new_v4();
+        let history = WatcherHistory::default();
+        history.publish(held, SessionStatus::default());
+        history.publish(other, SessionStatus::default());
+
+        let entry = {
+            let sessions = history.sessions.lock().unwrap();
+            Arc::clone(&sessions[&held])
+        };
+        let _guard = entry.lock().unwrap();
+
+        history.record(other, &[payload(1)]);
+        assert_eq!(history.snapshot(other, None).matches.len(), 1);
+    }
+
+    /// Purging is idempotent, so every caller can just call it.
+    #[test]
+    fn purging_twice_is_harmless() {
+        let id = Uuid::new_v4();
+        let history = history_with(id, 1);
+        history.purge(id);
+        history.purge(id);
+        assert_eq!(history.tracked_sessions(), 0);
+    }
+}

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -1,0 +1,407 @@
+//! #1171 - generic, user-configured regex watchers over the plain de-ANSI'd rows of the
+//! `vt100` screen mirror AC already keeps for every session.
+//!
+//! A sibling of `context_scrape`, not an extension of it. The two engines share only the
+//! read boundary on `SessionIoFanout`; `ContextScraper` keeps its 5 s interval, its single
+//! pattern per agent and its five sinks, untouched.
+//!
+//! **The engine cannot act.** Like `ContextScraper` (`context_scrape/mod.rs:5-8`) it holds
+//! narrow trait objects and no `AppHandle` and no `PtyManager` of its own, so the worst a
+//! hostile or careless pattern can do is put a wrong row in a window and a wrong number in a
+//! counter. Injection capability plus a loose pattern would be a feedback loop: inject,
+//! printed to the PTY, matches its own injection, inject again.
+//!
+//! **This is a best-effort indicator and not an audit log.** That is a property of the PTY
+//! channel and it is stated in the UI.
+//!
+//! # Measured cost
+//!
+//! Taken by `read_seam_timing` below at AC's default 30x120 grid, against a session with a
+//! live spinner - `output_sequence` advances on every CHUNK (`output.rs:160`), including
+//! chunks that change no character, so a visually still screen is not a quiet one and the
+//! unchanged short circuit must not be measured against one. Same form as
+//! `context_scrape/mod.rs:22-25`:
+//!
+//! - `get_screen_rows`: ~81 us
+//! - `get_screen_rows_since` on an UNCHANGED frame: ~30 ns
+//! - `get_screen_rows_since` on a CHANGED frame: ~82 us
+//!
+//! So a changed read costs what the existing sample costs, plus the wrap flags and the cursor
+//! row, which are O(1) under the guard the row clone already takes. An unchanged read is
+//! ~2700x cheaper because it clones nothing, and that is enforced by the TYPE -
+//! `ScreenRowsSince::Unchanged` carries no rows - rather than by this measurement.
+//!
+//! Machine: Windows 11, taken with optimizations on so the numbers are comparable to the
+//! ~200 us `context_scrape` records. A plain `cargo test` build is unoptimized and its
+//! numbers are not comparable to either; `--release` does not build the test target in this
+//! tree, because `load_sessions_raw_from_dir_for_test` is `#[cfg(debug_assertions)]`.
+
+/// Identifies one frame of one session's screen mirror.
+///
+/// **The size is part of the stamp on purpose.** `resize_screen_and_broadcast` reflows the
+/// grid without bumping `output_sequence` (`output.rs:202-212`), so a sequence-only stamp
+/// would report `Unchanged` over a screen that was just re-laid at a new width.
+///
+/// **`sequence` is monotonic only within one parser instance.** `register_session` inserts a
+/// fresh parser at `output_sequence: 0` (`output.rs:109-116`). That is safe here only because
+/// session ids are minted per spawn and AC never reuses one, not even on respawn
+/// (`context_scrape/mod.rs:232-233`). #955's replay tolerates a reset; this engine does not.
+/// If a future "reattach in place" ever reuses an id, the stamp would move BACKWARDS and the
+/// engine could report `Unchanged` over a completely different screen.
+///
+/// `output_sequence` itself is never modified by this module: it is also the replay ordering
+/// key `get_screen_snapshot` hands the frontend (`output.rs:274-285`, #955), and changing when
+/// it advances would change that contract. The seam only reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameStamp {
+    /// `ScreenReplayState::output_sequence` (`output.rs:160`).
+    pub sequence: u64,
+    pub rows: u16,
+    pub cols: u16,
+}
+
+/// One session's screen, as the engine needs to see it.
+///
+/// `wrapped` and `cursor_row` are read under the same guard the row clone already takes, at
+/// O(1) each. Fetching them separately would mean a second lock acquisition on a possibly
+/// different frame.
+pub struct ScreenFrame {
+    /// One entry per physical row, from `Screen::rows(0, cols)`.
+    pub rows: Vec<String>,
+    /// `Screen::row_wrapped(i)` for each i: does this physical row continue into the next
+    /// one. Same length as `rows`, by construction.
+    pub wrapped: Vec<bool>,
+    /// `Screen::cursor_position().0`. The row currently being written.
+    pub cursor_row: u16,
+    /// `None` only from the default trait implementation, which has no sequence to report.
+    /// `None` means "treat as changed", so "the default never reports `Unchanged`" falls out
+    /// of the type rather than out of a rule someone has to remember.
+    pub stamp: Option<FrameStamp>,
+}
+
+/// What a read of one session's screen can say.
+///
+/// The `Missing` and `Gone` split is what preserves the distinction `ScreenRowsRead` argues
+/// for at length (`context_scrape/mod.rs:39-45`): "we could not read" must never be confused
+/// with "there is nothing here any more".
+pub enum ScreenRowsSince {
+    /// The stamp matched. NO rows were cloned and no allocation was made.
+    Unchanged,
+    Frame(ScreenFrame),
+    /// No parser for this id. Says NOTHING about whether the session is over, exactly like
+    /// `get_screen_rows` returning `None` (`output.rs:287-294`). Keep sampling it.
+    Missing,
+    /// This backend has no session behind this id. Retire it now.
+    Gone,
+}
+
+impl ScreenRowsSince {
+    /// The frame, when there is one. Convenience for callers that treat every non-frame
+    /// outcome the same way.
+    pub fn frame(&self) -> Option<&ScreenFrame> {
+        match self {
+            ScreenRowsSince::Frame(frame) => Some(frame),
+            _ => None,
+        }
+    }
+}
+
+/// #1171 - the default `PtyBackend::screen_rows_since`, shared by the trait default so the
+/// mapping lives beside the types it maps into.
+///
+/// Everything that is not rows becomes `Missing`: a backend that only implements
+/// `get_screen_rows` has no richer oracle to offer, and `Missing` is the arm that keeps
+/// sampling rather than retiring.
+pub(crate) fn frame_from_screen_rows_read(
+    read: crate::pty::context_scrape::ScreenRowsRead,
+) -> ScreenRowsSince {
+    match read {
+        crate::pty::context_scrape::ScreenRowsRead::Rows(rows) => {
+            let wrapped = vec![false; rows.len()];
+            ScreenRowsSince::Frame(ScreenFrame {
+                rows,
+                wrapped,
+                cursor_row: 0,
+                stamp: None,
+            })
+        }
+        crate::pty::context_scrape::ScreenRowsRead::Unavailable
+        | crate::pty::context_scrape::ScreenRowsRead::SessionOver => ScreenRowsSince::Missing,
+    }
+}
+
+#[cfg(test)]
+mod read_seam_tests {
+    use super::*;
+    use crate::pty::output::{PtyOutputTarget, SessionIoFanout};
+    use crate::session::profile::IdleTuning;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
+    use uuid::Uuid;
+
+    fn timing_session_id() -> Uuid {
+        Uuid::new_v4()
+    }
+
+    fn fanout() -> SessionIoFanout {
+        SessionIoFanout::new(
+            Arc::new(Mutex::new(HashMap::new())),
+            crate::pty::idle_detector::IdleDetector::new(|_| {}, |_| {}),
+            None,
+        )
+    }
+
+    fn feed(fanout: &SessionIoFanout, id: Uuid, chunk: &[u8]) {
+        fanout.handle_output(&PtyOutputTarget::noop(), id, &id.to_string(), chunk.to_vec());
+    }
+
+    /// #1171, section 7.3 - the three numbers recorded in this module's doc comment.
+    ///
+    /// `#[ignore]`d so it never becomes a flaky timing gate, and kept in the tree so the
+    /// numbers can be re-taken rather than guessed at again:
+    ///
+    /// ```text
+    /// cargo test --config profile.dev.opt-level=2 --lib read_seam_timing -- --ignored --nocapture
+    /// ```
+    ///
+    /// The changed-frame measurement feeds a chunk between reads, which is what a session
+    /// with a live spinner does several times per second.
+    #[test]
+    #[ignore]
+    fn read_seam_timing() {
+        const ITERATIONS: u32 = 2_000;
+
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        for row in 0..30u16 {
+            feed(
+                &fanout,
+                id,
+                format!("\x1b[{};1Hrow {row} of a coding agent's screen, wide enough to be real\r\n", row + 1)
+                    .as_bytes(),
+            );
+        }
+
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            std::hint::black_box(fanout.get_screen_rows(id));
+        }
+        let full = start.elapsed() / ITERATIONS;
+
+        let seen = match fanout.get_screen_rows_since(id, None) {
+            ScreenRowsSince::Frame(frame) => frame.stamp,
+            other => panic!(
+                "expected a frame, got {}",
+                match other {
+                    ScreenRowsSince::Unchanged => "Unchanged",
+                    ScreenRowsSince::Missing => "Missing",
+                    ScreenRowsSince::Gone => "Gone",
+                    ScreenRowsSince::Frame(_) => unreachable!(),
+                }
+            ),
+        };
+
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            std::hint::black_box(fanout.get_screen_rows_since(id, seen));
+        }
+        let unchanged = start.elapsed() / ITERATIONS;
+
+        // The chunk that makes the frame change is fed OUTSIDE the timed region: what is
+        // being measured is the read, not `handle_output`.
+        let mut changed_total = std::time::Duration::ZERO;
+        for i in 0..ITERATIONS {
+            feed(&fanout, id, format!("\x1b[30;1Hspinner {i}").as_bytes());
+            let start = Instant::now();
+            std::hint::black_box(fanout.get_screen_rows_since(id, seen));
+            changed_total += start.elapsed();
+        }
+        let changed = changed_total / ITERATIONS;
+
+        println!("[#1171] get_screen_rows:                 {full:?}");
+        println!("[#1171] get_screen_rows_since UNCHANGED: {unchanged:?}");
+        println!("[#1171] get_screen_rows_since CHANGED:   {changed:?}");
+    }
+
+    /// 9.1.1 - an unchanged frame short-circuits, and the variant it returns cannot carry
+    /// rows even if someone later wanted it to. This is the acceptance criterion for
+    /// contention, enforced by the type rather than by a timing assertion (7.3).
+    #[test]
+    fn an_unchanged_frame_returns_unchanged_and_carries_no_rows() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        feed(&fanout, id, b"hello");
+
+        let seen = fanout
+            .get_screen_rows_since(id, None)
+            .frame()
+            .and_then(|frame| frame.stamp)
+            .expect("first read must be a frame carrying a stamp");
+
+        let again = fanout.get_screen_rows_since(id, Some(seen));
+        assert!(matches!(again, ScreenRowsSince::Unchanged));
+        assert!(
+            again.frame().is_none(),
+            "Unchanged must carry no frame and therefore no rows"
+        );
+    }
+
+    /// 9.1.2 - one `handle_output` chunk moves `sequence`, so the next read is a frame.
+    #[test]
+    fn one_output_chunk_makes_the_next_read_a_frame() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        feed(&fanout, id, b"first");
+
+        let seen = fanout
+            .get_screen_rows_since(id, None)
+            .frame()
+            .and_then(|frame| frame.stamp)
+            .expect("first read must be a frame");
+        assert!(matches!(
+            fanout.get_screen_rows_since(id, Some(seen)),
+            ScreenRowsSince::Unchanged
+        ));
+
+        feed(&fanout, id, b" second");
+        let next = fanout.get_screen_rows_since(id, Some(seen));
+        let frame = next.frame().expect("a new chunk must produce a frame");
+        assert_eq!(frame.stamp.unwrap().sequence, seen.sequence + 1);
+    }
+
+    /// 9.1.3 - **the regression a sequence-only stamp would let through.**
+    ///
+    /// `resize_screen_and_broadcast` reflows the grid and does NOT bump `output_sequence`
+    /// (`output.rs:202-212`). With the size out of the stamp this read would return
+    /// `Unchanged` over a screen that was just re-laid at a different width.
+    #[test]
+    fn a_resize_that_does_not_move_the_sequence_still_returns_a_frame() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        feed(&fanout, id, b"content");
+
+        let seen = fanout
+            .get_screen_rows_since(id, None)
+            .frame()
+            .and_then(|frame| frame.stamp)
+            .expect("first read must be a frame");
+
+        fanout.resize_screen_and_broadcast(id, 100, 24);
+
+        let after = fanout.get_screen_rows_since(id, Some(seen));
+        let frame = after
+            .frame()
+            .expect("a reflow must not be reported as Unchanged");
+        let stamp = frame.stamp.unwrap();
+        assert_eq!(
+            stamp.sequence, seen.sequence,
+            "the resize must not have moved the sequence, or this test proves nothing"
+        );
+        assert_eq!((stamp.rows, stamp.cols), (24, 100));
+    }
+
+    /// 9.1.5 - a poisoned `screen_parsers` is `Missing`, never `Unchanged`. Reporting
+    /// `Unchanged` would claim the screen is the one the caller last saw, which is precisely
+    /// what a lock we could not take cannot say.
+    #[test]
+    fn a_poisoned_parser_map_is_missing_and_not_unchanged() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        feed(&fanout, id, b"content");
+
+        let seen = fanout
+            .get_screen_rows_since(id, None)
+            .frame()
+            .and_then(|frame| frame.stamp)
+            .expect("first read must be a frame");
+
+        fanout.poison_screen_parsers_for_test();
+
+        assert!(matches!(
+            fanout.get_screen_rows_since(id, Some(seen)),
+            ScreenRowsSince::Missing
+        ));
+    }
+
+    /// 9.1.6 - the changed-frame read returns exactly what `get_screen_rows` returns, row
+    /// for row. The seam is a cheaper way to ask the same question, not a different one.
+    #[test]
+    fn a_changed_frame_returns_the_same_rows_as_get_screen_rows() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 30, 120);
+        feed(
+            &fanout,
+            id,
+            b"alpha\r\nbeta\r\ngamma with rather more text on it\r\n",
+        );
+
+        let expected = fanout.get_screen_rows(id).expect("rows");
+        let frame = fanout
+            .get_screen_rows_since(id, None)
+            .frame()
+            .map(|frame| frame.rows.clone())
+            .expect("frame");
+        assert_eq!(frame, expected);
+    }
+
+    /// 9.1.7 - `wrapped` and `cursor_row` are the parser's, for every row, and `wrapped` is
+    /// the same length as `rows` so the frame diff can index them together without a bound
+    /// check of its own.
+    #[test]
+    fn wrapped_and_cursor_row_mirror_the_parser() {
+        let fanout = fanout();
+        let id = timing_session_id();
+        fanout.register_session(id, IdleTuning::DEFAULT, 4, 10);
+        // 14 chars into a 10-column grid: row 0 wraps into row 1.
+        feed(&fanout, id, b"0123456789abcd");
+
+        let read = fanout.get_screen_rows_since(id, None);
+        let frame = read.frame().expect("frame");
+        assert_eq!(frame.rows.len(), frame.wrapped.len());
+        assert_eq!(frame.wrapped, vec![true, false, false, false]);
+        assert_eq!(frame.cursor_row, 1);
+    }
+
+    /// A session the fanout never registered is `Missing` at the fanout boundary: the fanout
+    /// knows nothing about children, so it can make no claim about the session (`output.rs:287-294`).
+    #[test]
+    fn an_unregistered_session_is_missing_at_the_fanout() {
+        let fanout = fanout();
+        assert!(matches!(
+            fanout.get_screen_rows_since(timing_session_id(), None),
+            ScreenRowsSince::Missing
+        ));
+    }
+
+    /// 9.1.8 - the default trait implementation never reports `Unchanged` and never invents a
+    /// stamp, whatever it is handed as `seen`.
+    #[test]
+    fn the_default_mapping_never_reports_unchanged_and_reports_no_stamp() {
+        use crate::pty::context_scrape::ScreenRowsRead;
+
+        let mapped = frame_from_screen_rows_read(ScreenRowsRead::Rows(vec![
+            "one".to_string(),
+            "two".to_string(),
+        ]));
+        let frame = mapped.frame().expect("rows must map to a frame");
+        assert!(frame.stamp.is_none());
+        assert_eq!(frame.wrapped, vec![false, false]);
+        assert_eq!(frame.cursor_row, 0);
+
+        assert!(matches!(
+            frame_from_screen_rows_read(ScreenRowsRead::Unavailable),
+            ScreenRowsSince::Missing
+        ));
+        assert!(matches!(
+            frame_from_screen_rows_read(ScreenRowsRead::SessionOver),
+            ScreenRowsSince::Missing
+        ));
+    }
+}

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -1474,8 +1474,9 @@ mod engine_tests {
         assert_eq!(harness.backends.resolutions.load(Ordering::Relaxed), 1);
     }
 
-    /// 9.3.27 - a state reading is idempotent. Five ticks of a screen that keeps being
-    /// repainted with the same content produce ONE event.
+    /// 9.3.27 and acceptance criterion A4 - a state reading is idempotent. Twenty-five ticks -
+    /// five seconds of a screen being repainted with the same content, which is what a live
+    /// spinner does - produce ONE event.
     #[tokio::test]
     async fn a_state_watcher_emits_once_for_a_value_that_does_not_change() {
         let harness = Harness::new();
@@ -1484,7 +1485,7 @@ mod engine_tests {
         harness.configure("a1", vec![state_watcher("ctx", r"Context (\d+)%")]);
         harness.backend.paint(id, &["idle", "Context 42%"]);
 
-        harness.ticks(5).await;
+        harness.ticks(25).await;
 
         let emitted = harness.emitted();
         assert_eq!(emitted.len(), 1);
@@ -2065,6 +2066,38 @@ mod engine_tests {
         );
     }
 
+    /// Acceptance criterion A5 - a transcript of more than a screenful delivered in ONE burst
+    /// reports its matches AND a non-zero `possiblyMissedFrames`, never a silent zero.
+    ///
+    /// A jump larger than the screen has no alignment that explains it, so the honest answer
+    /// is "the sampler could not follow" plus whatever the next stable frame turns out to hold.
+    #[tokio::test]
+    async fn a_burst_larger_than_the_screen_reports_matches_and_admits_it_may_have_missed_some() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher("row", "row", WatcherDedupe::None, 2000)],
+        );
+
+        let seed: Vec<String> = (0..30).map(|i| format!("seed {i}")).collect();
+        // 60 rows arrived between two samples: only the last 30 are still on the screen.
+        let after: Vec<String> = (30..60).map(|i| format!("row {i}")).collect();
+        harness.backend.paint(id, &as_refs(&seed));
+        harness.backend.paint(id, &as_refs(&after));
+        harness.backend.paint(id, &as_refs(&after));
+
+        harness.ticks(3).await;
+
+        assert!(!harness.emitted().is_empty(), "the burst must still report");
+        let snapshot = harness.history.snapshot(id, None);
+        assert!(
+            snapshot.possibly_missed_frames > 0,
+            "a jump larger than the screen must never report a silent zero"
+        );
+    }
+
     /// An occurrence watcher never fires on the tick a row is merely painted: the row has to
     /// have arrived from below, or held still for a tick. That is layer 1 doing the work.
     #[tokio::test]
@@ -2249,13 +2282,20 @@ mod engine_tests {
             .split("for session_id in outcome.destroyed_ids.iter().copied()")
             .nth(1)
             .expect("the destroy transaction must purge over destroyed_ids ONLY");
+        let loop_body = destroy
+            .split("\n    }")
+            .next()
+            .expect("its body must end somewhere");
         assert!(
-            destroy
-                .split("\n    }")
-                .next()
-                .expect("its body must end somewhere")
-                .contains("purge_session_side_state("),
+            loop_body.contains("purge_session_side_state("),
             "the destroyed-only loop must be the one that purges"
+        );
+        // 9.5.71 - and it must stay destroyed-ONLY. A root-agent session retained as `Exited`
+        // stays in the manager and its row is still in the list, so its post-mortem view still
+        // has a place to be shown and its buffer must survive.
+        assert!(
+            !loop_body.contains("retained_exited_ids"),
+            "retained-exited sessions keep their buffer; the purge loop must not reach them"
         );
     }
 

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod dedupe;
 pub mod frame;
+pub mod history;
 pub mod pattern;
 
 use std::collections::{BTreeMap, HashMap};
@@ -49,11 +50,13 @@ use futures::future::BoxFuture;
 use uuid::Uuid;
 
 use crate::config::coding_agents_catalog::command_executable_basename;
-use crate::config::settings::{WatcherEntry, WatcherMode};
+use crate::config::settings::WatcherEntry;
 use crate::pty::backend::PtyBackend;
 use crate::pty::context_scrape::ContextSessionLiveness;
 
-pub use crate::config::settings::WatcherDedupe;
+/// Re-exported so every watcher type reads from one module. They are DEFINED in
+/// `config/settings.rs`, because that is where the user writes them.
+pub use crate::config::settings::{WatcherDedupe, WatcherMode};
 
 /// 200 ms, against `ContextScraper`'s 5 s. The engine has to catch rows in transit, and a row
 /// that scrolls past between two samples is gone: the mirror keeps zero scrollback.
@@ -619,6 +622,11 @@ pub struct WatcherEngine {
     backends: Arc<dyn WatcherBackendSource>,
     patterns: Arc<dyn WatcherPatternSource>,
     sink: Arc<dyn WatcherEventSink>,
+    /// The engine publishes each session's STATUS here at the end of its tick, so
+    /// `get_watcher_activity` can be synchronous and take one per-session mutex instead of
+    /// resolving settings and the session manager itself. The MATCHES are written by the sink,
+    /// which is where the ring belongs.
+    history: history::WatcherHistoryState,
     /// Linearizes registration and retirement against evaluation and emission. Lock order is
     /// always sequence, then registered.
     sequence: Mutex<()>,
@@ -635,11 +643,13 @@ impl WatcherEngine {
         backends: Arc<dyn WatcherBackendSource>,
         patterns: Arc<dyn WatcherPatternSource>,
         sink: Arc<dyn WatcherEventSink>,
+        history: history::WatcherHistoryState,
     ) -> Arc<Self> {
         Arc::new(Self {
             backends,
             patterns,
             sink,
+            history,
             sequence: Mutex::new(()),
             registered: Mutex::new(HashMap::new()),
             compiled: Mutex::new(HashMap::new()),
@@ -827,13 +837,18 @@ impl WatcherEngine {
             return (None, false);
         };
 
-        let frame = match self.read_frame(id, session) {
+        let read = self.read_frame(id, session);
+        let frame = match read {
             // Nothing changed, so nothing can have started or stopped matching. No rows were
-            // cloned to reach this arm.
-            ScreenRowsSince::Unchanged => return (None, false),
-            // No reading this tick and NO claim about the session: keep it.
-            ScreenRowsSince::Missing => return (None, false),
-            // The backend says there is nothing behind this id. Retire it now.
+            // cloned to reach this arm - but the session HAS been ticked, so its status is
+            // published and `warmedUp` becomes true.
+            ScreenRowsSince::Unchanged | ScreenRowsSince::Missing => {
+                session.warmed_up = true;
+                self.history.publish(id, status_of(session, agent));
+                return (None, false);
+            }
+            // The backend says there is nothing behind this id. Retire it now, and publish
+            // nothing: an entry created here is one the purge that follows would have to race.
             ScreenRowsSince::Gone => return (None, true),
             ScreenRowsSince::Frame(frame) => frame,
         };
@@ -954,6 +969,11 @@ impl WatcherEngine {
 
         session.seq = next_seq;
 
+        // Published while the registration lock is still held, so a retirement cannot
+        // interleave: `purge_session_side_state` retires first and then purges, and creation
+        // requires registration, so a tick in flight can never resurrect a purged session.
+        self.history.publish(id, status_of(session, agent));
+
         if matches.is_empty() {
             return (None, false);
         }
@@ -1018,6 +1038,30 @@ impl WatcherEngine {
 
 /// What a match contributes to a payload, before the engine stamps identity on it.
 type Found = (Vec<Option<String>>, String, bool);
+
+/// The status of one session at the end of a tick.
+///
+/// Built from the RESOLVED watcher set rather than from the state map, so a watcher that
+/// reaches this agent but has never matched is still listed with a count of 0 - which is what
+/// lets the window say "configured and waiting" instead of "nothing reaches this session".
+fn status_of(session: &RegisteredSession, agent: &AgentResolution) -> history::SessionStatus {
+    history::SessionStatus {
+        possibly_missed_frames: session.diff.possibly_missed_frames(),
+        active_watchers: agent
+            .running
+            .iter()
+            .map(|watcher| {
+                let state = session.watchers.get(&watcher.id);
+                history::WatcherActivityCounter {
+                    watcher_id: watcher.id.clone(),
+                    mode: watcher.mode,
+                    count: state.map(|state| state.count).unwrap_or(0),
+                    degraded: state.is_some_and(|state| state.degraded),
+                }
+            })
+            .collect(),
+    }
+}
 
 /// Pull the capture groups 1..n out of a match, in order, without group 0.
 fn captures_of(regex: &regex::Regex, text: &str) -> Vec<Option<String>> {
@@ -1330,6 +1374,7 @@ mod engine_tests {
         backends: Arc<FakeBackends>,
         patterns: Arc<FakePatterns>,
         sink: Arc<FakeSink>,
+        history: history::WatcherHistoryState,
     }
 
     impl Harness {
@@ -1343,16 +1388,20 @@ mod engine_tests {
             });
             let patterns = Arc::new(FakePatterns::default());
             let sink = Arc::new(FakeSink::default());
+            let history: history::WatcherHistoryState =
+                Arc::new(history::WatcherHistory::default());
             Self {
                 engine: WatcherEngine::new(
                     Arc::clone(&backends) as Arc<dyn WatcherBackendSource>,
                     Arc::clone(&patterns) as Arc<dyn WatcherPatternSource>,
                     Arc::clone(&sink) as Arc<dyn WatcherEventSink>,
+                    Arc::clone(&history),
                 ),
                 backend,
                 backends,
                 patterns,
                 sink,
+                history,
             }
         }
 
@@ -2058,6 +2107,156 @@ mod engine_tests {
             Some("a1".to_string()),
         );
         assert!(harness.engine.is_session_registered(agent));
+    }
+
+    /// 9.5.62 and 9.5.66 - the engine publishes each session's STATUS at the end of every
+    /// tick, so the snapshot command can be synchronous, and the `seq` in the ring is the same
+    /// value the event carried. That shared identity is what lets the window merge a snapshot
+    /// with a live stream instead of guessing.
+    #[tokio::test]
+    async fn the_engine_publishes_status_every_tick_and_the_ring_shares_the_events_seq() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![
+                state_watcher("perm", "Permission required"),
+                occurrence_watcher("read", "Read", WatcherDedupe::None, 2000),
+            ],
+        );
+
+        // One tick with no match at all: the status is still published.
+        harness.backend.paint(id, &["idle"]);
+        harness.ticks(1).await;
+
+        let snapshot = harness.history.snapshot(id, None);
+        assert!(snapshot.warmed_up);
+        assert!(snapshot.matches.is_empty());
+        let counters: Vec<(&str, u64)> = snapshot
+            .active_watchers
+            .iter()
+            .map(|counter| (counter.watcher_id.as_str(), counter.count))
+            .collect();
+        assert_eq!(counters, vec![("perm", 0), ("read", 0)]);
+
+        harness.backend.paint(id, &["Permission required"]);
+        harness.ticks(1).await;
+
+        // The engine hands the batch to the sink; the ring is the SINK's job, so mirror what
+        // the production sink does and assert the identity that makes the merge possible.
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 1);
+        harness.history.record(id, &emitted);
+        let snapshot = harness.history.snapshot(id, None);
+        assert_eq!(snapshot.matches[0].seq, emitted[0].seq);
+        assert_eq!(snapshot.last_seq, emitted[0].seq);
+        assert_eq!(
+            snapshot
+                .active_watchers
+                .iter()
+                .find(|counter| counter.watcher_id == "perm")
+                .expect("counter")
+                .count,
+            1
+        );
+    }
+
+    /// 9.5.72 - **a session whose child exits on its own KEEPS its buffer.** It is retired from
+    /// sampling and nothing else: an API error or a CLI crash is exactly when the evidence is
+    /// worth keeping, and it is the only thing left to look at.
+    #[tokio::test]
+    async fn a_session_that_dies_on_its_own_is_retired_but_keeps_its_history() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("perm", "Permission required")]);
+        harness.backend.paint(id, &["Permission required"]);
+        harness.ticks(1).await;
+        harness.history.record(id, &harness.emitted());
+
+        // Twice: a read that says `Gone` makes the engine re-resolve the backend once and ask
+        // again, which is what covers a session that changed route.
+        harness.backend.push(id, Painted::Gone);
+        harness.backend.push(id, Painted::Gone);
+        harness.ticks(1).await;
+
+        assert!(!harness.engine.is_session_registered(id));
+        let snapshot = harness.history.snapshot(id, None);
+        assert_eq!(snapshot.matches.len(), 1, "the evidence must survive");
+        assert!(snapshot.warmed_up);
+    }
+
+    /// 9.5.68 and 9.5.70 - `purge_session_side_state` retires FIRST and purges second, and the
+    /// entry cannot come back: only the engine creates entries, and only while holding its
+    /// registration lock.
+    #[tokio::test]
+    async fn purging_a_destroyed_session_retires_it_first_and_the_entry_never_returns() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("perm", "Permission required")]);
+        harness.backend.paint(id, &["Permission required"]);
+        harness.ticks(1).await;
+        harness.history.record(id, &harness.emitted());
+        assert!(harness.history.snapshot(id, None).warmed_up);
+
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&harness.engine))
+            .manage(Arc::clone(&harness.history))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a mock app");
+        crate::commands::session::purge_session_side_state(app.handle(), id);
+
+        assert!(!harness.engine.is_session_registered(id));
+        assert!(!harness.history.snapshot(id, None).warmed_up);
+
+        // Whatever else ticks, the entry stays gone: the session is no longer registered, so
+        // no tick can publish it back.
+        harness.backend.paint(id, &["Permission required"]);
+        harness.ticks(5).await;
+        assert!(!harness.history.snapshot(id, None).warmed_up);
+    }
+
+    /// 9.5.68 and 9.5.69 (call-site guard) - **the finding revision 1 of the plan missed.**
+    ///
+    /// There are three production exits from `SessionManager`, not one, and the post-commit
+    /// cleanup is two parallel copies. A restart is a normal flow - the invoke handler, the
+    /// mailbox and a bulk settings save all reach it - so a purge wired into only the destroy
+    /// path would orphan up to 500 ring entries on every restart, under an id already gone
+    /// from the session list and therefore unreachable from the UI.
+    ///
+    /// This pins BOTH call sites against the source, so removing either one fails here rather
+    /// than leaking silently.
+    #[test]
+    fn both_post_commit_cleanups_purge_the_per_session_side_state() {
+        const SOURCE: &str = include_str!("../../commands/session.rs");
+
+        let restart = SOURCE
+            .split("fn publish_restart_destroyed")
+            .nth(1)
+            .expect("publish_restart_destroyed must exist");
+        let restart_body = restart
+            .split("\nasync fn ")
+            .next()
+            .expect("its body must end somewhere");
+        assert!(
+            restart_body.contains("purge_session_side_state("),
+            "the restart cleanup must purge; both restart paths publish through it"
+        );
+
+        let destroy = SOURCE
+            .split("for session_id in outcome.destroyed_ids.iter().copied()")
+            .nth(1)
+            .expect("the destroy transaction must purge over destroyed_ids ONLY");
+        assert!(
+            destroy
+                .split("\n    }")
+                .next()
+                .expect("its body must end somewhere")
+                .contains("purge_session_side_state("),
+            "the destroyed-only loop must be the one that purges"
+        );
     }
 
     /// 9.6.74 and 9.6.75 - **the Rust half of the TypeScript mirror.** The exact camelCase

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -36,6 +36,7 @@
 //! numbers are not comparable to either; `--release` does not build the test target in this
 //! tree, because `load_sessions_raw_from_dir_for_test` is `#[cfg(debug_assertions)]`.
 
+pub mod dedupe;
 pub mod frame;
 pub mod pattern;
 
@@ -66,6 +67,22 @@ pub const LIVENESS_PROBE_EVERY_TICKS: u64 = 25;
 
 /// The `row` field of a payload is capped at this many bytes, on a char boundary.
 pub const MAX_ROW_BYTES: usize = 256;
+
+/// At most this many matches per `(watcher, session)` per tick.
+pub const MATCHES_PER_WATCHER_PER_TICK: usize = 8;
+
+/// At most this many matches per session per tick, across all its watchers.
+pub const MATCHES_PER_SESSION_PER_TICK: usize = 16;
+
+/// The caps bound the RATE but not the duration, so a watcher that stays saturated would emit
+/// 40 events a second forever and turn the 500-entry ring over in 0.31 seconds - making the
+/// "older activations were dropped" banner permanent and useless. After this many consecutive
+/// degraded ticks the pair is suspended, then retried.
+pub const DEGRADED_TICKS_BEFORE_SUSPENSION: u32 = 25;
+
+/// How long a saturated `(watcher, session)` pair stays suspended before being retried.
+/// `degraded` stays true throughout, so the UI never claims it recovered.
+pub const SUSPENSION: Duration = Duration::from_secs(5);
 
 /// How many watchers may run on one agent. Resolution takes the first 8 in `BTreeMap` key
 /// order, which is alphabetical over user-chosen ids, so adding a watcher named `aaa-test`
@@ -510,7 +527,10 @@ pub struct WatcherMatchPayload {
 }
 
 /// Cap a row at `MAX_ROW_BYTES`, never splitting a character.
-fn truncate_row(text: &str) -> (String, bool) {
+///
+/// `pub(crate)` so `preview_watcher_pattern` shows the user exactly the string a real payload
+/// would carry, rather than a second truncation rule that happens to agree today.
+pub(crate) fn truncate_row(text: &str) -> (String, bool) {
     if text.len() <= MAX_ROW_BYTES {
         return (text.to_string(), false);
     }
@@ -545,16 +565,17 @@ impl Cached {
     }
 }
 
-/// The `state`-mode gate for one `(session, watcher)` pair.
+/// One `(session, watcher)` pair's whole state: the `state` gate, the `occurrence` dedupe
+/// keys, and the saturation bookkeeping.
 ///
-/// The gate is NOT `(captures, row)` alone. With only that pair, a second instance of a
-/// condition appearing while the first is still visible never emits: the lowest match still
-/// reads the same text, so the tuple never changes. That is the failure mode of the
+/// **The `state` gate is NOT `(captures, row)` alone.** With only that pair, a second instance
+/// of a condition appearing while the first is still visible never emits: the lowest match
+/// still reads the same text, so the tuple never changes. That is the failure mode of the
 /// permission-prompt watcher, which is the strongest argument for this engine existing.
 #[derive(Default)]
-struct StateGate {
-    /// What the watcher looked like when this gate was built. A watcher whose pattern or mode
-    /// was edited gets a fresh gate, because the old one describes a question no longer asked.
+struct WatcherSessionState {
+    /// What the watcher looked like when this state was built. A watcher whose pattern or mode
+    /// was edited starts again, because the old state describes a question no longer asked.
     signature: Option<(String, WatcherMode)>,
     last: Option<(Vec<Option<String>>, String, u64)>,
     /// Incremented whenever the number of matching logical rows RISES. Incrementing only on a
@@ -562,6 +583,14 @@ struct StateGate {
     /// change as the screen moves under it.
     generation: u64,
     last_match_count: usize,
+    keys: dedupe::DedupeKeys,
+    /// True while this pair is hitting a per-tick cap or is suspended.
+    degraded: bool,
+    degraded_ticks: u32,
+    degraded_logged: bool,
+    suspended_until: Option<std::time::Instant>,
+    /// Matches emitted for this pair since the session started.
+    count: u64,
 }
 
 /// One session the engine is sampling.
@@ -573,7 +602,12 @@ struct RegisteredSession {
     stamp: Option<FrameStamp>,
     /// Monotonic per session. The identity of a match, in the event and in the ring alike.
     seq: u64,
-    gates: HashMap<String, StateGate>,
+    /// Maintained for EVERY session regardless of configured modes, so switching a watcher's
+    /// mode at runtime needs no reseed.
+    diff: frame::FrameDiffState,
+    watchers: HashMap<String, WatcherSessionState>,
+    /// False until the engine has ticked this session at least once.
+    warmed_up: bool,
 }
 
 /// Runs every configured watcher over every registered session, five times a second.
@@ -661,7 +695,9 @@ impl WatcherEngine {
                     reader,
                     stamp: None,
                     seq: 0,
-                    gates: HashMap::new(),
+                    diff: frame::FrameDiffState::default(),
+                    watchers: HashMap::new(),
+                    warmed_up: false,
                 },
             );
     }
@@ -802,34 +838,121 @@ impl WatcherEngine {
             ScreenRowsSince::Frame(frame) => frame,
         };
         session.stamp = frame.stamp;
+        session.warmed_up = true;
 
-        // A watcher that stopped reaching this agent leaves no gate behind, so re-creating it
+        // A watcher that stopped reaching this agent leaves no state behind, so re-creating it
         // later starts from nothing - which is what "renaming is delete plus create" means.
         session
-            .gates
-            .retain(|gate_id, _| agent.running.iter().any(|w| &w.id == gate_id));
+            .watchers
+            .retain(|watcher_id, _| agent.running.iter().any(|w| &w.id == watcher_id));
 
-        let needs_state = agent
-            .running
-            .iter()
-            .any(|watcher| watcher.mode == WatcherMode::State);
-        if !needs_state {
-            return (None, false);
-        }
-
+        // The diff is advanced for EVERY session on every changed frame, whatever modes are
+        // configured, so switching a watcher to `occurrence` at runtime needs no reseed.
+        let evaluable = session.diff.advance(&frame);
         let logical = frame::logical_rows(&frame);
+        let selected = frame::select_logical(&logical, &evaluable);
+
+        let now = std::time::Instant::now();
+        let mut next_seq = session.seq;
+        let mut used_by_session = 0usize;
         let mut matches = Vec::new();
+
         for watcher in &agent.running {
-            if watcher.mode != WatcherMode::State {
-                continue;
-            }
             let Some(Some(compiled)) = compiled.get(&watcher.id) else {
                 continue;
             };
-            if let Some(payload) = evaluate_state(session, id, watcher, compiled, &logical, at) {
-                matches.push(payload);
+            let state = session.watchers.entry(watcher.id.clone()).or_default();
+
+            let signature = (watcher.pattern.clone(), watcher.mode);
+            if state.signature.as_ref() != Some(&signature) {
+                let count = state.count;
+                *state = WatcherSessionState {
+                    signature: Some(signature),
+                    count,
+                    ..WatcherSessionState::default()
+                };
+            }
+
+            // A suspended pair is skipped whole, and stays marked degraded while it is: the UI
+            // must never read "recovered" from a pair that is only being left alone.
+            if let Some(until) = state.suspended_until {
+                if now < until {
+                    continue;
+                }
+                state.suspended_until = None;
+                state.degraded_ticks = 0;
+            }
+
+            // The caps live HERE, immediately before the sink call, which is exactly where
+            // `ContextScraper`'s equality gate lives. Everything that passes them reaches both
+            // the event and the ring, and nothing else reaches either.
+            let budget = MATCHES_PER_WATCHER_PER_TICK
+                .min(MATCHES_PER_SESSION_PER_TICK.saturating_sub(used_by_session));
+
+            let (found, capped) = match watcher.mode {
+                WatcherMode::State => {
+                    let found = evaluate_state(state, compiled, &logical);
+                    match found {
+                        Some(_) if budget == 0 => (Vec::new(), true),
+                        Some(found) => (vec![found], false),
+                        None => (Vec::new(), false),
+                    }
+                }
+                WatcherMode::Occurrence => {
+                    let outcome =
+                        evaluate_occurrence(state, watcher, compiled, &selected, now, budget);
+                    state
+                        .keys
+                        .prune(now, Duration::from_millis(watcher.dedupe_window_ms));
+                    outcome
+                }
+            };
+
+            for (captures, row, row_truncated) in found {
+                next_seq += 1;
+                used_by_session += 1;
+                state.count += 1;
+                matches.push(WatcherMatchPayload {
+                    session_id: id.to_string(),
+                    seq: next_seq,
+                    watcher_id: watcher.id.clone(),
+                    mode: watcher.mode,
+                    at,
+                    captures,
+                    row,
+                    row_truncated,
+                });
+            }
+
+            if capped {
+                state.degraded = true;
+                if !state.degraded_logged {
+                    log::warn!(
+                        "[watchers] watcher '{}' on session {id} is over its per-tick cap; \
+                         matches beyond it are counted and dropped",
+                        watcher.id
+                    );
+                    state.degraded_logged = true;
+                }
+                state.degraded_ticks += 1;
+                if state.degraded_ticks >= DEGRADED_TICKS_BEFORE_SUSPENSION {
+                    state.suspended_until = Some(now + SUSPENSION);
+                    log::warn!(
+                        "[watchers] watcher '{}' on session {id} has been saturated for {} ticks; \
+                         suspending it for {}s, then retrying",
+                        watcher.id,
+                        state.degraded_ticks,
+                        SUSPENSION.as_secs()
+                    );
+                }
+            } else {
+                state.degraded = false;
+                state.degraded_ticks = 0;
+                state.degraded_logged = false;
             }
         }
+
+        session.seq = next_seq;
 
         if matches.is_empty() {
             return (None, false);
@@ -870,32 +993,61 @@ impl WatcherEngine {
     fn compile_count(&self) -> usize {
         self.compiles.load(Ordering::Relaxed)
     }
+
+    /// `(degraded, suspended, count)` for one `(session, watcher)` pair.
+    #[cfg(test)]
+    fn watcher_state(&self, id: Uuid, watcher_id: &str) -> Option<(bool, bool, u64)> {
+        let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+        let state = registered.get(&id)?.watchers.get(watcher_id)?;
+        Some((state.degraded, state.suspended_until.is_some(), state.count))
+    }
+
+    /// Bring a suspension forward to now, so the retry can be observed without a test that
+    /// sleeps for the suspension window.
+    #[cfg(test)]
+    fn expire_suspension_for_test(&self, id: Uuid, watcher_id: &str) {
+        let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(state) = registered
+            .get_mut(&id)
+            .and_then(|session| session.watchers.get_mut(watcher_id))
+        {
+            state.suspended_until = Some(std::time::Instant::now());
+        }
+    }
 }
 
-/// `state` mode over one frame: the LOWEST matching logical row wins, mirroring
+/// What a match contributes to a payload, before the engine stamps identity on it.
+type Found = (Vec<Option<String>>, String, bool);
+
+/// Pull the capture groups 1..n out of a match, in order, without group 0.
+fn captures_of(regex: &regex::Regex, text: &str) -> Vec<Option<String>> {
+    regex
+        .captures(text)
+        .map(|found| {
+            found
+                .iter()
+                .skip(1)
+                .map(|group| group.map(|m| m.as_str().to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+/// `state` mode over the FULL frame: the LOWEST matching logical row wins, mirroring
 /// `rows::extract` (`context_scrape/rows.rs:19-26`), because a statusline always sits below
 /// the transcript.
+///
+/// State mode does not use the frame diff at all: the whole frame is the reading, and the
+/// engine already holds it whenever the stamp changed.
 ///
 /// A transition to "no match" CLEARS the gate and emits nothing. The only consumer here is an
 /// activity log, and "the prompt disappeared" is not a log entry; clearing is what lets an
 /// identical re-appearance emit again, and it is why the payload needs no `present` field.
 fn evaluate_state(
-    session: &mut RegisteredSession,
-    id: Uuid,
-    watcher: &ResolvedWatcher,
+    state: &mut WatcherSessionState,
     compiled: &pattern::WatcherPattern,
     logical: &[frame::LogicalRow],
-    at: chrono::DateTime<chrono::Utc>,
-) -> Option<WatcherMatchPayload> {
-    let gate = session.gates.entry(watcher.id.clone()).or_default();
-    let signature = (watcher.pattern.clone(), watcher.mode);
-    if gate.signature.as_ref() != Some(&signature) {
-        *gate = StateGate {
-            signature: Some(signature),
-            ..StateGate::default()
-        };
-    }
-
+) -> Option<Found> {
     let regex = compiled.regex();
     let mut count = 0usize;
     let mut lowest: Option<&frame::LogicalRow> = None;
@@ -906,45 +1058,76 @@ fn evaluate_state(
         }
     }
 
-    if count > gate.last_match_count {
-        gate.generation += 1;
+    if count > state.last_match_count {
+        state.generation += 1;
     }
-    gate.last_match_count = count;
+    state.last_match_count = count;
 
     let Some(lowest) = lowest else {
-        gate.last = None;
+        state.last = None;
         return None;
     };
 
-    let captures = regex
-        .captures(&lowest.text)
-        .map(|found| {
-            found
-                .iter()
-                .skip(1)
-                .map(|group| group.map(|m| m.as_str().to_string()))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
     let (row, row_truncated) = truncate_row(&lowest.text);
-
-    let candidate = (captures, row, gate.generation);
-    if gate.last.as_ref() == Some(&candidate) {
+    let candidate = (captures_of(regex, &lowest.text), row, state.generation);
+    if state.last.as_ref() == Some(&candidate) {
         return None;
     }
-    gate.last = Some(candidate.clone());
+    state.last = Some(candidate.clone());
+    Some((candidate.0, candidate.1, row_truncated))
+}
 
-    session.seq += 1;
-    Some(WatcherMatchPayload {
-        session_id: id.to_string(),
-        seq: session.seq,
-        watcher_id: watcher.id.clone(),
-        mode: watcher.mode,
-        at,
-        captures: candidate.0,
-        row: candidate.1,
-        row_truncated,
-    })
+/// `occurrence` mode over the rows the diff declared evaluable: every match that survives the
+/// dedupe layer and the cap is an event. There is no equality gate, by definition.
+///
+/// Returns the matches to emit and whether the cap cut the tick short.
+fn evaluate_occurrence(
+    state: &mut WatcherSessionState,
+    watcher: &ResolvedWatcher,
+    compiled: &pattern::WatcherPattern,
+    selected: &[&frame::LogicalRow],
+    now: std::time::Instant,
+    budget: usize,
+) -> (Vec<Found>, bool) {
+    let regex = compiled.regex();
+    let window = Duration::from_millis(watcher.dedupe_window_ms);
+    let mut found = Vec::new();
+
+    for row in selected {
+        if !regex.is_match(&row.text) {
+            continue;
+        }
+        let captures = captures_of(regex, &row.text);
+
+        // Layer 2. The key is over the FULL logical row or its captures, never over the
+        // 256-byte payload row: two rows that differ only past the cap are two rows.
+        let admitted = match watcher.dedupe {
+            WatcherDedupe::None => true,
+            WatcherDedupe::Row => state.keys.admit(&row.text, now, window),
+            WatcherDedupe::Capture => {
+                let key = captures
+                    .iter()
+                    .map(|group| group.as_deref().unwrap_or("\u{0}"))
+                    .collect::<Vec<_>>()
+                    .join("\u{1f}");
+                state.keys.admit(&key, now, window)
+            }
+        };
+        if !admitted {
+            continue;
+        }
+
+        // Checked AFTER the dedupe so a suppressed repeat does not consume the budget, and
+        // BEFORE the push so the overflow reaches neither the event nor the ring.
+        if found.len() >= budget {
+            return (found, true);
+        }
+
+        let (text, row_truncated) = truncate_row(&row.text);
+        found.push((captures, text, row_truncated));
+    }
+
+    (found, false)
 }
 
 #[cfg(test)]
@@ -954,14 +1137,14 @@ mod engine_tests {
 
     /// What the scripted backend paints on the next read.
     enum Painted {
-        Frame(Vec<String>, Vec<bool>),
+        Frame(Vec<String>, Vec<bool>, u16),
         Unchanged,
         Missing,
         Gone,
     }
 
-    /// The rows of a frame with their wrap flags: what a repaint replays.
-    type PaintedRows = (Vec<String>, Vec<bool>);
+    /// The rows of a frame with their wrap flags and cursor row: what a repaint replays.
+    type PaintedRows = (Vec<String>, Vec<bool>, u16);
 
     /// A `PtyBackend` whose only real method is the watcher seam. Every other method is a
     /// stub, which is exactly the point: the engine never calls one.
@@ -974,12 +1157,20 @@ mod engine_tests {
     }
 
     impl ScriptedBackend {
+        /// Paint a screen with the cursor parked on row 0, so a row arriving by scroll is
+        /// evaluated on arrival. `paint_with_cursor` is for the tests that are ABOUT the
+        /// cursor rule.
         fn paint(&self, id: Uuid, rows: &[&str]) {
+            self.paint_with_cursor(id, rows, 0);
+        }
+
+        fn paint_with_cursor(&self, id: Uuid, rows: &[&str], cursor_row: u16) {
             self.push(
                 id,
                 Painted::Frame(
                     rows.iter().map(|r| r.to_string()).collect(),
                     vec![false; rows.len()],
+                    cursor_row,
                 ),
             );
         }
@@ -1052,16 +1243,16 @@ mod engine_tests {
                 .unwrap()
                 .get_mut(&id)
                 .and_then(|queue| queue.pop_front());
-            let (rows, wrapped) = match next {
+            let (rows, wrapped, cursor_row) = match next {
                 Some(Painted::Missing) => return ScreenRowsSince::Missing,
                 Some(Painted::Gone) => return ScreenRowsSince::Gone,
                 Some(Painted::Unchanged) => return ScreenRowsSince::Unchanged,
-                Some(Painted::Frame(rows, wrapped)) => {
+                Some(Painted::Frame(rows, wrapped, cursor_row)) => {
                     self.last
                         .lock()
                         .unwrap()
-                        .insert(id, (rows.clone(), wrapped.clone()));
-                    (rows, wrapped)
+                        .insert(id, (rows.clone(), wrapped.clone(), cursor_row));
+                    (rows, wrapped, cursor_row)
                 }
                 // A script that ran out repaints the same screen with a NEW sequence, which is
                 // what a session with a live spinner does several times per second.
@@ -1079,7 +1270,7 @@ mod engine_tests {
             ScreenRowsSince::Frame(ScreenFrame {
                 rows: rows.clone(),
                 wrapped,
-                cursor_row: rows.len().saturating_sub(1) as u16,
+                cursor_row,
                 stamp: Some(FrameStamp {
                     sequence: *sequence,
                     rows: rows.len() as u16,
@@ -1542,6 +1733,7 @@ mod engine_tests {
                     "th/to/main.rs)".to_string(),
                 ],
                 vec![false, true, false],
+                0,
             ),
         );
 
@@ -1571,6 +1763,275 @@ mod engine_tests {
         assert!(emitted[0].row_truncated);
         assert!(emitted[0].row.len() <= MAX_ROW_BYTES);
         assert!(long.starts_with(&emitted[0].row));
+    }
+
+    fn as_refs(rows: &[String]) -> Vec<&str> {
+        rows.iter().map(|row| row.as_str()).collect()
+    }
+
+    fn occurrence_watcher(
+        id: &str,
+        pattern: &str,
+        dedupe: WatcherDedupe,
+        window_ms: u64,
+    ) -> ResolvedWatcher {
+        ResolvedWatcher {
+            id: id.to_string(),
+            mode: WatcherMode::Occurrence,
+            pattern: pattern.to_string(),
+            dedupe,
+            dedupe_window_ms: window_ms,
+        }
+    }
+
+    /// 9.4.45 (the engine half) - **the cursor-row rule, end to end.**
+    ///
+    /// A path is written in two chunks across a tick boundary. Without the rule this produces
+    /// two events - one with `C:/repo/very/long/pa` and one with the whole path - and no
+    /// dedupe setting can merge them, because both the row AND the captures differ. With it,
+    /// exactly one event carries the complete capture.
+    #[tokio::test]
+    async fn a_row_written_in_two_chunks_produces_one_event_with_the_complete_capture() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher(
+                "read",
+                r"Read \((.+)\)",
+                WatcherDedupe::None,
+                2000,
+            )],
+        );
+
+        // Seed, then scroll the half-written row in UNDER THE CURSOR, then finish it, then
+        // hold still. The cursor on the bottom row is what a terminal that just printed a
+        // newline really looks like.
+        harness.backend.paint_with_cursor(id, &["a", "b", "c"], 2);
+        harness
+            .backend
+            .paint_with_cursor(id, &["b", "c", "Read (C:/repo/very/long/pa"], 2);
+        harness.backend.paint_with_cursor(
+            id,
+            &["b", "c", "Read (C:/repo/very/long/path/to/main.rs)"],
+            2,
+        );
+        harness.backend.paint_with_cursor(
+            id,
+            &["b", "c", "Read (C:/repo/very/long/path/to/main.rs)"],
+            2,
+        );
+
+        harness.ticks(4).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 1, "got {emitted:#?}");
+        assert_eq!(
+            emitted[0].captures[0].as_deref(),
+            Some("C:/repo/very/long/path/to/main.rs")
+        );
+    }
+
+    /// 9.4.50 - the same text at two positions at two times counts TWICE, and the two events
+    /// are told apart by `seq`. Layer 1 must not confuse them for each other; `at` cannot tell
+    /// them apart, which is why `seq` exists.
+    #[tokio::test]
+    async fn the_same_text_arriving_twice_counts_twice_with_different_seq() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher(
+                "done",
+                "Done",
+                WatcherDedupe::None,
+                2000,
+            )],
+        );
+        harness.backend.paint(id, &["a", "b", "c"]);
+        harness.backend.paint(id, &["b", "c", "Done"]);
+        harness.backend.paint(id, &["c", "Done", "Done"]);
+
+        harness.ticks(3).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 2);
+        assert_eq!(emitted[0].row, emitted[1].row);
+        assert_ne!(emitted[0].seq, emitted[1].seq);
+    }
+
+    /// 9.4.52 - the three dedupe keys, on the residual case layer 1 cannot separate: the same
+    /// path printed twice, truncated differently by the terminal.
+    #[tokio::test]
+    async fn the_capture_key_collapses_differently_truncated_rows_and_none_lets_everything_through()
+    {
+        for (dedupe, expected) in [(WatcherDedupe::Capture, 1), (WatcherDedupe::None, 2)] {
+            let harness = Harness::new();
+            let id = Uuid::new_v4();
+            harness.engine.register_session(id, "a1".to_string());
+            harness.configure(
+                "a1",
+                vec![occurrence_watcher("read", r"Read (\S+)", dedupe, 60_000)],
+            );
+            harness.backend.paint(id, &["a", "b", "c"]);
+            harness
+                .backend
+                .paint(id, &["b", "c", "Read C:/repo/main.rs"]);
+            harness.backend.paint(
+                id,
+                &["c", "Read C:/repo/main.rs", "Read C:/repo/main.rs (2)"],
+            );
+
+            harness.ticks(3).await;
+
+            assert_eq!(
+                harness.emitted().len(),
+                expected,
+                "dedupe={dedupe:?} should have produced {expected}"
+            );
+        }
+    }
+
+    /// ...and the window is a DEDUPLICATION window, not a mute button: the same key comes back
+    /// once it has passed.
+    #[tokio::test]
+    async fn a_repeated_key_is_admitted_again_once_the_dedupe_window_has_passed() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher("done", "Done", WatcherDedupe::Row, 1)],
+        );
+        harness.backend.paint(id, &["a", "b", "c"]);
+        harness.backend.paint(id, &["b", "c", "Done"]);
+        harness.ticks(2).await;
+        assert_eq!(harness.emitted().len(), 1);
+
+        std::thread::sleep(Duration::from_millis(5));
+        harness.backend.paint(id, &["c", "Done", "Done"]);
+        harness.ticks(1).await;
+
+        assert_eq!(harness.emitted().len(), 2);
+    }
+
+    /// 9.4.54 and 9.4.55 - **the caps, and where the overflow goes: nowhere.**
+    ///
+    /// A pattern that matches every row, against a full-screen repaint that stabilizes. Three
+    /// watchers would produce 90 matches; the per-watcher cap holds each to 8 and the
+    /// per-session cap holds the tick to 16, and every match beyond them reaches neither the
+    /// event nor anything else.
+    #[tokio::test]
+    async fn the_per_tick_caps_bound_the_batch_and_mark_the_watchers_degraded() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![
+                occurrence_watcher("w1", "row", WatcherDedupe::None, 2000),
+                occurrence_watcher("w2", "row", WatcherDedupe::None, 2000),
+                occurrence_watcher("w3", "row", WatcherDedupe::None, 2000),
+            ],
+        );
+
+        let seed: Vec<String> = (0..30).map(|i| format!("seed {i}")).collect();
+        let painted: Vec<String> = (0..30).map(|i| format!("row {i}")).collect();
+        harness.backend.paint(id, &as_refs(&seed));
+        harness.backend.paint(id, &as_refs(&painted));
+        harness.backend.paint(id, &as_refs(&painted));
+
+        harness.ticks(3).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(
+            emitted.len(),
+            MATCHES_PER_SESSION_PER_TICK,
+            "the session cap is the outer bound"
+        );
+        let w1 = emitted.iter().filter(|m| m.watcher_id == "w1").count();
+        assert_eq!(w1, MATCHES_PER_WATCHER_PER_TICK, "the per-watcher cap");
+        assert_eq!(
+            emitted.iter().filter(|m| m.watcher_id == "w3").count(),
+            0,
+            "the session budget was already spent when w3 was reached"
+        );
+
+        for watcher in ["w1", "w2", "w3"] {
+            let (degraded, _, _) = harness.engine.watcher_state(id, watcher).expect("state");
+            assert!(degraded, "{watcher} must be marked degraded");
+        }
+    }
+
+    /// 9.4.56 - the caps bound the RATE but not the duration, so a pair that stays saturated is
+    /// suspended, stays marked degraded while it is, and is retried afterwards.
+    #[tokio::test]
+    async fn a_pair_saturated_for_twenty_five_ticks_is_suspended_and_then_retried() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher(
+                "flood",
+                "row",
+                WatcherDedupe::None,
+                2000,
+            )],
+        );
+
+        // A transcript scrolling ten rows a tick: every tick brings ten new matching rows, so
+        // every tick is over the eight-per-watcher cap. A repaint would only degrade every
+        // other tick and the counter would reset in between, which is the whole point of
+        // requiring the ticks to be CONSECUTIVE.
+        let transcript: Vec<String> = (0..1000).map(|i| format!("row {i}")).collect();
+        for tick in 0..60usize {
+            let start = tick * 10;
+            harness
+                .backend
+                .paint(id, &as_refs(&transcript[start..start + 30]));
+        }
+
+        harness.ticks(40).await;
+
+        let (degraded, suspended, _) = harness.engine.watcher_state(id, "flood").expect("state");
+        assert!(suspended, "25 degraded ticks must suspend the pair");
+        assert!(degraded, "suspension must not read as recovery");
+
+        let before = harness.emitted().len();
+        harness.ticks(1).await;
+        assert_eq!(
+            harness.emitted().len(),
+            before,
+            "a suspended pair emits nothing at all"
+        );
+
+        harness.engine.expire_suspension_for_test(id, "flood");
+        harness.ticks(1).await;
+        assert!(
+            harness.emitted().len() > before,
+            "and it is retried once the suspension passes"
+        );
+    }
+
+    /// An occurrence watcher never fires on the tick a row is merely painted: the row has to
+    /// have arrived from below, or held still for a tick. That is layer 1 doing the work.
+    #[tokio::test]
+    async fn an_occurrence_watcher_fires_only_when_the_diff_declares_a_row_evaluable() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![occurrence_watcher("hit", "hit", WatcherDedupe::None, 2000)],
+        );
+        // The first tick seeds and evaluates nothing, even though the row is right there.
+        harness.backend.paint(id, &["hit", "hit", "hit"]);
+        harness.ticks(1).await;
+
+        assert!(harness.emitted().is_empty());
     }
 
     /// 9.3.24 - **a session with no agent is never registered**, so a plain shell costs this

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -609,8 +609,10 @@ struct RegisteredSession {
     /// mode at runtime needs no reseed.
     diff: frame::FrameDiffState,
     watchers: HashMap<String, WatcherSessionState>,
-    /// False until the engine has ticked this session at least once.
-    warmed_up: bool,
+    // Deliberately NO `warmed_up` flag here. "The engine has ticked this session" is already
+    // expressed by the existence of the session's `WatcherHistory` entry, which is the value
+    // the snapshot actually answers with; a second copy nobody reads is a fact that can only
+    // ever drift out of step with the one that counts.
 }
 
 /// Runs every configured watcher over every registered session, five times a second.
@@ -660,25 +662,42 @@ impl WatcherEngine {
 
     /// Own thread, own runtime, shutdown token: `ContextScraper::start`'s shape
     /// (`context_scrape/mod.rs:207-227`), which is `GitWatcher`'s.
+    ///
+    /// The loop is wrapped so a panic in a tick cannot end the engine SILENTLY. Without this,
+    /// the thread would unwind, every snapshot would freeze at its last value for the life of
+    /// the process, and nothing anywhere would say why: the window would keep answering, with
+    /// stale counters, which is worse than answering nothing. Containing at this boundary
+    /// follows `probe_child_contained` (`local_backend.rs:1119-1124`), which catches for the
+    /// same reason - a diagnostic path must not take something else down without a word.
     pub fn start(self: &Arc<Self>, shutdown: crate::shutdown::ShutdownSignal) {
         let engine = Arc::clone(self);
         std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new()
                 .expect("Failed to create tokio runtime for WatcherEngine");
-            rt.block_on(async move {
-                loop {
-                    tokio::select! {
-                        biased;
-                        _ = shutdown.token().cancelled() => {
-                            log::info!("[watchers] Shutdown signal received, stopping");
-                            break;
-                        }
-                        _ = tokio::time::sleep(TICK_INTERVAL) => {
-                            engine.tick().await;
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rt.block_on(async move {
+                    loop {
+                        tokio::select! {
+                            biased;
+                            _ = shutdown.token().cancelled() => {
+                                log::info!("[watchers] Shutdown signal received, stopping");
+                                break;
+                            }
+                            _ = tokio::time::sleep(TICK_INTERVAL) => {
+                                engine.tick().await;
+                            }
                         }
                     }
-                }
-            });
+                });
+            }));
+            if outcome.is_err() {
+                log::error!(
+                    "[watchers] the watcher engine thread PANICKED and has stopped. No further \
+                     activity will be sampled and every snapshot is frozen at its last value \
+                     until AgentsCommander restarts. Nothing else is affected: the engine holds \
+                     no PTY and no session state."
+                );
+            }
         });
     }
 
@@ -707,7 +726,6 @@ impl WatcherEngine {
                     seq: 0,
                     diff: frame::FrameDiffState::default(),
                     watchers: HashMap::new(),
-                    warmed_up: false,
                 },
             );
     }
@@ -770,25 +788,63 @@ impl WatcherEngine {
         out
     }
 
+    /// Publish "the engine reached you, and nothing watches you" for every registered session
+    /// no watcher applies to.
+    ///
+    /// **This is what makes the window's day-one empty state reachable at all.** Without it,
+    /// an unconfigured app and a session whose agent no watcher selects both answer
+    /// `warmedUp: false` FOREVER rather than for 200 ms. The condition the window uses for
+    /// "no watcher reaches this agent, here is the Configure button" is
+    /// `warmedUp && activeWatchers == []`, so it would never hold, and the two cases
+    /// `warmedUp` exists to tell apart would return byte-identical snapshots.
+    ///
+    /// It touches the registry and the history, and NOT the session: no backend is resolved,
+    /// no PTY is read, no `screen_parsers` lock is taken and no row is allocated - which is
+    /// what "the tick returns before touching any session" is protecting, and what the
+    /// zero-cost criterion measures. `Vec::new()` does not allocate either.
+    ///
+    /// Held under the same registration lock the tick uses, so the "creation requires
+    /// registration" rule that stops a purged session from being resurrected still holds.
+    fn publish_unwatched(&self, resolved: &HashMap<String, AgentResolution>) {
+        let _sequence = self.sequence.lock().unwrap_or_else(|e| e.into_inner());
+        let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+        for (id, session) in registered.iter() {
+            if resolved.contains_key(&session.agent_id) {
+                continue;
+            }
+            self.history.publish(
+                *id,
+                history::SessionStatus {
+                    possibly_missed_frames: session.diff.possibly_missed_frames(),
+                    active_watchers: Vec::new(),
+                },
+            );
+        }
+    }
+
     pub(crate) async fn tick(&self) {
         let tick_number = self.ticks.fetch_add(1, Ordering::Relaxed) + 1;
 
         // Settings FIRST, and the early exit is on the RESOLVED set rather than on an empty
         // registry: registration is per session, not per watcher, so a running agent with no
         // watcher configured would keep any registry non-empty. This is what actually
-        // delivers "zero cost when unconfigured" - no `screen_parsers` lock, no allocation.
+        // delivers "zero cost when unconfigured" - no `screen_parsers` lock, no row allocated,
+        // no backend resolved, no liveness probed.
         let resolved = self.patterns.resolve().await;
         if resolved.is_empty() {
+            self.publish_unwatched(&resolved);
             return;
         }
 
         let compiled = self.compile_for_tick(&resolved);
+        self.publish_unwatched(&resolved);
 
         // Snapshot first: the loop must not mutate `registered` while iterating it.
         let mut ids: Vec<(Uuid, String)> = {
             let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
             registered
                 .iter()
+                .filter(|(_, session)| resolved.contains_key(&session.agent_id))
                 .map(|(id, session)| (*id, session.agent_id.clone()))
                 .collect()
         };
@@ -843,7 +899,6 @@ impl WatcherEngine {
             // cloned to reach this arm - but the session HAS been ticked, so its status is
             // published and `warmedUp` becomes true.
             ScreenRowsSince::Unchanged | ScreenRowsSince::Missing => {
-                session.warmed_up = true;
                 self.history.publish(id, status_of(session, agent));
                 return (None, false);
             }
@@ -853,7 +908,6 @@ impl WatcherEngine {
             ScreenRowsSince::Frame(frame) => frame,
         };
         session.stamp = frame.stamp;
-        session.warmed_up = true;
 
         // A watcher that stopped reaching this agent leaves no state behind, so re-creating it
         // later starts from nothing - which is what "renaming is delete plus create" means.
@@ -905,14 +959,19 @@ impl WatcherEngine {
                 .min(MATCHES_PER_SESSION_PER_TICK.saturating_sub(used_by_session));
 
             let (found, capped) = match watcher.mode {
-                WatcherMode::State => {
-                    let found = evaluate_state(state, compiled, &logical);
-                    match found {
-                        Some(_) if budget == 0 => (Vec::new(), true),
-                        Some(found) => (vec![found], false),
-                        None => (Vec::new(), false),
+                WatcherMode::State => match evaluate_state(state, compiled, &logical) {
+                    // Dropped by the cap: the gate is NOT committed, so the same activation is
+                    // offered again next tick. Committing it here would turn the plan's "emits
+                    // nothing further for that key THIS TICK" into "never again", silently -
+                    // `degraded` clears on the next tick, so nothing would ever say the
+                    // activation was lost.
+                    Some(_) if budget == 0 => (Vec::new(), true),
+                    Some((found, commit)) => {
+                        state.commit_gate(commit);
+                        (vec![found], false)
                     }
-                }
+                    None => (Vec::new(), false),
+                },
                 WatcherMode::Occurrence => {
                     let outcome =
                         evaluate_occurrence(state, watcher, compiled, &selected, now, budget);
@@ -1077,6 +1136,22 @@ fn captures_of(regex: &regex::Regex, text: &str) -> Vec<Option<String>> {
         .unwrap_or_default()
 }
 
+/// The gate movement a `state` match would make **if it is actually emitted**.
+///
+/// Returned rather than applied, so a match the per-tick cap throws away cannot burn the gate
+/// it never passed through. The caller commits it with `commit_gate`, on the one path that
+/// emits.
+struct StateGateCommit {
+    last: (Vec<Option<String>>, String, u64),
+}
+
+impl WatcherSessionState {
+    /// Record that this `state` match was emitted. Called only after the caps let it through.
+    fn commit_gate(&mut self, commit: StateGateCommit) {
+        self.last = Some(commit.last);
+    }
+}
+
 /// `state` mode over the FULL frame: the LOWEST matching logical row wins, mirroring
 /// `rows::extract` (`context_scrape/rows.rs:19-26`), because a statusline always sits below
 /// the transcript.
@@ -1087,11 +1162,18 @@ fn captures_of(regex: &regex::Regex, text: &str) -> Vec<Option<String>> {
 /// A transition to "no match" CLEARS the gate and emits nothing. The only consumer here is an
 /// activity log, and "the prompt disappeared" is not a log entry; clearing is what lets an
 /// identical re-appearance emit again, and it is why the payload needs no `present` field.
+///
+/// **What is committed here and what is not.** `generation` and `last_match_count` describe
+/// the SCREEN, so they move on every tick that looked at one - and they must, or a count that
+/// rose during a dropped tick would rise a second time on the next one. `last` describes what
+/// was EMITTED, so it is handed back as a `StateGateCommit` and applied only when the match
+/// really goes out; otherwise a match dropped by the cap would match the gate on the next tick
+/// and the activation would never reappear.
 fn evaluate_state(
     state: &mut WatcherSessionState,
     compiled: &pattern::WatcherPattern,
     logical: &[frame::LogicalRow],
-) -> Option<Found> {
+) -> Option<(Found, StateGateCommit)> {
     let regex = compiled.regex();
     let mut count = 0usize;
     let mut lowest: Option<&frame::LogicalRow> = None;
@@ -1108,6 +1190,7 @@ fn evaluate_state(
     state.last_match_count = count;
 
     let Some(lowest) = lowest else {
+        // Nothing matched, so there is no match for a cap to drop: clearing is unconditional.
         state.last = None;
         return None;
     };
@@ -1117,8 +1200,10 @@ fn evaluate_state(
     if state.last.as_ref() == Some(&candidate) {
         return None;
     }
-    state.last = Some(candidate.clone());
-    Some((candidate.0, candidate.1, row_truncated))
+    Some((
+        (candidate.0.clone(), candidate.1.clone(), row_truncated),
+        StateGateCommit { last: candidate },
+    ))
 }
 
 /// `occurrence` mode over the rows the diff declared evaluable: every match that survives the
@@ -2015,6 +2100,125 @@ mod engine_tests {
         }
     }
 
+    /// **The regression that made a permission prompt vanish forever.**
+    ///
+    /// Two saturated `occurrence` watchers ahead of a `state` one in `BTreeMap` order spend the
+    /// whole 16-per-session budget, so the `state` watcher is handed `budget == 0` and its match
+    /// is dropped. If the gate were committed while evaluating, the next tick would find the
+    /// candidate equal to the gate and return nothing: the activation would never reappear
+    /// while the text and the generation held - and silently, because `degraded` clears on the
+    /// tick after.
+    ///
+    /// The plan says "emits nothing further for that key THIS TICK". This is the test that the
+    /// word "tick" is honoured.
+    #[tokio::test]
+    async fn a_state_match_dropped_by_the_session_cap_still_emits_on_the_next_tick() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![
+                occurrence_watcher("a-reads", "row", WatcherDedupe::None, 2000),
+                occurrence_watcher("b-tools", "row", WatcherDedupe::None, 2000),
+                state_watcher("z-permission", "Permission required"),
+            ],
+        );
+
+        // Seed, then a full repaint that settles nothing, then the tick where 29 rows become
+        // evaluable AT THE SAME TIME as the prompt appears on the bottom row. That coincidence
+        // is the whole scenario: the prompt has to arrive while the budget is already gone.
+        let seed: Vec<String> = (0..30).map(|i| format!("seed {i}")).collect();
+        let burst: Vec<String> = (0..30).map(|i| format!("row {i}")).collect();
+        let mut prompted = burst.clone();
+        prompted[29] = "Permission required".to_string();
+
+        harness.backend.paint(id, &as_refs(&seed));
+        harness.backend.paint(id, &as_refs(&burst));
+        harness.backend.paint(id, &as_refs(&prompted));
+
+        harness.ticks(3).await;
+
+        let during = harness.emitted();
+        assert_eq!(
+            during.len(),
+            MATCHES_PER_SESSION_PER_TICK,
+            "the two occurrence watchers must have spent the whole session budget"
+        );
+        assert!(
+            during.iter().all(|m| m.watcher_id != "z-permission"),
+            "the prompt was dropped by the cap on this tick, which is what the plan allows"
+        );
+        let (degraded, _, _) = harness
+            .engine
+            .watcher_state(id, "z-permission")
+            .expect("state");
+        assert!(degraded, "and it must say so");
+
+        // The screen holds still. The occurrence watchers take no budget - the only row that
+        // stabilizes is the prompt, which their pattern does not match - and the prompt is
+        // still on screen, so it MUST come through.
+        harness.backend.paint(id, &as_refs(&prompted));
+        harness.ticks(1).await;
+
+        let after: Vec<_> = harness
+            .emitted()
+            .into_iter()
+            .filter(|m| m.watcher_id == "z-permission")
+            .collect();
+        assert_eq!(
+            after.len(),
+            1,
+            "the activation the cap dropped has to reappear, or it is lost forever"
+        );
+        assert_eq!(after[0].row, "Permission required");
+    }
+
+    /// **P1-2's regression: the day-one empty state has to be reachable.**
+    ///
+    /// A registered agent session that no watcher reaches must answer `warmedUp: true` with
+    /// `activeWatchers: []`. That pair IS the window's "no watcher reaches this agent, here is
+    /// the Configure button" state, and it is what everybody sees on day one. Publishing
+    /// nothing left both this case and "the engine has not run yet" answering `warmedUp: false`
+    /// forever - byte-identical snapshots for the two cases the field exists to tell apart.
+    #[tokio::test]
+    async fn a_session_no_watcher_reaches_is_warmed_up_with_no_active_watchers() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.backend.paint(id, &["idle"]);
+
+        // Before the first tick: the engine really has not run.
+        assert!(!harness.history.snapshot(id, None).warmed_up);
+
+        // Day one: nothing configured at all, so the tick takes the early exit.
+        harness.ticks(1).await;
+
+        let snapshot = harness.history.snapshot(id, None);
+        assert!(snapshot.warmed_up);
+        assert!(snapshot.active_watchers.is_empty());
+        assert!(snapshot.matches.is_empty());
+        assert_eq!(
+            harness.backend.reads.load(Ordering::Relaxed),
+            0,
+            "and it must still not have touched the session: no read, no rows"
+        );
+        assert_eq!(
+            harness.backends.liveness_calls.load(Ordering::Relaxed),
+            0,
+            "nor probed a child nobody is watching"
+        );
+
+        // Watchers configured, but for a DIFFERENT agent: same answer, same reason.
+        harness.configure("other-agent", vec![state_watcher("w", "x")]);
+        harness.ticks(1).await;
+
+        let snapshot = harness.history.snapshot(id, None);
+        assert!(snapshot.warmed_up);
+        assert!(snapshot.active_watchers.is_empty());
+        assert_eq!(harness.backend.reads.load(Ordering::Relaxed), 0);
+    }
+
     /// 9.4.56 - the caps bound the RATE but not the duration, so a pair that stays saturated is
     /// suspended, stays marked degraded while it is, and is retried afterwards.
     #[tokio::test]
@@ -2269,8 +2473,12 @@ mod engine_tests {
             .split("fn publish_restart_destroyed")
             .nth(1)
             .expect("publish_restart_destroyed must exist");
+        // Delimited by the closing brace at column 0, which is where a top-level function ends
+        // whatever comes after it. Splitting on the NEXT declaration would let an unrelated
+        // function inserted in between extend this "body" downwards, and the guard would then
+        // pass with the purge living somewhere else entirely.
         let restart_body = restart
-            .split("\nasync fn ")
+            .split("\n}")
             .next()
             .expect("its body must end somewhere");
         assert!(

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -36,15 +36,36 @@
 //! numbers are not comparable to either; `--release` does not build the test target in this
 //! tree, because `load_sessions_raw_from_dir_for_test` is `#[cfg(debug_assertions)]`.
 
+pub mod frame;
 pub mod pattern;
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures::future::BoxFuture;
+use uuid::Uuid;
 
 use crate::config::coding_agents_catalog::command_executable_basename;
 use crate::config::settings::{WatcherEntry, WatcherMode};
+use crate::pty::backend::PtyBackend;
+use crate::pty::context_scrape::ContextSessionLiveness;
 
 pub use crate::config::settings::WatcherDedupe;
+
+/// 200 ms, against `ContextScraper`'s 5 s. The engine has to catch rows in transit, and a row
+/// that scrolls past between two samples is gone: the mirror keeps zero scrollback.
+pub const TICK_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Liveness is probed on every 25th tick, that is once per 5 seconds per session - exactly
+/// the rate `ContextScraper` already probes at. The probe is the expensive part of the old
+/// read path (it takes the `ptys` mutex and asks the OS about the child), and running it at
+/// the tick rate would make this engine 25x more expensive than the one it sits beside.
+pub const LIVENESS_PROBE_EVERY_TICKS: u64 = 25;
+
+/// The `row` field of a payload is capped at this many bytes, on a char boundary.
+pub const MAX_ROW_BYTES: usize = 256;
 
 /// How many watchers may run on one agent. Resolution takes the first 8 in `BTreeMap` key
 /// order, which is alphabetical over user-chosen ids, so adding a watcher named `aaa-test`
@@ -394,6 +415,1252 @@ pub(crate) fn frame_from_screen_rows_read(
         }
         crate::pty::context_scrape::ScreenRowsRead::Unavailable
         | crate::pty::context_scrape::ScreenRowsRead::SessionOver => ScreenRowsSince::Missing,
+    }
+}
+
+// ---- the engine ------------------------------------------------------------------------
+
+/// One session's backend, narrowed to the ONE call the engine is allowed to make on it.
+///
+/// The engine resolves this once at registration and keeps it, so the tick never touches the
+/// `PtyManager` mutex - "the one every terminal write, resize and kill locks on"
+/// (`local_backend.rs:1116-1117`) - nor the route registry inside `kind_for_session`. What is
+/// left per session per tick is a single `screen_parsers` acquisition, and that map is per
+/// backend, so local and container sessions do not contend with each other at all.
+///
+/// It is a wrapper and not a bare `Arc<dyn PtyBackend>` because a bare one would hand the
+/// engine `write`, `kill` and `spawn` along with the read it actually needs. The field is
+/// private and there is no accessor, so the capability boundary this module claims is
+/// expressed in the type rather than in a comment.
+pub struct SessionFrameReader(Arc<dyn PtyBackend>);
+
+impl SessionFrameReader {
+    pub fn new(backend: Arc<dyn PtyBackend>) -> Self {
+        Self(backend)
+    }
+
+    pub fn read(&self, id: Uuid, seen: Option<FrameStamp>) -> ScreenRowsSince {
+        self.0.screen_rows_since(id, seen)
+    }
+}
+
+/// Where a session's frame reader and its lightweight liveness come from.
+///
+/// The concrete implementation (`lib.rs`) owns the `PtyManager` handle; the engine holds only
+/// this, exactly as `ContextScraper` holds only `ScreenRowsSource`.
+pub trait WatcherBackendSource: Send + Sync {
+    fn reader_for(&self, id: Uuid) -> Option<SessionFrameReader>;
+
+    fn liveness(&self, id: Uuid) -> ContextSessionLiveness;
+}
+
+/// The configured watchers, resolved per agent, read fresh every tick.
+///
+/// `BoxFuture` and not a sync fn for the reason `ContextPatternSource` documents
+/// (`context_scrape/mod.rs:65-72`): the settings live behind a `tokio::sync::RwLock` whose
+/// `blocking_read` panics inside a runtime, and the tick is inside one.
+pub trait WatcherPatternSource: Send + Sync {
+    fn resolve(&self) -> BoxFuture<'_, HashMap<String, AgentResolution>>;
+}
+
+/// Where a tick's matches go. The concrete implementation holds the `AppHandle` and decides
+/// whether anyone is listening; the engine never learns either.
+pub trait WatcherEventSink: Send + Sync {
+    fn emit(&self, batch: WatcherMatchBatch);
+}
+
+/// One tick's matches for one session. Coalesced on purpose: `app.emit` reaches every window,
+/// so an uncoalesced per-match event would deliver thousands of payloads per second to four
+/// windows and make every detached terminal pay to deserialize events it discards.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherMatchBatch {
+    pub session_id: String,
+    pub matches: Vec<WatcherMatchPayload>,
+}
+
+/// The IPC contract. Mould: `ContextUsagePayload` (`context_scrape/mod.rs:104-115`).
+///
+/// **No `skip_serializing_if` on any field**, for the reason that payload documents in
+/// writing: an absent key must never become a third state beside null and the value. A
+/// frontend row is self-contained once inserted, which is why `session_id` is repeated on
+/// every match rather than read from the batch.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WatcherMatchPayload {
+    pub session_id: String,
+    /// Monotonic per session, assigned by the engine as the match passes the caps. The SAME
+    /// value the ring stores, so the window merges snapshot and stream on `(sessionId, seq)`
+    /// instead of guessing. Without it two matches from one tick are indistinguishable, and
+    /// identical rows at two positions are required to count twice.
+    pub seq: u64,
+    /// The key of the root `watchers` map. The same grouping key everywhere.
+    pub watcher_id: String,
+    pub mode: WatcherMode,
+    /// The TICK's instant, not the match's: a match has no instant of its own.
+    pub at: chrono::DateTime<chrono::Utc>,
+    /// Groups 1..n IN ORDER, without group 0. `Option` per element because an optional group
+    /// may not participate, and `""` is not "did not capture".
+    pub captures: Vec<Option<String>>,
+    /// The logical row, truncated to `MAX_ROW_BYTES` on a char boundary.
+    pub row: String,
+    /// Whether `row` lost bytes to the cap. `row.length >= 256` cannot answer this in
+    /// TypeScript, because the cap is on bytes and the row is multibyte.
+    pub row_truncated: bool,
+}
+
+/// Cap a row at `MAX_ROW_BYTES`, never splitting a character.
+fn truncate_row(text: &str) -> (String, bool) {
+    if text.len() <= MAX_ROW_BYTES {
+        return (text.to_string(), false);
+    }
+    let mut end = MAX_ROW_BYTES;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    (text[..end].to_string(), true)
+}
+
+/// A compiled pattern kept against the source it came from, so a recompile is decided by a
+/// changed string and a failure is STICKY: logged once per change, never once per tick.
+/// Mould: `Cached` (`context_scrape/mod.rs:127-156`).
+enum Cached {
+    Ok(Arc<pattern::WatcherPattern>),
+    Failed { source: String },
+}
+
+impl Cached {
+    fn source(&self) -> &str {
+        match self {
+            Cached::Ok(compiled) => compiled.source(),
+            Cached::Failed { source } => source,
+        }
+    }
+
+    fn pattern(&self) -> Option<Arc<pattern::WatcherPattern>> {
+        match self {
+            Cached::Ok(compiled) => Some(Arc::clone(compiled)),
+            Cached::Failed { .. } => None,
+        }
+    }
+}
+
+/// The `state`-mode gate for one `(session, watcher)` pair.
+///
+/// The gate is NOT `(captures, row)` alone. With only that pair, a second instance of a
+/// condition appearing while the first is still visible never emits: the lowest match still
+/// reads the same text, so the tuple never changes. That is the failure mode of the
+/// permission-prompt watcher, which is the strongest argument for this engine existing.
+#[derive(Default)]
+struct StateGate {
+    /// What the watcher looked like when this gate was built. A watcher whose pattern or mode
+    /// was edited gets a fresh gate, because the old one describes a question no longer asked.
+    signature: Option<(String, WatcherMode)>,
+    last: Option<(Vec<Option<String>>, String, u64)>,
+    /// Incremented whenever the number of matching logical rows RISES. Incrementing only on a
+    /// rise is what makes the gate scroll-stable: the count of a persistent condition does not
+    /// change as the screen moves under it.
+    generation: u64,
+    last_match_count: usize,
+}
+
+/// One session the engine is sampling.
+struct RegisteredSession {
+    agent_id: String,
+    /// Resolved at registration; re-resolved only when a read comes back `Missing` or `Gone`,
+    /// which covers a session that changed route.
+    reader: Option<SessionFrameReader>,
+    stamp: Option<FrameStamp>,
+    /// Monotonic per session. The identity of a match, in the event and in the ring alike.
+    seq: u64,
+    gates: HashMap<String, StateGate>,
+}
+
+/// Runs every configured watcher over every registered session, five times a second.
+///
+/// Its total capability is: read one session's screen through a narrowed reader, ask for that
+/// session's lightweight liveness, read the resolved watcher set, and hand a batch of matches
+/// to a sink. It cannot route, inject, wake, or destroy anything.
+pub struct WatcherEngine {
+    backends: Arc<dyn WatcherBackendSource>,
+    patterns: Arc<dyn WatcherPatternSource>,
+    sink: Arc<dyn WatcherEventSink>,
+    /// Linearizes registration and retirement against evaluation and emission. Lock order is
+    /// always sequence, then registered.
+    sequence: Mutex<()>,
+    registered: Mutex<HashMap<Uuid, RegisteredSession>>,
+    compiled: Mutex<HashMap<String, Cached>>,
+    ticks: AtomicU64,
+    /// Test-visible: the number of `pattern::compile` calls. The compile site is also the log
+    /// site, so this is what "logged once per change, not once per tick" is measured by.
+    compiles: AtomicUsize,
+}
+
+impl WatcherEngine {
+    pub fn new(
+        backends: Arc<dyn WatcherBackendSource>,
+        patterns: Arc<dyn WatcherPatternSource>,
+        sink: Arc<dyn WatcherEventSink>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            backends,
+            patterns,
+            sink,
+            sequence: Mutex::new(()),
+            registered: Mutex::new(HashMap::new()),
+            compiled: Mutex::new(HashMap::new()),
+            ticks: AtomicU64::new(0),
+            compiles: AtomicUsize::new(0),
+        })
+    }
+
+    /// Own thread, own runtime, shutdown token: `ContextScraper::start`'s shape
+    /// (`context_scrape/mod.rs:207-227`), which is `GitWatcher`'s.
+    pub fn start(self: &Arc<Self>, shutdown: crate::shutdown::ShutdownSignal) {
+        let engine = Arc::clone(self);
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new()
+                .expect("Failed to create tokio runtime for WatcherEngine");
+            rt.block_on(async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.token().cancelled() => {
+                            log::info!("[watchers] Shutdown signal received, stopping");
+                            break;
+                        }
+                        _ = tokio::time::sleep(TICK_INTERVAL) => {
+                            engine.tick().await;
+                        }
+                    }
+                }
+            });
+        });
+    }
+
+    /// Start sampling a session. Called once per AGENT session at the spawn chokepoint;
+    /// sessions with no agent are never registered, so a plain shell costs nothing - the same
+    /// rule `ContextScraper` follows (`commands/session.rs:2268-2274`).
+    ///
+    /// A fresh entry can never meet an existing one: session ids are minted per spawn and AC
+    /// never reuses one, not even on respawn. That is also what makes `FrameStamp` safe.
+    pub fn register_session(&self, id: Uuid, agent_id: String) {
+        let reader = self.backends.reader_for(id);
+        if reader.is_none() {
+            // Not fatal and not worth a warning per tick: the first read re-resolves it.
+            log::debug!("[watchers] session {id} has no backend route yet; will resolve on read");
+        }
+        let _sequence = self.sequence.lock().unwrap_or_else(|e| e.into_inner());
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(
+                id,
+                RegisteredSession {
+                    agent_id,
+                    reader,
+                    stamp: None,
+                    seq: 0,
+                    gates: HashMap::new(),
+                },
+            );
+    }
+
+    /// Stop sampling a session. Idempotent, so every caller can just call it.
+    pub fn retire_session(&self, id: Uuid) {
+        let _sequence = self.sequence.lock().unwrap_or_else(|e| e.into_inner());
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
+    }
+
+    pub fn is_session_registered(&self, id: Uuid) -> bool {
+        self.registered
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&id)
+    }
+
+    /// Compile every watcher this tick resolved, once each, and drop the cache entries of
+    /// watchers that are no longer configured.
+    fn compile_for_tick(
+        &self,
+        resolved: &HashMap<String, AgentResolution>,
+    ) -> HashMap<String, Option<Arc<pattern::WatcherPattern>>> {
+        let mut wanted: HashMap<&str, &Arc<ResolvedWatcher>> = HashMap::new();
+        for agent in resolved.values() {
+            for watcher in &agent.running {
+                wanted.entry(watcher.id.as_str()).or_insert(watcher);
+            }
+        }
+
+        let mut cache = self.compiled.lock().unwrap_or_else(|e| e.into_inner());
+        cache.retain(|id, _| wanted.contains_key(id.as_str()));
+
+        let mut out = HashMap::with_capacity(wanted.len());
+        for (id, watcher) in wanted {
+            if let Some(cached) = cache.get(id) {
+                if cached.source() == watcher.pattern {
+                    out.insert(id.to_string(), cached.pattern());
+                    continue;
+                }
+            }
+
+            self.compiles.fetch_add(1, Ordering::Relaxed);
+            let cached = match pattern::compile(&watcher.pattern) {
+                Ok(compiled) => Cached::Ok(Arc::new(compiled)),
+                Err(err) => {
+                    // Once per change, not once per tick: the cache below makes it sticky.
+                    log::warn!("[watchers] watcher '{id}' has an unusable pattern: {err}");
+                    Cached::Failed {
+                        source: watcher.pattern.clone(),
+                    }
+                }
+            };
+            out.insert(id.to_string(), cached.pattern());
+            cache.insert(id.to_string(), cached);
+        }
+        out
+    }
+
+    pub(crate) async fn tick(&self) {
+        let tick_number = self.ticks.fetch_add(1, Ordering::Relaxed) + 1;
+
+        // Settings FIRST, and the early exit is on the RESOLVED set rather than on an empty
+        // registry: registration is per session, not per watcher, so a running agent with no
+        // watcher configured would keep any registry non-empty. This is what actually
+        // delivers "zero cost when unconfigured" - no `screen_parsers` lock, no allocation.
+        let resolved = self.patterns.resolve().await;
+        if resolved.is_empty() {
+            return;
+        }
+
+        let compiled = self.compile_for_tick(&resolved);
+
+        // Snapshot first: the loop must not mutate `registered` while iterating it.
+        let mut ids: Vec<(Uuid, String)> = {
+            let registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+            registered
+                .iter()
+                .map(|(id, session)| (*id, session.agent_id.clone()))
+                .collect()
+        };
+        ids.sort_unstable_by_key(|(id, _)| *id);
+
+        let probe_liveness = tick_number.is_multiple_of(LIVENESS_PROBE_EVERY_TICKS);
+        let at = chrono::Utc::now();
+
+        for (id, agent_id) in ids {
+            let Some(agent) = resolved.get(&agent_id) else {
+                continue;
+            };
+
+            if probe_liveness
+                && matches!(
+                    self.backends.liveness(id),
+                    ContextSessionLiveness::SessionOver
+                )
+            {
+                self.retire_session(id);
+                continue;
+            }
+
+            let (batch, retire) = self.tick_session(id, agent, &compiled, at);
+            if retire {
+                self.retire_session(id);
+            }
+            if let Some(batch) = batch {
+                self.sink.emit(batch);
+            }
+        }
+    }
+
+    /// One session's whole tick, with both locks scoped inside so retirement and emission
+    /// happen outside them.
+    fn tick_session(
+        &self,
+        id: Uuid,
+        agent: &AgentResolution,
+        compiled: &HashMap<String, Option<Arc<pattern::WatcherPattern>>>,
+        at: chrono::DateTime<chrono::Utc>,
+    ) -> (Option<WatcherMatchBatch>, bool) {
+        let _sequence = self.sequence.lock().unwrap_or_else(|e| e.into_inner());
+        let mut registered = self.registered.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(session) = registered.get_mut(&id) else {
+            return (None, false);
+        };
+
+        let frame = match self.read_frame(id, session) {
+            // Nothing changed, so nothing can have started or stopped matching. No rows were
+            // cloned to reach this arm.
+            ScreenRowsSince::Unchanged => return (None, false),
+            // No reading this tick and NO claim about the session: keep it.
+            ScreenRowsSince::Missing => return (None, false),
+            // The backend says there is nothing behind this id. Retire it now.
+            ScreenRowsSince::Gone => return (None, true),
+            ScreenRowsSince::Frame(frame) => frame,
+        };
+        session.stamp = frame.stamp;
+
+        // A watcher that stopped reaching this agent leaves no gate behind, so re-creating it
+        // later starts from nothing - which is what "renaming is delete plus create" means.
+        session
+            .gates
+            .retain(|gate_id, _| agent.running.iter().any(|w| &w.id == gate_id));
+
+        let needs_state = agent
+            .running
+            .iter()
+            .any(|watcher| watcher.mode == WatcherMode::State);
+        if !needs_state {
+            return (None, false);
+        }
+
+        let logical = frame::logical_rows(&frame);
+        let mut matches = Vec::new();
+        for watcher in &agent.running {
+            if watcher.mode != WatcherMode::State {
+                continue;
+            }
+            let Some(Some(compiled)) = compiled.get(&watcher.id) else {
+                continue;
+            };
+            if let Some(payload) = evaluate_state(session, id, watcher, compiled, &logical, at) {
+                matches.push(payload);
+            }
+        }
+
+        if matches.is_empty() {
+            return (None, false);
+        }
+        (
+            Some(WatcherMatchBatch {
+                session_id: id.to_string(),
+                matches,
+            }),
+            false,
+        )
+    }
+
+    /// Read a session's frame, re-resolving its backend once when the read says the route may
+    /// have changed. The re-resolution is the only thing on this path that touches
+    /// `PtyManager`, and it does not run on a healthy tick.
+    fn read_frame(&self, id: Uuid, session: &mut RegisteredSession) -> ScreenRowsSince {
+        let first = match &session.reader {
+            Some(reader) => reader.read(id, session.stamp),
+            None => ScreenRowsSince::Missing,
+        };
+        match first {
+            ScreenRowsSince::Missing | ScreenRowsSince::Gone => {
+                match self.backends.reader_for(id) {
+                    Some(reader) => {
+                        let again = reader.read(id, session.stamp);
+                        session.reader = Some(reader);
+                        again
+                    }
+                    None => first,
+                }
+            }
+            other => other,
+        }
+    }
+
+    #[cfg(test)]
+    fn compile_count(&self) -> usize {
+        self.compiles.load(Ordering::Relaxed)
+    }
+}
+
+/// `state` mode over one frame: the LOWEST matching logical row wins, mirroring
+/// `rows::extract` (`context_scrape/rows.rs:19-26`), because a statusline always sits below
+/// the transcript.
+///
+/// A transition to "no match" CLEARS the gate and emits nothing. The only consumer here is an
+/// activity log, and "the prompt disappeared" is not a log entry; clearing is what lets an
+/// identical re-appearance emit again, and it is why the payload needs no `present` field.
+fn evaluate_state(
+    session: &mut RegisteredSession,
+    id: Uuid,
+    watcher: &ResolvedWatcher,
+    compiled: &pattern::WatcherPattern,
+    logical: &[frame::LogicalRow],
+    at: chrono::DateTime<chrono::Utc>,
+) -> Option<WatcherMatchPayload> {
+    let gate = session.gates.entry(watcher.id.clone()).or_default();
+    let signature = (watcher.pattern.clone(), watcher.mode);
+    if gate.signature.as_ref() != Some(&signature) {
+        *gate = StateGate {
+            signature: Some(signature),
+            ..StateGate::default()
+        };
+    }
+
+    let regex = compiled.regex();
+    let mut count = 0usize;
+    let mut lowest: Option<&frame::LogicalRow> = None;
+    for row in logical {
+        if regex.is_match(&row.text) {
+            count += 1;
+            lowest = Some(row);
+        }
+    }
+
+    if count > gate.last_match_count {
+        gate.generation += 1;
+    }
+    gate.last_match_count = count;
+
+    let Some(lowest) = lowest else {
+        gate.last = None;
+        return None;
+    };
+
+    let captures = regex
+        .captures(&lowest.text)
+        .map(|found| {
+            found
+                .iter()
+                .skip(1)
+                .map(|group| group.map(|m| m.as_str().to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let (row, row_truncated) = truncate_row(&lowest.text);
+
+    let candidate = (captures, row, gate.generation);
+    if gate.last.as_ref() == Some(&candidate) {
+        return None;
+    }
+    gate.last = Some(candidate.clone());
+
+    session.seq += 1;
+    Some(WatcherMatchPayload {
+        session_id: id.to_string(),
+        seq: session.seq,
+        watcher_id: watcher.id.clone(),
+        mode: watcher.mode,
+        at,
+        captures: candidate.0,
+        row: candidate.1,
+        row_truncated,
+    })
+}
+
+#[cfg(test)]
+mod engine_tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    /// What the scripted backend paints on the next read.
+    enum Painted {
+        Frame(Vec<String>, Vec<bool>),
+        Unchanged,
+        Missing,
+        Gone,
+    }
+
+    /// The rows of a frame with their wrap flags: what a repaint replays.
+    type PaintedRows = (Vec<String>, Vec<bool>);
+
+    /// A `PtyBackend` whose only real method is the watcher seam. Every other method is a
+    /// stub, which is exactly the point: the engine never calls one.
+    #[derive(Default)]
+    struct ScriptedBackend {
+        script: Mutex<HashMap<Uuid, VecDeque<Painted>>>,
+        last: Mutex<HashMap<Uuid, PaintedRows>>,
+        sequence: Mutex<HashMap<Uuid, u64>>,
+        reads: AtomicUsize,
+    }
+
+    impl ScriptedBackend {
+        fn paint(&self, id: Uuid, rows: &[&str]) {
+            self.push(
+                id,
+                Painted::Frame(
+                    rows.iter().map(|r| r.to_string()).collect(),
+                    vec![false; rows.len()],
+                ),
+            );
+        }
+
+        fn push(&self, id: Uuid, painted: Painted) {
+            self.script
+                .lock()
+                .unwrap()
+                .entry(id)
+                .or_default()
+                .push_back(painted);
+        }
+    }
+
+    impl PtyBackend for ScriptedBackend {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn spawn(
+            &self,
+            _spec: crate::pty::backend::BackendSpawnSpec,
+        ) -> BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn write(
+            &self,
+            _authority: &crate::pty::manager::BackendWriteAuthority,
+            _id: Uuid,
+            _data: &[u8],
+        ) -> Result<(), crate::errors::AppError> {
+            unreachable!("the engine must never be able to write to a PTY")
+        }
+        fn resize(&self, _id: Uuid, _cols: u16, _rows: u16) -> Result<(), crate::errors::AppError> {
+            unreachable!("the engine must never be able to resize a PTY")
+        }
+        fn kill(&self, _id: Uuid) -> Result<(), crate::errors::AppError> {
+            unreachable!("the engine must never be able to kill a session")
+        }
+        fn has_session(&self, _id: Uuid) -> bool {
+            true
+        }
+        fn get_screen_snapshot(&self, _id: Uuid) -> Option<crate::pty::output::PtyScreenSnapshot> {
+            None
+        }
+        fn get_pty_size(&self, _id: Uuid) -> Option<(u16, u16)> {
+            None
+        }
+        fn get_screen_rows(&self, _id: Uuid) -> crate::pty::context_scrape::ScreenRowsRead {
+            unreachable!("the engine reads through the #1171 seam, never the 5 s one")
+        }
+        fn register_response_watcher(
+            &self,
+            _session_id: Uuid,
+            _request_id: String,
+            _response_dir: std::path::PathBuf,
+        ) {
+        }
+        fn terminate_job_for_session(&self, _id: Uuid) -> bool {
+            false
+        }
+        fn kill_all_jobs(&self) -> (usize, usize) {
+            (0, 0)
+        }
+
+        fn screen_rows_since(&self, id: Uuid, _seen: Option<FrameStamp>) -> ScreenRowsSince {
+            self.reads.fetch_add(1, Ordering::Relaxed);
+            let next = self
+                .script
+                .lock()
+                .unwrap()
+                .get_mut(&id)
+                .and_then(|queue| queue.pop_front());
+            let (rows, wrapped) = match next {
+                Some(Painted::Missing) => return ScreenRowsSince::Missing,
+                Some(Painted::Gone) => return ScreenRowsSince::Gone,
+                Some(Painted::Unchanged) => return ScreenRowsSince::Unchanged,
+                Some(Painted::Frame(rows, wrapped)) => {
+                    self.last
+                        .lock()
+                        .unwrap()
+                        .insert(id, (rows.clone(), wrapped.clone()));
+                    (rows, wrapped)
+                }
+                // A script that ran out repaints the same screen with a NEW sequence, which is
+                // what a session with a live spinner does several times per second.
+                None => self
+                    .last
+                    .lock()
+                    .unwrap()
+                    .get(&id)
+                    .cloned()
+                    .unwrap_or_default(),
+            };
+            let mut sequences = self.sequence.lock().unwrap();
+            let sequence = sequences.entry(id).or_insert(0);
+            *sequence += 1;
+            ScreenRowsSince::Frame(ScreenFrame {
+                rows: rows.clone(),
+                wrapped,
+                cursor_row: rows.len().saturating_sub(1) as u16,
+                stamp: Some(FrameStamp {
+                    sequence: *sequence,
+                    rows: rows.len() as u16,
+                    cols: 120,
+                }),
+            })
+        }
+    }
+
+    struct FakeBackends {
+        backend: Arc<ScriptedBackend>,
+        liveness: Mutex<HashMap<Uuid, ContextSessionLiveness>>,
+        resolutions: AtomicUsize,
+        liveness_calls: AtomicUsize,
+    }
+
+    impl WatcherBackendSource for FakeBackends {
+        fn reader_for(&self, _id: Uuid) -> Option<SessionFrameReader> {
+            self.resolutions.fetch_add(1, Ordering::Relaxed);
+            Some(SessionFrameReader::new(
+                Arc::clone(&self.backend) as Arc<dyn PtyBackend>
+            ))
+        }
+
+        fn liveness(&self, id: Uuid) -> ContextSessionLiveness {
+            self.liveness_calls.fetch_add(1, Ordering::Relaxed);
+            self.liveness
+                .lock()
+                .unwrap()
+                .get(&id)
+                .copied()
+                .unwrap_or(ContextSessionLiveness::Live)
+        }
+    }
+
+    #[derive(Default)]
+    struct FakePatterns(Mutex<HashMap<String, AgentResolution>>);
+
+    impl WatcherPatternSource for FakePatterns {
+        fn resolve(&self) -> BoxFuture<'_, HashMap<String, AgentResolution>> {
+            Box::pin(async move { self.0.lock().unwrap().clone() })
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSink(Mutex<Vec<WatcherMatchBatch>>);
+
+    impl WatcherEventSink for FakeSink {
+        fn emit(&self, batch: WatcherMatchBatch) {
+            self.0.lock().unwrap().push(batch);
+        }
+    }
+
+    struct Harness {
+        engine: Arc<WatcherEngine>,
+        backend: Arc<ScriptedBackend>,
+        backends: Arc<FakeBackends>,
+        patterns: Arc<FakePatterns>,
+        sink: Arc<FakeSink>,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let backend = Arc::new(ScriptedBackend::default());
+            let backends = Arc::new(FakeBackends {
+                backend: Arc::clone(&backend),
+                liveness: Mutex::new(HashMap::new()),
+                resolutions: AtomicUsize::new(0),
+                liveness_calls: AtomicUsize::new(0),
+            });
+            let patterns = Arc::new(FakePatterns::default());
+            let sink = Arc::new(FakeSink::default());
+            Self {
+                engine: WatcherEngine::new(
+                    Arc::clone(&backends) as Arc<dyn WatcherBackendSource>,
+                    Arc::clone(&patterns) as Arc<dyn WatcherPatternSource>,
+                    Arc::clone(&sink) as Arc<dyn WatcherEventSink>,
+                ),
+                backend,
+                backends,
+                patterns,
+                sink,
+            }
+        }
+
+        fn configure(&self, agent_id: &str, watchers: Vec<ResolvedWatcher>) {
+            self.patterns.0.lock().unwrap().insert(
+                agent_id.to_string(),
+                AgentResolution {
+                    running: watchers.into_iter().map(Arc::new).collect(),
+                    over_budget: Vec::new(),
+                },
+            );
+        }
+
+        async fn ticks(&self, count: usize) {
+            for _ in 0..count {
+                self.engine.tick().await;
+            }
+        }
+
+        fn emitted(&self) -> Vec<WatcherMatchPayload> {
+            self.sink
+                .0
+                .lock()
+                .unwrap()
+                .iter()
+                .flat_map(|batch| batch.matches.clone())
+                .collect()
+        }
+
+        fn batches(&self) -> usize {
+            self.sink.0.lock().unwrap().len()
+        }
+    }
+
+    fn state_watcher(id: &str, pattern: &str) -> ResolvedWatcher {
+        ResolvedWatcher {
+            id: id.to_string(),
+            mode: WatcherMode::State,
+            pattern: pattern.to_string(),
+            dedupe: WatcherDedupe::Row,
+            dedupe_window_ms: 2000,
+        }
+    }
+
+    /// 9.3.25 and 9.3.26 - **the zero-cost promise, and the lock promise, together.**
+    ///
+    /// With a session registered and no watcher reaching its agent, the tick returns before
+    /// touching the session: no read, so no `screen_parsers` lock and no row allocation. And
+    /// the backend `Arc` is resolved exactly ONCE, at registration, so the tick path never
+    /// goes through `PtyManager` or the route registry however many times it runs.
+    #[tokio::test]
+    async fn an_unconfigured_app_touches_no_session_and_resolves_no_backend_per_tick() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+
+        harness.ticks(10).await;
+
+        assert_eq!(harness.backend.reads.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            harness.backends.resolutions.load(Ordering::Relaxed),
+            1,
+            "registration resolves the backend; no tick may resolve it again"
+        );
+
+        // ...and with a watcher configured, the reads happen and the resolution count is still 1.
+        harness.configure("a1", vec![state_watcher("w", "never")]);
+        harness.ticks(5).await;
+        assert_eq!(harness.backend.reads.load(Ordering::Relaxed), 5);
+        assert_eq!(harness.backends.resolutions.load(Ordering::Relaxed), 1);
+    }
+
+    /// 9.3.27 - a state reading is idempotent. Five ticks of a screen that keeps being
+    /// repainted with the same content produce ONE event.
+    #[tokio::test]
+    async fn a_state_watcher_emits_once_for_a_value_that_does_not_change() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("ctx", r"Context (\d+)%")]);
+        harness.backend.paint(id, &["idle", "Context 42%"]);
+
+        harness.ticks(5).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].captures, vec![Some("42".to_string())]);
+        assert_eq!(emitted[0].row, "Context 42%");
+        assert_eq!(emitted[0].mode, WatcherMode::State);
+        assert_eq!(emitted[0].seq, 1);
+    }
+
+    /// 9.3.28 - ...and it emits again the moment the reading changes.
+    #[tokio::test]
+    async fn a_state_watcher_emits_again_when_the_matched_row_changes() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("ctx", r"Context (\d+)%")]);
+        harness.backend.paint(id, &["Context 42%"]);
+        harness.backend.paint(id, &["Context 42%"]);
+        harness.backend.paint(id, &["Context 39%"]);
+
+        harness.ticks(3).await;
+
+        let captures: Vec<_> = harness
+            .emitted()
+            .iter()
+            .map(|m| m.captures[0].clone().unwrap())
+            .collect();
+        assert_eq!(captures, vec!["42", "39"]);
+    }
+
+    /// 9.3.29 - a state watcher that stops matching emits NOTHING. "The prompt disappeared" is
+    /// not a log entry, and clearing the gate is exactly what lets an identical re-appearance
+    /// emit again.
+    #[tokio::test]
+    async fn a_state_watcher_that_stops_matching_emits_nothing_and_re_emits_on_reappearance() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("perm", "Permission required")]);
+        harness.backend.paint(id, &["Permission required"]);
+        harness.backend.paint(id, &["gone"]);
+        harness.backend.paint(id, &["Permission required"]);
+
+        harness.ticks(3).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 2, "appearance, silence, appearance");
+        assert_eq!(emitted[0].row, "Permission required");
+        assert_eq!(emitted[1].row, "Permission required");
+        assert_ne!(emitted[0].seq, emitted[1].seq);
+    }
+
+    /// 9.3.30 - **the case a `(captures, row)` gate cannot express, and the strongest argument
+    /// for this engine existing.** A second permission prompt appears while the first is still
+    /// on screen: the lowest match reads the same text, so only the generation can tell them
+    /// apart.
+    #[tokio::test]
+    async fn a_second_identical_match_appearing_above_an_existing_one_emits() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("perm", "Permission required")]);
+        harness.backend.paint(id, &["Permission required", "idle"]);
+        harness
+            .backend
+            .paint(id, &["Permission required", "Permission required"]);
+
+        harness.ticks(2).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 2);
+        assert_eq!(
+            emitted[0].row, emitted[1].row,
+            "identical text: a (captures, row) gate would have suppressed the second"
+        );
+    }
+
+    /// 9.3.31 - a scroll that leaves the match count unchanged emits nothing. This is what
+    /// "incrementing the generation only on a RISE" buys: the count of a persistent condition
+    /// does not change as the screen moves under it.
+    #[tokio::test]
+    async fn a_scroll_that_leaves_the_match_count_unchanged_emits_nothing() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("perm", "Permission required")]);
+        harness
+            .backend
+            .paint(id, &["Permission required", "a", "b"]);
+        harness
+            .backend
+            .paint(id, &["a", "Permission required", "b"]);
+        harness
+            .backend
+            .paint(id, &["a", "b", "Permission required"]);
+
+        harness.ticks(3).await;
+
+        assert_eq!(harness.emitted().len(), 1);
+    }
+
+    /// 9.3.32 - the LOWEST match wins, mirroring `rows::extract`, because a statusline always
+    /// sits below the transcript.
+    #[tokio::test]
+    async fn the_lowest_matching_logical_row_wins() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("ctx", r"Context (\d+)%")]);
+        harness
+            .backend
+            .paint(id, &["Context 99%", "middle", "Context 42%"]);
+
+        harness.ticks(1).await;
+
+        assert_eq!(harness.emitted()[0].captures[0].as_deref(), Some("42"));
+    }
+
+    /// 9.3.33 - a pattern that does not compile is compiled ONCE and logged once, however many
+    /// ticks pass. The compile site is the log site, so the compile count IS the log count.
+    #[tokio::test]
+    async fn an_uncompilable_pattern_is_compiled_once_across_ten_ticks() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("broken", r"Read \((.+")]);
+        harness.backend.paint(id, &["anything"]);
+
+        harness.ticks(10).await;
+
+        assert_eq!(harness.engine.compile_count(), 1);
+        assert!(harness.emitted().is_empty());
+    }
+
+    /// A watcher whose pattern is edited recompiles, and its gate starts again - so the first
+    /// match under the new pattern is an event even if the old one had already emitted.
+    #[tokio::test]
+    async fn editing_a_pattern_recompiles_and_clears_that_watchers_gate() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "alpha")]);
+        harness.backend.paint(id, &["alpha beta"]);
+        harness.ticks(3).await;
+        assert_eq!(harness.engine.compile_count(), 1);
+        assert_eq!(harness.emitted().len(), 1);
+
+        harness.configure("a1", vec![state_watcher("w", "beta")]);
+        harness.ticks(3).await;
+
+        assert_eq!(harness.engine.compile_count(), 2);
+        assert_eq!(
+            harness.emitted().len(),
+            2,
+            "the row is the same, but the question is not: the gate must not suppress it"
+        );
+    }
+
+    /// 9.3.34 (first half) - `Gone` retires the session on that tick, with no waiting for the
+    /// 5 s probe.
+    #[tokio::test]
+    async fn a_session_reported_gone_is_retired_on_that_tick() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "x")]);
+        harness.backend.push(id, Painted::Gone);
+        harness.backend.push(id, Painted::Gone);
+
+        harness.ticks(1).await;
+
+        assert!(!harness.engine.is_session_registered(id));
+    }
+
+    /// `Missing` says NOTHING about the session, so it is kept and sampled again. Retiring on
+    /// it would strand a live session whose parser was momentarily unreadable.
+    #[tokio::test]
+    async fn a_session_reported_missing_is_kept() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "x")]);
+        harness.backend.push(id, Painted::Missing);
+        harness.backend.push(id, Painted::Missing);
+
+        harness.ticks(1).await;
+
+        assert!(harness.engine.is_session_registered(id));
+    }
+
+    /// 9.3.34 (second half) and 9.3.35 - liveness is probed on tick 25 and on no tick before
+    /// it, which is once per 5 s per session: exactly the rate the 5 s scraper probes at, and
+    /// the reason this engine is cheaper than the one it sits beside rather than 25x dearer.
+    #[tokio::test]
+    async fn liveness_is_probed_on_the_twenty_fifth_tick_and_retires_a_dead_session() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "never")]);
+        harness.backend.paint(id, &["idle"]);
+        harness
+            .backends
+            .liveness
+            .lock()
+            .unwrap()
+            .insert(id, ContextSessionLiveness::SessionOver);
+
+        harness.ticks(24).await;
+        assert_eq!(harness.backends.liveness_calls.load(Ordering::Relaxed), 0);
+        assert!(harness.engine.is_session_registered(id));
+
+        harness.ticks(1).await;
+        assert_eq!(harness.backends.liveness_calls.load(Ordering::Relaxed), 1);
+        assert!(!harness.engine.is_session_registered(id));
+    }
+
+    /// 9.3.37 - one event per `(session, tick)`, carrying every match that tick produced. The
+    /// coalescing is what keeps the IPC load off the per-tick caps.
+    #[tokio::test]
+    async fn one_event_carries_all_of_a_ticks_matches_for_a_session() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure(
+            "a1",
+            vec![
+                state_watcher("perm", "Permission required"),
+                state_watcher("ctx", r"Context (\d+)%"),
+            ],
+        );
+        harness
+            .backend
+            .paint(id, &["Permission required", "Context 42%"]);
+
+        harness.ticks(1).await;
+
+        assert_eq!(harness.batches(), 1);
+        let batch = &harness.sink.0.lock().unwrap()[0];
+        assert_eq!(batch.session_id, id.to_string());
+        assert_eq!(batch.matches.len(), 2);
+        assert_eq!(batch.matches[0].seq, 1);
+        assert_eq!(batch.matches[1].seq, 2);
+    }
+
+    /// An `Unchanged` read evaluates nothing: the screen the caller last saw cannot have
+    /// started or stopped matching.
+    #[tokio::test]
+    async fn an_unchanged_frame_produces_no_event() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "match me")]);
+        harness.backend.push(id, Painted::Unchanged);
+        harness.backend.push(id, Painted::Unchanged);
+
+        harness.ticks(2).await;
+
+        assert!(harness.emitted().is_empty());
+    }
+
+    /// A session whose agent no watcher reaches is skipped, even while another session on a
+    /// configured agent is being sampled.
+    #[tokio::test]
+    async fn a_session_whose_agent_has_no_watcher_is_skipped() {
+        let harness = Harness::new();
+        let watched = Uuid::new_v4();
+        let ignored = Uuid::new_v4();
+        harness.engine.register_session(watched, "a1".to_string());
+        harness.engine.register_session(ignored, "a2".to_string());
+        harness.configure("a1", vec![state_watcher("w", "hit")]);
+        harness.backend.paint(watched, &["hit"]);
+        harness.backend.paint(ignored, &["hit"]);
+
+        harness.ticks(1).await;
+
+        let emitted = harness.emitted();
+        assert_eq!(emitted.len(), 1);
+        assert_eq!(emitted[0].session_id, watched.to_string());
+    }
+
+    /// A wrapped path is matched as ONE logical row, which is the whole reason evaluation is
+    /// not on physical rows.
+    #[tokio::test]
+    async fn a_state_watcher_matches_across_a_wrapped_row() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("read", r"Read \((.+)\)")]);
+        harness.backend.push(
+            id,
+            Painted::Frame(
+                vec![
+                    "idle".to_string(),
+                    "Read (C:/repo/very/long/pa".to_string(),
+                    "th/to/main.rs)".to_string(),
+                ],
+                vec![false, true, false],
+            ),
+        );
+
+        harness.ticks(1).await;
+
+        assert_eq!(
+            harness.emitted()[0].captures[0].as_deref(),
+            Some("C:/repo/very/long/path/to/main.rs")
+        );
+    }
+
+    /// 9.6.38 - a row past the byte cap is truncated on a char boundary and SAYS so, because
+    /// `row.length >= 256` cannot answer that question in TypeScript.
+    #[tokio::test]
+    async fn an_over_long_row_is_truncated_on_a_char_boundary_and_flagged() {
+        let harness = Harness::new();
+        let id = Uuid::new_v4();
+        harness.engine.register_session(id, "a1".to_string());
+        harness.configure("a1", vec![state_watcher("w", "start")]);
+        // 3-byte chars, so the cap lands mid-character unless the boundary is respected.
+        let long = format!("start{}", "\u{4e2d}".repeat(200));
+        harness.backend.paint(id, &[&long]);
+
+        harness.ticks(1).await;
+
+        let emitted = harness.emitted();
+        assert!(emitted[0].row_truncated);
+        assert!(emitted[0].row.len() <= MAX_ROW_BYTES);
+        assert!(long.starts_with(&emitted[0].row));
+    }
+
+    /// 9.3.24 - **a session with no agent is never registered**, so a plain shell costs this
+    /// engine nothing, ever: no entry, no read, no allocation.
+    ///
+    /// Asserted against the real registration site, which is one helper shared with the #1032
+    /// scraper, rather than against a re-implementation of its condition.
+    #[test]
+    fn a_session_with_no_agent_is_never_registered() {
+        let harness = Harness::new();
+        let app = tauri::test::mock_builder()
+            .manage(Arc::clone(&harness.engine))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build a mock app");
+
+        let shell = Uuid::new_v4();
+        crate::commands::session::register_session_samplers(app.handle(), shell, None);
+        assert!(!harness.engine.is_session_registered(shell));
+
+        let agent = Uuid::new_v4();
+        crate::commands::session::register_session_samplers(
+            app.handle(),
+            agent,
+            Some("a1".to_string()),
+        );
+        assert!(harness.engine.is_session_registered(agent));
+    }
+
+    /// 9.6.74 and 9.6.75 - **the Rust half of the TypeScript mirror.** The exact camelCase
+    /// JSON, field for field, with EVERY field present: no `skip_serializing_if` anywhere, so
+    /// absent can never become a third state beside null and the value.
+    #[test]
+    fn the_payload_serializes_to_the_exact_camel_case_contract() {
+        let batch = WatcherMatchBatch {
+            session_id: "11111111-2222-3333-4444-555555555555".to_string(),
+            matches: vec![WatcherMatchPayload {
+                session_id: "11111111-2222-3333-4444-555555555555".to_string(),
+                seq: 7,
+                watcher_id: "permission-prompt".to_string(),
+                mode: WatcherMode::Occurrence,
+                at: chrono::DateTime::parse_from_rfc3339("2026-07-30T22:31:05Z")
+                    .expect("fixed instant")
+                    .with_timezone(&chrono::Utc),
+                captures: vec![Some("C:/repo/main.rs".to_string()), None],
+                row: "Read (C:/repo/main.rs)".to_string(),
+                row_truncated: false,
+            }],
+        };
+
+        assert_eq!(
+            serde_json::to_value(&batch).expect("serializes"),
+            serde_json::json!({
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "matches": [{
+                    "sessionId": "11111111-2222-3333-4444-555555555555",
+                    "seq": 7,
+                    "watcherId": "permission-prompt",
+                    "mode": "occurrence",
+                    "at": "2026-07-30T22:31:05Z",
+                    "captures": ["C:/repo/main.rs", null],
+                    "row": "Read (C:/repo/main.rs)",
+                    "rowTruncated": false
+                }]
+            })
+        );
+    }
+
+    /// The empty cases are present too, and are not elided: `captures: []` is a pattern with
+    /// no groups, and the UI falls back to the raw row on it.
+    #[test]
+    fn an_empty_capture_list_and_a_false_flag_are_both_written() {
+        let payload = WatcherMatchPayload {
+            session_id: "s".to_string(),
+            seq: 1,
+            watcher_id: "w".to_string(),
+            mode: WatcherMode::State,
+            at: chrono::DateTime::parse_from_rfc3339("2026-07-30T00:00:00Z")
+                .expect("fixed instant")
+                .with_timezone(&chrono::Utc),
+            captures: Vec::new(),
+            row: "Permission required".to_string(),
+            row_truncated: false,
+        };
+
+        let json = serde_json::to_value(&payload).expect("serializes");
+        let object = json.as_object().expect("object");
+        assert_eq!(object.len(), 8, "every field, always: {json}");
+        assert_eq!(object["captures"], serde_json::json!([]));
+        assert_eq!(object["rowTruncated"], serde_json::json!(false));
+        assert_eq!(object["mode"], serde_json::json!("state"));
     }
 }
 

--- a/src-tauri/src/pty/watchers/mod.rs
+++ b/src-tauri/src/pty/watchers/mod.rs
@@ -36,6 +36,273 @@
 //! numbers are not comparable to either; `--release` does not build the test target in this
 //! tree, because `load_sessions_raw_from_dir_for_test` is `#[cfg(debug_assertions)]`.
 
+pub mod pattern;
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex};
+
+use crate::config::coding_agents_catalog::command_executable_basename;
+use crate::config::settings::{WatcherEntry, WatcherMode};
+
+pub use crate::config::settings::WatcherDedupe;
+
+/// How many watchers may run on one agent. Resolution takes the first 8 in `BTreeMap` key
+/// order, which is alphabetical over user-chosen ids, so adding a watcher named `aaa-test`
+/// really can displace the eighth. That is why the dropped ones are both logged and reported
+/// per row by `preview_watcher_reach`, instead of leaving the user with a log line.
+pub const WATCHERS_PER_AGENT_BUDGET: usize = 8;
+
+/// `dedupeWindowMs` is clamped to this on read.
+///
+/// Without it, a large window plus a `row` key would grow the key set to every distinct row
+/// seen in that window; the 256-key bound per `(watcher, session)` is the other half of the
+/// same defence.
+pub const MAX_DEDUPE_WINDOW_MS: u64 = 60_000;
+
+/// One enabled, well-formed watcher, ready for a tick.
+///
+/// Shared behind an `Arc` because the same watcher usually reaches many agents and its
+/// pattern string must not be cloned once per agent per tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedWatcher {
+    pub id: String,
+    pub mode: WatcherMode,
+    pub pattern: String,
+    pub dedupe: WatcherDedupe,
+    /// Already clamped to `MAX_DEDUPE_WINDOW_MS`.
+    pub dedupe_window_ms: u64,
+}
+
+/// What resolution needs to know about one configured agent: `settings.agents[i]`, reduced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatcherAgent {
+    pub id: String,
+    pub command: String,
+}
+
+/// The watchers that apply to one agent right now.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentResolution {
+    /// In `BTreeMap` key order, at most `WATCHERS_PER_AGENT_BUDGET`.
+    pub running: Vec<Arc<ResolvedWatcher>>,
+    /// The ids that reach this agent but fell outside the budget, in the same order.
+    pub over_budget: Vec<String>,
+}
+
+/// Something resolution wants to say, at most once per changed value.
+///
+/// Returned rather than logged, so the preview commands can run the exact same rule on every
+/// keystroke without writing anything to `app.log`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolutionNotice {
+    /// What the notice is ABOUT, kind-prefixed: a watcher id or an agent id. The log-once
+    /// map is keyed by this and holds one entry per subject, so it is bounded by the number
+    /// of configured watchers and agents. Keying by the message instead would let a user
+    /// typing in Settings accumulate one entry per keystroke, which is the mistake
+    /// `context_scrape`'s compile cache documents at `mod.rs:127-132`.
+    pub subject: String,
+    /// The value the message was derived from. A changed detail logs again; an unchanged one
+    /// stays silent however many ticks pass.
+    pub detail: String,
+    pub message: String,
+}
+
+/// Cross the configured agents with the configured watchers.
+///
+/// Pure: no logging, no locks, no I/O. Called every tick by the engine's pattern source and
+/// on every keystroke by `preview_watcher_reach`, and both get the same answer because there
+/// is only one rule.
+///
+/// An agent appears in the map only when at least one watcher reaches it, so "the map is
+/// empty" is exactly "there is nothing to do this tick" - which is what lets the tick return
+/// before touching any session.
+pub fn resolve_watchers(
+    agents: &[WatcherAgent],
+    watchers: &BTreeMap<String, WatcherEntry>,
+) -> (HashMap<String, AgentResolution>, Vec<ResolutionNotice>) {
+    let mut notices = Vec::new();
+    let mut usable: Vec<(Arc<ResolvedWatcher>, Option<Vec<String>>)> = Vec::new();
+
+    for (id, entry) in watchers {
+        let config = match entry {
+            WatcherEntry::Valid(config) => config,
+            WatcherEntry::Invalid(value) => {
+                let detail = value.to_string();
+                notices.push(ResolutionNotice {
+                    subject: format!("invalid:{id}"),
+                    message: format!(
+                        "[watchers] watcher '{id}' is not a valid watcher and is being skipped; \
+                         every other watcher and every other setting is unaffected: {detail}"
+                    ),
+                    detail,
+                });
+                continue;
+            }
+        };
+
+        // Disabled is a state the user chose, not a problem. It keeps its configuration and
+        // says nothing.
+        if !config.enabled {
+            continue;
+        }
+
+        // A selector that does not tokenize skips the WHOLE watcher. Never "reaches
+        // everything": a typo in one entry must not silently widen a pattern to every agent.
+        let selector = match &config.commands {
+            None => None,
+            Some(list) => {
+                let mut stems = Vec::with_capacity(list.len());
+                let mut broken: Option<String> = None;
+                for token in list {
+                    match command_executable_basename(token) {
+                        Some(stem) => stems.push(stem),
+                        None => {
+                            broken = Some(token.clone());
+                            break;
+                        }
+                    }
+                }
+                if let Some(token) = broken {
+                    let detail = list.join("\u{1f}");
+                    notices.push(ResolutionNotice {
+                        subject: format!("commands:{id}"),
+                        message: format!(
+                            "[watchers] watcher '{id}' is being skipped: its commands selector \
+                             entry '{token}' is not a command. A watcher with an unreadable \
+                             selector reaches nobody, never everybody"
+                        ),
+                        detail,
+                    });
+                    continue;
+                }
+                Some(stems)
+            }
+        };
+
+        let mut dedupe_window_ms = config.dedupe_window_ms;
+        if dedupe_window_ms > MAX_DEDUPE_WINDOW_MS {
+            notices.push(ResolutionNotice {
+                subject: format!("clamp:{id}"),
+                message: format!(
+                    "[watchers] watcher '{id}' asks for a {dedupe_window_ms} ms dedupe window; \
+                     clamping to {MAX_DEDUPE_WINDOW_MS} ms"
+                ),
+                detail: dedupe_window_ms.to_string(),
+            });
+            dedupe_window_ms = MAX_DEDUPE_WINDOW_MS;
+        }
+
+        usable.push((
+            Arc::new(ResolvedWatcher {
+                id: id.clone(),
+                mode: config.mode,
+                pattern: config.pattern.clone(),
+                dedupe: config.dedupe,
+                dedupe_window_ms,
+            }),
+            selector,
+        ));
+    }
+
+    let mut resolved: HashMap<String, AgentResolution> = HashMap::new();
+    if usable.is_empty() {
+        return (resolved, notices);
+    }
+
+    for agent in agents {
+        // An agent whose own command does not tokenize is reached by selectorless watchers
+        // and by no watcher with a selector: there is no stem to compare against, and
+        // guessing one would be inventing a match. `validate_agent_commands`
+        // (`settings.rs:1473-1475`) already rejects such a command on save.
+        let agent_stem = command_executable_basename(&agent.command);
+
+        let mut running = Vec::new();
+        let mut over_budget = Vec::new();
+        for (watcher, selector) in &usable {
+            let reaches = match selector {
+                None => true,
+                Some(stems) => agent_stem
+                    .as_ref()
+                    .is_some_and(|stem| stems.iter().any(|candidate| candidate == stem)),
+            };
+            if !reaches {
+                continue;
+            }
+            if running.len() < WATCHERS_PER_AGENT_BUDGET {
+                running.push(Arc::clone(watcher));
+            } else {
+                over_budget.push(watcher.id.clone());
+            }
+        }
+
+        if running.is_empty() {
+            continue;
+        }
+        if !over_budget.is_empty() {
+            let detail = over_budget.join(",");
+            notices.push(ResolutionNotice {
+                subject: format!("budget:{}", agent.id),
+                message: format!(
+                    "[watchers] agent '{}' is over the {WATCHERS_PER_AGENT_BUDGET}-watcher \
+                     budget; these are configured but not running on it: {detail}",
+                    agent.id
+                ),
+                detail,
+            });
+        }
+        resolved.insert(
+            agent.id.clone(),
+            AgentResolution {
+                running,
+                over_budget,
+            },
+        );
+    }
+
+    (resolved, notices)
+}
+
+/// Log-once bookkeeping for `ResolutionNotice`s, across ticks.
+///
+/// Resolution runs five times a second, so every one of these messages would otherwise be a
+/// five-per-second log line for as long as the configuration stays wrong. Keyed by subject
+/// and holding the last detail logged for it: an unchanged problem stays silent, a CHANGED
+/// one speaks again, and the map cannot grow past one entry per watcher and agent.
+#[derive(Default)]
+pub struct ResolutionLog {
+    last: Mutex<HashMap<String, String>>,
+}
+
+impl ResolutionLog {
+    /// Log the notices whose subject is new or whose detail changed. Returns how many lines
+    /// were actually written, so "logged once across N ticks" is something a test can assert
+    /// rather than something a reader has to trust.
+    pub fn publish(&self, notices: Vec<ResolutionNotice>) -> usize {
+        if notices.is_empty() {
+            return 0;
+        }
+        let mut written = 0;
+        let mut last = self.last.lock().unwrap_or_else(|e| e.into_inner());
+        for notice in notices {
+            let changed = last
+                .get(&notice.subject)
+                .is_none_or(|previous| previous != &notice.detail);
+            if changed {
+                log::warn!("{}", notice.message);
+                last.insert(notice.subject, notice.detail);
+                written += 1;
+            }
+        }
+        written
+    }
+
+    /// Number of subjects currently remembered. The bound this type exists to keep.
+    #[cfg(test)]
+    fn remembered(&self) -> usize {
+        self.last.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+}
+
 /// Identifies one frame of one session's screen mirror.
 ///
 /// **The size is part of the stamp on purpose.** `resize_screen_and_broadcast` reflows the
@@ -131,6 +398,261 @@ pub(crate) fn frame_from_screen_rows_read(
 }
 
 #[cfg(test)]
+mod resolution_tests {
+    use super::*;
+    use crate::config::settings::WatcherConfig;
+
+    fn agent(id: &str, command: &str) -> WatcherAgent {
+        WatcherAgent {
+            id: id.to_string(),
+            command: command.to_string(),
+        }
+    }
+
+    fn watcher(commands: Option<&[&str]>) -> WatcherEntry {
+        WatcherEntry::Valid(WatcherConfig {
+            enabled: true,
+            mode: WatcherMode::Occurrence,
+            pattern: "x".to_string(),
+            commands: commands.map(|list| list.iter().map(|s| s.to_string()).collect()),
+            dedupe: WatcherDedupe::Row,
+            dedupe_window_ms: 2000,
+            captured_against: None,
+        })
+    }
+
+    fn map(entries: Vec<(&str, WatcherEntry)>) -> BTreeMap<String, WatcherEntry> {
+        entries
+            .into_iter()
+            .map(|(id, entry)| (id.to_string(), entry))
+            .collect()
+    }
+
+    fn running_ids(resolved: &HashMap<String, AgentResolution>, agent_id: &str) -> Vec<String> {
+        resolved
+            .get(agent_id)
+            .map(|entry| entry.running.iter().map(|w| w.id.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    /// 9.2.10 - the configuration the issue says cannot be expressed today: one watcher, every
+    /// agent. And its exact opposite, which only exists because `commands` is an `Option`.
+    #[test]
+    fn commands_absent_reaches_every_agent_and_an_empty_list_reaches_none() {
+        let agents = [agent("a1", "claude"), agent("a2", "codex")];
+
+        let (all, _) = resolve_watchers(&agents, &map(vec![("w", watcher(None))]));
+        assert_eq!(running_ids(&all, "a1"), vec!["w"]);
+        assert_eq!(running_ids(&all, "a2"), vec!["w"]);
+
+        let (none, _) = resolve_watchers(&agents, &map(vec![("w", watcher(Some(&[])))]));
+        assert!(
+            none.is_empty(),
+            "`[]` is the opposite of absent and must reach nobody"
+        );
+    }
+
+    /// 9.2.11 and 9.2.12 - the stem rule, in full. EXACT equality on the executable stem,
+    /// never a prefix: the catalog rejects `starts_with` in writing because `pi` and `agent`
+    /// false-match under it (`coding_agents_catalog.rs:494-497`), and this is the rule that
+    /// must not be re-derived anywhere else, in Rust or in TypeScript.
+    #[test]
+    fn a_commands_selector_matches_the_executable_stem_exactly() {
+        let agents = [
+            agent("plain", "claude"),
+            agent("shouting", "CLAUDE.EXE"),
+            agent("full-path", r"C:\Users\x\claude-sandbox-runtime\claude.cmd"),
+            agent("pi", "pi --provider claude"),
+            agent("through-cmd", "cmd /c claude"),
+            agent("through-npx", "npx claude"),
+            agent("prefix", "claude-phi"),
+        ];
+
+        let (resolved, _) =
+            resolve_watchers(&agents, &map(vec![("w", watcher(Some(&["claude"])))]));
+        let mut reached: Vec<&String> = resolved.keys().collect();
+        reached.sort();
+        assert_eq!(reached, vec!["full-path", "plain", "shouting"]);
+    }
+
+    /// 9.2.13 - disabled is a state the user chose. It reaches nobody and keeps every byte of
+    /// its configuration, so re-enabling it is one flag and not a re-entry.
+    #[test]
+    fn a_disabled_watcher_reaches_nobody_and_keeps_its_configuration() {
+        let mut entry = watcher(None);
+        if let WatcherEntry::Valid(config) = &mut entry {
+            config.enabled = false;
+        }
+        let watchers = map(vec![("w", entry)]);
+
+        let (resolved, notices) = resolve_watchers(&[agent("a1", "claude")], &watchers);
+        assert!(resolved.is_empty());
+        assert!(
+            notices.is_empty(),
+            "disabled is not a problem and must not produce a log line"
+        );
+        assert_eq!(watchers["w"].valid().expect("still valid").pattern, "x");
+    }
+
+    /// 9.2.14 - a selector entry that is not a command skips the WHOLE watcher. The failure
+    /// direction matters: "reaches nobody" loses a detection, "reaches everybody" would run a
+    /// user's pattern on agents they never selected.
+    #[test]
+    fn a_selector_entry_that_does_not_tokenize_skips_the_whole_watcher() {
+        let agents = [agent("a1", "claude"), agent("a2", "codex")];
+        let watchers = map(vec![("w", watcher(Some(&["claude", ""])))]);
+
+        let (resolved, notices) = resolve_watchers(&agents, &watchers);
+        assert!(
+            resolved.is_empty(),
+            "not even the readable half of the selector may reach anything"
+        );
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0].subject, "commands:w");
+
+        // ...and the notice is written once, however many ticks resolve the same thing.
+        let log = ResolutionLog::default();
+        assert_eq!(log.publish(notices.clone()), 1);
+        for _ in 0..10 {
+            assert_eq!(log.publish(notices.clone()), 0);
+        }
+        assert_eq!(log.remembered(), 1, "one subject, not one per tick");
+    }
+
+    /// 9.2.15 - an agent whose own command does not tokenize has no stem to compare against.
+    /// Selectorless watchers still reach it; no watcher WITH a selector does, because the
+    /// alternative would be inventing a stem and matching on the guess.
+    #[test]
+    fn an_agent_whose_command_does_not_tokenize_is_reached_only_without_a_selector() {
+        let agents = [agent("broken", "\"unterminated")];
+        let watchers = map(vec![
+            ("selectorless", watcher(None)),
+            ("selected", watcher(Some(&["claude"]))),
+        ]);
+
+        let (resolved, _) = resolve_watchers(&agents, &watchers);
+        assert_eq!(running_ids(&resolved, "broken"), vec!["selectorless"]);
+    }
+
+    /// 9.2.16 - the budget, and the fact that it resolves by alphabetical id order. Declared
+    /// debt (10.8), surfaced rather than fixed: the dropped ids come back in `over_budget` so
+    /// Settings can show "not running on <agent> (budget)" per row.
+    #[test]
+    fn only_the_first_eight_watchers_in_key_order_run_on_one_agent() {
+        let entries: Vec<(String, WatcherEntry)> = (1..=12)
+            .map(|i| (format!("w{i:02}"), watcher(None)))
+            .collect();
+        let watchers: BTreeMap<String, WatcherEntry> = entries.into_iter().collect();
+
+        let (resolved, notices) = resolve_watchers(&[agent("a1", "claude")], &watchers);
+        let entry = resolved.get("a1").expect("reached");
+        assert_eq!(
+            entry
+                .running
+                .iter()
+                .map(|w| w.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["w01", "w02", "w03", "w04", "w05", "w06", "w07", "w08"]
+        );
+        assert_eq!(entry.over_budget, vec!["w09", "w10", "w11", "w12"]);
+
+        assert_eq!(notices.len(), 1, "the four dropped ids are ONE line");
+        assert!(notices[0].message.contains("w09,w10,w11,w12"));
+        let log = ResolutionLog::default();
+        assert_eq!(log.publish(notices.clone()), 1);
+        assert_eq!(log.publish(notices), 0);
+    }
+
+    /// 9.2.20 - the clamp, and its one log line. Without it a large window plus a `row` key
+    /// grows the dedupe key set to every distinct row seen inside the window.
+    #[test]
+    fn a_dedupe_window_over_the_maximum_is_clamped_and_logged_once() {
+        let mut entry = watcher(None);
+        if let WatcherEntry::Valid(config) = &mut entry {
+            config.dedupe_window_ms = 3_600_000;
+        }
+
+        let (resolved, notices) =
+            resolve_watchers(&[agent("a1", "claude")], &map(vec![("w", entry)]));
+        assert_eq!(
+            resolved["a1"].running[0].dedupe_window_ms,
+            MAX_DEDUPE_WINDOW_MS
+        );
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0].subject, "clamp:w");
+
+        let log = ResolutionLog::default();
+        assert_eq!(log.publish(notices.clone()), 1);
+        assert_eq!(log.publish(notices), 0);
+    }
+
+    /// An entry that did not deserialize is skipped and logged once, and every OTHER watcher
+    /// still resolves. The settings half of this is pinned in `settings.rs`; this is the
+    /// resolution half.
+    #[test]
+    fn an_invalid_entry_is_skipped_and_logged_once_while_the_others_resolve() {
+        let watchers = map(vec![
+            (
+                "bad",
+                WatcherEntry::Invalid(serde_json::json!({ "mode": "State" })),
+            ),
+            ("good", watcher(None)),
+        ]);
+
+        let (resolved, notices) = resolve_watchers(&[agent("a1", "claude")], &watchers);
+        assert_eq!(running_ids(&resolved, "a1"), vec!["good"]);
+        assert_eq!(notices.len(), 1);
+        assert_eq!(notices[0].subject, "invalid:bad");
+
+        let log = ResolutionLog::default();
+        assert_eq!(log.publish(notices.clone()), 1);
+        assert_eq!(log.publish(notices), 0);
+    }
+
+    /// The log-once map is keyed by SUBJECT, so a user typing a selector in Settings cannot
+    /// accumulate one entry per keystroke - and a CHANGED value still speaks again, because a
+    /// second mistake is not the first one.
+    #[test]
+    fn the_log_once_map_holds_one_entry_per_subject_and_speaks_again_on_a_change() {
+        let log = ResolutionLog::default();
+        for attempt in 0..50 {
+            let notice = ResolutionNotice {
+                subject: "commands:w".to_string(),
+                detail: format!("half-typed-{attempt}"),
+                message: "…".to_string(),
+            };
+            assert_eq!(log.publish(vec![notice]), 1, "a changed value speaks again");
+        }
+        assert_eq!(log.remembered(), 1);
+    }
+
+    /// Two watchers reaching the same agent both run: there is no "most specific wins" rule,
+    /// because it would silently discard a pattern the user configured.
+    #[test]
+    fn two_watchers_reaching_the_same_agent_both_run() {
+        let watchers = map(vec![
+            ("a", watcher(Some(&["claude"]))),
+            ("b", watcher(None)),
+        ]);
+
+        let (resolved, _) = resolve_watchers(&[agent("a1", "claude")], &watchers);
+        assert_eq!(running_ids(&resolved, "a1"), vec!["a", "b"]);
+    }
+
+    /// A stem no agent has is not an error, it just reaches nobody. Settings shows
+    /// "reaches 0 agents" so the typo is visible where it was made.
+    #[test]
+    fn a_stem_no_agent_has_reaches_nobody_and_is_not_an_error() {
+        let (resolved, notices) = resolve_watchers(
+            &[agent("a1", "claude")],
+            &map(vec![("w", watcher(Some(&["gemni"])))]),
+        );
+        assert!(resolved.is_empty());
+        assert!(notices.is_empty());
+    }
+}
+
+#[cfg(test)]
 mod read_seam_tests {
     use super::*;
     use crate::pty::output::{PtyOutputTarget, SessionIoFanout};
@@ -153,7 +675,12 @@ mod read_seam_tests {
     }
 
     fn feed(fanout: &SessionIoFanout, id: Uuid, chunk: &[u8]) {
-        fanout.handle_output(&PtyOutputTarget::noop(), id, &id.to_string(), chunk.to_vec());
+        fanout.handle_output(
+            &PtyOutputTarget::noop(),
+            id,
+            &id.to_string(),
+            chunk.to_vec(),
+        );
     }
 
     /// #1171, section 7.3 - the three numbers recorded in this module's doc comment.
@@ -179,8 +706,11 @@ mod read_seam_tests {
             feed(
                 &fanout,
                 id,
-                format!("\x1b[{};1Hrow {row} of a coding agent's screen, wide enough to be real\r\n", row + 1)
-                    .as_bytes(),
+                format!(
+                    "\x1b[{};1Hrow {row} of a coding agent's screen, wide enough to be real\r\n",
+                    row + 1
+                )
+                .as_bytes(),
             );
         }
 

--- a/src-tauri/src/pty/watchers/pattern.rs
+++ b/src-tauri/src/pty/watchers/pattern.rs
@@ -1,0 +1,116 @@
+//! #1171 - compiling a user-configured watcher pattern.
+//!
+//! A separate compiler from `context_scrape/pattern.rs` and NOT a reuse of it, for exactly
+//! one reason: that one rejects any pattern without capture group 1 (`pattern.rs:44-48`,
+//! pinned by its own test at `:68-75`), because group 1 IS the context percentage there. A
+//! watcher pattern legitimately has zero groups - "did this appear at all" is a complete
+//! question - so the same rule would reject the simplest useful watcher.
+//!
+//! Everything else is identical, including the reasoning.
+
+use regex::{Regex, RegexBuilder};
+
+/// A compiled watcher pattern, kept with the source string it came from so the engine can
+/// tell a changed pattern from an unchanged one without recompiling to find out.
+#[derive(Debug)]
+pub struct WatcherPattern {
+    regex: Regex,
+    source: String,
+}
+
+impl WatcherPattern {
+    pub fn regex(&self) -> &Regex {
+        &self.regex
+    }
+
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+/// `regex` 1.x has no backtracking and is linear-time by construction, so a hostile pattern
+/// cannot burn CPU here and no matching timeout is needed - there is nothing to time out. It
+/// can still ask for an enormous compiled program, so the size limit is the bound that
+/// matters: past it, compilation FAILS rather than allocating.
+const SIZE_LIMIT_BYTES: usize = 1024 * 1024;
+
+/// Compile a user-supplied pattern, or say why it cannot be one.
+///
+/// The source is handed over VERBATIM by every caller, never trimmed: leading spaces are
+/// anchors, and the pattern is the only defence this feature has, so editing it can only
+/// weaken it (`lib.rs:589-601`).
+pub fn compile(source: &str) -> Result<WatcherPattern, String> {
+    let regex = RegexBuilder::new(source)
+        .size_limit(SIZE_LIMIT_BYTES)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    Ok(WatcherPattern {
+        regex,
+        source: source.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 9.2.21 - **the difference from `context_scrape::pattern::compile`.** "Did this string
+    /// appear" is a complete watcher, and it has no capture group.
+    #[test]
+    fn a_pattern_with_zero_capture_groups_compiles() {
+        let source = r"Permission required";
+        let pattern = compile(source).expect("zero groups must compile");
+        assert_eq!(pattern.source(), source);
+        assert!(pattern
+            .regex()
+            .is_match("  Permission required to run bash"));
+        assert_eq!(
+            pattern.regex().captures_len(),
+            1,
+            "group 0 only, which is precisely what the context compiler rejects"
+        );
+    }
+
+    #[test]
+    fn a_pattern_with_capture_groups_still_compiles_and_keeps_its_source() {
+        let source = r"Read \((.+)\)";
+        let pattern = compile(source).expect("compiles");
+        let captures = pattern
+            .regex()
+            .captures("  Read (C:/repo/src/main.rs)")
+            .expect("matches");
+        assert_eq!(&captures[1], "C:/repo/src/main.rs");
+    }
+
+    #[test]
+    fn an_uncompilable_pattern_is_rejected_rather_than_panicking() {
+        assert!(compile(r"Read \((.+").is_err());
+    }
+
+    /// 9.2.22 - the bound that actually matters. Nested bounded repeats are the cheap way to
+    /// ask for an enormous program from a short pattern; without the limit this is an
+    /// allocation, not an error.
+    #[test]
+    fn a_pattern_over_the_size_limit_fails_to_compile_rather_than_allocating() {
+        let hostile = format!("({})", r"(a{1000}){1000}");
+        let err = compile(&hostile).expect_err("must be rejected");
+        assert!(
+            err.to_lowercase().contains("size"),
+            "expected the size limit to be what refuses it, got: {err}"
+        );
+    }
+
+    /// 9.2.23 - the source is compiled verbatim. Leading spaces are an anchor, so trimming
+    /// would make a pattern match rows it was written to exclude.
+    #[test]
+    fn whitespace_is_part_of_the_pattern_and_is_never_trimmed() {
+        let pattern = compile("  Context ").expect("compiles");
+        assert_eq!(pattern.source(), "  Context ");
+        assert!(pattern.regex().is_match("  Context left"));
+        assert!(
+            !pattern.regex().is_match("Context left"),
+            "the leading spaces ARE the column anchor; trimming would fail this open"
+        );
+    }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import GuideApp from "./guide/App";
 import BrowserApp from "./browser/App";
 import SpecBoardApp from "./spec-board/App";
 import ResourceMonitorApp from "./resource-monitor/App";
+import WatchersApp from "./watchers/App";
 import ScreenshotOverlayApp from "./screenshot-overlay/App";
 import MainApp from "./main/App";
 import { initAutomationBridge } from "./shared/automation-bridge";
@@ -43,6 +44,11 @@ if (!isTauri) {
   render(() => <GuideApp />, root);
 } else if (windowType === "resource-monitor") {
   render(() => <ResourceMonitorApp />, root);
+} else if (windowType === "watchers") {
+  // #1171 - the query parameter is only read here, on the window's first creation. The
+  // window is a singleton, so every later open focuses it and re-scopes it through the
+  // `watchers_scope_request` event instead.
+  render(() => <WatchersApp initialSessionId={params.get("sessionId") || undefined} />, root);
 } else if (windowType === "screenshot-overlay") {
   document.documentElement.setAttribute("data-window", "screenshot-overlay");
   render(() => <ScreenshotOverlayApp />, root);

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -75,6 +75,10 @@ import type {
   ApiClientMintRequest,
   ApiClientMintResponse,
   SessionSelection,
+  WatcherActivitySnapshot,
+  WatcherMatchBatch,
+  WatcherPatternPreview,
+  WatcherReachEntry,
 } from "./types";
 import { decodeSessionSelection } from "./session-selection";
 
@@ -239,6 +243,36 @@ export const PtyAPI = {
 
   getSessionContext: (sessionId: string) =>
     transport.invoke<number | null>("get_session_context", { sessionId }),
+
+  /** #1171 - the session's watcher activity ring plus its loss and warm-up signals.
+   *  A session with no buffer answers with an empty snapshot, never null and never an
+   *  error, so the window's states are read from values and not from nullability. */
+  getWatcherActivity: (sessionId: string, limit?: number) =>
+    transport.invoke<WatcherActivitySnapshot>("get_watcher_activity", {
+      sessionId,
+      limit: limit ?? null,
+    }),
+
+  /** #1171 - compile a candidate pattern and, with a session, run it against its live rows.
+   *  Omitting `sessionId` compiles only, which is the common case: writing a regex in
+   *  Settings with no agent session running. A pattern that does not compile comes back as
+   *  `compiles: false` with the message, not as a rejected call. */
+  previewWatcherPattern: (pattern: string, sessionId?: string) =>
+    transport.invoke<WatcherPatternPreview>("preview_watcher_pattern", {
+      sessionId: sessionId ?? null,
+      pattern,
+    }),
+
+  /** #1171 - which agents a candidate selector reaches, and which of them it is out of
+   *  budget for. Exists so the Settings UI never reimplements stem normalization: the one
+   *  stem rule lives in Rust and the frontend's `starts_with` rule must not be ported. */
+  previewWatcherReach: (watcherId: string, commands?: string[] | null) =>
+    transport.invoke<WatcherReachEntry[]>("preview_watcher_reach", {
+      watcherId,
+      // `null` and an absent selector both mean "every agent"; `[]` means "none". The
+      // three stay distinct all the way to Rust's `Option<Vec<String>>`.
+      commands: commands ?? null,
+    }),
 
   subscribe: (sessionId: string) =>
     transport.invoke<{ rows: number; cols: number } | null>("subscribe_session", { sessionId }),
@@ -484,6 +518,18 @@ export const WindowAPI = {
 
   dockResourceMonitor: () =>
     transport.invoke<void>("dock_resource_monitor_window"),
+
+  /** #1171 - open the watcher activity window, or focus it and re-scope it to this session.
+   *  Tauri-only: the web client has no such window and this command has no no-op arm there,
+   *  so callers gate on `isTauri`. */
+  openWatchers: (sessionId: string) =>
+    transport.invoke<void>("open_watchers_window", { sessionId }),
+
+  /** #1171 - persist the watcher window's geometry through a dedicated one-field command
+   *  rather than `initWindowGeometry`, whose read-modify-write of the whole AppSettings
+   *  races the Settings save that edits the watcher map. */
+  setWatchersGeometry: (geometry: WindowGeometry) =>
+    transport.invoke<void>("set_watchers_geometry", { geometry }),
 };
 
 export const ScreenshotAPI = {
@@ -669,6 +715,31 @@ export function onSessionContext(
   callback: (data: SessionContextPayload) => void
 ): Promise<UnlistenFn> {
   return transport.listen<SessionContextPayload>("session_context", callback);
+}
+
+/**
+ * #1171 - one tick's watcher matches for one session.
+ *
+ * Delivery is directed at the `watchers` window label and coalesced into one batch per
+ * `(session, tick)`, and nothing is emitted at all while that window does not exist. The
+ * ring still records, so opening the window later shows the history.
+ */
+export function onWatcherMatches(
+  callback: (data: WatcherMatchBatch) => void
+): Promise<UnlistenFn> {
+  return transport.listen<WatcherMatchBatch>("watcher_matches", callback);
+}
+
+/**
+ * #1171 - re-scope an already-open watcher window.
+ *
+ * The window is a singleton, so its `?sessionId=` query parameter is only read on first
+ * creation; every later open focuses the existing window and arrives through here instead.
+ */
+export function onWatchersScopeRequest(
+  callback: (data: { sessionId: string }) => void
+): Promise<UnlistenFn> {
+  return transport.listen<{ sessionId: string }>("watchers_scope_request", callback);
 }
 
 export function onTelegramBridgeAttached(

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -76,9 +76,11 @@ import type {
   ApiClientMintResponse,
   SessionSelection,
   WatcherActivitySnapshot,
+  WatcherAgentDraftEntry,
+  WatcherDraftEntry,
   WatcherMatchBatch,
   WatcherPatternPreview,
-  WatcherReachEntry,
+  WatcherReachRow,
 } from "./types";
 import { decodeSessionSelection } from "./session-selection";
 
@@ -263,16 +265,29 @@ export const PtyAPI = {
       pattern,
     }),
 
-  /** #1171 - which agents a candidate selector reaches, and which of them it is out of
-   *  budget for. Exists so the Settings UI never reimplements stem normalization: the one
-   *  stem rule lives in Rust and the frontend's `starts_with` rule must not be ported. */
-  previewWatcherReach: (watcherId: string, commands?: string[] | null) =>
-    transport.invoke<WatcherReachEntry[]>("preview_watcher_reach", {
-      watcherId,
-      // `null` and an absent selector both mean "every agent"; `[]` means "none". The
-      // three stay distinct all the way to Rust's `Option<Vec<String>>`.
-      commands: commands ?? null,
-    }),
+  /**
+   * #1171 - resolve the WHOLE Settings draft, watchers and agents, and answer per row which
+   * agents its selector reaches and which of those it holds a slot on.
+   *
+   * Both halves travel because both are properties of the set, not of one row. Whether a
+   * watcher is inside an agent's 8 slots depends on every other enabled row and on where
+   * their ids fall in key order; and the modal edits agents and watchers in one store that
+   * one Save writes together, so resolving against the saved agent list would answer about a
+   * state the user has already left. A row-level call could only answer by inventing the rest
+   * of the set, and with an empty saved map nine rows added before Save would all report that
+   * they run while only eight do -- a positive claim about a watcher that will not run.
+   *
+   * Neither the stem rule nor the `BTreeMap` key order nor the number 8 is written a second
+   * time here: they stay in Rust, and the frontend's `starts_with` rule must not be ported.
+   *
+   * `null` and an absent selector both mean "every agent"; `[]` means "none". The three stay
+   * distinct all the way to Rust's `Option<Vec<String>>`.
+   */
+  previewWatcherReach: (
+    watchers: WatcherDraftEntry[],
+    agents: WatcherAgentDraftEntry[]
+  ) =>
+    transport.invoke<WatcherReachRow[]>("preview_watcher_reach", { watchers, agents }),
 
   subscribe: (sessionId: string) =>
     transport.invoke<{ rows: number; cols: number } | null>("subscribe_session", { sessionId }),
@@ -524,6 +539,20 @@ export const WindowAPI = {
    *  so callers gate on `isTauri`. */
   openWatchers: (sessionId: string) =>
     transport.invoke<void>("open_watchers_window", { sessionId }),
+
+  /**
+   * #1171 - the durable half of the scope handover: what `open_watchers_window` last asked
+   * for, whether or not a listener existed at the time.
+   *
+   * The window label exists the moment the builder returns, while the JavaScript listener
+   * exists only after the bundle loads, Solid mounts and the subscription completes a round
+   * trip. Tauri queues nothing for a listener that does not exist yet and the emit returns
+   * `Ok` either way, so a second open during the load would drop the user's order in silence.
+   * The window therefore subscribes first and then pulls this, exactly as it does for
+   * matches. `null` means nothing has been requested yet.
+   */
+  getWatchersScope: () =>
+    transport.invoke<string | null>("get_watchers_scope"),
 
   /** #1171 - persist the watcher window's geometry through a dedicated one-field command
    *  rather than `initWindowGeometry`, whose read-modify-write of the whole AppSettings

--- a/src/shared/time-format.test.ts
+++ b/src/shared/time-format.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatClockTime } from "./time-format";
+
+/**
+ * #1171 test 76: `at` parses with `new Date(value)` and the clock is zero-padded 24-hour
+ * `HH:MM:SS`, not the viewer's locale.
+ */
+describe("formatClockTime (#1171)", () => {
+  it("zero-pads to a fixed-width 24-hour clock", () => {
+    // Built from local parts so the assertion does not depend on the runner's timezone;
+    // what is being pinned is the FORMAT, not the conversion.
+    const morning = new Date(2026, 6, 30, 9, 5, 4);
+    expect(formatClockTime(morning.toISOString())).toBe("09:05:04");
+  });
+
+  it("uses 24-hour and never AM/PM", () => {
+    const afternoon = new Date(2026, 6, 30, 14, 31, 5);
+    expect(formatClockTime(afternoon.toISOString())).toBe("14:31:05");
+    expect(formatClockTime(afternoon.toISOString())).not.toMatch(/[AP]M/i);
+  });
+
+  it("keeps every row the same width, which is what the column needs", () => {
+    const values = [
+      new Date(2026, 0, 1, 0, 0, 0),
+      new Date(2026, 0, 1, 23, 59, 59),
+      new Date(2026, 0, 1, 7, 8, 9),
+    ].map((d) => formatClockTime(d.toISOString()));
+    expect(new Set(values.map((v) => v.length))).toEqual(new Set([8]));
+  });
+
+  it("accepts the RFC3339 the backend actually sends", () => {
+    expect(formatClockTime("2026-07-30T22:31:05Z")).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  it("degrades to a placeholder of the same width rather than throwing", () => {
+    expect(formatClockTime(null)).toBe("--:--:--");
+    expect(formatClockTime(undefined)).toBe("--:--:--");
+    expect(formatClockTime("")).toBe("--:--:--");
+    expect(formatClockTime("not a date")).toBe("--:--:--");
+  });
+});

--- a/src/shared/time-format.ts
+++ b/src/shared/time-format.ts
@@ -1,0 +1,18 @@
+/**
+ * #1171 - a zero-padded 24-hour clock, independent of locale.
+ *
+ * The Resource Monitor's own formatter (`resource-monitor/App.tsx:62-71`) could not be
+ * reused for two reasons: it is a module-local `const`, not exported, and it returns
+ * `toLocaleTimeString(...)`, which is `02:31:05 PM` under en-US. The watcher table needs a
+ * fixed-width column whose rows line up, so the format is pinned here instead of delegated
+ * to the viewer's locale. The Resource Monitor is deliberately left on its own formatter.
+ */
+export function formatClockTime(value: string | null | undefined): string {
+  if (!value) return "--:--:--";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "--:--:--";
+  const hours = String(parsed.getHours()).padStart(2, "0");
+  const minutes = String(parsed.getMinutes()).padStart(2, "0");
+  const seconds = String(parsed.getSeconds()).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -124,6 +124,138 @@ export interface SessionContextPayload {
   percent: number | null;
 }
 
+/** #1171 - what a watcher match means. Mirrors `WatcherMode` (`config/settings.rs`). */
+export type WatcherMode = "state" | "occurrence";
+
+/** #1171 - what makes two `occurrence` matches the same one inside the dedupe window. */
+export type WatcherDedupe = "row" | "capture" | "none";
+
+/**
+ * #1171 - one watcher activation.
+ *
+ * Mirrors `WatcherMatchPayload` (`pty/watchers/mod.rs`), pinned field for field by
+ * `the_payload_serializes_to_the_exact_camel_case_contract`. **No field is ever absent**:
+ * the Rust struct carries no `skip_serializing_if`, so absent never becomes a third state
+ * beside null and the value.
+ */
+export interface WatcherMatchPayload {
+  sessionId: string;
+  /**
+   * Monotonic per session. The same value the ring stores, so the window merges snapshot
+   * and stream on `(sessionId, seq)`. Two matches from one tick share `at` and are only
+   * distinguishable by this.
+   */
+  seq: number;
+  /** The key of the root `watchers` map. The same grouping key everywhere. */
+  watcherId: string;
+  mode: WatcherMode;
+  /** RFC3339 UTC. The tick's instant, not the match's: a match has no instant of its own. */
+  at: string;
+  /** Groups 1..n in order, without group 0. `null` per element means "did not capture". */
+  captures: (string | null)[];
+  /** The logical row, truncated to 256 bytes on a char boundary. */
+  row: string;
+  /** Whether `row` lost bytes to the cap; `row.length` cannot answer it, the cap is on bytes. */
+  rowTruncated: boolean;
+}
+
+/** #1171 - one tick's matches for one session, coalesced. Payload of `watcher_matches`. */
+export interface WatcherMatchBatch {
+  sessionId: string;
+  matches: WatcherMatchPayload[];
+}
+
+/** #1171 - one watcher's standing on one session. Present even when `count` is 0. */
+export interface WatcherActivityCounter {
+  watcherId: string;
+  mode: WatcherMode;
+  count: number;
+  /** True while this watcher is hitting a per-tick cap or is suspended. */
+  degraded: boolean;
+}
+
+/** #1171 - everything `get_watcher_activity` answers with. */
+export interface WatcherActivitySnapshot {
+  /** Oldest first. `limit` trims from the new end: the n most recent, still oldest first. */
+  matches: WatcherMatchPayload[];
+  /** The highest `seq` ever inserted for this session; the merge fence against the stream. */
+  lastSeq: number;
+  /** The ring dropped at least one entry since the session started. */
+  truncated: boolean;
+  /** Monotonic since the session started. NOT a count of lost matches. */
+  possiblyMissedFrames: number;
+  /**
+   * False until the engine has ticked this session at least once. Without it an empty
+   * `activeWatchers` cannot tell "no watcher reaches this agent" from "the engine has not
+   * run yet".
+   */
+  warmedUp: boolean;
+  activeWatchers: WatcherActivityCounter[];
+}
+
+/** #1171 - what a candidate pattern does, before it is saved. */
+export interface WatcherPatternPreview {
+  compiles: boolean;
+  error: string | null;
+  /**
+   * False when no session was given, or the session had no readable frame. This is what
+   * distinguishes "matched nothing" from "could not look".
+   */
+  sampled: boolean;
+  matchedRows: number;
+  totalRows: number;
+  /** Up to 3 matched logical rows, each truncated to 256 bytes. */
+  samples: string[];
+  /**
+   * True when the captures of the lowest match differed between two samples taken about a
+   * second apart: a pattern capturing a clock matches one row and still emits constantly.
+   */
+  capturesVolatile: boolean;
+}
+
+/** #1171 - which agents a candidate selector reaches. */
+export interface WatcherReachEntry {
+  agentId: string;
+  agentLabel: string;
+  commandStem: string;
+  /** False when the watcher reaches the agent but falls outside its 8-watcher budget. */
+  inBudget: boolean;
+}
+
+/** #1171 - one user-configured watcher. Mirrors `WatcherConfig` (`config/settings.rs`). */
+export interface WatcherConfig {
+  enabled: boolean;
+  mode: WatcherMode;
+  pattern: string;
+  /**
+   * Absent or null reaches every configured agent; present reaches only entries whose
+   * command executable stem matches exactly; `[]` reaches none. **Absent and `[]` are
+   * opposites**, which is why this is not a plain `string[]`.
+   */
+  commands?: string[] | null;
+  dedupe: WatcherDedupe;
+  dedupeWindowMs: number;
+  /** Free text, e.g. "claude 2.1.212". Never validated, never parsed. */
+  capturedAgainst?: string | null;
+}
+
+/**
+ * #1171 - one entry of the root `watchers` map, valid or not.
+ *
+ * Mirrors the untagged `WatcherEntry` (`config/settings.rs`), which exists so a hand-written
+ * `"mode": "State"` skips one watcher instead of failing the whole `AppSettings` parse and
+ * starting with no agents configured. The invalid value is kept verbatim so a save
+ * round-trips the user's bytes; typing this map as `WatcherConfig` alone would claim a
+ * guarantee the backend deliberately does not make, and an editor built on that claim would
+ * delete what it could not read.
+ */
+export type WatcherEntry = WatcherConfig | UnrecognizedWatcherEntry;
+
+/** An entry that did not deserialize as a `WatcherConfig`, preserved as-is. */
+export interface UnrecognizedWatcherEntry {
+  readonly [key: string]: unknown;
+}
+
 export interface SessionGroup {
   id: string;
   name: string;
@@ -484,6 +616,14 @@ export interface AppSettings {
   containerCredentialsFromHost: boolean;
   logLevel: LogLevel | null;
   screenshotCaptureHotkey?: string;
+  /**
+   * #1171 - root-level watcher patterns, keyed by watcher id. Optional because the Rust
+   * field skips serializing while the map is empty, so a user who configures nothing never
+   * sees the key appear.
+   */
+  watchers?: Record<string, WatcherEntry>;
+  /** #1171 - geometry of the watcher activity window; skipped while unset. */
+  watchersGeometry?: WindowGeometry;
 }
 
 // ── #1077 Portable dual project paths: get_settings resolution report ────────

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -305,10 +305,17 @@ export interface WatcherConfig {
  */
 export type WatcherEntry = WatcherConfig | UnrecognizedWatcherEntry;
 
-/** An entry that did not deserialize as a `WatcherConfig`, preserved as-is. */
-export interface UnrecognizedWatcherEntry {
-  readonly [key: string]: unknown;
-}
+/**
+ * An entry that did not deserialize as a `WatcherConfig`, preserved verbatim.
+ *
+ * This is `serde_json::Value` and therefore **any** JSON value, not only an object: a
+ * hand-written `"permission": "claude"`, `"permission": 7`, `"permission": null` or
+ * `"permission": ["claude"]` all land here and are all written back unchanged. Modelling
+ * only objects made the contract claim a narrowness Rust does not have, and forced every
+ * test of a real case through `as unknown as WatcherEntry` -- a cast is what a type says
+ * when it is wrong.
+ */
+export type UnrecognizedWatcherEntry = JsonValue;
 
 export interface SessionGroup {
   id: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,13 +213,67 @@ export interface WatcherPatternPreview {
   capturesVolatile: boolean;
 }
 
-/** #1171 - which agents a candidate selector reaches. */
+/**
+ * #1171 - one watcher row of the draft the Settings modal holds in memory.
+ *
+ * Only the three fields `reaches` and the budget depend on. `pattern`, `mode`, `dedupe` and
+ * `capturedAgainst` take part in neither and are deliberately not sent: the row already shows
+ * its pattern, and `previewWatcherPattern` answers compilability separately, so carrying it
+ * here would inflate every debounced payload to restate an answer already on screen.
+ */
+export interface WatcherDraftEntry {
+  id: string;
+  enabled: boolean;
+  commands?: string[] | null;
+}
+
+/**
+ * #1171 - one agent row of the same draft.
+ *
+ * The modal edits agents and watchers in ONE store and one Save writes both, so resolving
+ * against the SAVED agent list would answer about a state the user has already left. Two of
+ * the three agent edits over-report that way: deleting an agent leaves it named in a reach
+ * list it will not be in, and changing an agent's `command` leaves a watcher reported as
+ * reaching it under the old stem. Only adding an agent under-reports.
+ */
+export interface WatcherAgentDraftEntry {
+  id: string;
+  label: string;
+  command: string;
+}
+
+/** #1171 - one agent that a draft row's selector reaches. */
 export interface WatcherReachEntry {
   agentId: string;
   agentLabel: string;
   commandStem: string;
-  /** False when the watcher reaches the agent but falls outside its 8-watcher budget. */
-  inBudget: boolean;
+  /**
+   * Whether this row is enabled in the draft AND holds one of this agent's 8 slots once every
+   * other enabled row of the draft is counted. It is slot assignment, **not** a promise that
+   * the watcher will emit anything: a resolved watcher whose pattern does not compile is
+   * allocated a slot and is inert, and compilability is answered separately by
+   * `previewWatcherPattern`. A disabled row is always false here, and the editor, which owns
+   * `enabled`, says "disabled" rather than "budget".
+   */
+  allocated: boolean;
+}
+
+/**
+ * #1171 - the reach of one draft row.
+ *
+ * Exactly one per requested row, in request order. It carries `id` back because the editor
+ * filters unrecognised rows out of the request, so its table positions do not match the
+ * response positions. A row that reaches nobody is still present, with `entries: []`.
+ */
+export interface WatcherReachRow {
+  id: string;
+  /**
+   * Every agent this row's selector reaches, whether or not the row is enabled: reach is a
+   * property of the selector alone, and `allocated` is where enablement and budget land.
+   * Ordered by `agentLabel` with `agentId` as the tie-break, so the list does not reshuffle
+   * between keystrokes.
+   */
+  entries: WatcherReachEntry[];
 }
 
 /** #1171 - one user-configured watcher. Mirrors `WatcherConfig` (`config/settings.rs`). */

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1031,9 +1031,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
-  // The single writer of a watcher config into the map, which is where the editor's one
-  // invariant belongs: no call path can enable a row without a pattern, and none can leave an
-  // enabled row behind by emptying one.
+  // One of the two places the editor puts a row into the map, and each applies the editor's
+  // invariant: no path can enable a row without a pattern, and none can leave an enabled row
+  // behind by emptying one. The other is `renameWatcherEntry`, which creates a row under a
+  // new id and is where an earlier "there is only one writer" reading was wrong.
   const setWatcherConfig = (id: string, config: WatcherConfig) => {
     const next = withWatcherInvariant(config);
     mutateWatchers((map) => {

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -12,8 +12,13 @@ import type {
   ApiClientMintResponse,
   ApiClientMintScope,
   SessionBackendKind,
+  Session,
+  WatcherConfig,
+  WatcherEntry,
+  WatcherPatternPreview,
+  WatcherReachEntry,
 } from "../../shared/types";
-import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI } from "../../shared/ipc";
+import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI, PtyAPI } from "../../shared/ipc";
 import { toastStore } from "../../shared/stores/toasts";
 import { validateScreenshotHotkeySyntax } from "../../shared/screenshot-hotkey";
 import { settingsStore } from "../../shared/stores/settings";
@@ -25,6 +30,18 @@ import { codingAgentsStore } from "../stores/coding-agents";
 import TrashIcon from "./TrashIcon";
 import XMarkIcon from "./XMarkIcon";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
+import {
+  distinctCommandStems,
+  isWatcherConfig,
+  newWatcherConfig,
+  nextWatcherId,
+  renameWatcherEntry,
+  selectorMode,
+  sortedWatcherIds,
+  toggleCommandStem,
+  validateWatcherId,
+  withSelectorMode,
+} from "./settings-watchers";
 import {
   AC_MATRIX_ROOT_PLACEHOLDER,
   AC_REPLICA_ROOT_PLACEHOLDER,
@@ -93,21 +110,34 @@ const API_CLIENT_EXPIRY_MS: Record<Exclude<ApiClientExpiryOption, "default">, nu
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
-type SettingsTab = "general" | "agents" | "resources" | "integrations";
+type SettingsTab = "general" | "agents" | "resources" | "integrations" | "watchers";
 
 const TABS: { key: SettingsTab; label: string }[] = [
   { key: "general", label: "General" },
   { key: "agents", label: "Coding Agents" },
   { key: "resources", label: "Resources" },
+  { key: "watchers", label: "Watchers" },
   { key: "integrations", label: "Integrations" },
 ];
 
-const resolveSettingsSection = (s: string | undefined): SettingsTab =>
+/**
+ * Map an `open_settings` section to a tab.
+ *
+ * Exported for #1171's test: an unknown section falls back to `"general"` **silently**, so
+ * a caller asking for a tab that was never wired here opens the wrong one with no error and
+ * no log. That is exactly what happens today for `"resources"`, which the Resource Monitor
+ * asks for (`resource-monitor/App.tsx:422`) and which is missing below, so the one existing
+ * precedent for an auxiliary window requesting its own section is broken. `"watchers"` is
+ * wired because the activity window's day-one empty state depends on it.
+ */
+export const resolveSettingsSection = (s: string | undefined): SettingsTab =>
   s === "agents" || s === "profiles"
     ? "agents"
     : s === "integrations"
       ? "integrations"
-      : "general";
+      : s === "watchers"
+        ? "watchers"
+        : "general";
 
 const BYTES_PER_GIB = 1024 ** 3;
 const CONTAINER_IMAGE_EXAMPLE = "agentscommander/ac-claude:latest";
@@ -142,6 +172,413 @@ const cloneSettings = (value: AppSettings | null): AppSettings | null => {
   if (!value) return null;
   if (typeof structuredClone === "function") return structuredClone(value);
   return JSON.parse(JSON.stringify(value)) as AppSettings;
+};
+
+/** #1171 - how long the pattern and reach previews wait before asking the backend. */
+const WATCHER_PREVIEW_DEBOUNCE_MS = 300;
+
+/** #1171 - the sentinel of the "no session" option, which exercises the compile-only path. */
+const WATCHER_NO_SESSION = "";
+
+/**
+ * #1171 - one row of the Watchers tab.
+ *
+ * A component rather than a `render*` helper because each row owns two debounced backend
+ * previews and their timers; inside `<For>` every row gets its own reactive scope, so the
+ * cleanup is the framework's job instead of a bookkeeping map keyed by watcher id.
+ */
+const WatcherRow: Component<{
+  id: string;
+  config: WatcherConfig;
+  otherIds: string[];
+  stems: string[];
+  sessions: Session[];
+  onChange: (next: WatcherConfig) => void;
+  onRename: (nextId: string) => void;
+  onRemove: () => void;
+}> = (props) => {
+  const [renameDraft, setRenameDraft] = createSignal(props.id);
+  const [renaming, setRenaming] = createSignal(false);
+  const [preview, setPreview] = createSignal<WatcherPatternPreview | null>(null);
+  const [previewError, setPreviewError] = createSignal("");
+  const [reach, setReach] = createSignal<WatcherReachEntry[] | null>(null);
+  const [testSessionId, setTestSessionId] = createSignal(WATCHER_NO_SESSION);
+
+  // Preselect the active session when it qualifies, i.e. when it is an agent session. A
+  // plain shell has a screen but nothing a watcher would ever be configured against.
+  onMount(() => {
+    const active = props.sessions.find((s) => s.id === sessionsStore.activeId);
+    if (active) setTestSessionId(active.id);
+  });
+
+  const renameError = () =>
+    renameDraft() === props.id ? null : validateWatcherId(renameDraft(), props.otherIds);
+
+  const applyRename = () => {
+    if (renameError() || renameDraft() === props.id) return;
+    props.onRename(renameDraft());
+    setRenaming(false);
+  };
+
+  // Both previews are debounced and generation-guarded: the user types, and a slow answer
+  // for an older pattern must never overwrite the answer for the current one.
+  let previewGeneration = 0;
+  createEffect(() => {
+    const pattern = props.config.pattern;
+    const sessionId = testSessionId();
+    if (!pattern) {
+      setPreview(null);
+      setPreviewError("");
+      return;
+    }
+    const generation = (previewGeneration += 1);
+    const timer = setTimeout(() => {
+      PtyAPI.previewWatcherPattern(pattern, sessionId || undefined)
+        .then((result) => {
+          if (generation !== previewGeneration) return;
+          setPreview(result);
+          setPreviewError("");
+        })
+        .catch((err: unknown) => {
+          if (generation !== previewGeneration) return;
+          setPreview(null);
+          setPreviewError(errorMessage(err));
+        });
+    }, WATCHER_PREVIEW_DEBOUNCE_MS);
+    onCleanup(() => clearTimeout(timer));
+  });
+
+  let reachGeneration = 0;
+  createEffect(() => {
+    const commands = props.config.commands;
+    const watcherId = props.id;
+    const generation = (reachGeneration += 1);
+    const timer = setTimeout(() => {
+      PtyAPI.previewWatcherReach(watcherId, commands)
+        .then((entries) => {
+          if (generation === reachGeneration) setReach(entries);
+        })
+        .catch(() => {
+          if (generation === reachGeneration) setReach(null);
+        });
+    }, WATCHER_PREVIEW_DEBOUNCE_MS);
+    onCleanup(() => clearTimeout(timer));
+  });
+
+  const reachedCount = () => reach()?.filter((entry) => entry.inBudget).length ?? null;
+  const outOfBudget = () => reach()?.filter((entry) => !entry.inBudget) ?? [];
+
+  const update = <K extends keyof WatcherConfig>(key: K, value: WatcherConfig[K]) =>
+    props.onChange({ ...props.config, [key]: value });
+
+  return (
+    <div
+      class="settings-section"
+      data-ac-testid={`settings.watchers.row.${props.id}`}
+      data-ac-role="group"
+      data-ac-state={props.config.enabled ? "enabled" : "disabled"}
+    >
+      <div class="settings-color-row">
+        <span class="settings-section-title">{props.id}</span>
+        <button
+          class="settings-agent-remove"
+          onClick={props.onRemove}
+          title={`Delete "${props.id}"`}
+          aria-label={`Delete watcher ${props.id}`}
+          data-ac-testid={`settings.watchers.remove.${props.id}`}
+          data-ac-role="button"
+        >
+          <TrashIcon />
+        </button>
+      </div>
+
+      <label class="settings-checkbox-field">
+        <input
+          type="checkbox"
+          class="settings-checkbox"
+          checked={props.config.enabled}
+          onChange={(e) => update("enabled", e.currentTarget.checked)}
+          data-ac-testid={`settings.watchers.enabled.${props.id}`}
+          data-ac-role="checkbox"
+        />
+        <span>Enabled</span>
+      </label>
+
+      <label class="settings-field">
+        <span class="settings-label">Mode</span>
+        <select
+          class="settings-input"
+          value={props.config.mode}
+          onChange={(e) =>
+            update("mode", e.currentTarget.value as WatcherConfig["mode"])
+          }
+          data-ac-testid={`settings.watchers.mode.${props.id}`}
+          data-ac-role="combobox"
+        >
+          <option value="occurrence">Occurrence — every match is an event</option>
+          <option value="state">State — a reading, re-reported only when it changes</option>
+        </select>
+      </label>
+
+      <label class="settings-field">
+        <span class="settings-label">Pattern</span>
+        <input
+          class="settings-input"
+          type="text"
+          value={props.config.pattern}
+          onInput={(e) => update("pattern", e.currentTarget.value)}
+          placeholder="Read \((.+)\)"
+          spellcheck={false}
+          data-ac-testid={`settings.watchers.pattern.${props.id}`}
+          data-ac-role="textbox"
+        />
+      </label>
+      {/* The pattern is handed to the engine verbatim, never trimmed: a leading space is an
+          anchor, and the pattern is the only thing keeping a watcher narrow. */}
+      <div class="settings-label-hint">
+        Taken exactly as written, including leading and trailing spaces.
+      </div>
+
+      <div class="settings-field">
+        <span class="settings-label">Applies to</span>
+        <select
+          class="settings-input"
+          value={selectorMode(props.config)}
+          onChange={(e) =>
+            props.onChange(
+              withSelectorMode(
+                props.config,
+                e.currentTarget.value === "all" ? "all" : "selected"
+              )
+            )
+          }
+          data-ac-testid={`settings.watchers.selectorMode.${props.id}`}
+          data-ac-role="combobox"
+        >
+          <option value="all">All agents</option>
+          <option value="selected">Selected commands</option>
+        </select>
+      </div>
+
+      <Show when={selectorMode(props.config) === "selected"}>
+        <div
+          class="settings-api-client-scopes"
+          data-ac-testid={`settings.watchers.stems.${props.id}`}
+          data-ac-role="group"
+        >
+          <For each={props.stems}>
+            {(stem) => (
+              <label class="settings-api-client-scope">
+                <input
+                  type="checkbox"
+                  class="settings-checkbox"
+                  checked={(props.config.commands ?? []).includes(stem)}
+                  onChange={() => props.onChange(toggleCommandStem(props.config, stem))}
+                  data-ac-testid={`settings.watchers.stem.${props.id}.${stem}`}
+                  data-ac-role="checkbox"
+                />
+                <span>{stem}</span>
+              </label>
+            )}
+          </For>
+        </div>
+        {/* A stem no agent currently has is not an error: it simply reaches nobody until
+            such an agent exists. Free text is how that case is expressible at all. */}
+        <label class="settings-field">
+          <span class="settings-label">Commands</span>
+          <input
+            class="settings-input"
+            type="text"
+            value={(props.config.commands ?? []).join(", ")}
+            onInput={(e) =>
+              update(
+                "commands",
+                e.currentTarget.value
+                  .split(",")
+                  .map((entry) => entry.trim())
+                  .filter(Boolean)
+              )
+            }
+            placeholder="claude, codex"
+            spellcheck={false}
+            data-ac-testid={`settings.watchers.commands.${props.id}`}
+            data-ac-role="textbox"
+          />
+        </label>
+      </Show>
+
+      <div
+        class="settings-label-hint"
+        data-ac-testid={`settings.watchers.reach.${props.id}`}
+        data-ac-role="status"
+      >
+        <Show when={reachedCount() !== null} fallback="Resolving reach...">
+          {`Reaches ${reachedCount()} agent${reachedCount() === 1 ? "" : "s"}.`}
+          <Show when={outOfBudget().length > 0}>
+            {` Not running on ${outOfBudget()
+              .map((entry) => entry.agentLabel || entry.agentId)
+              .join(", ")} (budget).`}
+          </Show>
+        </Show>
+      </div>
+
+      <Show when={props.config.mode === "occurrence"}>
+        <label class="settings-field">
+          <span class="settings-label">Deduplicate by</span>
+          <select
+            class="settings-input"
+            value={props.config.dedupe}
+            onChange={(e) =>
+              update("dedupe", e.currentTarget.value as WatcherConfig["dedupe"])
+            }
+            data-ac-testid={`settings.watchers.dedupe.${props.id}`}
+            data-ac-role="combobox"
+          >
+            <option value="row">Row text</option>
+            <option value="capture">Captured groups</option>
+            <option value="none">Nothing — count every match</option>
+          </select>
+        </label>
+        <label class="settings-field">
+          <span class="settings-label">Dedupe window (ms)</span>
+          <input
+            class="settings-input settings-input-sm"
+            type="number"
+            min="0"
+            step="100"
+            value={props.config.dedupeWindowMs}
+            onInput={(e) => {
+              const value = parseInt(e.currentTarget.value, 10);
+              if (!Number.isNaN(value)) update("dedupeWindowMs", value);
+            }}
+            data-ac-testid={`settings.watchers.dedupeWindow.${props.id}`}
+            data-ac-role="spinbutton"
+          />
+        </label>
+      </Show>
+
+      <label class="settings-field">
+        <span class="settings-label">Captured against</span>
+        <input
+          class="settings-input"
+          type="text"
+          value={props.config.capturedAgainst ?? ""}
+          onInput={(e) => update("capturedAgainst", e.currentTarget.value || null)}
+          placeholder="claude 2.1.212"
+          data-ac-testid={`settings.watchers.capturedAgainst.${props.id}`}
+          data-ac-role="textbox"
+        />
+      </label>
+      <div class="settings-label-hint">
+        Free text. A TUI's layout changes between versions, and this is where the version
+        the pattern was written against is recorded.
+      </div>
+
+      <label class="settings-field">
+        <span class="settings-label">Test against</span>
+        <select
+          class="settings-input"
+          value={testSessionId()}
+          onChange={(e) => setTestSessionId(e.currentTarget.value)}
+          data-ac-testid={`settings.watchers.testSession.${props.id}`}
+          data-ac-role="combobox"
+        >
+          <option value={WATCHER_NO_SESSION}>No session (check syntax only)</option>
+          <For each={props.sessions}>
+            {(session) => <option value={session.id}>{session.name}</option>}
+          </For>
+        </select>
+      </label>
+
+      <div
+        class="settings-label-hint"
+        data-ac-testid={`settings.watchers.preview.${props.id}`}
+        data-ac-role="status"
+      >
+        <Show when={previewError()}>{`Preview failed: ${previewError()}`}</Show>
+        <Show when={!previewError() && preview()}>
+          {(result) => (
+            <Show
+              when={result().compiles}
+              fallback={`Does not compile: ${result().error ?? "unknown error"}`}
+            >
+              <Show
+                when={result().sampled}
+                fallback="Compiles. No session read, so nothing was matched against."
+              >
+                {`Compiles. Matches ${result().matchedRows} of ${result().totalRows} rows.`}
+                <Show when={result().capturesVolatile}>
+                  {" The capture changes between samples: in state mode this fires constantly."}
+                </Show>
+                <For each={result().samples}>
+                  {(sample) => <div class="settings-hint">{sample}</div>}
+                </For>
+              </Show>
+            </Show>
+          )}
+        </Show>
+      </div>
+
+      <Show
+        when={renaming()}
+        fallback={
+          <button
+            class="settings-add-btn"
+            onClick={() => {
+              setRenameDraft(props.id);
+              setRenaming(true);
+            }}
+            data-ac-testid={`settings.watchers.renameStart.${props.id}`}
+            data-ac-role="button"
+          >
+            Rename
+          </button>
+        }
+      >
+        <label class="settings-field">
+          <span class="settings-label">New id</span>
+          <input
+            class="settings-input"
+            type="text"
+            value={renameDraft()}
+            onInput={(e) => setRenameDraft(e.currentTarget.value)}
+            spellcheck={false}
+            data-ac-testid={`settings.watchers.renameInput.${props.id}`}
+            data-ac-role="textbox"
+          />
+        </label>
+        {/* Stated rather than implied: the id is the map key AND the grouping key the
+            activity window and the history counters use, so this really is delete plus
+            create and already-recorded activations keep the old id. */}
+        <div class="settings-label-hint">
+          Renaming deletes this watcher and creates a new one. Activations already recorded
+          keep the old id.
+        </div>
+        <Show when={renameError()}>
+          <div class="settings-api-client-error">{renameError()}</div>
+        </Show>
+        <div class="settings-color-row">
+          <button
+            class="settings-add-btn"
+            onClick={applyRename}
+            disabled={!!renameError() || renameDraft() === props.id}
+            data-ac-testid={`settings.watchers.renameConfirm.${props.id}`}
+            data-ac-role="button"
+          >
+            Rename
+          </button>
+          <button
+            class="settings-add-btn"
+            onClick={() => setRenaming(false)}
+            data-ac-testid={`settings.watchers.renameCancel.${props.id}`}
+            data-ac-role="button"
+          >
+            Cancel
+          </button>
+        </div>
+      </Show>
+    </div>
+  );
 };
 
 const SettingsModal: Component<{ onClose: () => void; section?: string }> = (props) => {
@@ -523,6 +960,63 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     if (!settings.data) return;
     setDraftDirty(true);
     setSettings("data", key as any, value as any);
+  };
+
+  // ── #1171 Watchers ────────────────────────────────────────────────────────
+  // The map is `Record<string, WatcherEntry>`, not of `WatcherConfig`: the Rust side keeps
+  // an entry it could not parse verbatim so one malformed watcher costs one watcher instead
+  // of the whole settings file. Everything below therefore reads through `isWatcherConfig`
+  // and writes only the keys it understood, so an unrecognized entry survives a save
+  // untouched — it rides along in the draft and out through `{...draft}` at save time.
+
+  const watcherMap = (): Record<string, WatcherEntry> => settings.data?.watchers ?? {};
+  const watcherIds = createMemo(() => sortedWatcherIds(settings.data?.watchers));
+  const unreadableWatcherIds = createMemo(() =>
+    watcherIds().filter((id) => !isWatcherConfig(watcherMap()[id]))
+  );
+  const commandStems = createMemo(() => distinctCommandStems(settings.data?.agents ?? []));
+  // `?? []` because these memos are eager and the modal is also mounted by tests and by
+  // `emitOpenSettings` before the session store has hydrated.
+  const agentSessions = createMemo(() =>
+    (sessionsStore.sessions ?? []).filter(
+      (session): session is Session => !!session.agentId
+    )
+  );
+
+  const mutateWatchers = (mutate: (map: Record<string, WatcherEntry>) => void) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    setSettings("data", produce((draft) => {
+      if (!draft) return;
+      draft.watchers ??= {};
+      mutate(draft.watchers);
+    }));
+  };
+
+  const setWatcherConfig = (id: string, config: WatcherConfig) => {
+    mutateWatchers((map) => {
+      map[id] = config;
+    });
+  };
+
+  const addWatcher = () => {
+    const id = nextWatcherId(watcherIds());
+    setWatcherConfig(id, newWatcherConfig());
+  };
+
+  const removeWatcher = (id: string) => {
+    mutateWatchers((map) => {
+      delete map[id];
+    });
+  };
+
+  const renameWatcher = (fromId: string, toId: string) => {
+    if (!settings.data) return;
+    setDraftDirty(true);
+    const renamed = renameWatcherEntry(watcherMap(), fromId, toId);
+    setSettings("data", produce((draft) => {
+      if (draft) draft.watchers = renamed;
+    }));
   };
 
   const updateAgent = (
@@ -2250,6 +2744,71 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     </div>
   );
 
+  const renderWatchersTab = () => (
+    <>
+      <div class="settings-section">
+        <div class="settings-section-title">Watchers</div>
+        <div class="settings-label-hint">
+          Regular expressions run over what a coding agent prints, every 200 ms. Matches
+          appear in the watcher activity window. Best-effort: activations can be missed, so
+          this is an indicator and not an audit log.
+        </div>
+      </div>
+
+      <Show when={unreadableWatcherIds().length > 0}>
+        {/* Named rather than hidden, and deliberately not offered for editing: the backend
+            preserves what it could not parse, and so does this editor. */}
+        <div
+          class="settings-section"
+          data-ac-testid="settings.watchers.unreadable"
+          data-ac-role="status"
+        >
+          <div class="settings-api-client-warning">
+            {`Not shown because this version could not read them: ${unreadableWatcherIds().join(", ")}. They are left exactly as written in settings.json.`}
+          </div>
+        </div>
+      </Show>
+
+      <For each={watcherIds()}>
+        {(id) => {
+          const entry = () => watcherMap()[id];
+          return (
+            <Show when={isWatcherConfig(entry()) ? (entry() as WatcherConfig) : null}>
+              {(config) => (
+                <WatcherRow
+                  id={id}
+                  config={config()}
+                  otherIds={watcherIds().filter((other) => other !== id)}
+                  stems={commandStems()}
+                  sessions={agentSessions()}
+                  onChange={(next) => setWatcherConfig(id, next)}
+                  onRename={(nextId) => renameWatcher(id, nextId)}
+                  onRemove={() => removeWatcher(id)}
+                />
+              )}
+            </Show>
+          );
+        }}
+      </For>
+
+      <Show when={watcherIds().length === 0}>
+        <div class="settings-label-hint" data-ac-testid="settings.watchers.empty">
+          No watchers configured. Nothing is evaluated and nothing costs anything until you
+          add one.
+        </div>
+      </Show>
+
+      <button
+        class="settings-add-btn"
+        onClick={addWatcher}
+        data-ac-testid="settings.watchers.add"
+        data-ac-role="button"
+      >
+        Add Watcher
+      </button>
+    </>
+  );
+
   const renderResourcesTab = () => (
     <>
       <div class="settings-section">
@@ -3066,6 +3625,7 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             <Show when={activeTab() === "resources"}>
               {renderResourcesTab()}
             </Show>
+            <Show when={activeTab() === "watchers"}>{renderWatchersTab()}</Show>
             <Show when={activeTab() === "integrations"}>
               {renderIntegrationsTab()}
             </Show>

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ import type {
   WatcherEntry,
   WatcherPatternPreview,
   WatcherReachEntry,
+  WatcherReachRow,
 } from "../../shared/types";
 import { SettingsAPI, TelegramAPI, ReposAPI, CodingAgentsAPI, PtyAPI } from "../../shared/ipc";
 import { toastStore } from "../../shared/stores/toasts";
@@ -31,15 +32,20 @@ import TrashIcon from "./TrashIcon";
 import XMarkIcon from "./XMarkIcon";
 import { mergeSettingsForSavePreservingProjects } from "./settings-save";
 import {
+  canEnableWatcher,
   distinctCommandStems,
   isWatcherConfig,
   newWatcherConfig,
   nextWatcherId,
+  reachRequestFingerprint,
   renameWatcherEntry,
   selectorMode,
   sortedWatcherIds,
   toggleCommandStem,
   validateWatcherId,
+  watcherBudgetNotice,
+  watcherReachRequest,
+  watcherReachSummary,
   withSelectorMode,
 } from "./settings-watchers";
 import {
@@ -183,9 +189,13 @@ const WATCHER_NO_SESSION = "";
 /**
  * #1171 - one row of the Watchers tab.
  *
- * A component rather than a `render*` helper because each row owns two debounced backend
- * previews and their timers; inside `<For>` every row gets its own reactive scope, so the
- * cleanup is the framework's job instead of a bookkeeping map keyed by watcher id.
+ * A component rather than a `render*` helper because each row owns a debounced pattern
+ * preview and its timer; inside `<For>` every row gets its own reactive scope, so the cleanup
+ * is the framework's job instead of a bookkeeping map keyed by watcher id.
+ *
+ * Reach is NOT owned here. Whether a row holds one of an agent's 8 slots depends on every
+ * other row of the draft and on the draft's agents, so one call for the whole section answers
+ * every row at once and each row renders the `entries` its `id` indexes.
  */
 const WatcherRow: Component<{
   id: string;
@@ -193,6 +203,9 @@ const WatcherRow: Component<{
   otherIds: string[];
   stems: string[];
   sessions: Session[];
+  /** This row's half of the section's answer; `null` while none is displayed. */
+  reach: WatcherReachEntry[] | null;
+  reachError: string;
   onChange: (next: WatcherConfig) => void;
   onRename: (nextId: string) => void;
   onRemove: () => void;
@@ -201,15 +214,24 @@ const WatcherRow: Component<{
   const [renaming, setRenaming] = createSignal(false);
   const [preview, setPreview] = createSignal<WatcherPatternPreview | null>(null);
   const [previewError, setPreviewError] = createSignal("");
-  const [reach, setReach] = createSignal<WatcherReachEntry[] | null>(null);
   const [testSessionId, setTestSessionId] = createSignal(WATCHER_NO_SESSION);
 
   // Preselect the active session when it qualifies, i.e. when it is an agent session. A
   // plain shell has a screen but nothing a watcher would ever be configured against.
-  onMount(() => {
+  //
+  // Reactive rather than read once on mount: the modal is opened by `emitOpenSettings` and by
+  // tests before the session store has hydrated, and a one-shot read would then preselect
+  // nothing for the rest of the modal's life. It stops the moment the user picks, so a later
+  // hydration never overrides a deliberate choice.
+  let sessionPickedByUser = false;
+  createEffect(() => {
+    if (sessionPickedByUser) return;
     const active = props.sessions.find((s) => s.id === sessionsStore.activeId);
     if (active) setTestSessionId(active.id);
   });
+
+  /** An empty pattern is a valid regex that matches every row, so enabling is gated on one. */
+  const enableBlocked = () => !props.config.enabled && !canEnableWatcher(props.config);
 
   const renameError = () =>
     renameDraft() === props.id ? null : validateWatcherId(renameDraft(), props.otherIds);
@@ -220,8 +242,8 @@ const WatcherRow: Component<{
     setRenaming(false);
   };
 
-  // Both previews are debounced and generation-guarded: the user types, and a slow answer
-  // for an older pattern must never overwrite the answer for the current one.
+  // Debounced and generation-guarded: the user types, and a slow answer for an older pattern
+  // must never overwrite the answer for the current one.
   let previewGeneration = 0;
   createEffect(() => {
     const pattern = props.config.pattern;
@@ -248,26 +270,6 @@ const WatcherRow: Component<{
     onCleanup(() => clearTimeout(timer));
   });
 
-  let reachGeneration = 0;
-  createEffect(() => {
-    const commands = props.config.commands;
-    const watcherId = props.id;
-    const generation = (reachGeneration += 1);
-    const timer = setTimeout(() => {
-      PtyAPI.previewWatcherReach(watcherId, commands)
-        .then((entries) => {
-          if (generation === reachGeneration) setReach(entries);
-        })
-        .catch(() => {
-          if (generation === reachGeneration) setReach(null);
-        });
-    }, WATCHER_PREVIEW_DEBOUNCE_MS);
-    onCleanup(() => clearTimeout(timer));
-  });
-
-  const reachedCount = () => reach()?.filter((entry) => entry.inBudget).length ?? null;
-  const outOfBudget = () => reach()?.filter((entry) => !entry.inBudget) ?? [];
-
   const update = <K extends keyof WatcherConfig>(key: K, value: WatcherConfig[K]) =>
     props.onChange({ ...props.config, [key]: value });
 
@@ -292,14 +294,26 @@ const WatcherRow: Component<{
         </button>
       </div>
 
+      {/* Refused rather than merely discouraged: an empty pattern matches every row, so
+          enabling one would fill the per-tick caps, turn the ring over, go degraded and
+          displace a useful watcher out of an agent's budget. Disabling stays available even
+          when the pattern is empty, which is the state a hand-written file can arrive in. */}
       <label class="settings-checkbox-field">
         <input
           type="checkbox"
           class="settings-checkbox"
           checked={props.config.enabled}
-          onChange={(e) => update("enabled", e.currentTarget.checked)}
+          disabled={enableBlocked()}
+          onChange={(e) => {
+            if (e.currentTarget.checked && !canEnableWatcher(props.config)) {
+              e.currentTarget.checked = false;
+              return;
+            }
+            update("enabled", e.currentTarget.checked);
+          }}
           data-ac-testid={`settings.watchers.enabled.${props.id}`}
           data-ac-role="checkbox"
+          data-ac-state={enableBlocked() ? "blocked" : "available"}
         />
         <span>Enabled</span>
       </label>
@@ -407,18 +421,29 @@ const WatcherRow: Component<{
         </label>
       </Show>
 
+      {/* Reach and allocation answer different questions, so they are worded differently:
+          `entries` is what this selector reaches, `allocated` is whether the row holds a slot
+          after Save. A rejected call renders the error rather than the previous answer, which
+          would belong to a draft that no longer exists. */}
       <div
         class="settings-label-hint"
         data-ac-testid={`settings.watchers.reach.${props.id}`}
         data-ac-role="status"
       >
-        <Show when={reachedCount() !== null} fallback="Resolving reach...">
-          {`Reaches ${reachedCount()} agent${reachedCount() === 1 ? "" : "s"}.`}
-          <Show when={outOfBudget().length > 0}>
-            {` Not running on ${outOfBudget()
-              .map((entry) => entry.agentLabel || entry.agentId)
-              .join(", ")} (budget).`}
-          </Show>
+        <Show
+          when={props.reachError}
+          fallback={
+            <Show when={props.reach} fallback="Resolving reach...">
+              {(entries) => (
+                <>
+                  {watcherReachSummary(props.config, entries())}
+                  {watcherBudgetNotice(props.config, entries())}
+                </>
+              )}
+            </Show>
+          }
+        >
+          {`Reach unknown: ${props.reachError}`}
         </Show>
       </div>
 
@@ -449,7 +474,13 @@ const WatcherRow: Component<{
             value={props.config.dedupeWindowMs}
             onInput={(e) => {
               const value = parseInt(e.currentTarget.value, 10);
-              if (!Number.isNaN(value)) update("dedupeWindowMs", value);
+              // The editor must not be able to write a value the Rust decoder would reject:
+              // a negative or unrepresentable one reclassifies this very row as unrecognised,
+              // which would take it out of the editor in the middle of being edited and leave
+              // the user with a warning naming an id they can no longer reach.
+              if (Number.isSafeInteger(value) && value >= 0) {
+                update("dedupeWindowMs", value);
+              }
             }}
             data-ac-testid={`settings.watchers.dedupeWindow.${props.id}`}
             data-ac-role="spinbutton"
@@ -479,7 +510,10 @@ const WatcherRow: Component<{
         <select
           class="settings-input"
           value={testSessionId()}
-          onChange={(e) => setTestSessionId(e.currentTarget.value)}
+          onChange={(e) => {
+            sessionPickedByUser = true;
+            setTestSessionId(e.currentTarget.value);
+          }}
           data-ac-testid={`settings.watchers.testSession.${props.id}`}
           data-ac-role="combobox"
         >
@@ -1018,6 +1052,69 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       if (draft) draft.watchers = renamed;
     }));
   };
+
+  // ── #1171 Reach, held by the section rather than by each row ───────────────
+  // Whether a watcher holds one of an agent's 8 slots cannot be answered from that watcher
+  // alone: it depends on every other enabled row, on where their ids fall in key order, and
+  // on the agents, which this same modal edits in this same draft. So one debounced call
+  // carries the whole draft and every row renders the `entries` its `id` indexes.
+
+  const reachRequest = createMemo(() =>
+    watcherReachRequest(settings.data?.watchers, settings.data?.agents ?? [])
+  );
+  const reachFingerprint = createMemo(() => reachRequestFingerprint(reachRequest()));
+  const [reachAnswer, setReachAnswer] = createSignal<WatcherReachRow[] | null>(null);
+  const [reachError, setReachError] = createSignal("");
+  /** Fingerprints whose call has been issued and has not settled. */
+  const reachInFlight = new Set<string>();
+
+  const reachByWatcherId = createMemo(() => {
+    const byId = new Map<string, WatcherReachEntry[]>();
+    for (const row of reachAnswer() ?? []) byId.set(row.id, row.entries);
+    return byId;
+  });
+
+  // One rule, keyed on the REQUEST and not on the draft. A `pattern` keystroke changes the
+  // draft but not the request, so it must change nothing at all: pairing an idempotence guard
+  // with a clear-on-any-change rule contradicts itself and leaves the row pending forever.
+  //
+  // The memo only re-runs this effect when the fingerprint actually differs, which is the
+  // "while the current fingerprint equals the displayed one, nothing is cleared and no call is
+  // made" half. The rest is here.
+  createEffect(() => {
+    const fingerprint = reachFingerprint();
+
+    // Cleared SYNCHRONOUSLY. A commit-time guard stops a stale answer from being written, not
+    // from being read: on its own it leaves the old answer on screen for the debounce plus the
+    // round trip, and a user who presses Save in that gap decides against an indicator
+    // belonging to a draft that no longer exists. Save itself is not blocked -- the
+    // requirement is that the indicator never states something false, not that the user waits.
+    setReachAnswer(null);
+    setReachError("");
+
+    // A call for this exact request is already out; its answer is the one to wait for. This is
+    // what makes A to B and back to A settle on A instead of re-clearing forever.
+    if (reachInFlight.has(fingerprint)) return;
+
+    const timer = setTimeout(() => {
+      const request = reachRequest();
+      reachInFlight.add(fingerprint);
+      PtyAPI.previewWatcherReach(request.watchers, request.agents)
+        .then((rows) => {
+          reachInFlight.delete(fingerprint);
+          if (reachFingerprint() !== fingerprint) return;
+          setReachAnswer(rows);
+          setReachError("");
+        })
+        .catch((err: unknown) => {
+          reachInFlight.delete(fingerprint);
+          if (reachFingerprint() !== fingerprint) return;
+          setReachAnswer(null);
+          setReachError(errorMessage(err));
+        });
+    }, WATCHER_PREVIEW_DEBOUNCE_MS);
+    onCleanup(() => clearTimeout(timer));
+  });
 
   const updateAgent = (
     index: number,
@@ -2781,6 +2878,10 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                   otherIds={watcherIds().filter((other) => other !== id)}
                   stems={commandStems()}
                   sessions={agentSessions()}
+                  // Indexed by id, not by position: the request leaves unrecognised rows out,
+                  // so response positions do not match table positions.
+                  reach={reachAnswer() ? reachByWatcherId().get(id) ?? [] : null}
+                  reachError={reachError()}
                   onChange={(next) => setWatcherConfig(id, next)}
                   onRename={(nextId) => renameWatcher(id, nextId)}
                   onRemove={() => removeWatcher(id)}

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -47,6 +47,7 @@ import {
   watcherReachRequest,
   watcherReachSummary,
   withSelectorMode,
+  withWatcherInvariant,
 } from "./settings-watchers";
 import {
   AC_MATRIX_ROOT_PLACEHOLDER,
@@ -248,12 +249,15 @@ const WatcherRow: Component<{
   createEffect(() => {
     const pattern = props.config.pattern;
     const sessionId = testSessionId();
+    // Taken BEFORE the empty-pattern branch. Clearing the preview without advancing the
+    // generation leaves an answer for the previous pattern still entitled to paint, so a
+    // slow "Compiles. Matches 30 of 30 rows." lands on a row that no longer has a pattern.
+    const generation = (previewGeneration += 1);
     if (!pattern) {
       setPreview(null);
       setPreviewError("");
       return;
     }
-    const generation = (previewGeneration += 1);
     const timer = setTimeout(() => {
       PtyAPI.previewWatcherPattern(pattern, sessionId || undefined)
         .then((result) => {
@@ -1027,9 +1031,13 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     }));
   };
 
+  // The single writer of a watcher config into the map, which is where the editor's one
+  // invariant belongs: no call path can enable a row without a pattern, and none can leave an
+  // enabled row behind by emptying one.
   const setWatcherConfig = (id: string, config: WatcherConfig) => {
+    const next = withWatcherInvariant(config);
     mutateWatchers((map) => {
-      map[id] = config;
+      map[id] = next;
     });
   };
 

--- a/src/sidebar/components/SettingsModal.watchers.test.tsx
+++ b/src/sidebar/components/SettingsModal.watchers.test.tsx
@@ -1,9 +1,17 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { AppSettings, WatcherConfig, WatcherEntry } from "../../shared/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AgentConfig,
+  AppSettings,
+  WatcherConfig,
+  WatcherEntry,
+  WatcherReachRow,
+} from "../../shared/types";
 import { FakeTransport } from "../../shared/testing/fake-transport";
 import {
   baseSettings,
+  click,
+  input,
   installBrowserDomStubs,
   renderWithFakeTransport,
   resetUiStoresForTests,
@@ -217,3 +225,665 @@ describe("the watcher commands selector, through a real save (#1171)", () => {
     }
   });
 });
+
+/** The debounce the section waits before asking the backend, mirrored from the modal. */
+const REACH_DEBOUNCE_MS = 300;
+
+const AGENT: AgentConfig = {
+  id: "a1",
+  label: "Claude",
+  command: "claude",
+  color: "#6366f1",
+  envs: [],
+  isolatedHome: false,
+};
+
+function reachRow(id: string, allocated = true): WatcherReachRow {
+  return {
+    id,
+    entries: [
+      { agentId: "a1", agentLabel: "Claude", commandStem: "claude", allocated },
+    ],
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * #1171 test 58h. The reach answer belongs to exactly one REQUEST, and the guard is keyed on
+ * that request rather than on "any change to the draft".
+ *
+ * The pair this replaces contradicted itself: an idempotence guard ("skip the call when the
+ * serialized request is unchanged") next to a clear-on-any-change rule means a `pattern`
+ * keystroke clears the answer and issues no call to replace it, leaving the row pending
+ * forever. That case is the last assertion here and it must fail against the old pair.
+ */
+describe("the reach preview, keyed on the request fingerprint (#1171 test 58h)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  function threeRows(): AppSettings {
+    return baseSettings({
+      agents: [AGENT],
+      watchers: {
+        alpha: { ...newWatcherConfig(), pattern: "a" },
+        beta: { ...newWatcherConfig(), pattern: "b" },
+        gamma: { ...newWatcherConfig(), pattern: "c" },
+      },
+    });
+  }
+
+  function transport(
+    reach: (args: Record<string, unknown>) => unknown = () =>
+      [reachRow("alpha"), reachRow("beta"), reachRow("gamma")]
+  ): FakeTransport {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", threeRows());
+    fake.resolve("get_web_server_status", false);
+    fake.resolve("save_settings_draft", undefined);
+    fake.onInvoke("preview_watcher_reach", reach);
+    fake.resolve("preview_watcher_pattern", {
+      compiles: true,
+      error: null,
+      sampled: false,
+      matchedRows: 0,
+      totalRows: 0,
+      samples: [],
+      capturesVolatile: false,
+    });
+    return fake;
+  }
+
+  /** Mount, let the settings land, and let the first debounced round settle. */
+  async function mounted(fake: FakeTransport) {
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+    await vi.advanceTimersByTimeAsync(0);
+    return rendered;
+  }
+
+  const reachText = (root: HTMLElement, id: string) =>
+    root.querySelector(`[data-ac-testid="settings.watchers.reach.${id}"]`)?.textContent ?? "";
+
+  const selectorMode = (root: HTMLElement, id: string, value: "all" | "selected") => {
+    const select = root.querySelector<HTMLSelectElement>(
+      `[data-ac-testid="settings.watchers.selectorMode.${id}"]`
+    )!;
+    select.value = value;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  };
+
+  it("sends one call for the whole draft, watchers and agents together", async () => {
+    const fake = transport();
+    const rendered = await mounted(fake);
+    try {
+      const call = fake.lastCall("preview_watcher_reach")!;
+      const sent = call.args as {
+        watchers: { id: string }[];
+        agents: { id: string; command: string }[];
+      };
+      expect(sent.watchers.map((row) => row.id)).toEqual(["alpha", "beta", "gamma"]);
+      expect(sent.agents).toEqual([{ id: "a1", label: "Claude", command: "claude" }]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("fires exactly one call for a selector edit, an add, a toggle and a delete", async () => {
+    const fake = transport();
+    const rendered = await mounted(fake);
+    try {
+      for (const act of [
+        () => selectorMode(rendered.root, "alpha", "selected"),
+        () =>
+          click(
+            rendered.root.querySelector('[data-ac-testid="settings.watchers.add"]')!
+          ),
+        () =>
+          click(
+            rendered.root.querySelector('[data-ac-testid="settings.watchers.enabled.alpha"]')!
+          ),
+        () =>
+          click(
+            rendered.root.querySelector('[data-ac-testid="settings.watchers.remove.gamma"]')!
+          ),
+      ]) {
+        fake.clearCalls();
+        act();
+        await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fake.callsFor("preview_watcher_reach")).toHaveLength(1);
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The agent half of the draft, which is the fail-open the amendment closed. The modal edits
+   * agents and watchers in ONE store that one Save writes together, so resolving against the
+   * saved agent list answers about a state the user has already left -- and two of the three
+   * agent edits over-report that way: deleting an agent leaves it named in a reach list it
+   * will not be in, and changing an agent's `command` leaves a watcher reported as reaching it
+   * under the old stem.
+   */
+  it("re-asks with the edited agent when the draft changes an agent's command", async () => {
+    const fake = transport();
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="agents" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+      fake.clearCalls();
+
+      // The command field only exists once the row's editor is open.
+      click(rendered.root.querySelector('[data-ac-testid="settings.agentRow.0.toggle"]')!);
+      await vi.advanceTimersByTimeAsync(0);
+      input(
+        rendered.root.querySelector<HTMLInputElement>(
+          '[data-ac-testid="settings.agentRow.0.command"]'
+        )!,
+        "codex"
+      );
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const calls = fake.callsFor("preview_watcher_reach");
+      expect(calls).toHaveLength(1);
+      expect((calls[0].args as { agents: { command: string }[] }).agents).toEqual([
+        { id: "a1", label: "Claude", command: "codex" },
+      ]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The permanent-pending case. A `pattern` keystroke changes the draft but NOT the request,
+   * so it must change nothing at all: no call, and above all no clearing.
+   */
+  it("neither calls nor clears on a pattern keystroke", async () => {
+    const fake = transport();
+    const rendered = await mounted(fake);
+    try {
+      const before = reachText(rendered.root, "alpha");
+      expect(before).toContain("Would reach 1 agent when enabled");
+
+      fake.clearCalls();
+      input(
+        rendered.root.querySelector<HTMLInputElement>(
+          '[data-ac-testid="settings.watchers.pattern.alpha"]'
+        )!,
+        "Read (.+)"
+      );
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS * 4);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fake.callsFor("preview_watcher_reach")).toHaveLength(0);
+      expect(reachText(rendered.root, "alpha")).toBe(before);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * Clearing has to be synchronous. A commit-time guard stops a stale answer from being
+   * WRITTEN, not from being READ, and this indicator is what a user consults before pressing
+   * Save.
+   */
+  it("clears the displayed answer at once and leaves it cleared until its own answer lands", async () => {
+    const pending = deferred<WatcherReachRow[]>();
+    let round = 0;
+    const fake = transport(() => {
+      round += 1;
+      return round === 1
+        ? [reachRow("alpha"), reachRow("beta"), reachRow("gamma")]
+        : pending.promise;
+    });
+    const rendered = await mounted(fake);
+    try {
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 1 agent");
+
+      selectorMode(rendered.root, "alpha", "selected");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toBe("Resolving reach...");
+
+      // The call is out and still unanswered: nothing reappears in the meantime.
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toBe("Resolving reach...");
+
+      pending.resolve([reachRow("alpha"), reachRow("beta"), reachRow("gamma")]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 1 agent");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("re-requests A and settles on A after A to B and back, when A had already answered", async () => {
+    const fake = transport();
+    const rendered = await mounted(fake);
+    try {
+      fake.clearCalls();
+      selectorMode(rendered.root, "alpha", "selected");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      selectorMode(rendered.root, "alpha", "all");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // No answer cache: a shape that returns is asked again rather than restored, because a
+      // cache would add an invalidation question to save one debounced call.
+      const calls = fake.callsFor("preview_watcher_reach");
+      expect(calls).toHaveLength(2);
+      expect(
+        (calls[1].args as { watchers: { commands: unknown }[] }).watchers[0].commands
+      ).toBeNull();
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 1 agent");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("awaits A's own answer after A to B and back, when A was still in flight", async () => {
+    const first = deferred<WatcherReachRow[]>();
+    const second = deferred<WatcherReachRow[]>();
+    const answers = [first.promise, second.promise];
+    const fake = transport(() => answers.shift() ?? []);
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      // Round A is issued and left pending.
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fake.callsFor("preview_watcher_reach")).toHaveLength(1);
+
+      // To B, which issues its own round.
+      selectorMode(rendered.root, "alpha", "selected");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fake.callsFor("preview_watcher_reach")).toHaveLength(2);
+
+      // And back to A while A is STILL in flight: its own answer is the one to wait for.
+      selectorMode(rendered.root, "alpha", "all");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS * 2);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fake.callsFor("preview_watcher_reach")).toHaveLength(2);
+      expect(reachText(rendered.root, "alpha")).toBe("Resolving reach...");
+
+      first.resolve([reachRow("alpha"), reachRow("beta"), reachRow("gamma")]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 1 agent");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("renders an error rather than the previous answer when a call is rejected", async () => {
+    let round = 0;
+    const fake = transport(() => {
+      round += 1;
+      if (round === 1) return [reachRow("alpha"), reachRow("beta"), reachRow("gamma")];
+      throw new Error("resolution failed");
+    });
+    const rendered = await mounted(fake);
+    try {
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 1 agent");
+
+      selectorMode(rendered.root, "alpha", "selected");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(reachText(rendered.root, "alpha")).toContain("Reach unknown");
+      expect(reachText(rendered.root, "alpha")).not.toContain("Would reach 1 agent");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("never lets a stale response overwrite a newer one", async () => {
+    const stale = deferred<WatcherReachRow[]>();
+    const fresh = deferred<WatcherReachRow[]>();
+    const answers = [stale.promise, fresh.promise];
+    const fake = transport(() => answers.shift() ?? []);
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      selectorMode(rendered.root, "alpha", "selected");
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The newer round answers "reaches nobody"; the older one, arriving after it, claims an
+      // agent and must be discarded.
+      fresh.resolve([
+        { id: "alpha", entries: [] },
+        reachRow("beta"),
+        reachRow("gamma"),
+      ]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 0 agents");
+
+      stale.resolve([reachRow("alpha"), reachRow("beta"), reachRow("gamma")]);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(reachText(rendered.root, "alpha")).toContain("Would reach 0 agents");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * #1171 test 58g, the editor half: a row the Rust decoder would reject is classified
+   * unrecognised, is not sent, consumes no budget slot, and survives a save verbatim.
+   */
+  it("leaves rows the decoder would reject out of the request and intact in the save", async () => {
+    const rejected: Record<string, WatcherEntry> = {
+      badcommands: { ...newWatcherConfig(), commands: [1] } as unknown as WatcherEntry,
+      negative: { ...newWatcherConfig(), dedupeWindowMs: -1 },
+      fractional: { ...newWatcherConfig(), dedupeWindowMs: 1.5 },
+      huge: { ...newWatcherConfig(), dedupeWindowMs: 1e30 },
+      unsafe: { ...newWatcherConfig(), dedupeWindowMs: Number.MAX_SAFE_INTEGER + 2 },
+    };
+    const accepted = {
+      boundary: { ...newWatcherConfig(), dedupeWindowMs: Number.MAX_SAFE_INTEGER },
+      good: { ...newWatcherConfig(), pattern: "Read" },
+    };
+
+    const fake = transport();
+    fake.resolve(
+      "get_settings",
+      baseSettings({ agents: [AGENT], watchers: { ...rejected, ...accepted } })
+    );
+
+    const rendered = await mounted(fake);
+    try {
+      const sent = fake.lastCall("preview_watcher_reach")!.args as {
+        watchers: { id: string }[];
+      };
+      expect(sent.watchers.map((row) => row.id).sort()).toEqual(["boundary", "good"]);
+
+      // Named, not hidden, and not offered for editing.
+      const notice = rendered.root.querySelector(
+        '[data-ac-testid="settings.watchers.unreadable"]'
+      );
+      for (const id of Object.keys(rejected)) {
+        expect(notice?.textContent).toContain(id);
+        expect(
+          rendered.root.querySelector(`[data-ac-testid="settings.watchers.row.${id}"]`)
+        ).toBeNull();
+      }
+
+      click(rendered.root.querySelector('[data-ac-testid="settings.save"]')!);
+      await vi.advanceTimersByTimeAsync(0);
+      const draft = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
+        .draft;
+      for (const [id, entry] of Object.entries(rejected)) {
+        expect(draft.watchers?.[id]).toEqual(entry);
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});
+
+/**
+ * #1171 tests 58i and 58k, through the rendered editor.
+ *
+ * An empty pattern is a valid regex that matches every row, so Add plus an accidental Save
+ * would otherwise activate a watcher that matches everything on every agent, fill the caps,
+ * turn the ring over and displace a useful watcher out of an agent's budget.
+ */
+describe("the birth state of a watcher row and how it reads (#1171)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  function transport(rows: WatcherReachRow[], watchers: Record<string, WatcherEntry>) {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings({ agents: [AGENT], watchers }));
+    fake.resolve("get_web_server_status", false);
+    fake.resolve("save_settings_draft", undefined);
+    fake.resolve("preview_watcher_reach", rows);
+    fake.resolve("preview_watcher_pattern", {
+      compiles: true,
+      error: null,
+      sampled: false,
+      matchedRows: 0,
+      totalRows: 0,
+      samples: [],
+      capturesVolatile: false,
+    });
+    return fake;
+  }
+
+  it("adds a disabled row and refuses to enable it while it has no pattern", async () => {
+    const fake = transport([reachRow("watcher-1")], {});
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.add"]')
+        ).toBeTruthy()
+      );
+      click(rendered.root.querySelector('[data-ac-testid="settings.watchers.add"]')!);
+
+      const checkbox = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.enabled.watcher-1"]'
+      );
+      expect(checkbox.checked).toBe(false);
+      expect(checkbox.disabled).toBe(true);
+
+      // Even forced, the change is refused rather than merely discouraged.
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(checkbox.checked).toBe(false);
+
+      click(rendered.root.querySelector('[data-ac-testid="settings.save"]')!);
+      await waitFor(() => expect(fake.lastCall("save_settings_draft")).toBeTruthy());
+      const draft = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
+        .draft;
+      expect((draft.watchers?.["watcher-1"] as WatcherConfig).enabled).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("lets the row be enabled once it has a pattern", async () => {
+    const fake = transport([reachRow("probe")], {
+      probe: { ...newWatcherConfig(), pattern: "Read" },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      const checkbox = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.enabled.probe"]'
+      );
+      expect(checkbox.disabled).toBe(false);
+      click(checkbox);
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.probe"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("enabled")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("states reach in the present tense with a budget badge only when the row is enabled", async () => {
+    const fake = transport([reachRow("probe", false)], {
+      probe: { ...newWatcherConfig(), pattern: "Read", enabled: true },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+            ?.textContent
+        ).toContain("Reaches 1 agent.")
+      );
+      expect(
+        rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+          ?.textContent
+      ).toContain("Not running on Claude (budget).");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("states a disabled row conditionally and never blames the budget for it", async () => {
+    const fake = transport([reachRow("probe", false)], {
+      probe: { ...newWatcherConfig(), pattern: "Read" },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+            ?.textContent
+        ).toContain("Would reach 1 agent when enabled.")
+      );
+      const text =
+        rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+          ?.textContent ?? "";
+      expect(text).not.toContain("budget");
+      expect(text).not.toContain("Add a pattern");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The other half of #1171 test 58g: the predicate rejects what serde rejects AND the editor
+   * cannot produce it. Writing a negative window would reclassify this very row as
+   * unrecognised, taking it out of the editor in the middle of being edited.
+   */
+  it("refuses to write a dedupe window the decoder would reject", async () => {
+    const fake = transport([reachRow("probe")], {
+      probe: { ...newWatcherConfig(), pattern: "Read", mode: "occurrence" },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      const field = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.dedupeWindow.probe"]'
+      );
+      for (const rejected of ["-1", String(Number.MAX_SAFE_INTEGER + 2)]) {
+        input(field, rejected);
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.row.probe"]')
+        ).toBeTruthy();
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.unreadable"]')
+        ).toBeNull();
+      }
+
+      input(field, "5000");
+      click(rendered.root.querySelector('[data-ac-testid="settings.save"]')!);
+      await waitFor(() => expect(fake.lastCall("save_settings_draft")).toBeTruthy());
+      const draft = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
+        .draft;
+      expect((draft.watchers?.probe as WatcherConfig).dedupeWindowMs).toBe(5000);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("names the missing pattern first on the state everyone sees after Add Watcher", async () => {
+    const fake = transport([reachRow("probe", false)], { probe: newWatcherConfig() });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+            ?.textContent
+        ).toBe("Would reach 1 agent when enabled. Add a pattern to enable it.")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});
+
+async function waitForElement<T extends Element>(
+  root: HTMLElement,
+  selector: string
+): Promise<T> {
+  await waitFor(() => expect(root.querySelector(selector)).toBeTruthy());
+  return root.querySelector<T>(selector)!;
+}

--- a/src/sidebar/components/SettingsModal.watchers.test.tsx
+++ b/src/sidebar/components/SettingsModal.watchers.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentConfig,
   AppSettings,
+  JsonValue,
   WatcherConfig,
   WatcherEntry,
   WatcherReachRow,
@@ -59,7 +60,7 @@ describe("resolveSettingsSection (#1171)", () => {
  * save path carries the entry through untouched, which is what this pins.
  */
 describe("saving a settings draft that holds an unreadable watcher (#1171)", () => {
-  const unreadable = { mode: "State", commands: "claude" } as WatcherEntry;
+  const unreadable = { mode: "State", commands: "claude" };
 
   it("carries the unreadable entry and the valid one through the save merge", () => {
     const draft = baseSettings({
@@ -193,7 +194,7 @@ describe("the watcher commands selector, through a real save (#1171)", () => {
       "get_settings",
       baseSettings({
         watchers: {
-          broken: { mode: "State", commands: "claude" } as WatcherEntry,
+          broken: { mode: "State", commands: "claude" },
           good: { ...newWatcherConfig(), pattern: "Read" },
         },
       })
@@ -431,6 +432,48 @@ describe("the reach preview, keyed on the request fingerprint (#1171 test 58h)",
   });
 
   /**
+   * Emptying the pattern clears the preview, but clearing without advancing the generation
+   * leaves an older answer entitled to paint: the row then reads "Compiles" over a pattern
+   * that no longer exists.
+   */
+  it("discards a pattern preview in flight when the pattern is emptied", async () => {
+    const pending = deferred<unknown>();
+    const fake = transport();
+    fake.onInvoke("preview_watcher_pattern", () => pending.promise);
+    const rendered = await mounted(fake);
+    try {
+      expect(fake.callsFor("preview_watcher_pattern").length).toBeGreaterThan(0);
+
+      input(
+        rendered.root.querySelector<HTMLInputElement>(
+          '[data-ac-testid="settings.watchers.pattern.alpha"]'
+        )!,
+        ""
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      pending.resolve({
+        compiles: true,
+        error: null,
+        sampled: true,
+        matchedRows: 30,
+        totalRows: 30,
+        samples: [],
+        capturesVolatile: false,
+      });
+      await vi.advanceTimersByTimeAsync(REACH_DEBOUNCE_MS * 2);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(
+        rendered.root.querySelector('[data-ac-testid="settings.watchers.preview.alpha"]')
+          ?.textContent
+      ).not.toContain("Compiles");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
    * The permanent-pending case. A `pattern` keystroke changes the draft but NOT the request,
    * so it must change nothing at all: no call, and above all no clearing.
    */
@@ -621,12 +664,26 @@ describe("the reach preview, keyed on the request fingerprint (#1171 test 58h)",
    * unrecognised, is not sent, consumes no budget slot, and survives a save verbatim.
    */
   it("leaves rows the decoder would reject out of the request and intact in the save", async () => {
+    // Written as the JSON the file holds, with no cast: `WatcherEntry` now admits any
+    // `serde_json::Value`, which is exactly what Rust preserves and hands back.
+    const raw = (over: Record<string, JsonValue>): WatcherEntry => ({
+      enabled: false,
+      mode: "occurrence",
+      pattern: "",
+      dedupe: "row",
+      dedupeWindowMs: 2000,
+      ...over,
+    });
     const rejected: Record<string, WatcherEntry> = {
-      badcommands: { ...newWatcherConfig(), commands: [1] } as unknown as WatcherEntry,
-      negative: { ...newWatcherConfig(), dedupeWindowMs: -1 },
-      fractional: { ...newWatcherConfig(), dedupeWindowMs: 1.5 },
-      huge: { ...newWatcherConfig(), dedupeWindowMs: 1e30 },
-      unsafe: { ...newWatcherConfig(), dedupeWindowMs: Number.MAX_SAFE_INTEGER + 2 },
+      badcommands: raw({ commands: [1] }),
+      negative: raw({ dedupeWindowMs: -1 }),
+      fractional: raw({ dedupeWindowMs: 1.5 }),
+      huge: raw({ dedupeWindowMs: 1e30 }),
+      unsafe: raw({ dedupeWindowMs: Number.MAX_SAFE_INTEGER + 2 }),
+      // The non-object shapes, which the old mirror could not even express.
+      scalar: "claude",
+      nothing: null,
+      listed: ["claude"],
     };
     const accepted = {
       boundary: { ...newWatcherConfig(), dedupeWindowMs: Number.MAX_SAFE_INTEGER },
@@ -741,6 +798,113 @@ describe("the birth state of a watcher row and how it reads (#1171)", () => {
       const draft = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
         .draft;
       expect((draft.watchers?.["watcher-1"] as WatcherConfig).enabled).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The invariant is `enabled => pattern !== ""`, and it has to hold on EVERY edit.
+   *
+   * Gating only the checkbox leaves this sequence open: type a pattern, enable, then delete
+   * the pattern. Save does not validate watchers, so it persists `enabled: true` with
+   * `pattern: ""` -- the global regex that matches every row on every agent, which is the
+   * flood this whole rule exists to prevent.
+   */
+  it("cannot be walked into an enabled watcher with an empty pattern", async () => {
+    const fake = transport([reachRow("watcher-1")], {});
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.add"]')
+        ).toBeTruthy()
+      );
+      click(rendered.root.querySelector('[data-ac-testid="settings.watchers.add"]')!);
+
+      const pattern = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.pattern.watcher-1"]'
+      );
+      input(pattern, "Read");
+
+      const checkbox = rendered.root.querySelector<HTMLInputElement>(
+        '[data-ac-testid="settings.watchers.enabled.watcher-1"]'
+      )!;
+      await waitFor(() => expect(checkbox.disabled).toBe(false));
+      click(checkbox);
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.watcher-1"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("enabled")
+      );
+
+      // And now the step the checkbox guard never saw.
+      input(pattern, "");
+
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.watcher-1"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("disabled")
+      );
+
+      click(rendered.root.querySelector('[data-ac-testid="settings.save"]')!);
+      await waitFor(() => expect(fake.lastCall("save_settings_draft")).toBeTruthy());
+      const saved = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
+        .draft.watchers?.["watcher-1"] as WatcherConfig;
+      expect(saved.pattern).toBe("");
+      expect(saved.enabled).toBe(false);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("disables a watcher loaded enabled the moment its pattern is emptied", async () => {
+    const fake = transport([reachRow("probe")], {
+      probe: { ...newWatcherConfig(), pattern: "Read", enabled: true },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      const pattern = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.pattern.probe"]'
+      );
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.probe"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("enabled")
+      );
+
+      input(pattern, "");
+
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.probe"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("disabled")
+      );
+      // Auto-disabling flips `enabled`, which is part of the reach request, so the answer is
+      // cleared and re-asked. Once it lands, the line names the missing condition rather than
+      // blaming the budget.
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.reach.probe"]')
+            ?.textContent
+        ).toContain("Add a pattern to enable it.")
+      );
     } finally {
       rendered.cleanup();
     }

--- a/src/sidebar/components/SettingsModal.watchers.test.tsx
+++ b/src/sidebar/components/SettingsModal.watchers.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppSettings, WatcherConfig, WatcherEntry } from "../../shared/types";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+import SettingsModal, { resolveSettingsSection } from "./SettingsModal";
+import { mergeSettingsForSavePreservingProjects } from "./settings-save";
+import { newWatcherConfig } from "./settings-watchers";
+
+/**
+ * #1171 test 59.
+ *
+ * `resolveSettingsSection` falls back to `"general"` for anything it does not know, with no
+ * error and no log. That silence is why this is pinned: the watcher activity window's
+ * day-one empty state offers a "Configure watchers" button, and an unwired section would
+ * land the user on General with nothing to explain it.
+ *
+ * The same gap is why `"resources"` is worth noticing: it is a member of `SettingsTab` and
+ * an entry in `TABS`, the Resource Monitor asks for it by name, and it resolves to
+ * `"general"` all the same. That is the broken precedent this test exists to not repeat.
+ */
+describe("resolveSettingsSection (#1171)", () => {
+  it('maps "watchers" to the Watchers tab and not to General', () => {
+    expect(resolveSettingsSection("watchers")).toBe("watchers");
+  });
+
+  it("keeps every section that already resolved", () => {
+    expect(resolveSettingsSection("agents")).toBe("agents");
+    expect(resolveSettingsSection("profiles")).toBe("agents");
+    expect(resolveSettingsSection("integrations")).toBe("integrations");
+  });
+
+  it("still falls back to General for an unknown or absent section", () => {
+    expect(resolveSettingsSection(undefined)).toBe("general");
+    expect(resolveSettingsSection("nope")).toBe("general");
+  });
+});
+
+/**
+ * #1171 - the editor must not delete what it could not read.
+ *
+ * The Rust `WatcherEntry` is untagged so a hand-written `"mode": "State"` costs one skipped
+ * watcher instead of the whole `AppSettings` parse, and the invalid value is kept verbatim
+ * so a save round-trips the user's bytes. That guarantee only survives if the frontend's
+ * save path carries the entry through untouched, which is what this pins.
+ */
+describe("saving a settings draft that holds an unreadable watcher (#1171)", () => {
+  const unreadable = { mode: "State", commands: "claude" } as WatcherEntry;
+
+  it("carries the unreadable entry and the valid one through the save merge", () => {
+    const draft = baseSettings({
+      watchers: {
+        broken: unreadable,
+        good: newWatcherConfig(),
+      },
+    });
+
+    const merged = mergeSettingsForSavePreservingProjects(draft, baseSettings(), draft);
+
+    expect(Object.keys(merged.watchers ?? {}).sort()).toEqual(["broken", "good"]);
+    expect(merged.watchers?.broken).toEqual(unreadable);
+    expect(merged.watchers?.good).toEqual(newWatcherConfig());
+  });
+
+  it("leaves the map absent when nothing was ever configured", () => {
+    const merged = mergeSettingsForSavePreservingProjects(
+      baseSettings(),
+      baseSettings(),
+      baseSettings()
+    );
+    expect(merged.watchers).toBeUndefined();
+  });
+});
+
+/**
+ * #1171 - "All agents" and an empty "Selected" are opposites, and they have to stay
+ * opposites all the way to the saved draft.
+ *
+ * `null` reaches every configured agent; `[]` reaches none. A plain multiselect cannot
+ * express both, which is why the selector is a mode. The other tests pin the pure
+ * functions; this one pins the payload that actually leaves the modal.
+ */
+describe("the watcher commands selector, through a real save (#1171)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  function watcherSettings(commands: WatcherConfig["commands"]): AppSettings {
+    return baseSettings({
+      watchers: { probe: { ...newWatcherConfig(), pattern: "Read", commands } },
+    });
+  }
+
+  async function savedWatcher(
+    initial: AppSettings,
+    startsAs: "all" | "selected",
+    pick: (root: HTMLElement) => void
+  ): Promise<WatcherEntry | undefined> {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", initial);
+    fake.resolve("get_web_server_status", false);
+    fake.resolve("preview_watcher_reach", []);
+    fake.resolve("preview_watcher_pattern", {
+      compiles: true,
+      error: null,
+      sampled: false,
+      matchedRows: 0,
+      totalRows: 0,
+      samples: [],
+      capturesVolatile: false,
+    });
+    fake.resolve("save_settings_draft", undefined);
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      // Wait for THIS test's settings, not the seed the modal paints from
+      // `settingsStore.current` while `get_settings` is still in flight.
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector<HTMLSelectElement>(
+            '[data-ac-testid="settings.watchers.selectorMode.probe"]'
+          )?.value
+        ).toBe(startsAs)
+      );
+
+      pick(rendered.root);
+
+      rendered.root
+        .querySelector<HTMLButtonElement>('[data-ac-testid="settings.save"]')!
+        .click();
+
+      await waitFor(() => expect(fake.lastCall("save_settings_draft")).toBeTruthy());
+      const draft = fake.lastCall("save_settings_draft")!.args as { draft: AppSettings };
+      return draft.draft.watchers?.probe;
+    } finally {
+      rendered.cleanup();
+    }
+  }
+
+  function selectMode(root: HTMLElement, value: "all" | "selected") {
+    const select = root.querySelector<HTMLSelectElement>(
+      '[data-ac-testid="settings.watchers.selectorMode.probe"]'
+    )!;
+    select.value = value;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  it('saves null when the user picks "All agents"', async () => {
+    const saved = await savedWatcher(watcherSettings(["claude"]), "selected", (root) =>
+      selectMode(root, "all")
+    );
+    expect((saved as WatcherConfig).commands).toBeNull();
+  });
+
+  it('saves an empty list, not null, when "Selected" is left empty', async () => {
+    const saved = await savedWatcher(watcherSettings(null), "all", (root) =>
+      selectMode(root, "selected")
+    );
+    expect((saved as WatcherConfig).commands).toEqual([]);
+  });
+
+  // A malformed entry must cost one watcher, not the tab and not the file.
+  it("renders the readable watchers, names the unreadable one, and edits neither by accident", async () => {
+    const fake = new FakeTransport();
+    fake.resolve(
+      "get_settings",
+      baseSettings({
+        watchers: {
+          broken: { mode: "State", commands: "claude" } as WatcherEntry,
+          good: { ...newWatcherConfig(), pattern: "Read" },
+        },
+      })
+    );
+    fake.resolve("get_web_server_status", false);
+    fake.resolve("preview_watcher_reach", []);
+
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.row.good"]')
+        ).toBeTruthy()
+      );
+
+      expect(
+        rendered.root.querySelector('[data-ac-testid="settings.watchers.row.broken"]')
+      ).toBeNull();
+
+      const notice = rendered.root.querySelector(
+        '[data-ac-testid="settings.watchers.unreadable"]'
+      );
+      expect(notice?.textContent).toContain("broken");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SettingsModal.watchers.test.tsx
+++ b/src/sidebar/components/SettingsModal.watchers.test.tsx
@@ -910,6 +910,66 @@ describe("the birth state of a watcher row and how it reads (#1171)", () => {
     }
   });
 
+  /**
+   * Rename is the other writer, and it was a way out of the state that editing is not.
+   *
+   * A hand-written `{ enabled: true, pattern: "" }` stays as written until the editor touches
+   * it, which is deliberate. But the id is what the 8-per-agent budget resolves in: a `zzz`
+   * sitting outside the first eight, renamed to `aaa` from this control, walks into budget,
+   * displaces a useful watcher and runs the global regex -- without anybody going near the
+   * pattern. Renaming is delete plus create, so the row it creates owes what every created
+   * row owes.
+   */
+  it("does not let Rename carry an enabled empty pattern into a new id", async () => {
+    const fake = transport([reachRow("zzz")], {
+      zzz: { ...newWatcherConfig(), pattern: "", enabled: true },
+    });
+    const rendered = renderWithFakeTransport(
+      () => <SettingsModal section="watchers" onClose={() => {}} />,
+      fake
+    );
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root
+            .querySelector('[data-ac-testid="settings.watchers.row.zzz"]')
+            ?.getAttribute("data-ac-state")
+        ).toBe("enabled")
+      );
+
+      click(rendered.root.querySelector('[data-ac-testid="settings.watchers.renameStart.zzz"]')!);
+      const field = await waitForElement<HTMLInputElement>(
+        rendered.root,
+        '[data-ac-testid="settings.watchers.renameInput.zzz"]'
+      );
+      input(field, "aaa");
+      click(
+        rendered.root.querySelector('[data-ac-testid="settings.watchers.renameConfirm.zzz"]')!
+      );
+
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="settings.watchers.row.aaa"]')
+        ).toBeTruthy()
+      );
+      expect(
+        rendered.root
+          .querySelector('[data-ac-testid="settings.watchers.row.aaa"]')
+          ?.getAttribute("data-ac-state")
+      ).toBe("disabled");
+
+      click(rendered.root.querySelector('[data-ac-testid="settings.save"]')!);
+      await waitFor(() => expect(fake.lastCall("save_settings_draft")).toBeTruthy());
+      const watchers = (fake.lastCall("save_settings_draft")!.args as { draft: AppSettings })
+        .draft.watchers;
+      expect(watchers?.zzz).toBeUndefined();
+      expect((watchers?.aaa as WatcherConfig).enabled).toBe(false);
+      expect((watchers?.aaa as WatcherConfig).pattern).toBe("");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
   it("lets the row be enabled once it has a pattern", async () => {
     const fake = transport([reachRow("probe")], {
       probe: { ...newWatcherConfig(), pattern: "Read" },

--- a/src/sidebar/components/settings-watchers.test.ts
+++ b/src/sidebar/components/settings-watchers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { AgentConfig, WatcherConfig, WatcherEntry } from "../../shared/types";
+import {
+  distinctCommandStems,
+  isWatcherConfig,
+  newWatcherConfig,
+  nextWatcherId,
+  renameWatcherEntry,
+  selectorMode,
+  sortedWatcherIds,
+  toggleCommandStem,
+  validateWatcherId,
+  withSelectorMode,
+} from "./settings-watchers";
+
+function agent(id: string, command: string): AgentConfig {
+  return {
+    id,
+    label: id,
+    command,
+    color: "#6366f1",
+    envs: [],
+    isolatedHome: false,
+  };
+}
+
+function config(overrides: Partial<WatcherConfig> = {}): WatcherConfig {
+  return { ...newWatcherConfig(), ...overrides };
+}
+
+describe("isWatcherConfig (#1171)", () => {
+  it("accepts an entry carrying every field the Rust serializer always writes", () => {
+    expect(isWatcherConfig(config())).toBe(true);
+  });
+
+  it("accepts commands absent, null or empty, which are three different meanings", () => {
+    expect(isWatcherConfig(config({ commands: undefined }))).toBe(true);
+    expect(isWatcherConfig(config({ commands: null }))).toBe(true);
+    expect(isWatcherConfig(config({ commands: [] }))).toBe(true);
+  });
+
+  // The exact hand-written mistakes the Rust wrapper exists to survive.
+  it('rejects a capitalized mode, which is what "mode": "State" deserializes to', () => {
+    expect(isWatcherConfig({ ...config(), mode: "State" } as WatcherEntry)).toBe(false);
+  });
+
+  it("rejects a string where commands must be a list", () => {
+    expect(isWatcherConfig({ ...config(), commands: "claude" } as WatcherEntry)).toBe(false);
+  });
+
+  it("rejects a stringly-typed dedupe window", () => {
+    expect(
+      isWatcherConfig({ ...config(), dedupeWindowMs: "2000" } as WatcherEntry)
+    ).toBe(false);
+  });
+
+  it("rejects a missing pattern and a missing mode", () => {
+    const { pattern: _pattern, ...noPattern } = config();
+    const { mode: _mode, ...noMode } = config();
+    expect(isWatcherConfig(noPattern as WatcherEntry)).toBe(false);
+    expect(isWatcherConfig(noMode as WatcherEntry)).toBe(false);
+  });
+
+  it("rejects a non-object entry", () => {
+    expect(isWatcherConfig("claude" as unknown as WatcherEntry)).toBe(false);
+    expect(isWatcherConfig(null as unknown as WatcherEntry)).toBe(false);
+  });
+});
+
+describe("the commands selector (#1171)", () => {
+  // The whole point of the two-state control: an empty multiselect must not become "[]".
+  it("reports absent and null as All agents, and any list as Selected", () => {
+    expect(selectorMode(config({ commands: undefined }))).toBe("all");
+    expect(selectorMode(config({ commands: null }))).toBe("all");
+    expect(selectorMode(config({ commands: [] }))).toBe("selected");
+    expect(selectorMode(config({ commands: ["claude"] }))).toBe("selected");
+  });
+
+  it("writes null for All agents and a list for Selected, keeping the two distinct", () => {
+    expect(withSelectorMode(config({ commands: ["claude"] }), "all").commands).toBeNull();
+    expect(withSelectorMode(config({ commands: null }), "selected").commands).toEqual([]);
+  });
+
+  it("restores the list the user had picked when switching back to Selected", () => {
+    const picked = config({ commands: ["claude", "codex"] });
+    const all = withSelectorMode(picked, "all");
+    expect(withSelectorMode(all, "selected").commands).toEqual([]);
+  });
+
+  it("toggles one stem without leaving the Selected state", () => {
+    const start = config({ commands: [] });
+    const added = toggleCommandStem(start, "claude");
+    expect(added.commands).toEqual(["claude"]);
+    expect(toggleCommandStem(added, "claude").commands).toEqual([]);
+    expect(selectorMode(toggleCommandStem(added, "claude"))).toBe("selected");
+  });
+});
+
+describe("watcher ids (#1171)", () => {
+  it("accepts the documented shape and rejects what it does not match", () => {
+    expect(validateWatcherId("permission-prompt", [])).toBeNull();
+    expect(validateWatcherId("w1", [])).toBeNull();
+    expect(validateWatcherId("", [])).not.toBeNull();
+    expect(validateWatcherId("Permission", [])).not.toBeNull();
+    expect(validateWatcherId("-leading", [])).not.toBeNull();
+    expect(validateWatcherId("has space", [])).not.toBeNull();
+    expect(validateWatcherId("a".repeat(41), [])).not.toBeNull();
+    expect(validateWatcherId("a".repeat(40), [])).toBeNull();
+  });
+
+  it("rejects an id another watcher already holds", () => {
+    expect(validateWatcherId("taken", ["taken"])).not.toBeNull();
+    expect(validateWatcherId("free", ["taken"])).toBeNull();
+  });
+
+  it("never proposes an id that already exists", () => {
+    expect(nextWatcherId([])).toBe("watcher-1");
+    expect(nextWatcherId(["watcher-1", "watcher-2"])).toBe("watcher-3");
+  });
+});
+
+describe("renaming a watcher (#1171)", () => {
+  // Renaming is delete plus create, so what must be proven is that it takes nothing else
+  // with it -- above all the entry this build could not read.
+  it("moves one key and preserves every other entry, unreadable ones included", () => {
+    const unreadable = { mode: "State", pattern: 7 } as WatcherEntry;
+    const watchers: Record<string, WatcherEntry> = {
+      keep: config({ pattern: "keep" }),
+      old: config({ pattern: "moved" }),
+      broken: unreadable,
+    };
+
+    const renamed = renameWatcherEntry(watchers, "old", "new");
+
+    expect(Object.keys(renamed).sort()).toEqual(["broken", "keep", "new"]);
+    expect(renamed["new"]).toEqual(config({ pattern: "moved" }));
+    expect(renamed["keep"]).toEqual(config({ pattern: "keep" }));
+    expect(renamed["broken"]).toBe(unreadable);
+  });
+
+  it("leaves the map alone when the id is not there", () => {
+    const watchers: Record<string, WatcherEntry> = { a: config() };
+    expect(renameWatcherEntry(watchers, "missing", "new")).toEqual(watchers);
+  });
+});
+
+describe("command stems for the Selected options (#1171)", () => {
+  it("collapses five entries sharing one executable into one option", () => {
+    const stems = distinctCommandStems([
+      agent("a", "claude"),
+      agent("b", String.raw`C:\tools\claude-sandbox-runtime\claude.cmd`),
+      agent("c", "CLAUDE.EXE"),
+      agent("d", "codex --sandbox workspace-write"),
+      agent("e", "claude"),
+    ]);
+    expect(stems).toEqual(["claude", "codex"]);
+  });
+
+  it("ignores an agent with no command", () => {
+    expect(distinctCommandStems([agent("a", "")])).toEqual([]);
+  });
+});
+
+describe("watcher map ordering (#1171)", () => {
+  it("lists ids in key order, which is the order the budget resolves in", () => {
+    expect(sortedWatcherIds({ b: config(), a: config(), c: config() })).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("treats an absent map as empty", () => {
+    expect(sortedWatcherIds(undefined)).toEqual([]);
+  });
+});

--- a/src/sidebar/components/settings-watchers.test.ts
+++ b/src/sidebar/components/settings-watchers.test.ts
@@ -49,31 +49,59 @@ describe("isWatcherConfig (#1171)", () => {
     expect(isWatcherConfig(config({ commands: [] }))).toBe(true);
   });
 
-  // The exact hand-written mistakes the Rust wrapper exists to survive.
+  // The exact hand-written mistakes the Rust wrapper exists to survive. Written as plain
+  // JSON, with no cast, because that is what the file holds and what `WatcherEntry` now says.
   it('rejects a capitalized mode, which is what "mode": "State" deserializes to', () => {
-    expect(isWatcherConfig({ ...config(), mode: "State" } as WatcherEntry)).toBe(false);
+    const entry: WatcherEntry = {
+      enabled: true,
+      mode: "State",
+      pattern: "x",
+      dedupe: "row",
+      dedupeWindowMs: 2000,
+    };
+    expect(isWatcherConfig(entry)).toBe(false);
   });
 
   it("rejects a string where commands must be a list", () => {
-    expect(isWatcherConfig({ ...config(), commands: "claude" } as WatcherEntry)).toBe(false);
+    const entry: WatcherEntry = {
+      enabled: true,
+      mode: "state",
+      pattern: "x",
+      commands: "claude",
+      dedupe: "row",
+      dedupeWindowMs: 2000,
+    };
+    expect(isWatcherConfig(entry)).toBe(false);
   });
 
   it("rejects a stringly-typed dedupe window", () => {
-    expect(
-      isWatcherConfig({ ...config(), dedupeWindowMs: "2000" } as WatcherEntry)
-    ).toBe(false);
+    const entry: WatcherEntry = {
+      enabled: true,
+      mode: "state",
+      pattern: "x",
+      dedupe: "row",
+      dedupeWindowMs: "2000",
+    };
+    expect(isWatcherConfig(entry)).toBe(false);
   });
 
   it("rejects a missing pattern and a missing mode", () => {
     const { pattern: _pattern, ...noPattern } = config();
     const { mode: _mode, ...noMode } = config();
-    expect(isWatcherConfig(noPattern as WatcherEntry)).toBe(false);
-    expect(isWatcherConfig(noMode as WatcherEntry)).toBe(false);
+    expect(isWatcherConfig(noPattern)).toBe(false);
+    expect(isWatcherConfig(noMode)).toBe(false);
   });
 
-  it("rejects a non-object entry", () => {
-    expect(isWatcherConfig("claude" as unknown as WatcherEntry)).toBe(false);
-    expect(isWatcherConfig(null as unknown as WatcherEntry)).toBe(false);
+  /**
+   * `WatcherEntry::Invalid` holds a `serde_json::Value`, so the entry Rust preserved and
+   * handed back can be any JSON value at all. A predicate that only ever sees objects is one
+   * whose callers had to lie to it with a cast.
+   */
+  it("rejects every non-object JSON value Rust can just as easily preserve", () => {
+    const entries: WatcherEntry[] = [null, 7, -1.5, "claude", true, false, ["claude"], []];
+    for (const entry of entries) {
+      expect(isWatcherConfig(entry)).toBe(false);
+    }
   });
 
   /**
@@ -163,7 +191,15 @@ describe("the reach request (#1171)", () => {
         fractional: config({ dedupeWindowMs: 1.5 }),
         huge: config({ dedupeWindowMs: 1e30 }),
         unsafe: config({ dedupeWindowMs: Number.MAX_SAFE_INTEGER + 2 }),
-        capitalized: { ...config(), mode: "State" } as WatcherEntry,
+        capitalized: {
+          enabled: true,
+          mode: "State",
+          pattern: "x",
+          dedupe: "row",
+          dedupeWindowMs: 2000,
+        },
+        scalar: "claude",
+        nothing: null,
       },
       agents
     );
@@ -312,16 +348,27 @@ describe("renaming a watcher (#1171)", () => {
   // Renaming is delete plus create, so what must be proven is that it takes nothing else
   // with it -- above all the entry this build could not read.
   it("moves one key and preserves every other entry, unreadable ones included", () => {
-    const unreadable = { mode: "State", pattern: 7 } as WatcherEntry;
+    const unreadable: WatcherEntry = { mode: "State", pattern: 7 };
     const watchers: Record<string, WatcherEntry> = {
       keep: config({ pattern: "keep" }),
       old: config({ pattern: "moved" }),
       broken: unreadable,
+      // The shapes a hand-written file can hold that are not objects at all.
+      scalar: "claude",
+      nothing: null,
     };
 
     const renamed = renameWatcherEntry(watchers, "old", "new");
 
-    expect(Object.keys(renamed).sort()).toEqual(["broken", "keep", "new"]);
+    expect(Object.keys(renamed).sort()).toEqual([
+      "broken",
+      "keep",
+      "new",
+      "nothing",
+      "scalar",
+    ]);
+    expect(renamed["scalar"]).toBe("claude");
+    expect(renamed["nothing"]).toBeNull();
     expect(renamed["new"]).toEqual(config({ pattern: "moved" }));
     expect(renamed["keep"]).toEqual(config({ pattern: "keep" }));
     expect(renamed["broken"]).toBe(unreadable);

--- a/src/sidebar/components/settings-watchers.test.ts
+++ b/src/sidebar/components/settings-watchers.test.ts
@@ -378,6 +378,40 @@ describe("renaming a watcher (#1171)", () => {
     const watchers: Record<string, WatcherEntry> = { a: config() };
     expect(renameWatcherEntry(watchers, "missing", "new")).toEqual(watchers);
   });
+
+  /**
+   * Renaming IS delete plus create, which the editor states next to the control, so the row
+   * it creates has to satisfy what every other created row satisfies.
+   *
+   * A hand-written `{ enabled: true, pattern: "" }` is deliberately legal for Rust and stays
+   * as written until the editor touches it. But moving it is the editor writing a row, and
+   * the id is what the 8-per-agent budget resolves in: a `zzz` sitting outside the first
+   * eight, renamed to `aaa`, walks into budget, displaces a useful watcher and runs the
+   * global regex -- with nobody having gone near the pattern.
+   */
+  it("applies the editor's invariant to the row it creates", () => {
+    const renamed = renameWatcherEntry(
+      { zzz: config({ enabled: true, pattern: "" }) },
+      "zzz",
+      "aaa"
+    );
+    expect((renamed["aaa"] as WatcherConfig).enabled).toBe(false);
+    expect((renamed["aaa"] as WatcherConfig).pattern).toBe("");
+  });
+
+  it("leaves a renamed row with a pattern exactly as it was", () => {
+    const original = config({ enabled: true, pattern: "Read" });
+    const renamed = renameWatcherEntry({ old: original }, "old", "new");
+    expect(renamed["new"]).toEqual(original);
+  });
+
+  it("still moves an unreadable entry byte for byte, invariant or not", () => {
+    // There is no config to hold an invariant over, and the contract is that what this build
+    // could not read comes back exactly as written.
+    const unreadable: WatcherEntry = { enabled: true, pattern: "", mode: "State" };
+    const renamed = renameWatcherEntry({ old: unreadable }, "old", "new");
+    expect(renamed["new"]).toBe(unreadable);
+  });
 });
 
 describe("command stems for the Selected options (#1171)", () => {

--- a/src/sidebar/components/settings-watchers.test.ts
+++ b/src/sidebar/components/settings-watchers.test.ts
@@ -1,15 +1,25 @@
 import { describe, expect, it } from "vitest";
-import type { AgentConfig, WatcherConfig, WatcherEntry } from "../../shared/types";
+import type {
+  AgentConfig,
+  WatcherConfig,
+  WatcherEntry,
+  WatcherReachEntry,
+} from "../../shared/types";
 import {
+  canEnableWatcher,
   distinctCommandStems,
   isWatcherConfig,
   newWatcherConfig,
   nextWatcherId,
+  reachRequestFingerprint,
   renameWatcherEntry,
   selectorMode,
   sortedWatcherIds,
   toggleCommandStem,
   validateWatcherId,
+  watcherBudgetNotice,
+  watcherReachRequest,
+  watcherReachSummary,
   withSelectorMode,
 } from "./settings-watchers";
 
@@ -64,6 +74,185 @@ describe("isWatcherConfig (#1171)", () => {
   it("rejects a non-object entry", () => {
     expect(isWatcherConfig("claude" as unknown as WatcherEntry)).toBe(false);
     expect(isWatcherConfig(null as unknown as WatcherEntry)).toBe(false);
+  });
+
+  /**
+   * #1171 test 58g, the whole numeric contract and not only the obvious member of it.
+   *
+   * `typeof n === "number" && n >= 0` is the naive correction and it must FAIL this: it still
+   * admits `1.5` and `1e30`, both of which serde rejects for a `u64`, so both would be sent
+   * to `preview_watcher_reach`, counted against an agent's budget, possibly push a real
+   * watcher out of it, and then be skipped by the engine after Save. `-1` alone does not
+   * exercise the gap.
+   */
+  it("rejects every dedupe window the Rust decoder rejects, not only the negative one", () => {
+    for (const dedupeWindowMs of [-1, 1.5, 1e30, Number.MAX_SAFE_INTEGER + 2, NaN]) {
+      expect(isWatcherConfig(config({ dedupeWindowMs }))).toBe(false);
+    }
+  });
+
+  it("accepts the boundary it can still hold exactly", () => {
+    expect(isWatcherConfig(config({ dedupeWindowMs: 0 }))).toBe(true);
+    expect(isWatcherConfig(config({ dedupeWindowMs: Number.MAX_SAFE_INTEGER }))).toBe(true);
+  });
+
+  // Deliberately narrower than `u64`: JavaScript cannot hold a value above 2^53 exactly, and
+  // rounding one silently would be worse than declining to edit it. The engine still runs
+  // such a row, clamped; the editor lists it as unrecognised.
+  it("classifies a hand-written window above 2^53 as unrecognised rather than rounding it", () => {
+    expect(isWatcherConfig(config({ dedupeWindowMs: 2 ** 53 + 2 }))).toBe(false);
+  });
+
+  it("requires every commands entry to be a string, not merely an array", () => {
+    expect(isWatcherConfig(config({ commands: [1] as unknown as string[] }))).toBe(false);
+    expect(isWatcherConfig(config({ commands: ["claude", "codex"] }))).toBe(true);
+  });
+});
+
+/**
+ * #1171 - the birth state of a new row is a decision, not a preference.
+ *
+ * An empty pattern is a valid regex that matches every row, so a row born enabled turns Add
+ * plus an accidental Save into a watcher that matches everything on every agent.
+ */
+describe("a brand-new watcher row (#1171 test 58k)", () => {
+  it("is born disabled", () => {
+    expect(newWatcherConfig().enabled).toBe(false);
+  });
+
+  it("cannot be enabled until it has a pattern", () => {
+    expect(canEnableWatcher(newWatcherConfig())).toBe(false);
+    expect(canEnableWatcher(config({ pattern: "Read" }))).toBe(true);
+    // A single space is a pattern: it is an anchor, and the engine takes it verbatim.
+    expect(canEnableWatcher(config({ pattern: " " }))).toBe(true);
+  });
+});
+
+/**
+ * #1171 test 58g and 58h, the request half.
+ *
+ * Both halves of the draft travel and nothing comes from disk, because running is a property
+ * of the whole set and the modal edits agents and watchers in one store that one Save writes
+ * together.
+ */
+describe("the reach request (#1171)", () => {
+  const agents = [agent("a1", "claude"), agent("a2", "codex")];
+
+  it("carries every valid row in key order, plus the draft agents", () => {
+    const request = watcherReachRequest(
+      { b: config({ pattern: "b" }), a: config({ pattern: "a", enabled: true }) },
+      agents
+    );
+    expect(request.watchers.map((row) => row.id)).toEqual(["a", "b"]);
+    expect(request.watchers[0]).toEqual({ id: "a", enabled: true, commands: null });
+    expect(request.agents).toEqual([
+      { id: "a1", label: "a1", command: "claude" },
+      { id: "a2", label: "a2", command: "codex" },
+    ]);
+  });
+
+  // A row this predicate calls valid and serde does not would be counted against the budget
+  // and then skipped by the engine, which is the same false positive the draft shape exists
+  // to remove.
+  it("leaves out every row the Rust decoder would reject", () => {
+    const request = watcherReachRequest(
+      {
+        good: config({ pattern: "ok" }),
+        badCommands: config({ commands: [1] as unknown as string[] }),
+        negative: config({ dedupeWindowMs: -1 }),
+        fractional: config({ dedupeWindowMs: 1.5 }),
+        huge: config({ dedupeWindowMs: 1e30 }),
+        unsafe: config({ dedupeWindowMs: Number.MAX_SAFE_INTEGER + 2 }),
+        capitalized: { ...config(), mode: "State" } as WatcherEntry,
+      },
+      agents
+    );
+    expect(request.watchers.map((row) => row.id)).toEqual(["good"]);
+  });
+
+  it("normalizes absent and null commands to one request, because they mean one thing", () => {
+    const absent = watcherReachRequest({ a: config({ commands: undefined }) }, agents);
+    const explicit = watcherReachRequest({ a: config({ commands: null }) }, agents);
+    expect(reachRequestFingerprint(absent)).toBe(reachRequestFingerprint(explicit));
+    // And `[]` stays the opposite of both.
+    const none = watcherReachRequest({ a: config({ commands: [] }) }, agents);
+    expect(reachRequestFingerprint(none)).not.toBe(reachRequestFingerprint(absent));
+  });
+
+  /**
+   * The fingerprint is what makes the guard consistent with itself: keying on "any change to
+   * the draft" clears the answer on a `pattern` keystroke and then issues no call to replace
+   * it, leaving the row pending forever.
+   */
+  it("is unchanged by a pattern keystroke and changed by everything that resolves", () => {
+    const base = { a: config({ pattern: "Read" }) };
+    const fingerprint = reachRequestFingerprint(watcherReachRequest(base, agents));
+
+    const typed = { a: config({ pattern: "Read (" }) };
+    expect(reachRequestFingerprint(watcherReachRequest(typed, agents))).toBe(fingerprint);
+
+    const changes: Record<string, WatcherEntry>[] = [
+      { a: config({ pattern: "Read", enabled: true }) },
+      { a: config({ pattern: "Read", commands: ["claude"] }) },
+      { a: config({ pattern: "Read" }), b: config({ pattern: "x" }) },
+      {},
+    ];
+    for (const changed of changes) {
+      expect(reachRequestFingerprint(watcherReachRequest(changed, agents))).not.toBe(
+        fingerprint
+      );
+    }
+
+    // An agent edit resolves too: deleting one and changing one's command both over-report
+    // if the saved list is used instead.
+    expect(
+      reachRequestFingerprint(watcherReachRequest(base, [agent("a1", "codex"), agents[1]]))
+    ).not.toBe(fingerprint);
+    expect(reachRequestFingerprint(watcherReachRequest(base, [agents[0]]))).not.toBe(
+      fingerprint
+    );
+  });
+});
+
+/** #1171 test 58i, the three wordings, which answer three different questions. */
+describe("how a row states its reach (#1171 test 58i)", () => {
+  const entry = (agentId: string, allocated: boolean): WatcherReachEntry => ({
+    agentId,
+    agentLabel: agentId.toUpperCase(),
+    commandStem: "claude",
+    allocated,
+  });
+
+  it("uses the present tense and the budget badge only for an enabled row", () => {
+    const enabled = config({ enabled: true, pattern: "Read" });
+    const entries = [entry("a1", true), entry("a2", false)];
+    expect(watcherReachSummary(enabled, entries)).toBe("Reaches 2 agents.");
+    expect(watcherBudgetNotice(enabled, entries)).toBe(" Not running on A2 (budget).");
+  });
+
+  // A disabled row holds no slot BECAUSE it is disabled, so naming that a budget outcome
+  // would name the wrong cause.
+  it("uses the conditional and shows no badge for a disabled row with a pattern", () => {
+    const disabled = config({ enabled: false, pattern: "Read" });
+    const entries = [entry("a1", false)];
+    expect(watcherReachSummary(disabled, entries)).toBe(
+      "Would reach 1 agent when enabled."
+    );
+    expect(watcherBudgetNotice(disabled, entries)).toBe("");
+  });
+
+  // The first state anyone sees after Add Watcher. "When enabled" alone offers a condition
+  // the editor refuses to let them meet, so the missing one is named first.
+  it("names the missing pattern first for a disabled row that has none", () => {
+    expect(watcherReachSummary(newWatcherConfig(), [entry("a1", false)])).toBe(
+      "Would reach 1 agent when enabled. Add a pattern to enable it."
+    );
+  });
+
+  it("reports reaching nobody without pretending it is an error", () => {
+    expect(watcherReachSummary(config({ enabled: true, pattern: "x" }), [])).toBe(
+      "Reaches 0 agents."
+    );
   });
 });
 

--- a/src/sidebar/components/settings-watchers.ts
+++ b/src/sidebar/components/settings-watchers.ts
@@ -40,8 +40,11 @@ const WATCHER_DEDUPES: readonly WatcherDedupe[] = ["row", "capture", "none"];
  * budget -- and it is unreachable in practice, because the frontend never sees the file's
  * bytes but what Rust re-serialized, and those three fields carry no `skip_serializing_if`.
  */
-export function isWatcherConfig(entry: WatcherEntry): entry is WatcherConfig {
-  if (typeof entry !== "object" || entry === null) return false;
+export function isWatcherConfig(entry: unknown): entry is WatcherConfig {
+  // `unknown` and not `WatcherEntry`: the value really is a `serde_json::Value`, so it can be
+  // a string, a number, `null` or an array as easily as an object, and a decoder that only
+  // accepts what it already believes is not a decoder.
+  if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return false;
   const candidate = entry as Partial<WatcherConfig>;
   if (typeof candidate.enabled !== "boolean") return false;
   if (!WATCHER_MODES.includes(candidate.mode as WatcherMode)) return false;
@@ -126,6 +129,25 @@ export function newWatcherConfig(): WatcherConfig {
  */
 export function canEnableWatcher(config: WatcherConfig): boolean {
   return config.pattern !== "";
+}
+
+/**
+ * The editor's one invariant, applied to every write: an enabled watcher has a pattern.
+ *
+ * Gating the checkbox alone is not enough, because `enabled` is not the only field that can
+ * break the pair. Type a pattern, enable the row, then delete the pattern, and the row is
+ * left `enabled: true` with `pattern: ""` -- the global regex that matches every row on every
+ * agent, which is the flood the whole rule exists to prevent. Save does not validate
+ * watchers, so it would be persisted.
+ *
+ * Auto-disabling rather than blocking the edit is deliberate: clearing a pattern to rewrite
+ * it is ordinary work, and refusing the keystroke would fight the user over a field they are
+ * in the middle of. The row says why it turned off, in the sentence
+ * `watcherReachSummary` gives it.
+ */
+export function withWatcherInvariant(config: WatcherConfig): WatcherConfig {
+  if (config.enabled && !canEnableWatcher(config)) return { ...config, enabled: false };
+  return config;
 }
 
 /** An id no existing watcher holds, so "Add watcher" never collides. */

--- a/src/sidebar/components/settings-watchers.ts
+++ b/src/sidebar/components/settings-watchers.ts
@@ -1,10 +1,13 @@
 import { commandExecutableBasename } from "../../shared/profile-utils";
 import type {
   AgentConfig,
+  WatcherAgentDraftEntry,
   WatcherConfig,
   WatcherDedupe,
+  WatcherDraftEntry,
   WatcherEntry,
   WatcherMode,
+  WatcherReachEntry,
 } from "../../shared/types";
 
 /**
@@ -24,10 +27,18 @@ const WATCHER_DEDUPES: readonly WatcherDedupe[] = ["row", "capture", "none"];
  * The Rust side keeps an unrecognized entry verbatim rather than dropping it, so that a
  * hand-written `"mode": "State"` costs one skipped watcher instead of the whole
  * `AppSettings` parse. The editor has to honour the same contract: what it cannot read, it
- * must not offer to edit, and must not delete on save.
+ * must not offer to edit, must not delete on save, and must not send to
+ * `preview_watcher_reach` -- a row this predicate calls valid and `serde` does not would be
+ * counted against an agent's budget, could push a real watcher out of it, and would then be
+ * skipped by the engine after Save.
  *
- * Every field required here is written unconditionally by the Rust serializer, so a valid
- * entry that made the round trip always carries all five, whatever the file omitted.
+ * **The predicate mirrors what the serializer emits and rejects everything the decoder would
+ * reject.** That is one-directional on purpose and it is not "the exact mirror of the
+ * decoder": `serde` accepts `enabled`, `dedupe` and `dedupeWindowMs` absent through
+ * `#[serde(default)]`, while this requires them present. Being stricter is the safe
+ * direction -- the worst it does is leave a row out of the request, which under-reports the
+ * budget -- and it is unreachable in practice, because the frontend never sees the file's
+ * bytes but what Rust re-serialized, and those three fields carry no `skip_serializing_if`.
  */
 export function isWatcherConfig(entry: WatcherEntry): entry is WatcherConfig {
   if (typeof entry !== "object" || entry === null) return false;
@@ -36,19 +47,40 @@ export function isWatcherConfig(entry: WatcherEntry): entry is WatcherConfig {
   if (!WATCHER_MODES.includes(candidate.mode as WatcherMode)) return false;
   if (typeof candidate.pattern !== "string") return false;
   if (!WATCHER_DEDUPES.includes(candidate.dedupe as WatcherDedupe)) return false;
-  if (typeof candidate.dedupeWindowMs !== "number") return false;
-  if (
-    candidate.commands !== undefined &&
-    candidate.commands !== null &&
-    !Array.isArray(candidate.commands)
-  ) {
-    return false;
-  }
+  if (!isDedupeWindowMs(candidate.dedupeWindowMs)) return false;
+  if (!isCommandsSelector(candidate.commands)) return false;
   return (
     candidate.capturedAgainst === undefined ||
     candidate.capturedAgainst === null ||
     typeof candidate.capturedAgainst === "string"
   );
+}
+
+/**
+ * `Vec<String>`, and not merely "an array".
+ *
+ * `commands: [1]` is an array, so a bare `Array.isArray` admits it while `serde` classifies
+ * the whole entry as `Invalid`. Absent and `null` both mean "every configured agent"; `[]`
+ * means "nobody". All three are legal and they are three different things.
+ */
+function isCommandsSelector(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+/**
+ * A `u64` this editor can actually hold.
+ *
+ * `typeof n === "number" && n >= 0` is the naive correction and it is not sufficient: it
+ * still admits `1.5` and `1e30`, both of which `serde` rejects for a `u64`, so both would
+ * travel and consume a budget slot. Safe-integer is deliberately NARROWER than `u64` as
+ * well: JavaScript cannot represent every `u64` exactly, so a hand-written value above 2^53
+ * is classified unrecognised rather than silently rounded. Such a row still runs in the
+ * engine, clamped, and the editor lists it instead of offering to edit a number it cannot
+ * hold.
+ */
+function isDedupeWindowMs(value: unknown): boolean {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 /** A watcher id is invalid, taken, or fine. Returns the message to show, or null. */
@@ -61,15 +93,39 @@ export function validateWatcherId(id: string, takenIds: readonly string[]): stri
   return null;
 }
 
-/** The shape a brand-new row starts from. Mirrors the Rust serde defaults. */
+/**
+ * The shape a brand-new row starts from.
+ *
+ * **Born disabled**, which is the one place this deviates from the Rust serde defaults, and
+ * deliberately. An empty pattern is a valid regex that matches every row, so a row born
+ * enabled turns Add plus an accidental Save into a watcher that matches everything on every
+ * agent: it fills the per-tick caps, turns the ring over, goes degraded and can displace a
+ * useful watcher out of an agent's budget, all without the user having written a pattern or
+ * looked at the preview. The editor also refuses to enable a row whose pattern is empty
+ * (`canEnableWatcher`).
+ *
+ * The serde default for a HAND-WRITTEN file stays `true`: an omitted `enabled` in a file
+ * someone wrote deliberately means on. Only the editor's new-row shape changes.
+ */
 export function newWatcherConfig(): WatcherConfig {
   return {
-    enabled: true,
+    enabled: false,
     mode: "occurrence",
     pattern: "",
     dedupe: "row",
     dedupeWindowMs: 2000,
   };
+}
+
+/**
+ * Whether the editor will let this row be enabled.
+ *
+ * The Rust compiler is NOT changed to reject an empty pattern: it is a legal regex, a
+ * hand-written one is bounded by the caps and the suspension rule, and the editor is where
+ * the user is.
+ */
+export function canEnableWatcher(config: WatcherConfig): boolean {
+  return config.pattern !== "";
 }
 
 /** An id no existing watcher holds, so "Add watcher" never collides. */
@@ -152,4 +208,108 @@ export function sortedWatcherIds(
   watchers: Readonly<Record<string, WatcherEntry>> | undefined
 ): string[] {
   return Object.keys(watchers ?? {}).sort();
+}
+
+/**
+ * What a row's reach reads as, which depends on whether the row is enabled.
+ *
+ * The two fields answer different questions and are therefore worded differently. `entries`
+ * is what the row's SELECTOR reaches, whatever its `enabled`; `allocated` is whether the row
+ * holds a slot on that agent after Save.
+ *
+ * A disabled row gets "would reach ... when enabled" rather than the present tense, because
+ * "reaches" on a watcher that is doing nothing is a false statement, and it is the
+ * over-reporting direction this feature refuses everywhere else. A disabled row with an empty
+ * pattern gets a second sentence naming the missing condition first: it is the state every
+ * user sees the instant they press Add Watcher, and "when enabled" alone offers a condition
+ * the editor refuses to let them meet. The reach is kept after it rather than hidden, because
+ * configuring the selector before the pattern is a legitimate order of work and it is the
+ * reason a disabled row's reach is reported at all.
+ */
+export function watcherReachSummary(
+  config: WatcherConfig,
+  entries: readonly WatcherReachEntry[]
+): string {
+  const count = `${entries.length} agent${entries.length === 1 ? "" : "s"}`;
+  if (config.enabled) return `Reaches ${count}.`;
+  const would = `Would reach ${count} when enabled.`;
+  return canEnableWatcher(config) ? would : `${would} Add a pattern to enable it.`;
+}
+
+/**
+ * The budget badge, which only an ENABLED row can carry.
+ *
+ * An enabled row that reaches an agent and holds no slot can only be out of budget, so the
+ * badge names the one real reason. A disabled row holds no slot BECAUSE it is disabled, and
+ * presenting that as a budget outcome would name the wrong cause, so it gets no badge at all.
+ *
+ * `allocated` is slot assignment and not a promise of output: a resolved watcher whose regex
+ * does not compile is allocated a slot and is inert. That dimension is answered on the same
+ * row by the pattern preview and is deliberately not restated here.
+ */
+export function watcherBudgetNotice(
+  config: WatcherConfig,
+  entries: readonly WatcherReachEntry[]
+): string {
+  if (!config.enabled) return "";
+  const displaced = entries.filter((entry) => !entry.allocated);
+  if (displaced.length === 0) return "";
+  const names = displaced.map((entry) => entry.agentLabel || entry.agentId).join(", ");
+  return ` Not running on ${names} (budget).`;
+}
+
+/** Both halves of one `preview_watcher_reach` call. */
+export interface WatcherReachRequest {
+  watchers: WatcherDraftEntry[];
+  agents: WatcherAgentDraftEntry[];
+}
+
+/**
+ * The exact request the Watchers section would send for this draft.
+ *
+ * Both halves come from the draft and nothing comes from disk. Whether a watcher holds one of
+ * an agent's 8 slots is a property of the whole set, and the modal edits agents and watchers
+ * in one store that one Save writes together, so an answer resolved against either saved half
+ * would describe a state the user has already left.
+ *
+ * Unrecognised entries are left out: resolution skips them before any budget is counted, so
+ * they consume no slot and sending them would only produce notices. They are still preserved
+ * verbatim for the save.
+ *
+ * `undefined` and `null` `commands` both mean "every configured agent" and are normalized to
+ * `null`, so two drafts that differ only in which of the two they hold are one request and
+ * not two.
+ */
+export function watcherReachRequest(
+  watchers: Readonly<Record<string, WatcherEntry>> | undefined,
+  agents: readonly AgentConfig[]
+): WatcherReachRequest {
+  const map = watchers ?? {};
+  const rows: WatcherDraftEntry[] = [];
+  for (const id of sortedWatcherIds(map)) {
+    const entry = map[id];
+    if (!isWatcherConfig(entry)) continue;
+    rows.push({ id, enabled: entry.enabled, commands: entry.commands ?? null });
+  }
+  return {
+    watchers: rows,
+    agents: agents.map((agent) => ({
+      id: agent.id,
+      label: agent.label,
+      command: agent.command,
+    })),
+  };
+}
+
+/**
+ * The identity of a request, which is what the displayed reach answer belongs to.
+ *
+ * Keying the guard on the REQUEST rather than on "any change to the draft" is what makes the
+ * rule consistent with itself: a `pattern` keystroke changes the draft but not the request,
+ * so under a clear-on-any-change rule the answer would be cleared and no call would ever
+ * replace it, leaving the row pending forever. Under this key a `pattern` keystroke changes
+ * nothing at all.
+ */
+export function reachRequestFingerprint(request: WatcherReachRequest): string {
+  return JSON.stringify(request);
 }

--- a/src/sidebar/components/settings-watchers.ts
+++ b/src/sidebar/components/settings-watchers.ts
@@ -211,6 +211,17 @@ export function distinctCommandStems(agents: readonly AgentConfig[]): string[] {
  * This really is delete plus create: the id is the map key and the same grouping key the
  * activity window and the history counters use, so activations already recorded under the
  * old id keep it. The UI says so next to the control.
+ *
+ * **And because it is a create, the row it produces goes through `withWatcherInvariant` like
+ * every other row the editor creates.** Without that, Rename is a way out of a state that
+ * editing has no way out of: a hand-written `{ enabled: true, pattern: "" }` is deliberately
+ * left as written until the editor touches it, but the id is exactly what the 8-per-agent
+ * budget resolves in, so a `zzz` sitting outside the first eight, renamed to `aaa`, walks
+ * into budget, displaces a useful watcher and runs the global regex -- with nobody having
+ * gone near the pattern.
+ *
+ * An entry this build could not read still moves byte for byte: there is no config to hold
+ * an invariant over, and preserving what it cannot read is the contract.
  */
 export function renameWatcherEntry(
   watchers: Readonly<Record<string, WatcherEntry>>,
@@ -219,8 +230,11 @@ export function renameWatcherEntry(
 ): Record<string, WatcherEntry> {
   const renamed: Record<string, WatcherEntry> = {};
   for (const [id, entry] of Object.entries(watchers)) {
-    if (id === fromId) renamed[toId] = entry;
-    else renamed[id] = entry;
+    if (id !== fromId) {
+      renamed[id] = entry;
+      continue;
+    }
+    renamed[toId] = isWatcherConfig(entry) ? withWatcherInvariant(entry) : entry;
   }
   return renamed;
 }

--- a/src/sidebar/components/settings-watchers.ts
+++ b/src/sidebar/components/settings-watchers.ts
@@ -1,0 +1,155 @@
+import { commandExecutableBasename } from "../../shared/profile-utils";
+import type {
+  AgentConfig,
+  WatcherConfig,
+  WatcherDedupe,
+  WatcherEntry,
+  WatcherMode,
+} from "../../shared/types";
+
+/**
+ * #1171 - the pure half of the Watchers settings tab, kept out of the TSX so it can be
+ * tested without rendering, following `settings-save.ts`.
+ */
+
+/** Ids are user-written, so they are constrained to what reads well as a chip and a map key. */
+export const WATCHER_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,39}$/;
+
+const WATCHER_MODES: readonly WatcherMode[] = ["state", "occurrence"];
+const WATCHER_DEDUPES: readonly WatcherDedupe[] = ["row", "capture", "none"];
+
+/**
+ * Whether an entry of the root `watchers` map is one this build understands.
+ *
+ * The Rust side keeps an unrecognized entry verbatim rather than dropping it, so that a
+ * hand-written `"mode": "State"` costs one skipped watcher instead of the whole
+ * `AppSettings` parse. The editor has to honour the same contract: what it cannot read, it
+ * must not offer to edit, and must not delete on save.
+ *
+ * Every field required here is written unconditionally by the Rust serializer, so a valid
+ * entry that made the round trip always carries all five, whatever the file omitted.
+ */
+export function isWatcherConfig(entry: WatcherEntry): entry is WatcherConfig {
+  if (typeof entry !== "object" || entry === null) return false;
+  const candidate = entry as Partial<WatcherConfig>;
+  if (typeof candidate.enabled !== "boolean") return false;
+  if (!WATCHER_MODES.includes(candidate.mode as WatcherMode)) return false;
+  if (typeof candidate.pattern !== "string") return false;
+  if (!WATCHER_DEDUPES.includes(candidate.dedupe as WatcherDedupe)) return false;
+  if (typeof candidate.dedupeWindowMs !== "number") return false;
+  if (
+    candidate.commands !== undefined &&
+    candidate.commands !== null &&
+    !Array.isArray(candidate.commands)
+  ) {
+    return false;
+  }
+  return (
+    candidate.capturedAgainst === undefined ||
+    candidate.capturedAgainst === null ||
+    typeof candidate.capturedAgainst === "string"
+  );
+}
+
+/** A watcher id is invalid, taken, or fine. Returns the message to show, or null. */
+export function validateWatcherId(id: string, takenIds: readonly string[]): string | null {
+  if (!id) return "An id is required.";
+  if (!WATCHER_ID_PATTERN.test(id)) {
+    return "Lowercase letters, digits and dashes, starting with a letter or digit, up to 40 characters.";
+  }
+  if (takenIds.includes(id)) return `"${id}" already exists.`;
+  return null;
+}
+
+/** The shape a brand-new row starts from. Mirrors the Rust serde defaults. */
+export function newWatcherConfig(): WatcherConfig {
+  return {
+    enabled: true,
+    mode: "occurrence",
+    pattern: "",
+    dedupe: "row",
+    dedupeWindowMs: 2000,
+  };
+}
+
+/** An id no existing watcher holds, so "Add watcher" never collides. */
+export function nextWatcherId(takenIds: readonly string[]): string {
+  for (let n = 1; ; n += 1) {
+    const candidate = `watcher-${n}`;
+    if (!takenIds.includes(candidate)) return candidate;
+  }
+}
+
+/**
+ * Which of the two selector states a config is in.
+ *
+ * Absent or null is "every configured agent"; a present list is "only these", and an empty
+ * present list is the valid, deliberate "nobody". A plain multiselect cannot express the
+ * first and the last as different things, which is why the UI carries this as a mode.
+ */
+export function selectorMode(config: WatcherConfig): "all" | "selected" {
+  return config.commands === undefined || config.commands === null ? "all" : "selected";
+}
+
+/** Switch selector state without losing the list the user already picked. */
+export function withSelectorMode(
+  config: WatcherConfig,
+  mode: "all" | "selected"
+): WatcherConfig {
+  if (mode === "all") return { ...config, commands: null };
+  return { ...config, commands: config.commands ?? [] };
+}
+
+/** Add or drop one stem from the `Selected` list, leaving `All agents` alone. */
+export function toggleCommandStem(config: WatcherConfig, stem: string): WatcherConfig {
+  const current = config.commands ?? [];
+  const next = current.includes(stem)
+    ? current.filter((entry) => entry !== stem)
+    : [...current, stem];
+  return { ...config, commands: next };
+}
+
+/**
+ * The distinct executable stems of the configured agents, for the `Selected` options.
+ *
+ * This populates a picker; it does **not** decide reach. Reach and budget come from
+ * `preview_watcher_reach`, because the one stem rule lives in Rust and the frontend's own
+ * `starts_with` rule in `suggestedContextRegex` must not be ported: the catalog rejects
+ * prefix matching in writing, `pi` and `agent` being the false-match risk.
+ */
+export function distinctCommandStems(agents: readonly AgentConfig[]): string[] {
+  const stems = new Set<string>();
+  for (const agent of agents) {
+    const stem = commandExecutableBasename(agent.command);
+    if (stem) stems.add(stem);
+  }
+  return [...stems].sort();
+}
+
+/**
+ * Rename a key of the watcher map, preserving every other entry including the ones this
+ * build could not read.
+ *
+ * This really is delete plus create: the id is the map key and the same grouping key the
+ * activity window and the history counters use, so activations already recorded under the
+ * old id keep it. The UI says so next to the control.
+ */
+export function renameWatcherEntry(
+  watchers: Readonly<Record<string, WatcherEntry>>,
+  fromId: string,
+  toId: string
+): Record<string, WatcherEntry> {
+  const renamed: Record<string, WatcherEntry> = {};
+  for (const [id, entry] of Object.entries(watchers)) {
+    if (id === fromId) renamed[toId] = entry;
+    else renamed[id] = entry;
+  }
+  return renamed;
+}
+
+/** Map entries in key order, which is the order the Rust `BTreeMap` resolves the budget in. */
+export function sortedWatcherIds(
+  watchers: Readonly<Record<string, WatcherEntry>> | undefined
+): string[] {
+  return Object.keys(watchers ?? {}).sort();
+}

--- a/src/terminal/components/StatusBar.tsx
+++ b/src/terminal/components/StatusBar.tsx
@@ -2,7 +2,8 @@ import { Component, Show, createMemo, onCleanup } from "solid-js";
 import { terminalStore } from "../stores/terminal";
 import { settingsStore } from "../../shared/stores/settings";
 import { voiceRecorder, formatRecordingTime } from "../../shared/voice-recorder";
-import { PtyAPI, emitOpenSettings } from "../../shared/ipc";
+import { PtyAPI, WindowAPI, emitOpenSettings } from "../../shared/ipc";
+import { isTauri } from "../../shared/platform";
 
 const MIC_DISABLED_TITLE =
   "Enable voice-to-text in Settings and set a Gemini API key to use this.";
@@ -54,6 +55,16 @@ const StatusBar: Component<{ detached?: boolean }> = (props) => {
   };
 
   onCleanup(cleanup);
+
+  // #1171 - opens the activity window scoped to this session, or focuses and re-scopes it
+  // when it is already open. Tauri-only: the web client renders this same StatusBar but has
+  // no such window and no arm for the command, and a button that returns a raw error is
+  // worse than an absent one.
+  const handleOpenWatchers = () => {
+    const sessionId = terminalStore.activeSessionId;
+    if (!sessionId) return;
+    WindowAPI.openWatchers(sessionId).catch(console.error);
+  };
 
   const handleClearInput = () => {
     const sessionId = terminalStore.activeSessionId;
@@ -123,6 +134,17 @@ const StatusBar: Component<{ detached?: boolean }> = (props) => {
           >
             &#x1F399;
           </button>
+          <Show when={isTauri}>
+            <button
+              class="status-bar-btn"
+              onClick={handleOpenWatchers}
+              title="Watcher activity"
+              data-ac-testid="statusBar.watchers"
+              data-ac-role="button"
+            >
+              &#x1F4E1;
+            </button>
+          </Show>
           <button
             class="status-bar-btn status-bar-btn-clear"
             onClick={handleClearInput}

--- a/src/terminal/components/StatusBar.watchers.test.tsx
+++ b/src/terminal/components/StatusBar.watchers.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// #1171 test 78 needs both sides of the `isTauri` gate in one file, so the module is
+// mocked behind a mutable flag rather than probed from the environment.
+let tauriEnvironment = true;
+vi.mock("../../shared/platform", () => ({
+  get isTauri() {
+    return tauriEnvironment;
+  },
+  get isBrowser() {
+    return !tauriEnvironment;
+  },
+  isWindows: false,
+}));
+
+import StatusBar from "./StatusBar";
+import { terminalStore } from "../stores/terminal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+} from "../../shared/testing/ui-harness";
+
+const WATCHERS_BTN = '[data-ac-testid="statusBar.watchers"]';
+
+describe("the StatusBar watcher-activity button (#1171)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+    tauriEnvironment = true;
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    terminalStore.setActiveSessionForTests(null);
+    document.body.replaceChildren();
+  });
+
+  function renderStatusBar() {
+    const fake = new FakeTransport();
+    return renderWithFakeTransport(() => <StatusBar />, fake);
+  }
+
+  it("renders whenever there is an active session, independent of the TASK panel", () => {
+    terminalStore.setActiveSessionForTests("session-1");
+    const rendered = renderStatusBar();
+    try {
+      const button = rendered.root.querySelector(WATCHERS_BTN);
+      expect(button).toBeTruthy();
+      // Inside `.status-bar-actions`, NOT `.workgroup-task-actions`. That placement is the
+      // whole reason it survives on a root-agent session, where the TASK bar is not
+      // rendered at all.
+      expect(button?.closest(".status-bar-actions")).toBeTruthy();
+      expect(button?.closest(".workgroup-task-actions")).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("does not render at all without an active session", () => {
+    terminalStore.setActiveSessionForTests(null);
+    const rendered = renderStatusBar();
+    try {
+      expect(rendered.root.querySelector(WATCHERS_BTN)).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // The web client renders this same StatusBar, but has no watchers window and no arm for
+  // `open_watchers_window`, so the button would return a raw error. Absent beats broken.
+  it("does not render in the web client", () => {
+    tauriEnvironment = false;
+    terminalStore.setActiveSessionForTests("session-1");
+    const rendered = renderStatusBar();
+    try {
+      expect(rendered.root.querySelector(WATCHERS_BTN)).toBeNull();
+      // The neighbouring buttons are still there, so this is the gate and not a dead bar.
+      expect(rendered.root.querySelector(".status-bar-btn-clear")).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("asks the backend to open the window scoped to the active session", () => {
+    terminalStore.setActiveSessionForTests("session-42");
+    const fake = new FakeTransport();
+    fake.resolve("open_watchers_window", undefined);
+    const rendered = renderWithFakeTransport(() => <StatusBar />, fake);
+    try {
+      rendered.root.querySelector<HTMLButtonElement>(WATCHERS_BTN)!.click();
+      expect(fake.lastCall("open_watchers_window")?.args).toEqual({
+        sessionId: "session-42",
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/watchers/App.test.tsx
+++ b/src/watchers/App.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import WatchersApp, { logicalGeometry } from "./App";
+import WatchersApp, { logicalGeometry, registerAll } from "./App";
+import { ALL_SESSIONS_LIMIT } from "./activity";
 import { FakeTransport } from "../shared/testing/fake-transport";
 import {
   input,
@@ -637,6 +638,151 @@ describe("the watcher activity window (#1171)", () => {
   });
 
   /**
+   * The synchronous drop has to be as wide as the fetch key that triggered it.
+   *
+   * Leaving a single session for "All sessions" narrows the per-session limit from 500 to
+   * 100, and `keepSessions` alone keeps every one of the 500 painted for the whole round
+   * trip -- and forever if the new fetch fails, which is exactly the "correct selector over
+   * stale rows" this guard exists to prevent.
+   */
+  it("drops what the new scope's limit no longer allows, before the new fetch resolves", async () => {
+    const held = snapshot({
+      matches: Array.from({ length: 150 }, (_, i) => match({ seq: i })),
+    });
+    const second = deferred<WatcherActivitySnapshot>();
+    let round = 0;
+    const fake = transportWith(held);
+    fake.onInvoke("get_watcher_activity", () => {
+      round += 1;
+      return round === 1 ? held : second.promise;
+    });
+
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelectorAll("tr.watchers-row")).toHaveLength(150)
+      );
+
+      const scope = rendered.root.querySelector<HTMLSelectElement>(
+        '[data-ac-testid="watchers.scope"]'
+      )!;
+      scope.value = "all";
+      scope.dispatchEvent(new Event("change", { bubbles: true }));
+
+      await waitFor(() =>
+        expect(rendered.root.querySelectorAll("tr.watchers-row")).toHaveLength(
+          ALL_SESSIONS_LIMIT
+        )
+      );
+      // And what survived is the newest, not whatever the filter happened to reach first.
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:149"]')).toBeTruthy();
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:0"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The three session listeners each fire their own `list_sessions`, and nothing polls the
+   * list afterwards, so an answer that resolves out of order is not a flicker: it is wrong
+   * permanently.
+   */
+  describe("reloading the session list (#1171)", () => {
+    const optionValues = (root: HTMLElement) =>
+      [
+        ...root.querySelectorAll<HTMLOptionElement>(
+          '[data-ac-testid="watchers.scope"] option'
+        ),
+      ].map((option) => option.value);
+
+    it("does not let a stale list resurrect a session that was destroyed", async () => {
+      const stale = deferred<Session[]>();
+      const lists: (Session[] | Promise<Session[]>)[] = [
+        [AGENT_SESSIONS[0]], // mount
+        stale.promise, // the create's reload, left in flight
+        [AGENT_SESSIONS[0]], // the destroy's reload, which answers first
+      ];
+      const fake = transportWith(snapshot());
+      fake.onInvoke("list_sessions", () => lists.shift() ?? [AGENT_SESSIONS[0]]);
+
+      const rendered = renderWithFakeTransport(() => <WatchersApp />, fake);
+      try {
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(1));
+
+        fake.emitFromBackend("session_created", AGENT_SESSIONS[1]);
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(2));
+
+        fake.emitFromBackend("session_destroyed", { id: "s2" });
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(3));
+        await waitFor(() => expect(optionValues(rendered.root)).toEqual(["all", "s1"]));
+
+        // The create's answer arrives last, describing a world that no longer exists.
+        stale.resolve(AGENT_SESSIONS);
+        await flush();
+        expect(optionValues(rendered.root)).toEqual(["all", "s1"]);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("does not let a stale list remove a session that was just created", async () => {
+      const stale = deferred<Session[]>();
+      const lists: (Session[] | Promise<Session[]>)[] = [
+        [AGENT_SESSIONS[0]], // mount
+        stale.promise, // the rename's reload, left in flight
+        AGENT_SESSIONS, // the create's reload, which answers first
+      ];
+      const fake = transportWith(snapshot());
+      fake.onInvoke("list_sessions", () => lists.shift() ?? AGENT_SESSIONS);
+
+      const rendered = renderWithFakeTransport(() => <WatchersApp />, fake);
+      try {
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(1));
+
+        fake.emitFromBackend("session_renamed", { id: "s1", name: "renamed" });
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(2));
+
+        fake.emitFromBackend("session_created", AGENT_SESSIONS[1]);
+        await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(3));
+        await waitFor(() => expect(optionValues(rendered.root)).toEqual(["all", "s1", "s2"]));
+
+        stale.resolve([AGENT_SESSIONS[0]]);
+        await flush();
+        expect(optionValues(rendered.root)).toEqual(["all", "s1", "s2"]);
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  /**
+   * Solid does not await the promise `onMount(async ...)` returns, so anything that escapes
+   * its `catch` is an unhandled rejection rather than an error anyone sees. A setup that
+   * fails has to stop the mount AND say so.
+   */
+  it("reports a failed setup instead of leaving an unhandled rejection behind", async () => {
+    const fake = transportWith(snapshot());
+    const realListen = fake.listen.bind(fake);
+    fake.listen = ((event: string, callback: (payload: never) => void) =>
+      event === "session_renamed"
+        ? Promise.reject(new Error("transport closed mid-subscribe"))
+        : realListen(event, callback)) as FakeTransport["listen"];
+
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.error"]')?.textContent
+        ).toContain("transport closed mid-subscribe")
+      );
+      // The mount stopped where it stood: nothing was fetched behind the failure.
+      expect(fake.callsFor("get_watcher_activity")).toHaveLength(0);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
    * The P0 this suite itself used to expose: `onMount` crosses several awaits, and a window
    * closed inside one of them left the continuation registering listeners, fetching and
    * starting a poll against a component that no longer existed.
@@ -660,6 +806,76 @@ describe("the watcher activity window (#1171)", () => {
     fake.emitFromBackend("watcher_matches", { sessionId: "s1", matches: [match()] });
     await flush();
     expect(fake.callsFor("get_watcher_activity")).toHaveLength(0);
+  });
+});
+
+/**
+ * #1171 - the setup sequence behind the geometry listeners.
+ *
+ * Registering them one at a time and keeping each unlisten in its own local means a later
+ * registration that REJECTS strands the earlier one: it never reaches the component's
+ * cleanup, and the window is gone with a live move handler still attached to it.
+ */
+describe("registering a set of listeners as one unit (#1171)", () => {
+  it("hands over a single release when every registration succeeds", async () => {
+    const released: string[] = [];
+    const release = await registerAll(
+      [
+        () => Promise.resolve(() => released.push("moved")),
+        () => Promise.resolve(() => released.push("resized")),
+      ],
+      () => false
+    );
+    expect(release).toBeTruthy();
+    release!();
+    expect(released).toEqual(["moved", "resized"]);
+  });
+
+  it("releases what it already holds when a later registration rejects", async () => {
+    const released: string[] = [];
+    await expect(
+      registerAll(
+        [
+          () => Promise.resolve(() => released.push("moved")),
+          () => Promise.reject(new Error("the window is gone")),
+        ],
+        () => false
+      )
+    ).rejects.toThrow("the window is gone");
+    expect(released).toEqual(["moved"]);
+  });
+
+  it("releases what it already holds when the window closes mid-sequence", async () => {
+    const released: string[] = [];
+    let closed = false;
+    const release = await registerAll(
+      [
+        () =>
+          Promise.resolve(() => released.push("moved")).finally(() => {
+            closed = true;
+          }),
+        () => Promise.resolve(() => released.push("resized")),
+      ],
+      () => closed
+    );
+    expect(release).toBeNull();
+    expect(released).toEqual(["moved"]);
+  });
+
+  it("releases a fully registered set when the window closed on the LAST await", async () => {
+    const released: string[] = [];
+    let closed = false;
+    const release = await registerAll(
+      [
+        () =>
+          Promise.resolve(() => released.push("moved")).finally(() => {
+            closed = true;
+          }),
+      ],
+      () => closed
+    );
+    expect(release).toBeNull();
+    expect(released).toEqual(["moved"]);
   });
 });
 

--- a/src/watchers/App.test.tsx
+++ b/src/watchers/App.test.tsx
@@ -1,0 +1,326 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import WatchersApp from "./App";
+import { FakeTransport } from "../shared/testing/fake-transport";
+import {
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  session,
+  waitFor,
+} from "../shared/testing/ui-harness";
+import type { WatcherActivitySnapshot, WatcherMatchPayload } from "../shared/types";
+
+function snapshot(
+  overrides: Partial<WatcherActivitySnapshot> = {}
+): WatcherActivitySnapshot {
+  return {
+    matches: [],
+    lastSeq: 0,
+    truncated: false,
+    possiblyMissedFrames: 0,
+    warmedUp: true,
+    activeWatchers: [],
+    ...overrides,
+  };
+}
+
+function match(overrides: Partial<WatcherMatchPayload> = {}): WatcherMatchPayload {
+  return {
+    sessionId: "s1",
+    seq: 1,
+    watcherId: "reads",
+    mode: "occurrence",
+    at: "2026-07-30T22:31:05Z",
+    captures: ["C:/repo/main.rs"],
+    row: "Read (C:/repo/main.rs)",
+    rowTruncated: false,
+    ...overrides,
+  };
+}
+
+const AGENT_SESSIONS = [
+  session({
+    id: "s1",
+    name: "claude@repo",
+    agentId: "a1",
+    agentLabel: "Claude Sandbox",
+    workingDirectory: "C:/p/.ac/wg-19-team/__agent_dev-rust",
+  }),
+  session({
+    id: "s2",
+    name: "codex@repo",
+    agentId: "a2",
+    agentLabel: "Codex",
+    workingDirectory: "C:/p/.ac/wg-20-team/__agent_dev-ui",
+  }),
+];
+
+function transportWith(snap: WatcherActivitySnapshot): FakeTransport {
+  const fake = new FakeTransport();
+  fake.resolve("list_sessions", AGENT_SESSIONS);
+  fake.resolve("get_settings", { agents: [] });
+  fake.resolve("get_watcher_activity", snap);
+  return fake;
+}
+
+describe("the watcher activity window (#1171)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  // #1171 test 81, the four states told apart from snapshot values alone.
+  it("shows the warming state before the engine has ticked, never the day-one message", async () => {
+    const fake = transportWith(snapshot({ warmedUp: false }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.empty.warming"]')
+        ).toBeTruthy()
+      );
+      expect(
+        rendered.root.querySelector('[data-ac-testid="watchers.empty.unconfigured"]')
+      ).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("offers Configure watchers once warmed up with nothing reaching the agent", async () => {
+    const fake = transportWith(snapshot({ warmedUp: true, activeWatchers: [] }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.configure"]')).toBeTruthy()
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("lists what it is waiting for, with mode and a zero counter", async () => {
+    const fake = transportWith(
+      snapshot({
+        activeWatchers: [
+          { watcherId: "permission", mode: "state", count: 0, degraded: false },
+        ],
+      })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.waiting.permission"]')
+        ).toBeTruthy()
+      );
+      const entry = rendered.root.querySelector('[data-ac-testid="watchers.waiting.permission"]');
+      expect(entry?.textContent).toContain("state");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #1171 tests 82 and 83.
+  it("keeps the truncated banner and the unsampled note as separate elements", async () => {
+    const fake = transportWith(
+      snapshot({ matches: [match()], truncated: true, possiblyMissedFrames: 3 })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.truncated"]')).toBeTruthy()
+      );
+      const truncated = rendered.root.querySelector('[data-ac-testid="watchers.truncated"]');
+      const missed = rendered.root.querySelector('[data-ac-testid="watchers.missedFrames"]');
+      expect(missed).toBeTruthy();
+      expect(truncated).not.toBe(missed);
+      expect(truncated?.textContent).not.toBe(missed?.textContent);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows the best-effort footer in every state", async () => {
+    for (const snap of [
+      snapshot({ warmedUp: false }),
+      snapshot({ warmedUp: true }),
+      snapshot({ matches: [match()] }),
+    ]) {
+      const fake = transportWith(snap);
+      const rendered = renderWithFakeTransport(
+        () => <WatchersApp initialSessionId="s1" />,
+        fake
+      );
+      try {
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.footer"]')).toBeTruthy()
+        );
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.footer"]')?.textContent
+        ).toContain("not an audit log");
+      } finally {
+        rendered.cleanup();
+      }
+    }
+  });
+
+  // #1171 test 84.
+  it("renders a row containing HTML-looking text as text", async () => {
+    const hostile = "<img src=x onerror=alert(1)> Read (<script>)";
+    const fake = transportWith(
+      snapshot({ matches: [match({ captures: [hostile], row: hostile })] })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.table"]')).toBeTruthy()
+      );
+      expect(rendered.root.querySelector("img")).toBeNull();
+      expect(rendered.root.querySelector("script")).toBeNull();
+      expect(rendered.root.textContent).toContain(hostile);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #1171 test 85.
+  it("distinguishes a state row from an occurrence row", async () => {
+    const fake = transportWith(
+      snapshot({
+        matches: [
+          match({ seq: 1, mode: "occurrence", watcherId: "reads" }),
+          match({ seq: 2, mode: "state", watcherId: "permission" }),
+        ],
+      })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy()
+      );
+      const occurrence = rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]');
+      const state = rendered.root.querySelector('[data-ac-testid="watchers.row.s1:2"]');
+      expect(occurrence?.getAttribute("data-ac-mode")).toBe("occurrence");
+      expect(state?.getAttribute("data-ac-mode")).toBe("state");
+      expect(occurrence?.textContent).not.toBe(state?.textContent);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  // #1171 test 80.
+  it("hides the Agent and Workgroup chips in single-session scope and shows them in All sessions", async () => {
+    const fake = transportWith(snapshot({ matches: [match()] }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.table"]')).toBeTruthy()
+      );
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.filter.agent"]')).toBeNull();
+      expect(
+        rendered.root.querySelector('[data-ac-testid="watchers.filter.workgroup"]')
+      ).toBeNull();
+
+      const scope = rendered.root.querySelector<HTMLSelectElement>(
+        '[data-ac-testid="watchers.scope"]'
+      )!;
+      scope.value = "all";
+      scope.dispatchEvent(new Event("change", { bubbles: true }));
+
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.filter.agent"]')
+        ).toBeTruthy()
+      );
+      expect(
+        rendered.root.querySelector('[data-ac-testid="watchers.filter.workgroup"]')
+      ).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * #1171 test 79, the frontend half. The backend focuses the existing window and emits
+   * `watchers_scope_request` instead of building a second one; what is left to prove here
+   * is that the window actually changes scope when that event arrives.
+   */
+  it("re-scopes to the requested session when the window is already open", async () => {
+    const fake = transportWith(snapshot({ matches: [match()] }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector<HTMLSelectElement>('[data-ac-testid="watchers.scope"]')
+            ?.value
+        ).toBe("s1")
+      );
+
+      fake.emitFromBackend("watchers_scope_request", { sessionId: "s2" });
+
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector<HTMLSelectElement>('[data-ac-testid="watchers.scope"]')
+            ?.value
+        ).toBe("s2")
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("shows a match that arrives on the event stream, exactly once", async () => {
+    const fake = transportWith(snapshot({ matches: [match({ seq: 1 })] }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy()
+      );
+
+      // The same match the snapshot already carried, plus a genuinely new one.
+      fake.emitFromBackend("watcher_matches", {
+        sessionId: "s1",
+        matches: [match({ seq: 1 }), match({ seq: 2 })],
+      });
+
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:2"]')).toBeTruthy()
+      );
+      expect(
+        rendered.root.querySelectorAll('[data-ac-testid="watchers.row.s1:1"]')
+      ).toHaveLength(1);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("ignores a batch for a session outside the current scope", async () => {
+    const fake = transportWith(snapshot({ matches: [match()] }));
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy()
+      );
+
+      fake.emitFromBackend("watcher_matches", {
+        sessionId: "s2",
+        matches: [match({ sessionId: "s2", seq: 9 })],
+      });
+
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s2:9"]')).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+});

--- a/src/watchers/App.test.tsx
+++ b/src/watchers/App.test.tsx
@@ -1,15 +1,20 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import WatchersApp from "./App";
+import WatchersApp, { logicalGeometry } from "./App";
 import { FakeTransport } from "../shared/testing/fake-transport";
 import {
+  input,
   installBrowserDomStubs,
   renderWithFakeTransport,
   resetUiStoresForTests,
   session,
   waitFor,
 } from "../shared/testing/ui-harness";
-import type { WatcherActivitySnapshot, WatcherMatchPayload } from "../shared/types";
+import type {
+  Session,
+  WatcherActivitySnapshot,
+  WatcherMatchPayload,
+} from "../shared/types";
 
 function snapshot(
   overrides: Partial<WatcherActivitySnapshot> = {}
@@ -61,7 +66,26 @@ function transportWith(snap: WatcherActivitySnapshot): FakeTransport {
   fake.resolve("list_sessions", AGENT_SESSIONS);
   fake.resolve("get_settings", { agents: [] });
   fake.resolve("get_watcher_activity", snap);
+  // The authoritative scope, pulled after the subscribe. `null` is "nothing was requested",
+  // which leaves the query parameter standing.
+  fake.resolve("get_watchers_scope", null);
   return fake;
+}
+
+/** A promise this test resolves by hand, so an ordering can be pinned instead of raced. */
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let every already-resolved microtask run, without waiting on a condition. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) await Promise.resolve();
 }
 
 describe("the watcher activity window (#1171)", () => {
@@ -322,5 +346,359 @@ describe("the watcher activity window (#1171)", () => {
     } finally {
       rendered.cleanup();
     }
+  });
+
+  /**
+   * #1171 test 77, the race the earlier version of this test did not run.
+   *
+   * Waiting for the snapshot row to be in the DOM and only then emitting proves nothing: it
+   * passes even if the window fetched before it subscribed, or dropped whatever arrived
+   * first. The overlap has to land while the invoke is still pending.
+   */
+  it("merges an overlap that arrives while the snapshot fetch is still in flight", async () => {
+    const activity = deferred<WatcherActivitySnapshot>();
+    const fake = transportWith(snapshot());
+    fake.onInvoke("get_watcher_activity", () => activity.promise);
+
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      // The fetch is out, so the subscribe that precedes it has completed.
+      await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(1));
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.table"]')).toBeNull();
+
+      // seq 7 overlaps the snapshot; seq 8 is only on the stream.
+      fake.emitFromBackend("watcher_matches", {
+        sessionId: "s1",
+        matches: [match({ seq: 7 }), match({ seq: 8 })],
+      });
+
+      activity.resolve(snapshot({ matches: [match({ seq: 6 }), match({ seq: 7 })], lastSeq: 7 }));
+
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:6"]')).toBeTruthy()
+      );
+      expect(
+        rendered.root.querySelectorAll('[data-ac-testid="watchers.row.s1:7"]')
+      ).toHaveLength(1);
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:8"]')).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * #1171 test 79d, both orderings of the same race. They fail differently, which is why
+   * neither one alone is enough.
+   */
+  describe("settling the scope on mount (#1171 test 79d)", () => {
+    it("adopts the event and never fetches the scope it was about to leave", async () => {
+      const pull = deferred<string | null>();
+      const fake = transportWith(snapshot());
+      fake.onInvoke("get_watchers_scope", () => pull.promise);
+
+      const rendered = renderWithFakeTransport(
+        () => <WatchersApp initialSessionId="s1" />,
+        fake
+      );
+      try {
+        await waitFor(() => expect(fake.callsFor("get_watchers_scope")).toHaveLength(1));
+        // Nothing at all is fetched before the scope is settled.
+        expect(fake.callsFor("get_watcher_activity")).toHaveLength(0);
+
+        fake.emitFromBackend("watchers_scope_request", { sessionId: "s2" });
+        // The pull answers a THIRD session, and it lost: an event was handled since it was
+        // issued.
+        pull.resolve("s1");
+
+        await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(1));
+        expect(fake.callsFor("get_watcher_activity")[0].args.sessionId).toBe("s2");
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("re-scopes on an event that arrives during the first fetch, without waiting for the poll", async () => {
+      const first = deferred<WatcherActivitySnapshot>();
+      const fake = transportWith(snapshot());
+      fake.onInvoke("get_watcher_activity", (args) =>
+        args.sessionId === "s1" ? first.promise : snapshot({ matches: [match({ sessionId: "s2", seq: 4 })] })
+      );
+
+      const rendered = renderWithFakeTransport(
+        () => <WatchersApp initialSessionId="s1" />,
+        fake
+      );
+      try {
+        await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(1));
+
+        fake.emitFromBackend("watchers_scope_request", { sessionId: "s2" });
+
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s2:4"]')).toBeTruthy()
+        );
+
+        // The first scope's answer lands last and must change nothing.
+        first.resolve(snapshot({ matches: [match({ sessionId: "s1", seq: 1 })] }));
+        await flush();
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeNull();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  /**
+   * #1171 test 79e, the content guard. Three assertions that fail independently, because a
+   * correct selector over the previous session's rows is the failure this exists to prevent.
+   */
+  describe("guarding what is painted (#1171 test 79e)", () => {
+    it("drops the previous scope's rows synchronously, before the new fetch resolves and when it rejects", async () => {
+      const second = deferred<WatcherActivitySnapshot>();
+      const fake = transportWith(snapshot());
+      fake.onInvoke("get_watcher_activity", (args) =>
+        args.sessionId === "s1"
+          ? snapshot({ matches: [match({ sessionId: "s1", seq: 1 })] })
+          : second.promise
+      );
+
+      const rendered = renderWithFakeTransport(
+        () => <WatchersApp initialSessionId="s1" />,
+        fake
+      );
+      try {
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy()
+        );
+
+        const scope = rendered.root.querySelector<HTMLSelectElement>(
+          '[data-ac-testid="watchers.scope"]'
+        )!;
+        scope.value = "s2";
+        scope.dispatchEvent(new Event("change", { bubbles: true }));
+
+        // Already gone, with the new answer still in flight.
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeNull()
+        );
+
+        // And still gone once the new fetch fails outright.
+        second.reject(new Error("backend said no"));
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.error"]')).toBeTruthy()
+        );
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeNull();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+
+    it("keeps the newer counters when two fetches of the SAME scope resolve out of order", async () => {
+      // Both deferred answers are for s1, so only the request counter can tell them apart: a
+      // generation keyed on the SCOPE sees one value and lets the older one commit its
+      // `lastSeq`, `warmedUp`, `degraded` and counters over the newer ones, leaving the table
+      // and the counters describing two different instants.
+      const older = deferred<WatcherActivitySnapshot>();
+      const newer = deferred<WatcherActivitySnapshot>();
+      const forS1 = [older.promise, newer.promise];
+      const fake = transportWith(snapshot());
+      fake.onInvoke("get_watcher_activity", (args) =>
+        args.sessionId === "s1" ? forS1.shift() ?? snapshot() : snapshot()
+      );
+
+      const rendered = renderWithFakeTransport(
+        () => <WatchersApp initialSessionId="s1" />,
+        fake
+      );
+      try {
+        // Round one for s1, left in flight.
+        await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(1));
+
+        fake.emitFromBackend("watchers_scope_request", { sessionId: "s2" });
+        await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(2));
+
+        // Back to s1: round two for the same scope, also left in flight.
+        fake.emitFromBackend("watchers_scope_request", { sessionId: "s1" });
+        await waitFor(() => expect(fake.callsFor("get_watcher_activity")).toHaveLength(3));
+
+        newer.resolve(
+          snapshot({
+            activeWatchers: [
+              { watcherId: "reads", mode: "occurrence", count: 9, degraded: true },
+            ],
+          })
+        );
+        await waitFor(() =>
+          expect(rendered.root.querySelector('[data-ac-testid="watchers.degraded"]')).toBeTruthy()
+        );
+
+        older.resolve(
+          snapshot({
+            activeWatchers: [
+              { watcherId: "reads", mode: "occurrence", count: 0, degraded: false },
+            ],
+          })
+        );
+        await flush();
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.degraded"]')
+        ).toBeTruthy();
+      } finally {
+        rendered.cleanup();
+      }
+    });
+  });
+
+  /**
+   * #1171 test 79f. In "All sessions" the scope is a SET derived from the session list, and
+   * the session listeners rewrite it without touching the selection. A generation keyed on
+   * the selected session passes every other test here and fails this one.
+   */
+  it("refetches when a session enters the scope in All sessions, keeping its rows", async () => {
+    const fake = new FakeTransport();
+    let listed = [AGENT_SESSIONS[0]];
+    fake.onInvoke("list_sessions", () => listed);
+    fake.resolve("get_settings", { agents: [] });
+    fake.resolve("get_watchers_scope", null);
+    fake.onInvoke("get_watcher_activity", (args) =>
+      snapshot({ matches: [match({ sessionId: String(args.sessionId), seq: 1 })] })
+    );
+
+    const rendered = renderWithFakeTransport(() => <WatchersApp />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy()
+      );
+
+      listed = AGENT_SESSIONS;
+      fake.emitFromBackend("session_created", { sessionId: "s2" });
+
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s2:1"]')).toBeTruthy()
+      );
+      expect(rendered.root.querySelector('[data-ac-testid="watchers.row.s1:1"]')).toBeTruthy();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * A degraded watcher has by definition already emitted matches, so the marker that only
+   * lived inside the "configured and waiting" branch could never be reached.
+   */
+  it("shows the degraded marker while the table is showing rows", async () => {
+    const fake = transportWith(
+      snapshot({
+        matches: [match()],
+        activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 40, degraded: true }],
+      })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.table"]')).toBeTruthy()
+      );
+      const marker = rendered.root.querySelector('[data-ac-testid="watchers.degraded"]');
+      expect(marker?.textContent).toContain("reads");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /** "Nothing has matched yet" over activations a filter is hiding is a false statement. */
+  it("says the filters are hiding the activations rather than that none exist", async () => {
+    const fake = transportWith(
+      snapshot({
+        matches: [match()],
+        activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 1, degraded: false }],
+      })
+    );
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    try {
+      await waitFor(() =>
+        expect(rendered.root.querySelector('[data-ac-testid="watchers.table"]')).toBeTruthy()
+      );
+
+      const search = rendered.root.querySelector<HTMLInputElement>(
+        '[data-ac-testid="watchers.filter.text"]'
+      )!;
+      input(search, "nothing will ever match this");
+
+      await waitFor(() =>
+        expect(
+          rendered.root.querySelector('[data-ac-testid="watchers.empty.filtered"]')
+        ).toBeTruthy()
+      );
+      expect(
+        rendered.root.querySelector('[data-ac-testid="watchers.empty.waiting"]')
+      ).toBeNull();
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  /**
+   * The P0 this suite itself used to expose: `onMount` crosses several awaits, and a window
+   * closed inside one of them left the continuation registering listeners, fetching and
+   * starting a poll against a component that no longer existed.
+   */
+  it("stops the mount where it is when the window closes mid-flight", async () => {
+    const sessions = deferred<Session[]>();
+    const fake = transportWith(snapshot());
+    fake.onInvoke("list_sessions", () => sessions.promise);
+
+    const rendered = renderWithFakeTransport(() => <WatchersApp initialSessionId="s1" />, fake);
+    await waitFor(() => expect(fake.callsFor("list_sessions")).toHaveLength(1));
+
+    rendered.cleanup();
+    sessions.resolve(AGENT_SESSIONS);
+    await flush();
+
+    expect(fake.callsFor("get_watchers_scope")).toHaveLength(0);
+    expect(fake.callsFor("get_watcher_activity")).toHaveLength(0);
+
+    // And the listeners are gone with it: this must reach nobody rather than throw.
+    fake.emitFromBackend("watcher_matches", { sessionId: "s1", matches: [match()] });
+    await flush();
+    expect(fake.callsFor("get_watcher_activity")).toHaveLength(0);
+  });
+});
+
+/**
+ * #1171 - the pure conversion behind the geometry the activity window persists.
+ *
+ * `outerPosition()` and `innerSize()` answer in PHYSICAL pixels while the window builder's
+ * `position` and `inner_size` take LOGICAL ones, so writing back what was read multiplies the
+ * rect by the scale factor on every save-and-reopen cycle. The defect is invisible at a scale
+ * factor of 1, which is the only one a headless run ever has, so it is pinned here.
+ */
+describe("persisting the activity window's geometry (#1171)", () => {
+  it("converts a physical rect to the logical one the builder restores", () => {
+    expect(logicalGeometry({ x: 300, y: 150, width: 2205, height: 1200 }, 1.5)).toEqual({
+      x: 200,
+      y: 100,
+      width: 1470,
+      height: 800,
+    });
+  });
+
+  it("round-trips at 100%, where the two units coincide", () => {
+    const rect = { x: 10, y: 20, width: 1470, height: 800 };
+    expect(logicalGeometry(rect, 1)).toEqual(rect);
+  });
+
+  it("is stable under repeated save-and-reopen at a fractional factor", () => {
+    // The reopened window reports the same physical rect the logical one asks for, so a
+    // second save must produce the same numbers rather than shrink or grow them.
+    const once = logicalGeometry({ x: 0, y: 0, width: 2205, height: 1200 }, 1.5);
+    const twice = logicalGeometry(
+      { x: 0, y: 0, width: once.width * 1.5, height: once.height * 1.5 },
+      1.5
+    );
+    expect(twice).toEqual(once);
+  });
+
+  it("treats an impossible scale factor as 1 rather than producing Infinity", () => {
+    const rect = { x: 1, y: 2, width: 3, height: 4 };
+    expect(logicalGeometry(rect, 0)).toEqual(rect);
   });
 });

--- a/src/watchers/App.tsx
+++ b/src/watchers/App.tsx
@@ -23,12 +23,14 @@ import { isTauri } from "../shared/platform";
 import { settingsStore } from "../shared/stores/settings";
 import { formatClockTime } from "../shared/time-format";
 import type { UnlistenFn } from "../shared/transport";
-import type { Session, WatcherActivitySnapshot } from "../shared/types";
+import type { Session, WatcherActivitySnapshot, WindowGeometry } from "../shared/types";
 import {
   ALL_SESSIONS_LIMIT,
   SINGLE_SESSION_LIMIT,
   type ActivityRow,
   anyTruncated,
+  capPerSession,
+  degradedWatchers,
   distinct,
   filterRows,
   freezeRow,
@@ -50,11 +52,63 @@ import "./styles/watchers.css";
 const POLL_FOCUSED_MS = 10_000;
 const POLL_UNFOCUSED_MS = 15_000;
 
+/** How long a move or resize settles before the rect is persisted. */
+const GEOMETRY_SAVE_DEBOUNCE_MS = 500;
+
 /** How close to the top still counts as pinned, in pixels. */
 const PIN_TO_TOP_SLACK_PX = 8;
 
+/**
+ * Physical device pixels to the logical ones the window builder takes.
+ *
+ * `outerPosition()` and `innerSize()` answer in `Physical*`, while `WebviewWindowBuilder`'s
+ * `position` and `inner_size` are documented as logical, so persisting what was read would
+ * multiply the rect by the scale factor on every save-and-reopen cycle: at 150% DPI a
+ * 1470-wide window reopens 2205 wide, then 3307, and walks off the screen. Rounded because
+ * `WindowGeometry` is integral on both sides of the IPC and a half pixel means nothing here.
+ *
+ * Exported for the conversion test: it is pure arithmetic and the defect it fixes is
+ * invisible at a scale factor of 1, which is the only one a headless run ever has.
+ */
+export function logicalGeometry(
+  physical: WindowGeometry,
+  scaleFactor: number
+): WindowGeometry {
+  // A zero or absent factor would turn every coordinate into Infinity or NaN. Treating an
+  // impossible factor as 1 keeps the previous rect rather than persisting nonsense.
+  const factor = scaleFactor > 0 ? scaleFactor : 1;
+  return {
+    x: Math.round(physical.x / factor),
+    y: Math.round(physical.y / factor),
+    width: Math.round(physical.width / factor),
+    height: Math.round(physical.height / factor),
+  };
+}
+
 const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
-  // `null` is the "All sessions" scope.
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+  // `onMount` crosses several awaits and the window can be closed inside any of them, so
+  // every registration goes through `register`, which unlistens immediately when its
+  // continuation lands after teardown, and every await is followed by a `disposed` check.
+  // The shape is `terminal/App.tsx`'s. Without it a fast close leaves listeners, a fetch and
+  // a poll running against a component that is already gone.
+  const listeners: UnlistenFn[] = [];
+  let disposed = false;
+  let cleanupGeometry: (() => void) | null = null;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  const mountDisposed = Symbol("watchersMountDisposed");
+
+  const register = async (registration: Promise<UnlistenFn>): Promise<void> => {
+    const unlisten = await registration;
+    if (disposed) {
+      unlisten();
+      throw mountDisposed;
+    }
+    listeners.push(unlisten);
+  };
+
+  // `null` is the "All sessions" scope. The query parameter is the INITIAL value only, so the
+  // first paint has a scope without waiting for a round trip; the pull below is authoritative.
   const [scopeSessionId, setScopeSessionId] = createSignal<string | null>(
     props.initialSessionId ?? null
   );
@@ -62,6 +116,8 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
   const [rows, setRows] = createSignal<ActivityRow[]>([]);
   const [snapshots, setSnapshots] = createSignal<WatcherActivitySnapshot[]>([]);
   const [loadError, setLoadError] = createSignal("");
+  /** False until the mount has settled the scope. Nothing may be fetched before it. */
+  const [scopeSettled, setScopeSettled] = createSignal(false);
 
   const [watcherFilter, setWatcherFilter] = createSignal<Set<string>>(new Set());
   const [agentFilter, setAgentFilter] = createSignal<Set<string>>(new Set());
@@ -84,6 +140,7 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
     return agentSessions().map((s) => s.id);
   });
   const isAllSessions = () => scopeSessionId() === null;
+  const scopeLimit = () => (isAllSessions() ? ALL_SESSIONS_LIMIT : SINGLE_SESSION_LIMIT);
 
   /** Live agent label by id, falling back to what was frozen into the row, so renaming an
    *  entry updates old rows instead of leaving them lying. Precedent: `liveAgentLabel`. */
@@ -93,6 +150,16 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
       : null;
     return live || row.frozenAgentLabel || row.agentId || "";
   };
+
+  // The window loads its own settings and never applied the theme, so a user on light got a
+  // dark window. Hung off the store rather than a mount-time read because the poll already
+  // refreshes it, which makes a theme change land within one poll instead of at the next open.
+  createEffect(() => {
+    document.documentElement.classList.toggle(
+      "light-theme",
+      !!settingsStore.current?.themeLight
+    );
+  });
 
   // The scope select is driven by an effect rather than by `value=`, because the window
   // opens scoped to a session whose `<option>` does not exist yet: the list arrives with
@@ -117,8 +184,12 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
     })
   );
 
-  const view = createMemo(() => resolveView(snapshots(), visibleRows().length));
+  // Resolved from the UNFILTERED count as well as the visible one: the empty states are
+  // statements about the activations, so a filter that hides everything must not be able to
+  // say "nothing has matched yet".
+  const view = createMemo(() => resolveView(snapshots(), rows().length, visibleRows().length));
   const activeWatchers = createMemo(() => mergeActiveWatchers(snapshots()));
+  const degraded = createMemo(() => degradedWatchers(snapshots()));
   const truncated = createMemo(() => anyTruncated(snapshots()));
   const missedFrames = createMemo(() => totalPossiblyMissedFrames(snapshots()));
 
@@ -168,130 +239,240 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
     set(next);
   };
 
+  /**
+   * One monotonic counter over every fetch, and the only thing that decides whether a
+   * response may paint.
+   *
+   * It covers the scope selector, the re-scope event, the adoption of the pull, the mount's
+   * first fetch and the poll, and it also covers two fetches of the SAME scope racing each
+   * other, which a scope-keyed generation lets through: the older poll response would
+   * otherwise commit an older `lastSeq`, `warmedUp`, `degraded` and counters over the newer
+   * ones, leaving the table and the counters describing two different instants.
+   */
+  let requestCounter = 0;
+
   const refresh = async () => {
+    const request = (requestCounter += 1);
     const ids = scopeIds();
-    const limit = isAllSessions() ? ALL_SESSIONS_LIMIT : SINGLE_SESSION_LIMIT;
+    const limit = scopeLimit();
     try {
       const fetched = await Promise.all(
         ids.map((id) => PtyAPI.getWatcherActivity(id, limit))
       );
+      if (disposed || request !== requestCounter) return;
       setSnapshots(fetched);
       setLoadError("");
       const incoming = fetched.flatMap((snapshot, index) =>
         snapshot.matches.map((match) => freezeRow(match, sessionById(ids[index])))
       );
-      setRows((prev) => mergeRows(keepSessions(prev, ids), incoming));
+      setRows((prev) => capPerSession(mergeRows(keepSessions(prev, ids), incoming), limit));
     } catch (err) {
+      if (disposed || request !== requestCounter) return;
       setLoadError(err instanceof Error ? err.message : String(err));
     }
   };
 
   const reloadSessions = async () => {
     try {
-      setSessions(await SessionAPI.list());
+      const listed = await SessionAPI.list();
+      if (disposed) return;
+      setSessions(listed);
     } catch (err) {
+      if (disposed) return;
       console.error("[watchers] failed to list sessions:", err);
     }
   };
 
-  const listeners: UnlistenFn[] = [];
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The scope-adoption guard, which is NOT the request counter.
+   *
+   * This one decides which scope is adopted; that one decides which fetch may paint. They
+   * protect different things and each leaves the other's failure open, so they must not be
+   * merged.
+   */
+  let scopeEventGeneration = 0;
+
+  /**
+   * What a fetch is actually parameterised by: the ids AND the per-session limit.
+   *
+   * Stated over `scopeIds()` rather than over a list of callers, because every enumeration of
+   * "the callers that must refetch" has been short by one. In "All sessions" the three session
+   * listeners rewrite the derived set without touching the selection, and a generation keyed
+   * on the selected session would miss exactly that; reloading the session list under a
+   * single-session scope leaves this key alone and correctly changes nothing.
+   */
+  const fetchScopeKey = createMemo(() => `${scopeLimit()}|${scopeIds().join(",")}`);
+  let paintedScopeKey: string | null = null;
+
+  createEffect(() => {
+    // Nothing is fetched until the mount has settled the scope: a fetch before that issues a
+    // round of calls for a session the window is about to leave.
+    if (!scopeSettled()) return;
+    const key = fetchScopeKey();
+    if (key === paintedScopeKey) return;
+    paintedScopeKey = key;
+
+    // A scope change drops the content it invalidates, SYNCHRONOUSLY. A commit-time check
+    // stops a stale result from being written; it does not remove rows already on screen,
+    // which would otherwise stay for the whole round trip and stay forever if the new fetch
+    // fails. "A correct selector over stale rows" is the failure this exists to prevent.
+    const ids = scopeIds();
+    setSnapshots([]);
+    setRows((prev) => keepSessions(prev, ids));
+    setLoadError("");
+    void refresh();
+  });
 
   const schedulePoll = () => {
+    if (disposed) return;
     if (pollTimer) clearTimeout(pollTimer);
     const delay = document.hasFocus() ? POLL_FOCUSED_MS : POLL_UNFOCUSED_MS;
     pollTimer = setTimeout(() => {
-      void refresh();
-      // The poll also refreshes the settings store, so a watcher saved from the modal turns
-      // the "no watcher reaches this agent" state into "configured and waiting" without the
-      // user reopening the window. There is no cross-window settings event to use instead.
-      settingsStore.refresh();
-      schedulePoll();
+      pollTimer = null;
+      // Chained rather than fired: a round that outlives its own period would otherwise stack
+      // against a per-session mutex, and in "All sessions" one round is already N calls.
+      void refresh().then(() => {
+        if (disposed) return;
+        // The poll also refreshes the settings store, so a watcher saved from the modal turns
+        // the "no watcher reaches this agent" state into "configured and waiting" without the
+        // user reopening the window. There is no cross-window settings event to use instead.
+        settingsStore.refresh();
+        schedulePoll();
+      });
     }, delay);
   };
 
   onMount(async () => {
-    // The store does not autoload, and the live agent-label fallback needs it.
-    settingsStore.load().catch((err) => console.error("[watchers] settings load:", err));
+    try {
+      // The store does not autoload, and both the live agent-label fallback and the theme
+      // need it. A failure here costs labels and the theme, not the window.
+      await settingsStore
+        .load()
+        .catch((err) => console.error("[watchers] settings load:", err));
+      if (disposed) return;
 
-    // Subscribe BEFORE fetching: a match landing between the two would otherwise be lost.
-    // The overlap it creates is exact rather than heuristic, because the merge keys on
-    // `(sessionId, seq)`.
-    listeners.push(
-      await onWatcherMatches((batch) => {
-        if (!scopeIds().includes(batch.sessionId)) return;
-        const session = sessionById(batch.sessionId);
-        const incoming = batch.matches.map((match) => freezeRow(match, session));
-        setRows((prev) => mergeRows(prev, incoming));
-        if (pinnedTop() && scrollEl) scrollEl.scrollTop = 0;
-      })
-    );
-    listeners.push(
-      await onWatchersScopeRequest(({ sessionId }) => {
-        setScopeSessionId(sessionId);
-        void refresh();
-      })
-    );
-    listeners.push(
-      await onSessionCreated(() => {
-        void reloadSessions();
-      })
-    );
-    listeners.push(
-      await onSessionDestroyed(() => {
-        void reloadSessions();
-      })
-    );
-    listeners.push(
-      await onSessionRenamed(() => {
-        void reloadSessions();
-      })
-    );
+      // Subscribe BEFORE fetching: a match landing between the two would otherwise be lost.
+      // The overlap it creates is exact rather than heuristic, because the merge keys on
+      // `(sessionId, seq)`.
+      await register(
+        onWatcherMatches((batch) => {
+          if (!scopeIds().includes(batch.sessionId)) return;
+          const session = sessionById(batch.sessionId);
+          const incoming = batch.matches.map((match) => freezeRow(match, session));
+          setRows((prev) => capPerSession(mergeRows(prev, incoming), scopeLimit()));
+          if (pinnedTop() && scrollEl) scrollEl.scrollTop = 0;
+        })
+      );
+      await register(
+        onWatchersScopeRequest(({ sessionId }) => {
+          scopeEventGeneration += 1;
+          setScopeSessionId(sessionId);
+          // No fetch is issued here. Every fetch is issued by the scope effect, keyed on the
+          // fetch scope itself.
+        })
+      );
+      await register(onSessionCreated(() => void reloadSessions()));
+      await register(onSessionDestroyed(() => void reloadSessions()));
+      await register(onSessionRenamed(() => void reloadSessions()));
 
-    await reloadSessions();
-    await refresh();
-    schedulePoll();
+      await reloadSessions();
+      if (disposed) return;
 
-    if (isTauri) void trackGeometry();
+      // The pull, issued AFTER the subscribe and adopted unless an event has been handled
+      // since. The window label exists the moment the builder returns while this listener
+      // exists only now, and Tauri queues nothing for a listener that did not exist yet, so an
+      // emit that raced the subscribe is recovered exactly here. A failure leaves the query
+      // parameter standing, which is the scope the window was opened with.
+      const generationAtIssue = scopeEventGeneration;
+      try {
+        const pulled = await WindowAPI.getWatchersScope();
+        if (disposed) return;
+        if (pulled && scopeEventGeneration === generationAtIssue) setScopeSessionId(pulled);
+      } catch (err) {
+        if (disposed) return;
+        console.error("[watchers] failed to pull the requested scope:", err);
+      }
+
+      // Only now may anything be fetched.
+      setScopeSettled(true);
+      schedulePoll();
+
+      if (isTauri) {
+        // Held in a variable that the SYNCHRONOUS `onCleanup` below runs. Calling `onCleanup`
+        // from an async continuation would attach to no owner at all, and these listeners
+        // would outlive the window.
+        cleanupGeometry = await trackGeometry();
+        if (disposed) {
+          cleanupGeometry?.();
+          cleanupGeometry = null;
+        }
+      }
+    } catch (error) {
+      if (error !== mountDisposed) throw error;
+    }
   });
 
   /** Persist through the dedicated one-field command, never `initWindowGeometry`: that one
    *  read-modify-writes the whole AppSettings on a debounce, which races the Settings save
-   *  that edits the watcher map. */
-  const trackGeometry = async () => {
+   *  that edits the watcher map. The rect is converted to logical pixels first; see
+   *  `logicalGeometry`. */
+  const trackGeometry = async (): Promise<(() => void) | null> => {
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    if (disposed) return null;
     const win = getCurrentWindow();
     let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
     const save = () => {
       if (saveTimer) clearTimeout(saveTimer);
-      saveTimer = setTimeout(async () => {
-        try {
-          const position = await win.outerPosition();
-          const size = await win.outerSize();
-          await WindowAPI.setWatchersGeometry({
-            x: position.x,
-            y: position.y,
-            width: size.width,
-            height: size.height,
-          });
-        } catch (err) {
-          console.error("[watchers] failed to save geometry:", err);
-        }
-      }, 500);
+      saveTimer = setTimeout(() => {
+        void (async () => {
+          try {
+            const factor = await win.scaleFactor();
+            const position = await win.outerPosition();
+            // `innerSize`, because the builder restores through `inner_size`.
+            const size = await win.innerSize();
+            if (disposed) return;
+            await WindowAPI.setWatchersGeometry(
+              logicalGeometry(
+                { x: position.x, y: position.y, width: size.width, height: size.height },
+                factor
+              )
+            );
+          } catch (err) {
+            console.error("[watchers] failed to save geometry:", err);
+          }
+        })();
+      }, GEOMETRY_SAVE_DEBOUNCE_MS);
     };
+
     const unlistenMoved = await win.onMoved(save);
+    if (disposed) {
+      unlistenMoved();
+      return null;
+    }
     const unlistenResized = await win.onResized(save);
-    onCleanup(() => {
+    if (disposed) {
+      unlistenMoved();
+      unlistenResized();
+      return null;
+    }
+    return () => {
       unlistenMoved();
       unlistenResized();
       if (saveTimer) clearTimeout(saveTimer);
-    });
+    };
   };
 
   onCleanup(() => {
+    disposed = true;
     for (const unlisten of listeners) unlisten();
     listeners.length = 0;
-    if (pollTimer) clearTimeout(pollTimer);
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+    cleanupGeometry?.();
+    cleanupGeometry = null;
   });
 
   const onScroll = () => {
@@ -300,8 +481,9 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
   };
 
   const changeScope = (value: string) => {
+    // No fetch here either: changing the scope changes `fetchScopeKey`, and that is what
+    // invalidates, drops and refetches.
     setScopeSessionId(value === "all" ? null : value);
-    void refresh();
   };
 
   const openWatcherSettings = () => {
@@ -444,6 +626,17 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
           Some screen output was not sampled
         </div>
       </Show>
+      {/* Outside the table states on purpose. A degraded watcher has by definition already
+          emitted matches, so a marker living inside the "configured and waiting" branch is
+          exactly where it can never be reached: one visible row sends the window to the
+          table instead. */}
+      <Show when={degraded().length > 0}>
+        <div class="watchers-note watchers-note-degraded" data-ac-testid="watchers.degraded">
+          {`Degraded: ${degraded()
+            .map((counter) => counter.watcherId)
+            .join(", ")} hit a per-tick cap, so some activations were not recorded.`}
+        </div>
+      </Show>
 
       <div
         class="watchers-body"
@@ -497,6 +690,27 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
                 )}
               </For>
             </ul>
+          </div>
+        </Show>
+
+        {/* Its own state, because saying "nothing has matched yet" over activations the user
+            is filtering out is false and gives them nothing to act on. */}
+        <Show when={view() === "filtered"}>
+          <div
+            class="watchers-empty"
+            data-ac-testid="watchers.empty.filtered"
+            data-ac-role="status"
+          >
+            <p>{`No activations match the current filters (${rows().length} hidden).`}</p>
+            <button
+              type="button"
+              class="watchers-cta"
+              onClick={clearFilters}
+              data-ac-testid="watchers.filtered.clear"
+              data-ac-role="button"
+            >
+              Clear filters
+            </button>
           </div>
         </Show>
 

--- a/src/watchers/App.tsx
+++ b/src/watchers/App.tsx
@@ -85,6 +85,42 @@ export function logicalGeometry(
   };
 }
 
+/**
+ * Register a set of listeners as one unit, and hand back a single release for all of them.
+ *
+ * Registering them one at a time with each unlisten in its own local is what leaks: a later
+ * registration that REJECTS leaves the earlier one alive and unreachable, attached to a
+ * window that is on its way out, because nothing ever puts it where the cleanup can see it.
+ * Here everything that succeeded is held in one place and the `finally` releases it on every
+ * path that does not hand it over -- a rejection, or the window closing on any await.
+ *
+ * `null` means the set was released rather than handed over, so the caller owns nothing.
+ * Exported for its own test: the failure it exists for needs a registration that rejects,
+ * which no real Tauri window produces on demand.
+ */
+export async function registerAll(
+  registrations: readonly (() => Promise<UnlistenFn>)[],
+  isDisposed: () => boolean
+): Promise<(() => void) | null> {
+  const registered: UnlistenFn[] = [];
+  const release = () => {
+    for (const unlisten of registered.splice(0)) unlisten();
+  };
+  let handedOver = false;
+  try {
+    for (const registration of registrations) {
+      if (isDisposed()) return null;
+      registered.push(await registration());
+    }
+    // Checked again after the last await, which the loop's own guard never reaches.
+    if (isDisposed()) return null;
+    handedOver = true;
+    return release;
+  } finally {
+    if (!handedOver) release();
+  }
+}
+
 const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
   // ── Lifecycle ──────────────────────────────────────────────────────────────
   // `onMount` crosses several awaits and the window can be closed inside any of them, so
@@ -272,13 +308,25 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
     }
   };
 
+  /**
+   * The same monotonic rule as the activity fetch, and for a worse reason.
+   *
+   * The three session listeners each fire their own `list_sessions`, unserialized, and
+   * nothing polls the list afterwards. So an older answer that resolves last does not cause a
+   * flicker: it resurrects a session that was destroyed, or removes one that was just
+   * created, and the window stays wrong until it is reopened. In "All sessions" that list
+   * also IS the scope, so a wrong list is a wrong set of fetches.
+   */
+  let sessionsRequestCounter = 0;
+
   const reloadSessions = async () => {
+    const request = (sessionsRequestCounter += 1);
     try {
       const listed = await SessionAPI.list();
-      if (disposed) return;
+      if (disposed || request !== sessionsRequestCounter) return;
       setSessions(listed);
     } catch (err) {
-      if (disposed) return;
+      if (disposed || request !== sessionsRequestCounter) return;
       console.error("[watchers] failed to list sessions:", err);
     }
   };
@@ -316,9 +364,14 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
     // stops a stale result from being written; it does not remove rows already on screen,
     // which would otherwise stay for the whole round trip and stay forever if the new fetch
     // fails. "A correct selector over stale rows" is the failure this exists to prevent.
+    //
+    // The drop is as wide as the key that triggered it: leaving one session for "All
+    // sessions" narrows the per-session limit from 500 to 100, so dropping only what left the
+    // scope would keep 500 rows of a session now entitled to 100.
     const ids = scopeIds();
+    const limit = scopeLimit();
     setSnapshots([]);
-    setRows((prev) => keepSessions(prev, ids));
+    setRows((prev) => capPerSession(keepSessions(prev, ids), limit));
     setLoadError("");
     void refresh();
   });
@@ -408,7 +461,13 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
         }
       }
     } catch (error) {
-      if (error !== mountDisposed) throw error;
+      // Never re-thrown. Solid does not await the promise this `onMount` returns, so anything
+      // that escapes here is an unhandled rejection instead of an error somebody sees, and
+      // the window would sit half-started with nothing on screen saying so. The sentinel is
+      // not a failure at all: it means the window closed while the mount was still running.
+      if (error === mountDisposed || disposed) return;
+      console.error("[watchers] the window failed to finish starting up:", error);
+      setLoadError(error instanceof Error ? error.message : String(error));
     }
   });
 
@@ -445,22 +504,31 @@ const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
       }, GEOMETRY_SAVE_DEBOUNCE_MS);
     };
 
-    const unlistenMoved = await win.onMoved(save);
-    if (disposed) {
-      unlistenMoved();
-      return null;
-    }
-    const unlistenResized = await win.onResized(save);
-    if (disposed) {
-      unlistenMoved();
-      unlistenResized();
-      return null;
-    }
-    return () => {
-      unlistenMoved();
-      unlistenResized();
+    const stopSaving = () => {
       if (saveTimer) clearTimeout(saveTimer);
+      saveTimer = null;
     };
+
+    try {
+      const release = await registerAll(
+        [() => win.onMoved(save), () => win.onResized(save)],
+        () => disposed
+      );
+      if (!release) {
+        stopSaving();
+        return null;
+      }
+      return () => {
+        release();
+        stopSaving();
+      };
+    } catch (err) {
+      // Geometry tracking is best-effort: losing it costs a persisted rect, not the window.
+      // What must not happen is escaping into `onMount`, whose promise nobody awaits.
+      stopSaving();
+      console.error("[watchers] failed to track the window geometry:", err);
+      return null;
+    }
   };
 
   onCleanup(() => {

--- a/src/watchers/App.tsx
+++ b/src/watchers/App.tsx
@@ -1,0 +1,627 @@
+import {
+  Component,
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import {
+  PtyAPI,
+  SessionAPI,
+  WindowAPI,
+  emitOpenSettings,
+  onSessionCreated,
+  onSessionDestroyed,
+  onSessionRenamed,
+  onWatcherMatches,
+  onWatchersScopeRequest,
+} from "../shared/ipc";
+import { isTauri } from "../shared/platform";
+import { settingsStore } from "../shared/stores/settings";
+import { formatClockTime } from "../shared/time-format";
+import type { UnlistenFn } from "../shared/transport";
+import type { Session, WatcherActivitySnapshot } from "../shared/types";
+import {
+  ALL_SESSIONS_LIMIT,
+  SINGLE_SESSION_LIMIT,
+  type ActivityRow,
+  anyTruncated,
+  distinct,
+  filterRows,
+  freezeRow,
+  keepSessions,
+  mergeActiveWatchers,
+  mergeRows,
+  resolveView,
+  rowKey,
+  totalPossiblyMissedFrames,
+} from "./activity";
+import WatchersTitlebar from "./components/WatchersTitlebar";
+import "./styles/watchers.css";
+
+/** Snapshot poll cadence. The snapshot is the ONLY carrier of `truncated`,
+ *  `possiblyMissedFrames`, `warmedUp`, `activeWatchers` and `degraded`, and there is no
+ *  cross-window settings event to hang a refresh on, so without a poll those five freeze at
+ *  their mount values. Cadence copies the Resource Monitor's written precedent
+ *  (`ActionBar.tsx:81-87`). */
+const POLL_FOCUSED_MS = 10_000;
+const POLL_UNFOCUSED_MS = 15_000;
+
+/** How close to the top still counts as pinned, in pixels. */
+const PIN_TO_TOP_SLACK_PX = 8;
+
+const WatchersApp: Component<{ initialSessionId?: string }> = (props) => {
+  // `null` is the "All sessions" scope.
+  const [scopeSessionId, setScopeSessionId] = createSignal<string | null>(
+    props.initialSessionId ?? null
+  );
+  const [sessions, setSessions] = createSignal<Session[]>([]);
+  const [rows, setRows] = createSignal<ActivityRow[]>([]);
+  const [snapshots, setSnapshots] = createSignal<WatcherActivitySnapshot[]>([]);
+  const [loadError, setLoadError] = createSignal("");
+
+  const [watcherFilter, setWatcherFilter] = createSignal<Set<string>>(new Set());
+  const [agentFilter, setAgentFilter] = createSignal<Set<string>>(new Set());
+  const [workgroupFilter, setWorkgroupFilter] = createSignal<Set<string>>(new Set());
+  const [textFilter, setTextFilter] = createSignal("");
+  const [expandedKey, setExpandedKey] = createSignal<string | null>(null);
+
+  let scrollEl: HTMLDivElement | undefined;
+  let scopeEl: HTMLSelectElement | undefined;
+  const [pinnedTop, setPinnedTop] = createSignal(true);
+
+  // Only agent sessions are ever registered with the engine, exactly as with the context
+  // scraper. A plain shell has a screen but never a watcher.
+  const agentSessions = createMemo(() => sessions().filter((s) => !!s.agentId));
+  const sessionById = (id: string) => sessions().find((s) => s.id === id);
+
+  const scopeIds = createMemo(() => {
+    const single = scopeSessionId();
+    if (single) return [single];
+    return agentSessions().map((s) => s.id);
+  });
+  const isAllSessions = () => scopeSessionId() === null;
+
+  /** Live agent label by id, falling back to what was frozen into the row, so renaming an
+   *  entry updates old rows instead of leaving them lying. Precedent: `liveAgentLabel`. */
+  const agentLabel = (row: ActivityRow): string => {
+    const live = row.agentId
+      ? settingsStore.current?.agents?.find((a) => a.id === row.agentId)?.label
+      : null;
+    return live || row.frozenAgentLabel || row.agentId || "";
+  };
+
+  // The scope select is driven by an effect rather than by `value=`, because the window
+  // opens scoped to a session whose `<option>` does not exist yet: the list arrives with
+  // `list_sessions`, and a `<select>` silently ignores a value it has no option for. Without
+  // re-applying it once the options land, the control would read "All sessions" while the
+  // window was in fact scoped to one.
+  createEffect(() => {
+    const desired = scopeSessionId() ?? "all";
+    const options = agentSessions();
+    if (!scopeEl) return;
+    if (desired === "all" || options.some((s) => s.id === desired)) {
+      scopeEl.value = desired;
+    }
+  });
+
+  const visibleRows = createMemo(() =>
+    filterRows(rows(), {
+      watchers: watcherFilter(),
+      agents: agentFilter(),
+      workgroups: workgroupFilter(),
+      text: textFilter(),
+    })
+  );
+
+  const view = createMemo(() => resolveView(snapshots(), visibleRows().length));
+  const activeWatchers = createMemo(() => mergeActiveWatchers(snapshots()));
+  const truncated = createMemo(() => anyTruncated(snapshots()));
+  const missedFrames = createMemo(() => totalPossiblyMissedFrames(snapshots()));
+
+  const watcherOptions = createMemo(() => distinct(rows().map((r) => r.watcherId)).sort());
+  const agentOptions = createMemo(() => {
+    const seen = new Map<string, string>();
+    for (const row of rows()) {
+      if (row.agentId && !seen.has(row.agentId)) seen.set(row.agentId, agentLabel(row));
+    }
+    return [...seen.entries()].map(([id, label]) => ({ id, label }));
+  });
+  const workgroupOptions = createMemo(() =>
+    distinct(
+      rows()
+        .map((r) => r.workgroup)
+        .filter((wg): wg is string => !!wg)
+    ).sort()
+  );
+  // A label the user wrote can repeat while an id cannot, so a duplicate gets a short id
+  // suffix rather than two chips that read the same.
+  const agentChipText = (option: { id: string; label: string }) => {
+    const duplicate = agentOptions().filter((o) => o.label === option.label).length > 1;
+    return duplicate ? `${option.label} (${option.id.slice(0, 6)})` : option.label;
+  };
+
+  const filtersActive = () =>
+    watcherFilter().size > 0 ||
+    agentFilter().size > 0 ||
+    workgroupFilter().size > 0 ||
+    textFilter().trim() !== "";
+
+  const clearFilters = () => {
+    setWatcherFilter(new Set<string>());
+    setAgentFilter(new Set<string>());
+    setWorkgroupFilter(new Set<string>());
+    setTextFilter("");
+  };
+
+  const toggleFilter = (
+    get: () => Set<string>,
+    set: (next: Set<string>) => void,
+    value: string
+  ) => {
+    const next = new Set(get());
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    set(next);
+  };
+
+  const refresh = async () => {
+    const ids = scopeIds();
+    const limit = isAllSessions() ? ALL_SESSIONS_LIMIT : SINGLE_SESSION_LIMIT;
+    try {
+      const fetched = await Promise.all(
+        ids.map((id) => PtyAPI.getWatcherActivity(id, limit))
+      );
+      setSnapshots(fetched);
+      setLoadError("");
+      const incoming = fetched.flatMap((snapshot, index) =>
+        snapshot.matches.map((match) => freezeRow(match, sessionById(ids[index])))
+      );
+      setRows((prev) => mergeRows(keepSessions(prev, ids), incoming));
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const reloadSessions = async () => {
+    try {
+      setSessions(await SessionAPI.list());
+    } catch (err) {
+      console.error("[watchers] failed to list sessions:", err);
+    }
+  };
+
+  const listeners: UnlistenFn[] = [];
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const schedulePoll = () => {
+    if (pollTimer) clearTimeout(pollTimer);
+    const delay = document.hasFocus() ? POLL_FOCUSED_MS : POLL_UNFOCUSED_MS;
+    pollTimer = setTimeout(() => {
+      void refresh();
+      // The poll also refreshes the settings store, so a watcher saved from the modal turns
+      // the "no watcher reaches this agent" state into "configured and waiting" without the
+      // user reopening the window. There is no cross-window settings event to use instead.
+      settingsStore.refresh();
+      schedulePoll();
+    }, delay);
+  };
+
+  onMount(async () => {
+    // The store does not autoload, and the live agent-label fallback needs it.
+    settingsStore.load().catch((err) => console.error("[watchers] settings load:", err));
+
+    // Subscribe BEFORE fetching: a match landing between the two would otherwise be lost.
+    // The overlap it creates is exact rather than heuristic, because the merge keys on
+    // `(sessionId, seq)`.
+    listeners.push(
+      await onWatcherMatches((batch) => {
+        if (!scopeIds().includes(batch.sessionId)) return;
+        const session = sessionById(batch.sessionId);
+        const incoming = batch.matches.map((match) => freezeRow(match, session));
+        setRows((prev) => mergeRows(prev, incoming));
+        if (pinnedTop() && scrollEl) scrollEl.scrollTop = 0;
+      })
+    );
+    listeners.push(
+      await onWatchersScopeRequest(({ sessionId }) => {
+        setScopeSessionId(sessionId);
+        void refresh();
+      })
+    );
+    listeners.push(
+      await onSessionCreated(() => {
+        void reloadSessions();
+      })
+    );
+    listeners.push(
+      await onSessionDestroyed(() => {
+        void reloadSessions();
+      })
+    );
+    listeners.push(
+      await onSessionRenamed(() => {
+        void reloadSessions();
+      })
+    );
+
+    await reloadSessions();
+    await refresh();
+    schedulePoll();
+
+    if (isTauri) void trackGeometry();
+  });
+
+  /** Persist through the dedicated one-field command, never `initWindowGeometry`: that one
+   *  read-modify-writes the whole AppSettings on a debounce, which races the Settings save
+   *  that edits the watcher map. */
+  const trackGeometry = async () => {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    const win = getCurrentWindow();
+    let saveTimer: ReturnType<typeof setTimeout> | null = null;
+    const save = () => {
+      if (saveTimer) clearTimeout(saveTimer);
+      saveTimer = setTimeout(async () => {
+        try {
+          const position = await win.outerPosition();
+          const size = await win.outerSize();
+          await WindowAPI.setWatchersGeometry({
+            x: position.x,
+            y: position.y,
+            width: size.width,
+            height: size.height,
+          });
+        } catch (err) {
+          console.error("[watchers] failed to save geometry:", err);
+        }
+      }, 500);
+    };
+    const unlistenMoved = await win.onMoved(save);
+    const unlistenResized = await win.onResized(save);
+    onCleanup(() => {
+      unlistenMoved();
+      unlistenResized();
+      if (saveTimer) clearTimeout(saveTimer);
+    });
+  };
+
+  onCleanup(() => {
+    for (const unlisten of listeners) unlisten();
+    listeners.length = 0;
+    if (pollTimer) clearTimeout(pollTimer);
+  });
+
+  const onScroll = () => {
+    if (!scrollEl) return;
+    setPinnedTop(scrollEl.scrollTop <= PIN_TO_TOP_SLACK_PX);
+  };
+
+  const changeScope = (value: string) => {
+    setScopeSessionId(value === "all" ? null : value);
+    void refresh();
+  };
+
+  const openWatcherSettings = () => {
+    // Focus first: the Settings modal is mounted only in the sidebar, so with this window in
+    // front the modal would open behind it and nothing visible would happen.
+    WindowAPI.focusMain()
+      .catch((err) => console.error("[watchers] focus main:", err))
+      .finally(() => {
+        emitOpenSettings("watchers").catch((err) =>
+          console.error("[watchers] open settings:", err)
+        );
+      });
+  };
+
+  return (
+    <div class="watchers-window" data-ac-testid="watchers.window">
+      <WatchersTitlebar />
+
+      <div class="watchers-filter-bar" data-ac-testid="watchers.filters" data-ac-role="toolbar">
+        <div class="watchers-filter-group">
+          <span class="watchers-filter-label">Scope</span>
+          <select
+            class="watchers-select"
+            ref={(el) => (scopeEl = el)}
+            onChange={(e) => changeScope(e.currentTarget.value)}
+            data-ac-testid="watchers.scope"
+            data-ac-role="combobox"
+          >
+            <option value="all">All sessions</option>
+            <For each={agentSessions()}>
+              {(session) => <option value={session.id}>{session.name}</option>}
+            </For>
+          </select>
+        </div>
+
+        <Show when={watcherOptions().length > 0}>
+          <div class="watchers-filter-group" data-ac-testid="watchers.filter.watcher">
+            <span class="watchers-filter-label">Watcher</span>
+            <For each={watcherOptions()}>
+              {(value) => (
+                <button
+                  type="button"
+                  class="watchers-chip"
+                  classList={{ "is-active": watcherFilter().has(value) }}
+                  onClick={() => toggleFilter(watcherFilter, setWatcherFilter, value)}
+                  aria-pressed={watcherFilter().has(value)}
+                  data-ac-testid={`watchers.filter.watcher.${value}`}
+                  data-ac-role="button"
+                >
+                  {value}
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+
+        {/* In single-session scope Agent and Workgroup have one possible value each and
+            filter nothing, so they are not rendered -- the gesture the Resource Monitor
+            already uses for an empty option list. */}
+        <Show when={isAllSessions() && agentOptions().length > 0}>
+          <div class="watchers-filter-group" data-ac-testid="watchers.filter.agent">
+            <span class="watchers-filter-label">Agent</span>
+            <For each={agentOptions()}>
+              {(option) => (
+                <button
+                  type="button"
+                  class="watchers-chip"
+                  classList={{ "is-active": agentFilter().has(option.id) }}
+                  onClick={() => toggleFilter(agentFilter, setAgentFilter, option.id)}
+                  aria-pressed={agentFilter().has(option.id)}
+                  data-ac-testid={`watchers.filter.agent.${option.id}`}
+                  data-ac-role="button"
+                >
+                  {agentChipText(option)}
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+
+        <Show when={isAllSessions() && workgroupOptions().length > 0}>
+          <div class="watchers-filter-group" data-ac-testid="watchers.filter.workgroup">
+            <span class="watchers-filter-label">Workgroup</span>
+            <For each={workgroupOptions()}>
+              {(value) => (
+                <button
+                  type="button"
+                  class="watchers-chip"
+                  classList={{ "is-active": workgroupFilter().has(value) }}
+                  onClick={() => toggleFilter(workgroupFilter, setWorkgroupFilter, value)}
+                  aria-pressed={workgroupFilter().has(value)}
+                  data-ac-testid={`watchers.filter.workgroup.${value}`}
+                  data-ac-role="button"
+                >
+                  {value}
+                </button>
+              )}
+            </For>
+          </div>
+        </Show>
+
+        <input
+          class="watchers-search"
+          type="text"
+          placeholder="Filter captures..."
+          value={textFilter()}
+          onInput={(e) => setTextFilter(e.currentTarget.value)}
+          data-ac-testid="watchers.filter.text"
+          data-ac-role="searchbox"
+        />
+
+        <Show when={filtersActive()}>
+          <button
+            type="button"
+            class="watchers-clear"
+            onClick={clearFilters}
+            data-ac-testid="watchers.filter.clear"
+            data-ac-role="button"
+          >
+            Clear filters
+          </button>
+        </Show>
+      </div>
+
+      <Show when={loadError()}>
+        <div class="watchers-banner watchers-banner-error" data-ac-testid="watchers.error">
+          {loadError()}
+        </div>
+      </Show>
+
+      {/* Two distinct signals, never merged: `truncated` is exact knowledge that something
+          was dropped; `possiblyMissedFrames` is uncertainty about whether anything was. */}
+      <Show when={truncated()}>
+        <div class="watchers-banner" data-ac-testid="watchers.truncated">
+          Older activations were dropped (buffer limit)
+        </div>
+      </Show>
+      <Show when={missedFrames() > 0}>
+        <div class="watchers-note" data-ac-testid="watchers.missedFrames">
+          Some screen output was not sampled
+        </div>
+      </Show>
+
+      <div
+        class="watchers-body"
+        ref={(el) => (scrollEl = el)}
+        onScroll={onScroll}
+        data-ac-testid="watchers.body"
+      >
+        <Show when={view() === "warming"}>
+          <div class="watchers-empty" data-ac-testid="watchers.empty.warming" data-ac-role="status">
+            Waiting for the first sample...
+          </div>
+        </Show>
+
+        <Show when={view() === "unconfigured"}>
+          <div
+            class="watchers-empty"
+            data-ac-testid="watchers.empty.unconfigured"
+            data-ac-role="status"
+          >
+            <p>No configured watcher reaches this session's agent.</p>
+            <button
+              type="button"
+              class="watchers-cta"
+              onClick={openWatcherSettings}
+              data-ac-testid="watchers.configure"
+              data-ac-role="button"
+            >
+              Configure watchers
+            </button>
+          </div>
+        </Show>
+
+        <Show when={view() === "waiting"}>
+          <div
+            class="watchers-empty"
+            data-ac-testid="watchers.empty.waiting"
+            data-ac-role="status"
+          >
+            <p>Configured and waiting. Nothing has matched yet.</p>
+            <ul class="watchers-waiting-list">
+              <For each={activeWatchers()}>
+                {(counter) => (
+                  <li data-ac-testid={`watchers.waiting.${counter.watcherId}`}>
+                    <span class="watchers-chip is-static">{counter.watcherId}</span>
+                    <span class="watchers-mode">{counter.mode}</span>
+                    <span class="watchers-count">{counter.count}</span>
+                    <Show when={counter.degraded}>
+                      <span class="watchers-degraded">degraded</span>
+                    </Show>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+        </Show>
+
+        <Show when={view() === "rows"}>
+          <table class="watchers-table" data-ac-testid="watchers.table">
+            <thead>
+              <tr>
+                <th class="watchers-col-time">Time</th>
+                <th class="watchers-col-watcher">Watcher</th>
+                <Show when={isAllSessions()}>
+                  <th class="watchers-col-session">Session</th>
+                </Show>
+                <th class="watchers-col-captures">Captures</th>
+              </tr>
+            </thead>
+            <tbody>
+              <For each={visibleRows()}>
+                {(row) => {
+                  const key = rowKey(row);
+                  const expanded = () => expandedKey() === key;
+                  const primary = () => row.captures[0] ?? row.row;
+                  return (
+                    <>
+                      <tr
+                        class="watchers-row"
+                        classList={{ "is-expanded": expanded() }}
+                        onClick={() => setExpandedKey(expanded() ? null : key)}
+                        data-ac-testid={`watchers.row.${key}`}
+                        data-ac-role="row"
+                        data-ac-mode={row.mode}
+                      >
+                        <td class="watchers-col-time">{formatClockTime(row.at)}</td>
+                        <td class="watchers-col-watcher">
+                          <span
+                            class="watchers-chip is-static"
+                            style={{ "--watcher-hue": `${watcherHue(row.watcherId)}deg` }}
+                          >
+                            {row.watcherId}
+                          </span>
+                          {/* State and occurrence rows are otherwise identical, and the word
+                              "state" invites reading the last such row as the current state. */}
+                          <span class="watchers-mode" title={modeTitle(row.mode)}>
+                            {row.mode === "state" ? "state" : "occ"}
+                          </span>
+                        </td>
+                        <Show when={isAllSessions()}>
+                          <td class="watchers-col-session">
+                            <div class="watchers-session-name">{row.sessionName}</div>
+                            <div class="watchers-session-meta">
+                              {[agentLabel(row), row.workgroup].filter(Boolean).join(" - ")}
+                            </div>
+                          </td>
+                        </Show>
+                        <td class="watchers-col-captures">
+                          {/* Left-side ellipsis, so a path's tail (the file name) stays
+                              visible, which is the part worth reading. */}
+                          <span class="watchers-capture" dir="rtl">
+                            {primary()}
+                          </span>
+                          <Show when={row.captures.length > 1}>
+                            <For each={row.captures.slice(1)}>
+                              {(capture) => (
+                                <span class="watchers-capture-extra">{capture ?? "-"}</span>
+                              )}
+                            </For>
+                          </Show>
+                          <button
+                            type="button"
+                            class="watchers-copy"
+                            title="Copy"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              void navigator.clipboard?.writeText(primary());
+                            }}
+                            data-ac-testid={`watchers.copy.${key}`}
+                            data-ac-role="button"
+                          >
+                            &#x29C9;
+                          </button>
+                        </td>
+                      </tr>
+                      <Show when={expanded()}>
+                        <tr class="watchers-raw-row">
+                          <td colSpan={isAllSessions() ? 4 : 3}>
+                            {/* Wrapped, not scrolled: the real behavior of the repository's
+                                raw-text container, and a nested horizontal scroller inside a
+                                vertically scrolling table is worse for a 256-byte row. */}
+                            <div class="watchers-raw" data-ac-testid={`watchers.raw.${key}`}>
+                              {row.row}
+                            </div>
+                            <Show when={row.rowTruncated}>
+                              <div class="watchers-note">Row truncated at 256 bytes</div>
+                            </Show>
+                          </td>
+                        </tr>
+                      </Show>
+                    </>
+                  );
+                }}
+              </For>
+            </tbody>
+          </table>
+        </Show>
+      </div>
+
+      <div class="watchers-footer" data-ac-testid="watchers.footer">
+        Best-effort. Activations can be missed. This is not an audit log.
+      </div>
+    </div>
+  );
+};
+
+/** A stable hue per watcher id, so the same watcher keeps its colour across openings. */
+function watcherHue(watcherId: string): number {
+  let hash = 0;
+  for (let i = 0; i < watcherId.length; i += 1) {
+    hash = (hash * 31 + watcherId.charCodeAt(i)) % 360;
+  }
+  return hash;
+}
+
+function modeTitle(mode: string): string {
+  return mode === "state"
+    ? "State: records when the condition was first seen, not that it still holds"
+    : "Occurrence: one event per match";
+}
+
+export default WatchersApp;

--- a/src/watchers/activity.test.ts
+++ b/src/watchers/activity.test.ts
@@ -7,6 +7,8 @@ import type {
 import {
   type ActivityRow,
   anyTruncated,
+  capPerSession,
+  degradedWatchers,
   filterRows,
   freezeRow,
   keepSessions,
@@ -131,6 +133,96 @@ describe("merging the snapshot with the stream (#1171)", () => {
   });
 });
 
+/**
+ * #1171 - the 500/100 limits are not only fetch parameters.
+ *
+ * The ring caps what a SNAPSHOT returns; the event stream keeps appending for as long as the
+ * window is open, so without a structural bound after every merge the frontend grows without
+ * one. A single session can deliver dozens of rows a second.
+ */
+describe("bounding what the window holds (#1171)", () => {
+  const burst = (sessionId: string, count: number, from = 0) =>
+    Array.from({ length: count }, (_, i) =>
+      freezeRow(match({ sessionId, seq: from + i }), session({ id: sessionId }))
+    );
+
+  it("keeps at most the limit per session and drops the oldest", () => {
+    const capped = capPerSession(mergeRows([], burst("s1", 250)), 100);
+    expect(capped).toHaveLength(100);
+    // Newest first, so the survivors are the highest seqs.
+    expect(capped[0].seq).toBe(249);
+    expect(Math.min(...capped.map((r) => r.seq))).toBe(150);
+  });
+
+  it("bounds each session on its own, not the table as a whole", () => {
+    const both = mergeRows(burst("s1", 30), burst("s2", 30));
+    const capped = capPerSession(both, 10);
+    expect(capped.filter((r) => r.sessionId === "s1")).toHaveLength(10);
+    expect(capped.filter((r) => r.sessionId === "s2")).toHaveLength(10);
+  });
+
+  /** Hours of streaming, one small batch at a time, is the shape that actually happens. */
+  it("stays bounded across many merges rather than only at the end", () => {
+    let held: ActivityRow[] = [];
+    for (let round = 0; round < 200; round += 1) {
+      held = capPerSession(mergeRows(held, burst("s1", 20, round * 20)), 100);
+      expect(held.length).toBeLessThanOrEqual(100);
+    }
+    expect(held[0].seq).toBe(200 * 20 - 1);
+  });
+
+  it("leaves a table under the limit untouched", () => {
+    const rows = mergeRows([], burst("s1", 5));
+    expect(capPerSession(rows, 100).map((r) => r.seq)).toEqual(rows.map((r) => r.seq));
+  });
+});
+
+/**
+ * #1171 - Solid's `<For>` keys on object identity, not on the logical key, so a poll that
+ * rebuilds the whole ring would rebuild and re-animate every row on screen every ten seconds.
+ */
+describe("row identity across merges (#1171)", () => {
+  it("keeps the object it already held for a key it already has", () => {
+    const held = freezeRow(match({ seq: 1 }), session());
+    const identicalSnapshot = freezeRow(match({ seq: 1 }), session());
+    expect(identicalSnapshot).not.toBe(held);
+
+    const merged = mergeRows([held], [identicalSnapshot]);
+    expect(merged[0]).toBe(held);
+  });
+
+  it("takes the newer object when the older one was frozen before its session was known", () => {
+    const orphan = freezeRow(match({ seq: 1 }), undefined);
+    const resolved = freezeRow(match({ seq: 1 }), session());
+    const merged = mergeRows([orphan], [resolved]);
+    expect(merged[0]).toBe(resolved);
+    expect(merged[0].agentId).toBe("agent_1");
+  });
+});
+
+describe("surfacing degraded watchers (#1171)", () => {
+  /**
+   * A degraded watcher has BY DEFINITION already emitted matches, so a marker that only
+   * renders inside the "configured and waiting" branch is exactly where it can never be
+   * reached: one visible row sends the window to the table instead.
+   */
+  it("reports a degraded watcher that has already matched", () => {
+    const degraded = degradedWatchers([
+      snapshot({
+        activeWatchers: [
+          { watcherId: "reads", mode: "occurrence", count: 4000, degraded: true },
+          { watcherId: "quiet", mode: "state", count: 1, degraded: false },
+        ],
+      }),
+    ]);
+    expect(degraded.map((c) => c.watcherId)).toEqual(["reads"]);
+  });
+
+  it("reports nothing when no watcher is capped", () => {
+    expect(degradedWatchers([snapshot()])).toEqual([]);
+  });
+});
+
 describe("filtering (#1171)", () => {
   const rows = [
     row({ sessionId: "s1", seq: 1, watcherId: "reads", agentId: "a1", workgroup: "WG-1" }),
@@ -173,17 +265,17 @@ describe("filtering (#1171)", () => {
 });
 
 /**
- * #1171 test 81. Four states, told apart from snapshot VALUES with no nullability -- and
- * `warming` is its own state so the day-one message never flickers before the first tick.
+ * #1171 test 81. The empty states, told apart from snapshot VALUES with no nullability --
+ * and `warming` is its own state so the day-one message never flickers before the first tick.
  */
 describe("resolving which state the window shows (#1171)", () => {
   it("shows warming until the engine has ticked, even with no watchers", () => {
-    expect(resolveView([snapshot({ warmedUp: false })], 0)).toBe("warming");
-    expect(resolveView([], 0)).toBe("warming");
+    expect(resolveView([snapshot({ warmedUp: false })], 0, 0)).toBe("warming");
+    expect(resolveView([], 0, 0)).toBe("warming");
   });
 
   it("shows the unconfigured state only once warmed up with nothing reaching", () => {
-    expect(resolveView([snapshot({ warmedUp: true, activeWatchers: [] })], 0)).toBe(
+    expect(resolveView([snapshot({ warmedUp: true, activeWatchers: [] })], 0, 0)).toBe(
       "unconfigured"
     );
   });
@@ -192,16 +284,41 @@ describe("resolving which state the window shows (#1171)", () => {
     const waiting = snapshot({
       activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 0, degraded: false }],
     });
-    expect(resolveView([waiting], 0)).toBe("waiting");
+    expect(resolveView([waiting], 0, 0)).toBe("waiting");
   });
 
   it("shows the table as soon as a row is visible", () => {
-    expect(resolveView([snapshot({ warmedUp: false })], 1)).toBe("rows");
+    expect(resolveView([snapshot({ warmedUp: false })], 1, 1)).toBe("rows");
   });
 
   it("counts a scope as warmed when any of its sessions has ticked", () => {
-    const view = resolveView([snapshot({ warmedUp: false }), snapshot({ warmedUp: true })], 0);
+    const view = resolveView(
+      [snapshot({ warmedUp: false }), snapshot({ warmedUp: true })],
+      0,
+      0
+    );
     expect(view).toBe("unconfigured");
+  });
+
+  /**
+   * The empty states are statements about the ACTIVATIONS. Deciding them from filtered rows
+   * makes a filter that happens to hide everything say "nothing has matched yet", which is
+   * false and which the user cannot attribute to the filter they just set.
+   */
+  it("blames the filters, not the watchers, when a filter hides every activation", () => {
+    const waiting = snapshot({
+      activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 4, degraded: false }],
+    });
+    expect(resolveView([waiting], 4, 0)).toBe("filtered");
+  });
+
+  it("still says filtered when nothing reaches but activations are held", () => {
+    // Rows outlive the watcher that produced them: deleting a watcher empties
+    // `activeWatchers` while the ring keeps its activations, and a filter over those must
+    // not be reported as "no configured watcher reaches this agent".
+    expect(resolveView([snapshot({ warmedUp: true, activeWatchers: [] })], 3, 0)).toBe(
+      "filtered"
+    );
   });
 });
 

--- a/src/watchers/activity.test.ts
+++ b/src/watchers/activity.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Session,
+  WatcherActivitySnapshot,
+  WatcherMatchPayload,
+} from "../shared/types";
+import {
+  type ActivityRow,
+  anyTruncated,
+  filterRows,
+  freezeRow,
+  keepSessions,
+  mergeActiveWatchers,
+  mergeRows,
+  resolveView,
+  rowKey,
+  totalPossiblyMissedFrames,
+} from "./activity";
+
+function match(overrides: Partial<WatcherMatchPayload> = {}): WatcherMatchPayload {
+  return {
+    sessionId: "s1",
+    seq: 1,
+    watcherId: "reads",
+    mode: "occurrence",
+    at: "2026-07-30T22:31:05Z",
+    captures: ["C:/repo/main.rs"],
+    row: "Read (C:/repo/main.rs)",
+    rowTruncated: false,
+    ...overrides,
+  };
+}
+
+// Only the fields these tests read; the cast is the fixture admitting it is partial.
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "s1",
+    name: "claude@repo",
+    workingDirectory: "C:/proj/.ac/wg-19-dev-v4-team/__agent_dev-rust",
+    agentId: "agent_1",
+    agentLabel: "Claude Sandbox",
+    ...overrides,
+  } as Session;
+}
+
+function snapshot(
+  overrides: Partial<WatcherActivitySnapshot> = {}
+): WatcherActivitySnapshot {
+  return {
+    matches: [],
+    lastSeq: 0,
+    truncated: false,
+    possiblyMissedFrames: 0,
+    warmedUp: true,
+    activeWatchers: [],
+    ...overrides,
+  };
+}
+
+const row = (overrides: Partial<ActivityRow> = {}): ActivityRow => ({
+  ...freezeRow(match(), session()),
+  ...overrides,
+});
+
+describe("freezing a row (#1171)", () => {
+  it("takes the workgroup from the working directory, not from the session name", () => {
+    const frozen = freezeRow(
+      match(),
+      session({ name: "renamed by the user", workingDirectory: "C:/p/.ac/wg-7-team/x" })
+    );
+    expect(frozen.workgroup).toBe("WG-7-TEAM");
+  });
+
+  it("keeps the session id as the name when the session is already gone", () => {
+    const frozen = freezeRow(match({ sessionId: "ghost" }), undefined);
+    expect(frozen.sessionName).toBe("ghost");
+    expect(frozen.agentId).toBeNull();
+    expect(frozen.workgroup).toBeNull();
+  });
+});
+
+/**
+ * #1171 test 77. The window subscribes before it fetches, so a match arriving during the
+ * fetch is in BOTH the stream and the snapshot. It must be shown exactly once.
+ */
+describe("merging the snapshot with the stream (#1171)", () => {
+  it("neither duplicates nor loses a match that arrives during the fetch", () => {
+    const streamed = freezeRow(match({ seq: 7 }), session());
+    const fromSnapshot = [
+      freezeRow(match({ seq: 6 }), session()),
+      freezeRow(match({ seq: 7 }), session()), // the overlap
+    ];
+
+    const merged = mergeRows([streamed], fromSnapshot);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.map((r) => r.seq).sort()).toEqual([6, 7]);
+  });
+
+  it("keeps two matches of the same tick apart, which only `seq` can do", () => {
+    // Same `at`, same watcher, same row text: legal under `dedupe: "none"`.
+    const a = freezeRow(match({ seq: 1 }), session());
+    const b = freezeRow(match({ seq: 2 }), session());
+    expect(rowKey(a)).not.toBe(rowKey(b));
+    expect(mergeRows([], [a, b])).toHaveLength(2);
+  });
+
+  it("does not collapse the same seq coming from two different sessions", () => {
+    const a = freezeRow(match({ sessionId: "s1", seq: 1 }), session({ id: "s1" }));
+    const b = freezeRow(match({ sessionId: "s2", seq: 1 }), session({ id: "s2" }));
+    expect(mergeRows([], [a, b])).toHaveLength(2);
+  });
+
+  it("orders newest first, breaking a tie on seq", () => {
+    const older = freezeRow(match({ seq: 1, at: "2026-07-30T22:00:00Z" }), session());
+    const newer = freezeRow(match({ seq: 2, at: "2026-07-30T23:00:00Z" }), session());
+    const sameTick = freezeRow(match({ seq: 3, at: "2026-07-30T23:00:00Z" }), session());
+    const merged = mergeRows([], [older, newer, sameTick]);
+    expect(merged.map((r) => r.seq)).toEqual([3, 2, 1]);
+  });
+
+  it("is idempotent, so a poll that returns the same ring changes nothing", () => {
+    const rows = [freezeRow(match({ seq: 1 }), session())];
+    expect(mergeRows(rows, rows)).toHaveLength(1);
+  });
+
+  it("drops rows whose session left the scope", () => {
+    const kept = freezeRow(match({ sessionId: "s1" }), session({ id: "s1" }));
+    const gone = freezeRow(match({ sessionId: "s2" }), session({ id: "s2" }));
+    expect(keepSessions([kept, gone], ["s1"]).map((r) => r.sessionId)).toEqual(["s1"]);
+  });
+});
+
+describe("filtering (#1171)", () => {
+  const rows = [
+    row({ sessionId: "s1", seq: 1, watcherId: "reads", agentId: "a1", workgroup: "WG-1" }),
+    row({ sessionId: "s2", seq: 2, watcherId: "errors", agentId: "a2", workgroup: "WG-2" }),
+  ];
+  const none = {
+    watchers: new Set<string>(),
+    agents: new Set<string>(),
+    workgroups: new Set<string>(),
+    text: "",
+  };
+
+  it("passes everything through when no filter is set", () => {
+    expect(filterRows(rows, none)).toHaveLength(2);
+  });
+
+  it("ORs within one dimension", () => {
+    const filtered = filterRows(rows, { ...none, watchers: new Set(["reads", "errors"]) });
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("ANDs between dimensions", () => {
+    const filtered = filterRows(rows, {
+      ...none,
+      watchers: new Set(["reads"]),
+      agents: new Set(["a2"]),
+    });
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("matches free text against the captures, case-insensitively", () => {
+    expect(filterRows(rows, { ...none, text: "MAIN.RS" })).toHaveLength(2);
+    expect(filterRows(rows, { ...none, text: "nothing here" })).toHaveLength(0);
+  });
+
+  it("excludes a row with no workgroup once a workgroup filter is on", () => {
+    const orphan = row({ sessionId: "s3", seq: 3, workgroup: null });
+    expect(filterRows([orphan], { ...none, workgroups: new Set(["WG-1"]) })).toHaveLength(0);
+  });
+});
+
+/**
+ * #1171 test 81. Four states, told apart from snapshot VALUES with no nullability -- and
+ * `warming` is its own state so the day-one message never flickers before the first tick.
+ */
+describe("resolving which state the window shows (#1171)", () => {
+  it("shows warming until the engine has ticked, even with no watchers", () => {
+    expect(resolveView([snapshot({ warmedUp: false })], 0)).toBe("warming");
+    expect(resolveView([], 0)).toBe("warming");
+  });
+
+  it("shows the unconfigured state only once warmed up with nothing reaching", () => {
+    expect(resolveView([snapshot({ warmedUp: true, activeWatchers: [] })], 0)).toBe(
+      "unconfigured"
+    );
+  });
+
+  it("shows waiting when watchers reach but nothing has matched", () => {
+    const waiting = snapshot({
+      activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 0, degraded: false }],
+    });
+    expect(resolveView([waiting], 0)).toBe("waiting");
+  });
+
+  it("shows the table as soon as a row is visible", () => {
+    expect(resolveView([snapshot({ warmedUp: false })], 1)).toBe("rows");
+  });
+
+  it("counts a scope as warmed when any of its sessions has ticked", () => {
+    const view = resolveView([snapshot({ warmedUp: false }), snapshot({ warmedUp: true })], 0);
+    expect(view).toBe("unconfigured");
+  });
+});
+
+describe("aggregating snapshots across a scope (#1171)", () => {
+  it("sums a watcher's counts and keeps degraded sticky across sessions", () => {
+    const merged = mergeActiveWatchers([
+      snapshot({
+        activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 2, degraded: false }],
+      }),
+      snapshot({
+        activeWatchers: [{ watcherId: "reads", mode: "occurrence", count: 3, degraded: true }],
+      }),
+    ]);
+    expect(merged).toEqual([
+      { watcherId: "reads", mode: "occurrence", count: 5, degraded: true },
+    ]);
+  });
+
+  it("reports truncation if any session dropped entries", () => {
+    expect(anyTruncated([snapshot(), snapshot({ truncated: true })])).toBe(true);
+    expect(anyTruncated([snapshot(), snapshot()])).toBe(false);
+  });
+
+  it("sums the unaligned frames across the scope", () => {
+    expect(
+      totalPossiblyMissedFrames([
+        snapshot({ possiblyMissedFrames: 2 }),
+        snapshot({ possiblyMissedFrames: 5 }),
+      ])
+    ).toBe(7);
+  });
+});

--- a/src/watchers/activity.test.ts
+++ b/src/watchers/activity.test.ts
@@ -175,6 +175,74 @@ describe("bounding what the window holds (#1171)", () => {
     const rows = mergeRows([], burst("s1", 5));
     expect(capPerSession(rows, 100).map((r) => r.seq)).toEqual(rows.map((r) => r.seq));
   });
+
+  /**
+   * The survivors are chosen by `seq`, which is monotonic per session, and NOT by the wall
+   * clock the rows are displayed in order of.
+   *
+   * `at` is the TICK's instant and comes from the machine's clock. Let that clock step back
+   * -- NTP, a manual change, a VM resume -- with the array already full, and every new match
+   * arrives with an `at` that sorts BEHIND everything already held. A cap that keeps the
+   * first N of the time sort then discards precisely the newest activity, on every event and
+   * every snapshot, until the clock catches up to where it was.
+   */
+  it("keeps the newest activity when the system clock steps backwards", () => {
+    const held = Array.from({ length: 5 }, (_, i) =>
+      freezeRow(match({ seq: i, at: `2026-07-30T22:00:0${i}Z` }), session())
+    );
+    // The clock went back a minute; this is the most recent match all the same.
+    const afterTheStep = freezeRow(
+      match({ seq: 99, at: "2026-07-30T21:59:00Z" }),
+      session()
+    );
+
+    const capped = capPerSession(mergeRows(held, [afterTheStep]), 5);
+
+    expect(capped).toHaveLength(5);
+    expect([...capped.map((r) => r.seq)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 99]);
+  });
+
+  it("drops the lowest seqs of each session independently under a clock step", () => {
+    const stepped = [
+      freezeRow(match({ sessionId: "s1", seq: 7, at: "2026-07-30T21:00:00Z" }), session({ id: "s1" })),
+      freezeRow(match({ sessionId: "s2", seq: 7, at: "2026-07-30T21:00:00Z" }), session({ id: "s2" })),
+    ];
+    const older = [
+      freezeRow(match({ sessionId: "s1", seq: 1, at: "2026-07-30T22:00:00Z" }), session({ id: "s1" })),
+      freezeRow(match({ sessionId: "s2", seq: 1, at: "2026-07-30T22:00:00Z" }), session({ id: "s2" })),
+    ];
+    const capped = capPerSession(mergeRows(older, stepped), 1);
+    expect(capped.map((r) => `${r.sessionId}:${r.seq}`).sort()).toEqual(["s1:7", "s2:7"]);
+  });
+});
+
+/**
+ * Within one session `seq` is monotonic and exact. `at` is the tick's instant, shared by
+ * every match of that tick, and its RFC3339 TEXT does not even sort correctly against a
+ * fractional-second sibling: `.` sorts before `Z`, so `...00.100Z` reads as older than
+ * `...00Z`.
+ */
+describe("ordering rows for display (#1171)", () => {
+  it("orders one session by seq, not by the text of its timestamps", () => {
+    const whole = freezeRow(match({ seq: 1, at: "2026-07-30T22:00:00Z" }), session());
+    const fractional = freezeRow(
+      match({ seq: 2, at: "2026-07-30T22:00:00.100Z" }),
+      session()
+    );
+    expect(mergeRows([], [whole, fractional]).map((r) => r.seq)).toEqual([2, 1]);
+  });
+
+  it("still orders two sessions against each other by time", () => {
+    const older = freezeRow(
+      match({ sessionId: "s1", seq: 50, at: "2026-07-30T22:00:00Z" }),
+      session({ id: "s1" })
+    );
+    const newer = freezeRow(
+      match({ sessionId: "s2", seq: 1, at: "2026-07-30T23:00:00Z" }),
+      session({ id: "s2" })
+    );
+    expect(mergeRows([], [older, newer]).map((r) => r.sessionId)).toEqual(["s2", "s1"]);
+  });
 });
 
 /**

--- a/src/watchers/activity.test.ts
+++ b/src/watchers/activity.test.ts
@@ -243,6 +243,95 @@ describe("ordering rows for display (#1171)", () => {
     );
     expect(mergeRows([], [older, newer]).map((r) => r.sessionId)).toEqual(["s2", "s1"]);
   });
+
+  /**
+   * The same RFC3339 defect, on the branch that compares two SESSIONS. Moving only the
+   * intra-session branch off the text left this one exactly as it was: `.` sorts before `Z`,
+   * so a fractional second reads as older than the whole second it comes after.
+   */
+  it("compares two sessions as instants, not as the text of their timestamps", () => {
+    const whole = freezeRow(
+      match({ sessionId: "s1", seq: 1, at: "2026-07-30T22:00:00Z" }),
+      session({ id: "s1" })
+    );
+    const fractional = freezeRow(
+      match({ sessionId: "s2", seq: 1, at: "2026-07-30T22:00:00.100Z" }),
+      session({ id: "s2" })
+    );
+    expect(mergeRows([], [whole, fractional]).map((r) => r.sessionId)).toEqual(["s2", "s1"]);
+  });
+
+  it("puts a timezone offset in its real place rather than where its text falls", () => {
+    // 21:30-01:00 IS 22:30Z, later than 22:00Z, and no text comparison can see that.
+    const utc = freezeRow(
+      match({ sessionId: "s1", seq: 1, at: "2026-07-30T22:00:00Z" }),
+      session({ id: "s1" })
+    );
+    const offset = freezeRow(
+      match({ sessionId: "s2", seq: 1, at: "2026-07-30T21:30:00-01:00" }),
+      session({ id: "s2" })
+    );
+    expect(mergeRows([], [utc, offset]).map((r) => r.sessionId)).toEqual(["s2", "s1"]);
+  });
+
+  /**
+   * The order has to be TOTAL and TRANSITIVE, not merely right on the pairs anyone thought
+   * of. Mixing "by seq inside a session" with "by time across sessions" builds a cycle: with
+   * a clock step, A precedes B by seq, B precedes C by time, and C precedes A by time.
+   * `Array.prototype.sort` is entitled to return anything at all for a comparator like that,
+   * so the same rows can come back in a different order depending only on the order they were
+   * merged in -- which means the poll can reshuffle the table on its own, with no new data.
+   */
+  it("returns one order for the same rows however they arrive, under a clock step", () => {
+    const late = freezeRow(
+      match({ sessionId: "s1", seq: 2, at: "2026-07-30T21:00:00Z" }),
+      session({ id: "s1" })
+    );
+    const early = freezeRow(
+      match({ sessionId: "s1", seq: 1, at: "2026-07-30T23:00:00Z" }),
+      session({ id: "s1" })
+    );
+    const other = freezeRow(
+      match({ sessionId: "s2", seq: 1, at: "2026-07-30T22:00:00Z" }),
+      session({ id: "s2" })
+    );
+
+    const permutations = [
+      [late, early, other],
+      [late, other, early],
+      [early, late, other],
+      [early, other, late],
+      [other, late, early],
+      [other, early, late],
+    ];
+    const orders = permutations.map((rows) =>
+      mergeRows([], rows).map((r) => `${r.sessionId}:${r.seq}`)
+    );
+
+    // Every permutation agrees, and they agree on what the Time column shows.
+    for (const order of orders) {
+      expect(order).toEqual(["s1:1", "s2:1", "s1:2"]);
+    }
+  });
+
+  it("gives an unparseable timestamp a definite place instead of a broken comparison", () => {
+    const broken = freezeRow(
+      match({ sessionId: "s1", seq: 1, at: "not a timestamp" }),
+      session({ id: "s1" })
+    );
+    const alsoBroken = freezeRow(
+      match({ sessionId: "s2", seq: 1, at: "" }),
+      session({ id: "s2" })
+    );
+    const good = freezeRow(
+      match({ sessionId: "s3", seq: 1, at: "2026-07-30T22:00:00Z" }),
+      session({ id: "s3" })
+    );
+    const order = mergeRows([], [broken, alsoBroken, good]).map((r) => r.sessionId);
+    // Oldest, so they sink rather than claiming to be the newest activity; and the two
+    // unparseable ones still order against each other rather than comparing as NaN.
+    expect(order).toEqual(["s3", "s1", "s2"]);
+  });
 });
 
 /**

--- a/src/watchers/activity.ts
+++ b/src/watchers/activity.ts
@@ -78,6 +78,11 @@ export function freezeRow(
  * The window subscribes before it fetches, so the snapshot and the stream overlap on
  * purpose: losing that overlap would lose matches, and not deduplicating it would show them
  * twice. Keying on `(sessionId, seq)` makes the overlap exact rather than heuristic.
+ *
+ * **A key already held keeps its existing object.** Solid's `<For>` keys on object identity,
+ * not on the logical key, and every poll builds fresh `freezeRow` results for the whole ring;
+ * replacing the held object with an identical snapshot would rebuild and re-animate every row
+ * on screen every ten seconds. The one deliberate exception is below.
  */
 export function mergeRows(
   existing: readonly ActivityRow[],
@@ -85,8 +90,52 @@ export function mergeRows(
 ): ActivityRow[] {
   const byKey = new Map<string, ActivityRow>();
   for (const row of existing) byKey.set(rowKey(row), row);
-  for (const row of incoming) byKey.set(rowKey(row), row);
+  for (const row of incoming) {
+    const key = rowKey(row);
+    const held = byKey.get(key);
+    byKey.set(key, held ? keepIdentity(held, row) : row);
+  }
   return [...byKey.values()].sort(compareRowsNewestFirst);
+}
+
+/**
+ * The one metadata update worth losing identity over.
+ *
+ * A match frozen before its session list had loaded carries no agent and no workgroup, and
+ * `sessionName` falls back to the raw id. The same match arriving again once the list is in
+ * hand is the one case where replacing the object is an improvement rather than churn.
+ * `agentId` is the exact test: every session this window scopes has one, so a null can only
+ * mean the session was not found when the row was frozen.
+ */
+function keepIdentity(held: ActivityRow, incoming: ActivityRow): ActivityRow {
+  return held.agentId === null && incoming.agentId !== null ? incoming : held;
+}
+
+/**
+ * Keep at most `limit` rows per session, newest first, and drop the rest.
+ *
+ * The 500 and 100 limits are not only fetch parameters: without this the frontend grows
+ * without a bound the backend has, because the ring caps what a SNAPSHOT returns while the
+ * event stream keeps appending for as long as the window stays open. One session can deliver
+ * dozens of rows a second, so an afternoon's uptime is hundreds of thousands of objects, a
+ * `sort` whose cost climbs with every batch, and a `<For>` rendering all of it. It also makes
+ * the truncation the banner announces true of the window and not only of the buffer.
+ *
+ * `rows` is expected newest-first, which is what `mergeRows` returns.
+ */
+export function capPerSession(
+  rows: readonly ActivityRow[],
+  limit: number
+): ActivityRow[] {
+  const seen = new Map<string, number>();
+  const kept: ActivityRow[] = [];
+  for (const row of rows) {
+    const count = seen.get(row.sessionId) ?? 0;
+    if (count >= limit) continue;
+    seen.set(row.sessionId, count + 1);
+    kept.push(row);
+  }
+  return kept;
 }
 
 /** Newest first; `seq` breaks the tie between two matches of the same tick. */
@@ -151,14 +200,28 @@ export function distinct<T>(values: readonly T[]): T[] {
  * `warming` is its own state and not empty state 1: until the engine has ticked a session
  * once, an empty `activeWatchers` means "not known yet", and showing "no watcher reaches
  * this agent" for the first 200 ms of every session would be a lie that flickers.
+ *
+ * `filtered` is the fifth state and it exists because the other four are statements about the
+ * ACTIVATIONS, not about the table. Deciding them from filtered rows means a filter that
+ * happens to hide everything produces "Configured and waiting. Nothing has matched yet.",
+ * which is false and which the user cannot even attribute to the filter they just set.
  */
-export type ActivityView = "warming" | "unconfigured" | "waiting" | "rows";
+export type ActivityView =
+  | "warming"
+  | "unconfigured"
+  | "waiting"
+  | "filtered"
+  | "rows";
 
 export function resolveView(
   snapshots: readonly WatcherActivitySnapshot[],
+  totalRows: number,
   visibleRows: number
 ): ActivityView {
   if (visibleRows > 0) return "rows";
+  // There ARE activations; the filters are what is hiding them. Said before the snapshot is
+  // consulted, because no reading of the snapshot can make "nothing has matched" true here.
+  if (totalRows > 0) return "filtered";
   if (snapshots.length === 0 || !snapshots.some((snapshot) => snapshot.warmedUp)) {
     return "warming";
   }
@@ -187,6 +250,19 @@ export function mergeActiveWatchers(
     }
   }
   return [...byId.values()].sort((a, b) => a.watcherId.localeCompare(b.watcherId));
+}
+
+/**
+ * The watchers currently hitting a per-tick cap or suspended, across the scope.
+ *
+ * Surfaced on its own because a degraded watcher has, by definition, already emitted matches:
+ * hanging the marker off the "configured and waiting" branch puts it exactly where it can
+ * never be reached, since one visible row sends the window to the table instead.
+ */
+export function degradedWatchers(
+  snapshots: readonly WatcherActivitySnapshot[]
+): WatcherActivityCounter[] {
+  return mergeActiveWatchers(snapshots).filter((counter) => counter.degraded);
 }
 
 /** True when any session in scope dropped entries, i.e. the table is missing older rows. */

--- a/src/watchers/activity.ts
+++ b/src/watchers/activity.ts
@@ -1,0 +1,203 @@
+import { extractWorkgroupName } from "../shared/path-extractors";
+import type {
+  Session,
+  WatcherActivityCounter,
+  WatcherActivitySnapshot,
+  WatcherMatchPayload,
+  WatcherMode,
+} from "../shared/types";
+
+/**
+ * #1171 - the pure half of the activity window: merging, freezing and filtering.
+ *
+ * Kept out of the TSX so the merge in particular can be tested directly. It is the piece
+ * that decides whether a match arriving while the snapshot is in flight is shown once,
+ * twice, or not at all.
+ */
+
+/** How many matches to ask for per session, per scope. */
+export const SINGLE_SESSION_LIMIT = 500;
+export const ALL_SESSIONS_LIMIT = 100;
+
+/**
+ * One table row: a match plus the labels resolved when it was inserted.
+ *
+ * The labels are frozen because a row must survive its session's death still saying which
+ * session, agent and workgroup it came from. The agent label is re-resolved live for
+ * display, with the frozen value as the fallback, so renaming an entry does not leave rows
+ * lying about it.
+ */
+export interface ActivityRow {
+  sessionId: string;
+  seq: number;
+  watcherId: string;
+  mode: WatcherMode;
+  at: string;
+  captures: (string | null)[];
+  row: string;
+  rowTruncated: boolean;
+  sessionName: string;
+  agentId: string | null;
+  frozenAgentLabel: string | null;
+  workgroup: string | null;
+}
+
+/** The identity of a row. `at` cannot carry it: it is the tick's instant, so two matches
+ *  from one tick share it, and with `dedupe: "none"` they can be identical in every other
+ *  field too. `seq` is the only thing that separates them. */
+export function rowKey(row: Pick<ActivityRow, "sessionId" | "seq">): string {
+  return `${row.sessionId}:${row.seq}`;
+}
+
+/** Resolve and freeze the labels of one match. */
+export function freezeRow(
+  payload: WatcherMatchPayload,
+  session: Session | undefined
+): ActivityRow {
+  return {
+    sessionId: payload.sessionId,
+    seq: payload.seq,
+    watcherId: payload.watcherId,
+    mode: payload.mode,
+    at: payload.at,
+    captures: payload.captures,
+    row: payload.row,
+    rowTruncated: payload.rowTruncated,
+    sessionName: session?.name ?? payload.sessionId,
+    agentId: session?.agentId ?? null,
+    frozenAgentLabel: session?.agentLabel ?? null,
+    // The backend derives the pair from the spawn cwd and says in writing that it is "not
+    // the user-renamable session.name", so this follows the same source.
+    workgroup: session ? extractWorkgroupName(session.workingDirectory) : null,
+  };
+}
+
+/**
+ * Merge new rows into the ones already held, newest first.
+ *
+ * The window subscribes before it fetches, so the snapshot and the stream overlap on
+ * purpose: losing that overlap would lose matches, and not deduplicating it would show them
+ * twice. Keying on `(sessionId, seq)` makes the overlap exact rather than heuristic.
+ */
+export function mergeRows(
+  existing: readonly ActivityRow[],
+  incoming: readonly ActivityRow[]
+): ActivityRow[] {
+  const byKey = new Map<string, ActivityRow>();
+  for (const row of existing) byKey.set(rowKey(row), row);
+  for (const row of incoming) byKey.set(rowKey(row), row);
+  return [...byKey.values()].sort(compareRowsNewestFirst);
+}
+
+/** Newest first; `seq` breaks the tie between two matches of the same tick. */
+export function compareRowsNewestFirst(a: ActivityRow, b: ActivityRow): number {
+  if (a.at !== b.at) return a.at < b.at ? 1 : -1;
+  if (a.sessionId !== b.sessionId) return a.sessionId < b.sessionId ? -1 : 1;
+  return b.seq - a.seq;
+}
+
+/** Drop rows whose session left the scope, so switching scope does not keep stale rows. */
+export function keepSessions(
+  rows: readonly ActivityRow[],
+  sessionIds: readonly string[]
+): ActivityRow[] {
+  const kept = new Set(sessionIds);
+  return rows.filter((row) => kept.has(row.sessionId));
+}
+
+export interface ActivityFilters {
+  watchers: ReadonlySet<string>;
+  agents: ReadonlySet<string>;
+  workgroups: ReadonlySet<string>;
+  text: string;
+}
+
+/** AND between dimensions, OR within one, matching the Resource Monitor's filter shape. */
+export function filterRows(
+  rows: readonly ActivityRow[],
+  filters: ActivityFilters
+): ActivityRow[] {
+  const needle = filters.text.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (filters.watchers.size > 0 && !filters.watchers.has(row.watcherId)) return false;
+    if (filters.agents.size > 0 && !(row.agentId && filters.agents.has(row.agentId))) {
+      return false;
+    }
+    if (
+      filters.workgroups.size > 0 &&
+      !(row.workgroup && filters.workgroups.has(row.workgroup))
+    ) {
+      return false;
+    }
+    if (needle) {
+      const haystack = row.captures
+        .filter((capture): capture is string => capture !== null)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+/** Distinct values in first-seen order, the Resource Monitor's `distinct`. */
+export function distinct<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+/**
+ * What the window is showing right now, decided from snapshot VALUES with no nullability.
+ *
+ * `warming` is its own state and not empty state 1: until the engine has ticked a session
+ * once, an empty `activeWatchers` means "not known yet", and showing "no watcher reaches
+ * this agent" for the first 200 ms of every session would be a lie that flickers.
+ */
+export type ActivityView = "warming" | "unconfigured" | "waiting" | "rows";
+
+export function resolveView(
+  snapshots: readonly WatcherActivitySnapshot[],
+  visibleRows: number
+): ActivityView {
+  if (visibleRows > 0) return "rows";
+  if (snapshots.length === 0 || !snapshots.some((snapshot) => snapshot.warmedUp)) {
+    return "warming";
+  }
+  const active = snapshots.flatMap((snapshot) => snapshot.activeWatchers);
+  return active.length === 0 ? "unconfigured" : "waiting";
+}
+
+/** The reaching watchers across every session in scope, one entry per id. */
+export function mergeActiveWatchers(
+  snapshots: readonly WatcherActivitySnapshot[]
+): WatcherActivityCounter[] {
+  const byId = new Map<string, WatcherActivityCounter>();
+  for (const snapshot of snapshots) {
+    for (const counter of snapshot.activeWatchers) {
+      const seen = byId.get(counter.watcherId);
+      byId.set(
+        counter.watcherId,
+        seen
+          ? {
+              ...seen,
+              count: seen.count + counter.count,
+              degraded: seen.degraded || counter.degraded,
+            }
+          : { ...counter }
+      );
+    }
+  }
+  return [...byId.values()].sort((a, b) => a.watcherId.localeCompare(b.watcherId));
+}
+
+/** True when any session in scope dropped entries, i.e. the table is missing older rows. */
+export function anyTruncated(snapshots: readonly WatcherActivitySnapshot[]): boolean {
+  return snapshots.some((snapshot) => snapshot.truncated);
+}
+
+/** Frames the sampler could not align, summed across the scope. Not a count of lost
+ *  matches: above zero it means "something may have been missed", never how much. */
+export function totalPossiblyMissedFrames(
+  snapshots: readonly WatcherActivitySnapshot[]
+): number {
+  return snapshots.reduce((total, snapshot) => total + snapshot.possiblyMissedFrames, 0);
+}

--- a/src/watchers/activity.ts
+++ b/src/watchers/activity.ts
@@ -112,7 +112,7 @@ function keepIdentity(held: ActivityRow, incoming: ActivityRow): ActivityRow {
 }
 
 /**
- * Keep at most `limit` rows per session, newest first, and drop the rest.
+ * Keep at most `limit` rows per session and drop the rest, preserving the input order.
  *
  * The 500 and 100 limits are not only fetch parameters: without this the frontend grows
  * without a bound the backend has, because the ring caps what a SNAPSHOT returns while the
@@ -121,28 +121,59 @@ function keepIdentity(held: ActivityRow, incoming: ActivityRow): ActivityRow {
  * `sort` whose cost climbs with every batch, and a `<For>` rendering all of it. It also makes
  * the truncation the banner announces true of the window and not only of the buffer.
  *
- * `rows` is expected newest-first, which is what `mergeRows` returns.
+ * **The survivors are chosen by `seq`, never by the order the rows are displayed in.** `at`
+ * is the tick's instant and it comes from the machine's clock; let that clock step back --
+ * NTP, a manual change, a VM resume -- with the table already full, and every new match
+ * arrives sorting BEHIND everything already held. Keeping the first N of the display order
+ * would then discard precisely the newest activity, on every event and every snapshot, until
+ * the clock caught up to where it had been. `seq` is monotonic per session by contract and
+ * has no such failure.
+ *
+ * The cost is one sort of the seqs of each over-limit session, which is bounded by `limit`
+ * plus the batch that pushed it over.
  */
 export function capPerSession(
   rows: readonly ActivityRow[],
   limit: number
 ): ActivityRow[] {
-  const seen = new Map<string, number>();
-  const kept: ActivityRow[] = [];
+  const seqsBySession = new Map<string, number[]>();
   for (const row of rows) {
-    const count = seen.get(row.sessionId) ?? 0;
-    if (count >= limit) continue;
-    seen.set(row.sessionId, count + 1);
-    kept.push(row);
+    const seqs = seqsBySession.get(row.sessionId);
+    if (seqs) seqs.push(row.seq);
+    else seqsBySession.set(row.sessionId, [row.seq]);
   }
-  return kept;
+
+  // The lowest `seq` that still survives, per session. Absent means that session is under
+  // the limit and keeps everything.
+  const survivesFrom = new Map<string, number>();
+  for (const [sessionId, seqs] of seqsBySession) {
+    if (seqs.length <= limit) continue;
+    seqs.sort((a, b) => b - a);
+    survivesFrom.set(sessionId, seqs[limit - 1]);
+  }
+  if (survivesFrom.size === 0) return rows.slice();
+
+  // `(sessionId, seq)` is the row key, so no session holds a `seq` twice and this keeps
+  // exactly `limit` of them.
+  return rows.filter((row) => {
+    const threshold = survivesFrom.get(row.sessionId);
+    return threshold === undefined || row.seq >= threshold;
+  });
 }
 
-/** Newest first; `seq` breaks the tie between two matches of the same tick. */
+/**
+ * Newest first.
+ *
+ * Within one session `seq` decides on its own: it is monotonic and exact, while `at` is the
+ * TICK's instant, shared by every match of that tick, and its RFC3339 text does not even
+ * compare correctly against a fractional-second sibling -- `.` sorts before `Z`, so
+ * `...00.100Z` reads as older than `...00Z`. Across sessions there is no shared counter, so
+ * time is what is left, with the id as a stable tie-break.
+ */
 export function compareRowsNewestFirst(a: ActivityRow, b: ActivityRow): number {
+  if (a.sessionId === b.sessionId) return b.seq - a.seq;
   if (a.at !== b.at) return a.at < b.at ? 1 : -1;
-  if (a.sessionId !== b.sessionId) return a.sessionId < b.sessionId ? -1 : 1;
-  return b.seq - a.seq;
+  return a.sessionId < b.sessionId ? -1 : 1;
 }
 
 /** Drop rows whose session left the scope, so switching scope does not keep stale rows. */

--- a/src/watchers/activity.ts
+++ b/src/watchers/activity.ts
@@ -95,7 +95,7 @@ export function mergeRows(
     const held = byKey.get(key);
     byKey.set(key, held ? keepIdentity(held, row) : row);
   }
-  return [...byKey.values()].sort(compareRowsNewestFirst);
+  return sortRowsNewestFirst([...byKey.values()]);
 }
 
 /**
@@ -162,18 +162,52 @@ export function capPerSession(
 }
 
 /**
- * Newest first.
+ * When a row is displayed at, in milliseconds, as an INSTANT rather than as text.
  *
- * Within one session `seq` decides on its own: it is monotonic and exact, while `at` is the
- * TICK's instant, shared by every match of that tick, and its RFC3339 text does not even
- * compare correctly against a fractional-second sibling -- `.` sorts before `Z`, so
- * `...00.100Z` reads as older than `...00Z`. Across sessions there is no shared counter, so
- * time is what is left, with the id as a stable tie-break.
+ * RFC3339 does not sort correctly as a string: `.` comes before `Z`, so `...00.100Z` reads
+ * as older than the `...00Z` it actually follows, and an offset like `21:30-01:00` -- which
+ * is 22:30Z -- lands wherever its digits happen to fall.
+ *
+ * An `at` this build cannot parse is treated as the oldest thing there is. It has to get a
+ * definite value: `NaN` would make every comparison involving it return `false` both ways,
+ * which is precisely how a comparator stops being a comparator. Oldest is also the
+ * fail-closed choice, since the alternative is a row of unknown age claiming to be the
+ * newest activity.
  */
-export function compareRowsNewestFirst(a: ActivityRow, b: ActivityRow): number {
-  if (a.sessionId === b.sessionId) return b.seq - a.seq;
-  if (a.at !== b.at) return a.at < b.at ? 1 : -1;
-  return a.sessionId < b.sessionId ? -1 : 1;
+function displayInstant(row: ActivityRow): number {
+  const parsed = Date.parse(row.at);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+}
+
+/**
+ * Newest first, as a total and transitive order.
+ *
+ * **Choosing which rows survive and choosing how they are shown are two different jobs.**
+ * `capPerSession` picks survivors by `seq`, because that is the only value a clock step
+ * cannot lie about. This picks a position on screen, and it is keyed on the instant first,
+ * because the table has a Time column and an order that contradicts its own visible column
+ * is worse than one that follows it.
+ *
+ * The key is one tuple of totally ordered scalars -- `(instant desc, sessionId asc, seq
+ * desc)` -- and that is what makes the order transitive. Mixing "by `seq` inside a session"
+ * with "by time across sessions" does not: under a clock step A precedes B by `seq`, B
+ * precedes C by time and C precedes A by time, a cycle, and `Array.prototype.sort` is
+ * entitled to return anything at all for a comparator like that. The visible consequence is
+ * that the same rows come back in a different order depending only on the order they were
+ * merged in, so a poll carrying no new data can reshuffle the table under the user.
+ */
+function sortRowsNewestFirst(rows: readonly ActivityRow[]): ActivityRow[] {
+  // Decorate, sort, undecorate: `Date.parse` runs once per row rather than once per
+  // comparison, which over 500 rows is 500 parses instead of some 4500.
+  const decorated = rows.map((row) => ({ row, instant: displayInstant(row) }));
+  decorated.sort((a, b) => {
+    if (a.instant !== b.instant) return a.instant < b.instant ? 1 : -1;
+    if (a.row.sessionId !== b.row.sessionId) {
+      return a.row.sessionId < b.row.sessionId ? -1 : 1;
+    }
+    return b.row.seq - a.row.seq;
+  });
+  return decorated.map((entry) => entry.row);
 }
 
 /** Drop rows whose session left the scope, so switching scope does not keep stale rows. */

--- a/src/watchers/components/WatchersTitlebar.tsx
+++ b/src/watchers/components/WatchersTitlebar.tsx
@@ -1,0 +1,68 @@
+import { Component } from "solid-js";
+
+/**
+ * #1171 - the window is `decorations(false)`, so the frame is HTML.
+ *
+ * The Tauri window API is imported inside each handler rather than at module scope,
+ * following the Resource Monitor (`resource-monitor/App.tsx:145`, `:155`) rather than
+ * `SpecBoardTitlebar`, which calls `getCurrentWindow()` while the component is being
+ * constructed. Deferring it means the window still renders where that API does not exist,
+ * which is what makes this testable outside Tauri.
+ *
+ * The controls stop propagation so a click on them is not also read as a window drag.
+ */
+const WatchersTitlebar: Component = () => {
+  const withWindow = async (action: "minimize" | "toggleMaximize" | "close") => {
+    try {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      await getCurrentWindow()[action]();
+    } catch (err) {
+      console.error(`[watchers] window ${action} failed:`, err);
+    }
+  };
+
+  return (
+    <div data-tauri-drag-region class="watchers-titlebar">
+      <div data-tauri-drag-region class="watchers-titlebar-title">
+        Watcher Activity
+      </div>
+      <div class="watchers-titlebar-controls">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void withWindow("minimize");
+          }}
+          title="Minimize"
+          data-ac-testid="watchers.titlebar.minimize"
+          data-ac-role="button"
+        >
+          &#x2014;
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void withWindow("toggleMaximize");
+          }}
+          title="Maximize"
+          data-ac-testid="watchers.titlebar.maximize"
+          data-ac-role="button"
+        >
+          &#x25A1;
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            void withWindow("close");
+          }}
+          title="Close"
+          data-ac-testid="watchers.titlebar.close"
+          data-ac-role="button"
+        >
+          &#x2715;
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WatchersTitlebar;

--- a/src/watchers/styles/watchers.css
+++ b/src/watchers/styles/watchers.css
@@ -182,6 +182,12 @@ body,
   flex-shrink: 0;
 }
 
+/* Louder than the sampling note and quieter than the loss banner: a degraded watcher IS
+   dropping activations, but only while it stays saturated. */
+.watchers-note-degraded {
+  color: var(--status-pending);
+}
+
 /* ── Table ────────────────────────────────────────────────────────────────── */
 
 .watchers-body {

--- a/src/watchers/styles/watchers.css
+++ b/src/watchers/styles/watchers.css
@@ -1,0 +1,410 @@
+@import "../../sidebar/styles/variables.css";
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  font-family: var(--font-ui);
+  font-size: var(--font-size-md);
+  color: var(--sidebar-fg);
+  background: var(--sidebar-bg);
+}
+
+.watchers-window {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  /* Regions are separated by background shift and opacity rather than borders. */
+  background: var(--sidebar-bg);
+}
+
+/* ── Titlebar ─────────────────────────────────────────────────────────────── */
+
+.watchers-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 32px;
+  padding-left: var(--spacing-md);
+  background: var(--titlebar-bg);
+  color: var(--titlebar-fg);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.watchers-titlebar-title {
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.watchers-titlebar-controls {
+  display: flex;
+  height: 100%;
+}
+
+.watchers-titlebar-controls button {
+  width: 42px;
+  border: none;
+  background: transparent;
+  color: var(--titlebar-fg);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.watchers-titlebar-controls button:hover {
+  background: var(--titlebar-btn-hover);
+  color: var(--sidebar-fg);
+}
+
+.watchers-titlebar-controls button:last-child:hover {
+  background: var(--titlebar-btn-close-hover);
+  color: #fff;
+}
+
+/* ── Filter bar ───────────────────────────────────────────────────────────── */
+
+.watchers-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--toolbar-bg);
+  flex-shrink: 0;
+}
+
+.watchers-filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.watchers-filter-label {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--sidebar-fg-dim);
+}
+
+.watchers-select,
+.watchers-search {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-surface);
+  color: var(--sidebar-fg);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+}
+
+.watchers-search {
+  min-width: 160px;
+  flex: 1 1 160px;
+}
+
+.watchers-select:focus,
+.watchers-search:focus {
+  outline: none;
+  border-color: var(--sidebar-accent);
+}
+
+.watchers-chip {
+  padding: 2px var(--spacing-sm);
+  border: 1px solid var(--sidebar-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.watchers-chip:hover {
+  color: var(--sidebar-fg);
+  border-color: var(--sidebar-accent);
+}
+
+.watchers-chip.is-active {
+  background: var(--toolbar-btn-bg);
+  border-color: var(--sidebar-accent);
+  color: var(--toolbar-btn-fg);
+}
+
+/* A row's watcher chip is a label, not a control: same shape, no pointer. */
+.watchers-chip.is-static {
+  cursor: default;
+  color: hsl(var(--watcher-hue, 0deg) 70% 70%);
+  border-color: hsl(var(--watcher-hue, 0deg) 70% 70% / 0.35);
+}
+
+.watchers-clear {
+  padding: 2px var(--spacing-sm);
+  border: none;
+  background: transparent;
+  color: var(--sidebar-accent);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+/* ── Banners ──────────────────────────────────────────────────────────────── */
+
+.watchers-banner {
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: rgba(234, 179, 8, 0.12);
+  color: var(--status-pending);
+  font-size: var(--font-size-sm);
+  flex-shrink: 0;
+}
+
+.watchers-banner-error {
+  background: rgba(255, 59, 92, 0.12);
+  color: var(--status-exited);
+}
+
+/* Weaker than the banner on purpose: uncertainty is not the same claim as loss. */
+.watchers-note {
+  padding: var(--spacing-xs) var(--spacing-md);
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  flex-shrink: 0;
+}
+
+/* ── Table ────────────────────────────────────────────────────────────────── */
+
+.watchers-body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.watchers-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.watchers-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: var(--sidebar-bg);
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-align: left;
+}
+
+.watchers-col-time {
+  width: 78px;
+}
+
+.watchers-col-watcher {
+  width: 190px;
+}
+
+.watchers-col-session {
+  width: 200px;
+}
+
+.watchers-row {
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  animation: watchers-row-in var(--transition-normal) ease-out;
+}
+
+@keyframes watchers-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.watchers-row:hover {
+  background: var(--sidebar-hover);
+}
+
+.watchers-row.is-expanded {
+  background: var(--sidebar-active);
+}
+
+.watchers-row td {
+  padding: var(--spacing-xs) var(--spacing-md);
+  vertical-align: top;
+}
+
+.watchers-col-time {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: var(--font-size-sm);
+  color: var(--sidebar-fg-dim);
+  white-space: nowrap;
+}
+
+.watchers-mode {
+  margin-left: var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  color: var(--sidebar-fg-dim);
+  opacity: 0.75;
+}
+
+.watchers-session-name {
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watchers-session-meta {
+  font-size: var(--font-size-sm);
+  color: var(--sidebar-fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watchers-col-captures {
+  position: relative;
+}
+
+/* `dir="rtl"` in the markup puts the ellipsis on the LEFT, so a path keeps its tail --
+   the file name -- visible, which is the part worth reading. */
+.watchers-capture {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+
+.watchers-capture-extra {
+  display: inline-block;
+  margin-right: var(--spacing-xs);
+  padding: 0 var(--spacing-xs);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-surface);
+  color: var(--sidebar-fg-dim);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: var(--font-size-sm);
+}
+
+.watchers-copy {
+  position: absolute;
+  top: var(--spacing-xs);
+  right: var(--spacing-xs);
+  border: none;
+  background: transparent;
+  color: var(--sidebar-fg-dim);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.watchers-row:hover .watchers-copy {
+  opacity: 1;
+}
+
+.watchers-copy:hover {
+  color: var(--sidebar-accent);
+}
+
+.watchers-raw-row td {
+  padding: 0 var(--spacing-md) var(--spacing-sm);
+  background: var(--sidebar-active);
+}
+
+.watchers-raw {
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  background: var(--sidebar-bg);
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+  font-size: var(--font-size-sm);
+  /* Wrapped rather than scrolled: a nested horizontal scroller inside a vertically
+     scrolling table is worse for a row already capped at 256 bytes. */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Empty states ─────────────────────────────────────────────────────────── */
+
+.watchers-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  min-height: 180px;
+  padding: var(--spacing-lg);
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+.watchers-cta {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: 1px solid var(--sidebar-accent);
+  border-radius: var(--radius-sm);
+  background: var(--toolbar-btn-bg);
+  color: var(--toolbar-btn-fg);
+  font-family: var(--font-ui);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.watchers-cta:hover {
+  background: var(--toolbar-btn-hover);
+}
+
+.watchers-waiting-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.watchers-waiting-list li {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.watchers-count {
+  font-family: "Cascadia Code", "JetBrains Mono", monospace;
+}
+
+.watchers-degraded {
+  color: var(--status-pending);
+}
+
+/* ── Footer ───────────────────────────────────────────────────────────────── */
+
+.watchers-footer {
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: var(--toolbar-bg);
+  color: var(--sidebar-fg-dim);
+  font-size: var(--font-size-sm);
+  flex-shrink: 0;
+}

--- a/test-debt.allowlist.json
+++ b/test-debt.allowlist.json
@@ -256,6 +256,14 @@
       "issue": 1064,
       "reason": "#1064 Stage E cross-process lock-order PARENT: spawns Stage D's landed cli_workgroup child helper via current_exe --exact --ignored and proves the project-only deletion holds the project gate across processes (plan section 10.4 item 22, acceptance items 43/44). It launches a child test process and must run under --test-threads=1, so it stays out of the standard debug cargo test lane.",
       "resolution": "Run as Stage F acceptance or manually with cargo test --lib -- --ignored --test-threads=1 --exact commands::entity_creation::stage_e_cross_process::cli_workgroup_deletion_takes_project_gate_only_cross_process."
+    },
+    {
+      "id": "rust:src-tauri/src/pty/watchers/mod.rs::read_seam_tests::read_seam_timing",
+      "category": "ignored-rust-test",
+      "owner": "dev-rust",
+      "issue": 1171,
+      "reason": "#1171 reference measurement for the watcher read seam, not a behavior test. It prints the three numbers recorded in the module doc comment (the full read, the unchanged read and the changed read) via println and asserts nothing, so as a standard cargo test lane member it would be a timing gate with no pass criterion and would go flaky under parallel load. The behavior these numbers exist to justify is pinned by the type instead, in an_unchanged_frame_returns_unchanged_and_carries_no_rows (plan section 7.3, acceptance criterion A10).",
+      "resolution": "Stays ignored by design as a measurement. Re-take the numbers by hand with cargo test --config profile.dev.opt-level=2 --lib read_seam_timing -- --ignored --nocapture and update the module doc comment when the read seam changes."
     }
   ]
 }


### PR DESCRIPTION
Closes #1171

Generic regex pattern watchers over PTY output, with a configurable editor and a detached activity window.

## What this adds

A per-session engine that reads the existing shared vt100 mirror every 200 ms, diffs it against the previous frame with scroll alignment, and evaluates configured regexes **only on newly-arrived rows**. Rows that already scrolled are complete by construction, so they need no stabilization; only the cursor region does.

Watchers are configured as data in a root-level `watchers` map in `settings.json`, with a `commands` selector that matches the executable stem: absent means every agent, a list means only those stems, present-but-empty means none. `AgentConfig` gains no new field, so the 20+ construction sites stay untouched.

Two modes: `state` (idempotent, reuses the existing equality gate) and `occurrence` (each match is an event). Matches are coalesced per session per tick into one directed event, and nothing is emitted at all when the activity window is closed.

The UI adds a Watchers section in Settings, a StatusBar button next to the microphone, and a singleton activity window with a table, filters by watcher/agent/workgroup, three empty states and a permanently visible best-effort footer.

## Honest limits, surfaced in the UI

This is a best-effort indicator, **not an audit log**, and the window says so. The engine detects well what the TUI leaves at rest on screen and poorly what it makes pass through during an output burst. Output that never reaches the PTY — MCP, subagents, collapsed tool output, harness injection — is unreachable by any design over the PTY. Prose false positives are accepted by design: a model writing *about* a command triggers a content watcher.

Nine further limits are declared in section 10 of the plan rather than left silent, including one that is not fixable with the available `vt100` API: a wrapped line whose head has scrolled off the top can be evaluated as if it started at row 0.

## Process

Full delivery path. The plan lives at `plans/1171-pty-pattern-watchers.md` and is **tracked in this branch** — it was previously excluded by `.gitignore`, so the certified specification was in no commit and a clean would have removed it.

The plan was certified, implemented, and then **decertified**: review found that two of its contracts could not sustain the UI the same document specified. It was rewritten over three rounds with two independent reviewers, recertified with a new digest, and reimplemented. The invalidated digest is named as null inside the file so no verification step can accept it.

Review found, among others: a session restart that leaked the history ring, an alignment predicate that was unsatisfiable in practice, a payload with no identity that made snapshot/stream merging impossible, a reach indicator that over-reported budget, a comparator with a cycle, and a Rename path that bypassed the editor's invariant. Three findings were reached independently by two reviewers.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --lib`: all exit 0 (3181 passing).
- `npx tsc --noEmit`, `npx vitest run`: both exit 0 (1468 passing).
- Visual end-to-end validation on a disposable instance with isolated state.

The visual pass found a blocker that 1468 green tests did not: the window was missing from `capabilities/default.json`, so Tauri denied it `event.listen` and the feature did not work. It was made visible by the error banner added during review — without that change the window would have been silently dead.

Confirmed live afterwards: a watcher is born disabled and cannot be enabled without a pattern; the reach indicator renders its three states correctly against the real backend; the empty-state button opens Settings on the Watchers tab; a real file-read activation reaches the window **with the file path visible**; re-scoping discards out-of-scope rows synchronously; and window geometry survives a close/reopen round trip under a 1.5 device pixel ratio.

Two items are declared unconfirmed rather than passing: the footer's literal text (present and correctly positioned at DOM level, but unreadable through the capture path) and the workgroup chip (not exercised, as the test agents were not workgroup replicas).

## Known preexisting issue, out of scope

Two `session::selection` tests fail intermittently under load, in the same helper, with evidence pointing to a race in the test itself rather than in the code. Preexisting and unrelated to this change; not touched.
