### PR TITLE
feat(memory): rotate an origin Agent Matrix memory/ at fresh session spawn (refs #1172)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -7276,14 +7276,14 @@ mod tests {
             "#1172 D5: the memory rotation must stay behind `start_fresh && context_result.is_ok()`. \
              A resume must NEVER rotate: this chokepoint also serves the app-startup restore path."
         );
-        // Counting the call WITH its argument rather than the bare identifier:
-        // the production comment above the gate names the function too, so a
-        // bare-identifier count can never be 1. This needle is the property that
-        // actually matters, namely zero ungated calls.
+        // Count INVOCATIONS, argument-independent: the needle stops at the open
+        // paren, so a second ungated call spelled any other way
+        // (`..._at_spawn(cwd.as_str())`, `..._at_spawn(&cwd.clone())`) is still
+        // caught. A bare-identifier count cannot be used here, because the
+        // production comment above the gate names the function too; that comment
+        // writes it WITHOUT a paren, so it stays out of this count.
         assert_eq!(
-            normalized
-                .matches("rotate_origin_memory_at_spawn(&cwd);")
-                .count(),
+            normalized.matches("rotate_origin_memory_at_spawn(").count(),
             1,
             "#1172 D5: exactly one rotation call site, and it is the gated one. \
              A resume must NEVER rotate."

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -7276,17 +7276,38 @@ mod tests {
             "#1172 D5: the memory rotation must stay behind `start_fresh && context_result.is_ok()`. \
              A resume must NEVER rotate: this chokepoint also serves the app-startup restore path."
         );
-        // Count INVOCATIONS, argument-independent: the needle stops at the open
-        // paren, so a second ungated call spelled any other way
-        // (`..._at_spawn(cwd.as_str())`, `..._at_spawn(&cwd.clone())`) is still
-        // caught. A bare-identifier count cannot be used here, because the
-        // production comment above the gate names the function too; that comment
-        // writes it WITHOUT a paren, so it stays out of this count.
+        // Now close the CLASS of ungated second calls, rather than one spelling
+        // of one. Any needle shaped like an invocation loses this game: the
+        // callee text can be rewritten indefinitely - a different argument, the
+        // path wrapped in parens so it reads `..._at_spawn)(`, a block comment
+        // between the identifier and the paren, an alias bound by `use .. as ..`
+        // or `let f = ..` and invoked under another name - and each rewrite needs
+        // a new needle.
+        //
+        // What NO such rewrite can avoid is naming the function. So count the
+        // BARE identifier, which is invariant under all of them, and pin the one
+        // legitimate mention that is not a call: the comment 5.4 requires above
+        // the gate. Two assertions, and together they leave no room:
+        //   - the comment mention appears exactly once, so it cannot be
+        //     duplicated to absorb the budget of a smuggled-in call;
+        //   - the identifier appears exactly twice in total, which is that
+        //     comment plus the single call inside the gated block the first
+        //     assertion already pinned.
+        // Two minus one minus one is zero occurrences left over, whatever they
+        // would have been spelled like.
+        let comment_mention = "`rotate_origin_memory_at_spawn`returns`()`";
         assert_eq!(
-            normalized.matches("rotate_origin_memory_at_spawn(").count(),
+            normalized.matches(comment_mention).count(),
             1,
-            "#1172 D5: exactly one rotation call site, and it is the gated one. \
-             A resume must NEVER rotate."
+            "#1172 D5: the comment above the gate must keep naming the rotation exactly once; \
+             it is the one non-call mention the identifier count below budgets for."
+        );
+        assert_eq!(
+            normalized.matches("rotate_origin_memory_at_spawn").count(),
+            2,
+            "#1172 D5: the rotation must be named exactly twice in production - once in the \
+             comment above the gate, once in the gated call itself. A third mention means a \
+             second call site, and an ungated rotation makes a RESUME empty the agent's memory."
         );
     }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1973,6 +1973,11 @@ async fn create_session_inner_impl<R: tauri::Runtime>(
             let context_result = coordinator
                 .run_blocking_seed_work({
                     let cwd = cwd.clone();
+                    // #1172 D5: capture the FINAL fresh-versus-resume decision. `skip_auto_resume`
+                    // is a `mut` parameter of this function whose only mutation is the #756 mirror
+                    // at :1470, ~500 lines above, so the value read here is final. `true` means AC
+                    // is deliberately NOT resuming: a fresh conversation begins.
+                    let start_fresh = skip_auto_resume;
                     let target_filename = target_filename.clone();
                     let managed_filenames = managed_filenames.clone();
                     let container_repos = container_repos.clone();
@@ -1989,15 +1994,34 @@ async fn create_session_inner_impl<R: tauri::Runtime>(
                         let activation: Option<
                             crate::config::seed_manifest::ManifestActivationToken,
                         > = None;
-                        crate::config::session_context::materialize_agent_context_file_with_filename_activated(
-                            &cwd,
-                            &target_filename,
-                            &managed_filenames,
-                            is_coordinator,
-                            auto_self_clear,
-                            container_repos.as_ref(),
-                            activation.as_ref(),
-                        )
+                        let context_result =
+                            crate::config::session_context::materialize_agent_context_file_with_filename_activated(
+                                &cwd,
+                                &target_filename,
+                                &managed_filenames,
+                                is_coordinator,
+                                auto_self_clear,
+                                container_repos.as_ref(),
+                                activation.as_ref(),
+                            );
+                        // #1172 - rotate the origin Agent Matrix's `memory/` for the fresh session
+                        // about to start, so it begins with a clean write target and the previous
+                        // session's memory is preserved under `memory_<ts>/`.
+                        //
+                        // Two gates, both load-bearing (D5):
+                        //   - `start_fresh`: a RESUME never rotates. This chokepoint also serves the
+                        //     app-startup restore path (`create_session_inner_for_restore`, :1239),
+                        //     which continues an existing conversation; emptying `memory/` under a
+                        //     resumed agent is the one outcome the user ruled out.
+                        //   - `is_ok()`: a launch that is about to roll back (:2016-2036) leaves no
+                        //     rotation behind.
+                        //
+                        // Never fails a launch: `rotate_origin_memory_at_spawn` returns `()` and every
+                        // error path inside it warns and returns.
+                        if start_fresh && context_result.is_ok() {
+                            crate::config::agent_memory::rotate_origin_memory_at_spawn(&cwd);
+                        }
+                        context_result
                     }
                 })
                 .await;
@@ -7224,6 +7248,45 @@ mod tests {
         assert_eq!(
             count, 2,
             "create_session_inner must keep both archive activation gates"
+        );
+    }
+
+    // T16 (#1172 D5). The fresh-versus-resume gate is one boolean at a call site
+    // inside a large async function the suite does not drive end to end, so it
+    // has no natural unit test: deleting `start_fresh &&` compiles, passes every
+    // other test, and silently starts rotating memory on every app-startup
+    // restore, which is the exact outcome the user ruled out.
+    #[test]
+    fn memory_rotation_stays_gated_on_a_fresh_launch() {
+        let source = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/commands/session.rs"
+        ))
+        .expect("read session.rs");
+        let production = source
+            .split("#[cfg(test)]\nmod tests")
+            .next()
+            .expect("production session source");
+        let normalized = production.split_whitespace().collect::<String>();
+        let gated_call = "ifstart_fresh&&context_result.is_ok(){crate::config::agent_memory::rotate_origin_memory_at_spawn(&cwd);}";
+
+        assert_eq!(
+            normalized.matches(gated_call).count(),
+            1,
+            "#1172 D5: the memory rotation must stay behind `start_fresh && context_result.is_ok()`. \
+             A resume must NEVER rotate: this chokepoint also serves the app-startup restore path."
+        );
+        // Counting the call WITH its argument rather than the bare identifier:
+        // the production comment above the gate names the function too, so a
+        // bare-identifier count can never be 1. This needle is the property that
+        // actually matters, namely zero ungated calls.
+        assert_eq!(
+            normalized
+                .matches("rotate_origin_memory_at_spawn(&cwd);")
+                .count(),
+            1,
+            "#1172 D5: exactly one rotation call site, and it is the gated one. \
+             A resume must NEVER rotate."
         );
     }
 

--- a/src-tauri/src/config/agent_memory.rs
+++ b/src-tauri/src/config/agent_memory.rs
@@ -1,0 +1,503 @@
+//! #1172 - rotate an origin Agent Matrix's `memory/` to a timestamped sibling at
+//! session spawn, so a fresh agent starts with a clean write target and the
+//! previous session's memory is preserved rather than deleted.
+
+use std::path::{Path, PathBuf};
+
+/// Mirrors the `"memory"` entry of
+/// `crate::commands::entity_creation::AGENT_MATRIX_DIRS` (`entity_creation.rs:128`).
+const MEMORY_DIR_NAME: &str = "memory";
+
+/// Deliberate independent twin of `phone::mailbox::ARCHIVE_TIMESTAMP_FORMAT`
+/// (`mailbox.rs:848`), per D3. That constant is part of the `self-clear/`
+/// naming contract the #749 resume prompt and the CLI help expose to agents.
+/// The two must stay free to diverge, so the literal is duplicated instead of
+/// exported from `phone` into `config`.
+const MEMORY_ROTATION_TIMESTAMP_FORMAT: &str = "%Y%m%d_%H%M%S";
+
+/// Two jobs, both load-bearing: it renders a path for logs so operators never
+/// read `\\?\C:\...` in `app.log`, and it performs the `Path` to `String`
+/// conversion that `is_canonical_agent_matrix_dir` requires. Same private
+/// one-liner as `replica_identity.rs:23-25` and `root_agent.rs:1924`. The
+/// conversion goes through `to_string_lossy`, so it is lossy in principle; that
+/// is fail-safe here, because a degraded path fails `canonicalize` and the
+/// caller rotates nothing.
+fn display_path(path: &Path) -> String {
+    crate::path_utils::path_to_string_without_windows_verbatim_prefix(path)
+}
+
+/// Create `path` as an empty directory, treating "someone else already made it"
+/// as success. `AlreadyExists` means a concurrent session won the race to the
+/// same desired end state, so warning about it would report a failure where
+/// nothing failed (D9 sub-decision).
+fn ensure_dir(path: &Path) -> std::io::Result<()> {
+    match std::fs::create_dir(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Launch-path entry point (D5). Returns nothing and never propagates an error:
+/// every internal failure path warns and returns, so a rotation cannot abort a
+/// session launch (acceptance criterion 3).
+///
+/// The FRESH-versus-resume decision is the caller's, not this function's. The
+/// call site in `commands/session.rs` gates on `skip_auto_resume`; see D5 for
+/// why that flag is the signal and what each entry point passes.
+pub(crate) fn rotate_origin_memory_at_spawn(agent_root: &str) {
+    let Some(matrix_root) = resolve_rotatable_matrix_root(agent_root) else {
+        return;
+    };
+    let timestamp = chrono::Local::now()
+        .format(MEMORY_ROTATION_TIMESTAMP_FORMAT)
+        .to_string();
+    match rotate_memory_dir(&matrix_root, &timestamp) {
+        Ok(Some(dst)) => log::info!(
+            "[memory] #1172: rotated {} -> {} at fresh session spawn",
+            // 11.3.1: the source is a pure function of `matrix_root`.
+            display_path(&matrix_root.join(MEMORY_DIR_NAME)),
+            display_path(&dst)
+        ),
+        // Absent `memory/` (repaired in place, D9), or present and empty (D2).
+        // Acceptance criterion 2 requires nothing at info level or above here.
+        Ok(None) => {}
+        Err(e) => log::warn!(
+            "[memory] #1172: memory rotation failed for {} (non-fatal; the session still launches): {}",
+            display_path(&matrix_root),
+            e
+        ),
+    }
+}
+
+/// Resolve the origin Agent Matrix whose `memory/` this session rotates, or
+/// `None` when nothing may be rotated.
+///
+/// D7: the replica identity is read with the read-only reader.
+/// `resolve_replica_matrix_root` is not used because it rewrites `config.json`
+/// on every call through `local_config_io::update_config_json_object`, and the
+/// context path has already read and repaired that file by the time this runs.
+///
+/// D6: `ac-root-agent` cannot satisfy `is_canonical_agent_matrix_dir`, so the
+/// Root Agent is excluded by the filter itself.
+fn resolve_rotatable_matrix_root(agent_root: &str) -> Option<PathBuf> {
+    let candidate = if crate::config::session_context::is_replica_agent_dir(agent_root) {
+        let (_config, identity) =
+            crate::config::replica_identity::read_wg_replica_config_read_only(Path::new(
+                agent_root,
+            ))
+            .ok()?;
+        display_path(&identity.matrix_dir)
+    } else {
+        agent_root.to_string()
+    };
+    // Re-validate whatever the identity resolved to. A replica pointing at
+    // something that is not a canonical matrix rotates nothing.
+    if !crate::config::session_context::is_canonical_agent_matrix_dir(&candidate) {
+        return None;
+    }
+    // Canonical (verbatim on Windows) is what the filesystem calls below use;
+    // logging normalizes it (11.3.2).
+    std::fs::canonicalize(&candidate).ok()
+}
+
+/// The deterministic core, modeled on `phone::mailbox::archive_root_md`
+/// (`mailbox.rs:1595-1617`). The timestamp is injected by the caller, so this is
+/// testable without mocking the clock.
+///
+/// `Ok(None)` means no rotation happened: `memory/` was absent (and has been
+/// recreated empty, D9) or was present and empty (D2).
+/// `Ok(Some(dst))` is the rotated directory.
+fn rotate_memory_dir(matrix_root: &Path, timestamp: &str) -> std::io::Result<Option<PathBuf>> {
+    let src = matrix_root.join(MEMORY_DIR_NAME);
+    let Ok(metadata) = std::fs::symlink_metadata(&src) else {
+        // D9: absent is repaired, not merely skipped. Without this, a failed
+        // recreate below would leave the matrix permanently without a write
+        // target, because this branch is what every later launch takes.
+        // Best-effort: a failure here warns and still reports "no rotation".
+        if let Err(e) = ensure_dir(&src) {
+            log::warn!(
+                "[memory] #1172: could not restore a missing memory/ at {} (non-fatal): {}",
+                display_path(&src),
+                e
+            );
+        }
+        return Ok(None);
+    };
+    // 11.3.4: `is_symlink()` alone is FALSE for a Windows junction, which is
+    // exactly the case this rejects. Renaming a junction would move the link
+    // entry and the recreate below would replace the user's link with a real
+    // directory. Same call shape as `mailbox.rs:89-91`. This reaches for the
+    // `pub(crate)` helper in `entity_creation` rather than the private copy in
+    // `session_context.rs:2322`, whose doc forbids refactoring the inlined
+    // checks into a shared helper *there*; reusing an already-shared
+    // `pub(crate)` one from another module is what `mailbox.rs:90` does.
+    if !metadata.is_dir()
+        || crate::commands::entity_creation::metadata_is_link_or_reparse(&metadata)
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "memory is not a real directory",
+        ));
+    }
+    // D2: an empty `memory/` is not rotated.
+    if std::fs::read_dir(&src)?.next().is_none() {
+        return Ok(None);
+    }
+    let dst = matrix_root.join(format!("{}_{}", MEMORY_DIR_NAME, timestamp));
+    // Refuse to clobber (`mailbox.rs:1606-1613`). `symlink_metadata` rather
+    // than `exists()`, so a dangling link at the destination also blocks. This
+    // is a best-effort fast path, NOT an atomic guarantee; see section 7 for
+    // what actually makes data loss impossible in the residual race.
+    if std::fs::symlink_metadata(&dst).is_ok() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "memory rotation target already exists",
+        ));
+    }
+    // No retry loop, per `mailbox.rs:1615` and its rationale at `:1590-1593`.
+    std::fs::rename(&src, &dst)?;
+    // Restore the write target so the layout contract of `entity_creation.rs:128`
+    // stays complete. The rotation itself already succeeded, so this warns
+    // rather than turning into `Err`; D9's self-repair above is what keeps a
+    // failure here from being permanent.
+    if let Err(e) = ensure_dir(&src) {
+        log::warn!(
+            "[memory] #1172: rotated {} but failed to recreate an empty memory/ at {} (the next fresh launch restores it): {}",
+            display_path(&dst),
+            display_path(&src),
+            e
+        );
+    }
+    Ok(Some(dst))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every rotated sibling of `memory/`, sorted, as directory names.
+    fn rotated_entries(matrix_root: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(matrix_root)
+            .expect("read matrix root")
+            .map(|entry| entry.expect("dir entry").file_name())
+            .filter_map(|name| name.to_str().map(str::to_string))
+            .filter(|name| name.starts_with("memory_"))
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn entry_count(dir: &Path) -> usize {
+        std::fs::read_dir(dir).expect("read dir").count()
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+
+    // T1 - D9 and acceptance criterion 2. Pass 1 asserted the opposite (that
+    // nothing is created), which pinned the terminal state G4 describes.
+    #[test]
+    fn rotate_memory_dir_absent_memory_is_repaired_not_rotated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+
+        let got = rotate_memory_dir(matrix_root, "20260102_030405").expect("absent memory is Ok");
+
+        assert!(
+            got.is_none(),
+            "an absent memory/ must not report a rotation"
+        );
+        let memory = matrix_root.join("memory");
+        assert!(memory.is_dir(), "D9: an absent memory/ is created empty");
+        assert_eq!(entry_count(&memory), 0, "the restored memory/ starts empty");
+        assert!(
+            rotated_entries(matrix_root).is_empty(),
+            "nothing is rotated when there was no memory/"
+        );
+    }
+
+    // T2 - D2.
+    #[test]
+    fn rotate_memory_dir_empty_memory_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+        let memory = matrix_root.join("memory");
+        std::fs::create_dir(&memory).unwrap();
+
+        let got = rotate_memory_dir(matrix_root, "20260102_030405").expect("empty memory is Ok");
+
+        assert!(got.is_none(), "D2: an empty memory/ is not rotated");
+        assert!(memory.is_dir(), "the empty memory/ stays where it is");
+        assert_eq!(entry_count(&memory), 0);
+        assert!(
+            rotated_entries(matrix_root).is_empty(),
+            "D2: no empty rotation directory is created"
+        );
+    }
+
+    // T3 - acceptance criterion 1 and D1.
+    #[test]
+    fn rotate_memory_dir_moves_contents_and_recreates_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+        let memory = matrix_root.join("memory");
+        write_file(&memory.join("MEMORY.md"), "remembered bytes");
+        // `std::fs::rename` moves the whole subtree in one call: source and
+        // destination are siblings and therefore always on one volume.
+        write_file(&memory.join("notes").join("deep.md"), "nested");
+
+        let got = rotate_memory_dir(matrix_root, "20260102_030405").expect("rotation succeeds");
+
+        let expected_dst = matrix_root.join("memory_20260102_030405");
+        assert_eq!(got, Some(expected_dst.clone()));
+        assert_eq!(
+            std::fs::read_to_string(expected_dst.join("MEMORY.md")).unwrap(),
+            "remembered bytes",
+            "the archive keeps the original bytes"
+        );
+        assert!(
+            expected_dst.join("notes").join("deep.md").is_file(),
+            "the whole subtree moves with the rename"
+        );
+        assert!(memory.is_dir(), "D1: memory/ is recreated");
+        assert_eq!(
+            entry_count(&memory),
+            0,
+            "D1: the recreated memory/ is empty"
+        );
+    }
+
+    // T4 - acceptance criterion 4.
+    #[test]
+    fn rotate_memory_dir_refuses_existing_target_without_clobber() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+        let existing = matrix_root.join("memory_20260102_030405");
+        write_file(&existing.join("sentinel.md"), "earlier archive");
+        write_file(&matrix_root.join("memory").join("MEMORY.md"), "live memory");
+
+        let err = rotate_memory_dir(matrix_root, "20260102_030405")
+            .expect_err("an existing target must refuse");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            std::fs::read_to_string(matrix_root.join("memory").join("MEMORY.md")).unwrap(),
+            "live memory",
+            "the live memory/ is left exactly where it was"
+        );
+        assert_eq!(
+            std::fs::read_to_string(existing.join("sentinel.md")).unwrap(),
+            "earlier archive",
+            "the pre-existing archive is never clobbered"
+        );
+    }
+
+    // T5 - this exercises the `!metadata.is_dir()` half of the condition ONLY.
+    // T14 is what guards the reparse half; a regular file is rejected by
+    // `is_dir()` even with the original `is_symlink()` bug in place.
+    #[test]
+    fn rotate_memory_dir_refuses_non_directory_memory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+        let memory = matrix_root.join("memory");
+        std::fs::write(&memory, "not a directory").unwrap();
+
+        let err = rotate_memory_dir(matrix_root, "20260102_030405")
+            .expect_err("a non-directory memory must refuse");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            std::fs::read_to_string(&memory).unwrap(),
+            "not a directory",
+            "the file is untouched"
+        );
+    }
+
+    // T6 - the decided return shape: raw canonical (verbatim on Windows),
+    // normalized only for logging (11.3.2).
+    #[test]
+    fn resolve_rotatable_matrix_root_accepts_canonical_matrix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix = tmp.path().join(".ac").join("_agent_x");
+        std::fs::create_dir_all(&matrix).unwrap();
+
+        let got = resolve_rotatable_matrix_root(matrix.to_str().unwrap());
+
+        assert_eq!(got, Some(std::fs::canonicalize(&matrix).unwrap()));
+    }
+
+    // T7 - acceptance criterion 5. The `role_experiment` shape: a replica that
+    // does carry a `memory/` but has no `config.json`, so the identity read
+    // fails and nothing is rotated.
+    #[test]
+    fn resolve_rotatable_matrix_root_rejects_replica_without_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let replica = tmp.path().join(".ac").join("wg-1-team").join("__agent_x");
+        write_file(&replica.join("memory").join("MEMORY.md"), "replica memory");
+
+        assert_eq!(
+            resolve_rotatable_matrix_root(replica.to_str().unwrap()),
+            None,
+            "a replica with no config.json resolves to nothing"
+        );
+
+        rotate_origin_memory_at_spawn(replica.to_str().unwrap());
+
+        assert_eq!(
+            std::fs::read_to_string(replica.join("memory").join("MEMORY.md")).unwrap(),
+            "replica memory",
+            "a replica's own memory/ is never touched"
+        );
+        assert!(
+            rotated_entries(&replica).is_empty(),
+            "no rotation directory is created inside a replica"
+        );
+    }
+
+    // T8.
+    #[test]
+    fn resolve_rotatable_matrix_root_rejects_plain_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plain = tmp.path().join("just-a-folder");
+        std::fs::create_dir_all(&plain).unwrap();
+
+        assert_eq!(resolve_rotatable_matrix_root(plain.to_str().unwrap()), None);
+    }
+
+    // T9 - criteria 1 and 3 through the entry point, on the real clock.
+    #[test]
+    fn rotate_origin_memory_at_spawn_rotates_a_direct_matrix_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix = tmp.path().join(".ac").join("_agent_x");
+        write_file(&matrix.join("memory").join("MEMORY.md"), "direct matrix");
+
+        rotate_origin_memory_at_spawn(matrix.to_str().unwrap());
+
+        let rotated = rotated_entries(&matrix);
+        assert_eq!(rotated.len(), 1, "exactly one rotation directory");
+        let suffix = rotated[0]
+            .strip_prefix("memory_")
+            .expect("rotated name keeps the memory_ prefix");
+        // `%Y%m%d_%H%M%S` is 8 + 1 + 6. Byte slices rather than `regex`, which
+        // has no business being pulled into a unit test.
+        assert_eq!(suffix.len(), 15, "timestamp suffix is 8 + 1 + 6 characters");
+        let bytes = suffix.as_bytes();
+        assert!(bytes[..8].iter().all(u8::is_ascii_digit), "date is digits");
+        assert_eq!(
+            bytes[8], b'_',
+            "date and time are separated by an underscore"
+        );
+        assert!(bytes[9..].iter().all(u8::is_ascii_digit), "time is digits");
+        assert_eq!(
+            std::fs::read_to_string(matrix.join(&rotated[0]).join("MEMORY.md")).unwrap(),
+            "direct matrix"
+        );
+        let memory = matrix.join("memory");
+        assert!(memory.is_dir());
+        assert_eq!(entry_count(&memory), 0);
+    }
+
+    // T12 - the D7 happy path, the one every real session takes. T7 exercises
+    // only its failing branch.
+    #[test]
+    fn resolve_rotatable_matrix_root_follows_a_replica_to_its_origin_matrix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join(".ac");
+        let matrix = workspace.join("_agent_x");
+        write_file(&matrix.join("memory").join("MEMORY.md"), "origin memory");
+        let replica = workspace.join("wg-1-team").join("__agent_x");
+        // `expected_wg_replica_identity` derives the matrix from the layout and
+        // compares only the persisted string's agent name, so the value has to
+        // name `_agent_x`.
+        write_file(
+            &replica.join("config.json"),
+            "{\"identity\": \"../../_agent_x\"}",
+        );
+
+        rotate_origin_memory_at_spawn(replica.to_str().unwrap());
+
+        let rotated = rotated_entries(&matrix);
+        assert_eq!(rotated.len(), 1, "the rotation landed in the origin matrix");
+        assert_eq!(
+            std::fs::read_to_string(matrix.join(&rotated[0]).join("MEMORY.md")).unwrap(),
+            "origin memory"
+        );
+        let memory = matrix.join("memory");
+        assert!(memory.is_dir(), "the matrix keeps an empty memory/");
+        assert_eq!(entry_count(&memory), 0);
+        assert!(
+            !replica.join("memory").exists() && rotated_entries(&replica).is_empty(),
+            "the replica itself gains no memory* entry"
+        );
+    }
+
+    // T13 - D6 is an explicit, user-visible exclusion and currently rests on
+    // nothing but the `_agent_` prefix inside a predicate in another module.
+    #[test]
+    fn rotate_origin_memory_at_spawn_leaves_the_root_agent_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_agent = tmp.path().join(".ac").join("ac-root-agent");
+        write_file(&root_agent.join("memory").join("MEMORY.md"), "root memory");
+
+        rotate_origin_memory_at_spawn(root_agent.to_str().unwrap());
+
+        assert_eq!(
+            std::fs::read_to_string(root_agent.join("memory").join("MEMORY.md")).unwrap(),
+            "root memory",
+            "D6: the Root Agent is never rotated"
+        );
+        assert!(rotated_entries(&root_agent).is_empty());
+    }
+
+    // T14 - THE ONLY GUARD on the reparse-point correction (11.3.4). Without
+    // it, a later "simplification" back to `metadata.file_type().is_symlink()`
+    // passes `cargo test`, `cargo clippy`, and review, and silently starts
+    // renaming junctions, replacing the user's link with a real directory.
+    // Junction creation needs no elevation, unlike `std::os::windows::fs::symlink_dir`,
+    // which is why this runs in CI; `commands/session.rs:5210` is the precedent.
+    #[cfg(windows)]
+    #[test]
+    fn rotate_memory_dir_refuses_a_junction_at_memory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let matrix_root = tmp.path();
+        let target = matrix_root.join("real_target");
+        write_file(&target.join("sentinel.md"), "linked bytes");
+        let link = matrix_root.join("memory");
+        let output = std::process::Command::new("cmd")
+            .arg("/C")
+            .arg("mklink")
+            .arg("/J")
+            .arg(&link)
+            .arg(&target)
+            .output()
+            .expect("failed to invoke mklink");
+        assert!(
+            output.status.success(),
+            "failed to create junction link='{}' target='{}': stdout={} stderr={}",
+            link.display(),
+            target.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let err = rotate_memory_dir(matrix_root, "20260102_030405")
+            .expect_err("a junction at memory must refuse");
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            std::fs::symlink_metadata(&link).is_ok(),
+            "the junction entry still exists"
+        );
+        assert_eq!(
+            std::fs::read_to_string(target.join("sentinel.md")).unwrap(),
+            "linked bytes",
+            "the junction target is untouched"
+        );
+        assert!(rotated_entries(matrix_root).is_empty());
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod activity_log;
 pub mod agent_command;
 pub mod agent_config;
 pub mod agent_creation;
+pub(crate) mod agent_memory;
 pub mod archive_gate;
 pub mod coding_agent_mutations;
 pub mod coding_agent_profiles;

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -1449,7 +1449,16 @@ fn path_parent_is_workspace(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn is_canonical_agent_matrix_dir(cwd: &str) -> bool {
+/// True only for an ORIGIN Agent Matrix: a real (non-symlink) `_agent_*`
+/// directory whose canonical parent is a workspace directory.
+///
+/// #1172's memory rotation (`config::agent_memory`) is the second consumer and
+/// depends on both halves of that contract. It relies on the `_agent_` prefix to
+/// reject every `__agent_*` replica, including the `role_experiment` replicas
+/// that do carry a `memory/` of their own (`cli/role_experiment.rs:2259-2267`),
+/// and on the `ac-root-agent` name failing the prefix so the Root Agent is never
+/// rotated (D6). Widening either half silently widens what rotation may move.
+pub(crate) fn is_canonical_agent_matrix_dir(cwd: &str) -> bool {
     let path = Path::new(cwd);
     if !has_agent_matrix_dir_name(path) {
         return false;
@@ -3434,7 +3443,7 @@ fn default_context_dynamic_values(
 
     let matrix_section = match matrix_root {
         Some(matrix_root) => format!(
-            "3. **Your origin Agent Matrix, but only for the canonical agent state listed below:**\n   ```\n   {matrix_root}\n   ```\n   Allowed there:\n   - `memory/`\n   - `plans/`\n   - `skills/`\n   - `Role.md`\n\n",
+            "3. **Your origin Agent Matrix, but only for the canonical agent state listed below:**\n   ```\n   {matrix_root}\n   ```\n   Read-only there: every rotated `memory_YYYYMMDD_hhmmss/` archive of your own memory. Read them freely; never modify or delete them.\n   Allowed for reading and writing there:\n   - `memory/`\n   - `plans/`\n   - `skills/`\n   - `Role.md`\n\n",
             matrix_root = matrix_root,
         ),
         None => String::new(),
@@ -3531,7 +3540,7 @@ fn default_context_dynamic_values(
         )
     } else {
         format!(
-            "the entries listed above{ms}, except for explicitly requested AgentsCommander CLI operations covered by the exception below. This includes other agents' replica directories, and any other agent's `memory/`, `plans/`, `skills/`, or `Role.md`: another agent's memory is private; do not read, list, search, or summarize it, even if asked. If you need information another agent holds, message that agent and ask.",
+            "the entries listed above{ms}, except for explicitly requested AgentsCommander CLI operations covered by the exception below. This includes other agents' replica directories, and any other agent's `memory*` directories (the live `memory/` and every rotated `memory_YYYYMMDD_hhmmss/`), `plans/`, `skills/`, or `Role.md`: another agent's memory is private whether it is live or rotated; do not read, list, search, or summarize it, even if asked. If you need information another agent holds, message that agent and ask.",
             ms = messaging_read_phrase,
         )
     };
@@ -4182,7 +4191,7 @@ fn normalize_context_for_compat(value: &str) -> String {
     value.replace("\r\n", "\n").trim_end().to_string()
 }
 
-fn is_replica_agent_dir(cwd: &str) -> bool {
+pub(crate) fn is_replica_agent_dir(cwd: &str) -> bool {
     std::path::Path::new(cwd)
         .file_name()
         .and_then(|name| name.to_str())
@@ -5029,6 +5038,96 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(out.contains("`agency-templates status` and `agency-templates list` report on"));
         assert!(out
             .contains("those two reads are grants, while direct writes to them stay CLI-managed"));
+    }
+
+    // T10 (#1172, acceptance criterion 6): another agent's memory is private
+    // whether it is live or rotated, so the peer-privacy clause covers the whole
+    // `memory*` glob rather than the live directory alone.
+    #[test]
+    fn default_context_marks_every_memory_directory_private() {
+        let out = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            Some("C:/fake/_agent_architect"),
+            &no_skill_section(),
+        );
+        assert!(
+            out.contains("`memory*` directories"),
+            "expected the peer-privacy clause to cover the memory* glob, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("every rotated `memory_YYYYMMDD_hhmmss/`"),
+            "expected rotated archives named explicitly, got:\n{}",
+            out
+        );
+        assert!(
+            out.contains("private whether it is live or rotated"),
+            "expected privacy to hold for both live and rotated memory, got:\n{}",
+            out
+        );
+    }
+
+    // T11 (#1172): locks the invariant documented above `DefaultContextDynamicValues`
+    // - the Root Agent holds a project-wide read grant and must never receive the
+    // peer-privacy clause. The #1172 copy edit must not leak into that branch.
+    #[test]
+    fn root_context_still_omits_the_peer_memory_privacy_clause() {
+        let out = default_context_as_root("C:/fake/ac-root-agent", None, &no_skill_section());
+        assert!(
+            !out.contains("memory is private"),
+            "the Root Agent branch must stay free of the peer-privacy clause, got:\n{}",
+            out
+        );
+    }
+
+    // T15 (#1172 D4, O1): the own-archive grant is READ-ONLY and lives INSIDE
+    // numbered entry 3, which is `String::new()` when the agent has no origin
+    // matrix. An agent must never be promised a grant its own document does not
+    // print, which is the failure #923 D8 exists to prevent.
+    #[test]
+    fn own_archive_read_grant_renders_only_with_an_origin_matrix() {
+        const GRANT: &str =
+            "Read-only there: every rotated `memory_YYYYMMDD_hhmmss/` archive of your own memory";
+
+        let wg = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            Some("C:/fake/_agent_architect"),
+            &no_skill_section(),
+        );
+        let entry_3 = wg
+            .find("3. **Your origin Agent Matrix")
+            .expect("entry 3 renders when the agent has an origin matrix");
+        let grant = wg.find(GRANT).expect("the own-archive grant renders");
+        let role_md = entry_3
+            + wg[entry_3..]
+                .find("- `Role.md`")
+                .expect("entry 3 carries the canonical-state list");
+        assert!(
+            grant > entry_3 && grant < role_md,
+            "the read-only archive clause must sit inside entry 3, above its list, got:\n{}",
+            wg
+        );
+
+        // O1: no origin matrix, so no entry 3, so no grant - but the peer-privacy
+        // half is unconditional and must still render.
+        let none = default_context("C:/fake/plain/agent", None, &no_skill_section());
+        assert!(
+            !none.contains("Read-only there"),
+            "an agent with no origin matrix must not be promised an archive grant, got:\n{}",
+            none
+        );
+        assert!(
+            none.contains("`memory*` directories"),
+            "the peer-privacy half renders for every non-root agent, got:\n{}",
+            none
+        );
+
+        let root = default_context_as_root("C:/fake/ac-root-agent", None, &no_skill_section());
+        assert!(
+            !root.contains("Read-only there"),
+            "the Root Agent has no origin matrix and no entry 3, got:\n{}",
+            root
+        );
     }
 
     fn read_forbidden_bullet(out: &str) -> &str {


### PR DESCRIPTION
Closes #1172

## What this does

When a session starts **fresh**, the origin Agent Matrix that owns the session's canonical state begins with a clean `memory/`. Whatever the previous session left there is preserved intact under a sibling `memory_YYYYMMDD_hhmmss/`, never deleted.

The generated context additionally treats every `memory*` directory of another agent as private, while an agent keeps read access to its own rotated archives.

## Why

Memory written by an agent used to persist indefinitely and keep influencing later sessions, with no mechanism to retire it. The goal is to capture what models decide is worth remembering, keep it as an artifact the user can inspect and act on, and stop it from participating in day-to-day operation.

`memory/` was already a directory AgentsCommander creates and declares but never reads, lists, copies, syncs, or injects. The only link to a running agent is written by the agent itself, through its `Role.md`.

## Scope decisions (user-owned, recorded in the plan)

- **Fresh launches only.** A resume never rotates. The gate reads `skip_auto_resume`, which the launch path already resolves. Restore-on-app-start and the reopen paths are resumes; manual restart, mass restart on settings write, and self-handoff-and-switch are fresh launches by the code's own documented semantics.
- **An empty `memory/` is not rotated.** Only a directory with content rotates, so an agent that wrote nothing produces no empty archive.
- **The recreated `memory/` is empty, with no stub.**
- **No retention and no sweep.** Rotated directories accumulate without an upper bound.
- **No `.gitignore` change.** Rotated directories stay tracked; the resulting `git status` noise is accepted.
- **Rotation is intentionally invisible to the agent.** Preserving for the user, not for the model, is the objective — not a defect.

## Delivery

Full path. Plan certified at `Plan-SHA256: 6C2021F8E4CA867F1F5046EF78B4F7D94390623F8A7DCBAB970009171226CE14`, verified before implementation, after implementation, and after the merge.

- **architect** wrote and certified the plan (`plans/1172-rotate-agent-memory-at-spawn.md`), then resolved consensus after review.
- **dev-rust** enriched the plan, then implemented from a cold start against the frozen digest.
- **dev-rust-grinch** reviewed the plan adversarially, then the implementation over three rounds, then the merge.

Review found and fixed, before landing:

- A failed `memory/` recreate would have left the matrix permanently broken, with a test certifying that breakage as correct. Resolved with self-repair; the test was inverted.
- `is_symlink()` does not detect Windows junctions. Replaced with the repo's canonical reparse helper.
- The privacy grant was moved so it does not concede write access over the very files the feature exists to preserve.
- The T16 guard was strengthened twice: first it counted one argument spelling, then it missed a parenthesized call path. It now closes the whole intra-file class, verified against five mutants that were each compiled, run and reverted.

## Known limitation, deferred to #1175

T16 reads and counts tokens in `commands/session.rs` only. A cross-file alias evades it — verified by compiling and running the real test. Closing this properly requires a behavioral test with a new seam in the launch path, which is more invasive than this feature. Deferred deliberately: every honest-oversight mutant is caught today, and adversarial review across three rounds found no path where memory is lost or corrupted.

## Verification

On the merged tree, with `-j 2`:

- `cargo check --all-targets`: exit 0
- `cargo clippy --all-targets -- -D warnings`: exit 0, no warnings
- `cargo fmt --all -- --check`: exit 0
- `commands::session`: 135 passed
- `config::agent_memory`: 12 passed
- `config::session_context::tests`: 150 passed, 1 ignored
- `cargo test --lib`: 3197 passed, 0 failed, 22 ignored

Branch updated with `origin/main` (24 commits, the #1171 watchers feature) with no conflicts. The patch-id of `33a4a796..b7be29b` and of `fae6b09..f807037` are identical, confirming the merge did not alter the feature's patch.

Non-visual change: no shipper build.
