### PR TITLE
feat(scripts): add cross-platform skills checker for SKILL.md structure (refs #1213)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test": "vitest run",
     "test:debt": "node scripts/check-test-debt.mjs",
     "test:debt:self": "node scripts/check-test-debt.mjs --self-test",
+    "check:skills": "node scripts/01-skills-checker.mjs",
+    "check:skills:self": "node scripts/01-skills-checker.mjs --self-test",
     "test:watch": "vitest",
     "smoke:cli-release-windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ./scripts/smoke-cli-release-windows.ps1",
     "smoke:profile-matrix": "node scripts/smoke-profile-matrix-preview.mjs",

--- a/plans/1213-skills-checker.md
+++ b/plans/1213-skills-checker.md
@@ -1,0 +1,2151 @@
+# Implementation Plan: #1213 Cross-platform skills checker (`scripts/01-skills-checker.mjs`)
+
+Status: READY_FOR_IMPLEMENTATION
+
+Certified by the architect in the Step 7 consensus pass, after the Step 5 dev-rust enrichment and the
+Step 6 dev-rust-grinch adversarial pass. No implementation decision is left open (Section 13, Section
+16.3).
+
+Full path. This file is the complete cold-start specification: the implementer will have only this
+file, so every decision below is closed.
+
+**Read this before Section 6.** The plan was written in four passes and each one changed rules the
+previous pass got wrong. The records are Sections 14, 15 and 16; the normative text is Sections 1
+through 13. Where a record and a numbered section disagree, **the numbered section wins**, because
+that is what the implementer follows.
+
+- **Step 5 (dev-rust), Section 14.** All five Section 12 unknowns resolved against pinned source with
+  `file:line`, including vendored `serde_yaml 0.9.34`. Seven fidelity defects, two of them false
+  passes where the checker would have approved a file the indexer rejects.
+- **Step 6 (dev-rust-grinch), Section 15.** Seventeen further defects: three more false passes and
+  six false positives. Codebase Memory gate verified green at `f08b8241`. The taxonomy grew from 28
+  codes to 31 and the self-test from 75 cases to 109. Three of its findings change the *shape* of the
+  traversal and the YAML parser, not just their wording.
+- **Step 7 (architect), Section 16.** Eight cross-reference gaps the enrichment passes left behind,
+  two of them behaviour-affecting: a self-test case asserting a code that no longer exists, and a
+  taxonomy code with no case at all. The self-test is now **110 cases** and 14 acceptance criteria.
+
+The single most important structural fact, because it is what produced most of the defects above: the
+`.mjs` is a hand-maintained second implementation of `session_context.rs:206-714`. Every rule here is
+a claim about that range. Section 10 item 4 and Section 15.5 both say the same thing about what that
+costs over time.
+
+## 1. Issue, baseline and objective
+
+- Issue: https://github.com/mblua/AgentsCommander/issues/1213 (`Add cross-platform skills checker
+  script to validate SKILL.md structure`).
+- Branch: `feature/1213-skills-checker`, created from `main` at
+  `f08b82419b7943d694965af000630bf053e2922a`.
+- **Baseline for every coordinate in this plan: `f08b8241`.** The branch has no commits on it yet, so
+  every `file:line` below is valid at branch HEAD.
+- Delivery classification: FULL. One new file with a full CLI surface, a hand-written parser, a
+  finding taxonomy, a machine-readable output format and a self-test harness.
+
+**Objective.** Ship one Node script that tells a skill author, from any machine and any OS and
+without launching the app, exactly which `SKILL.md` files AgentsCommander would reject and why, using
+the same rules the Rust indexer enforces.
+
+**Non-objective.** The checker does not change, wrap, call or link the Rust indexer. It is a second,
+independent implementation of the same rules, and Section 11 treats the resulting drift as the
+project's main long-term risk.
+
+## 2. Evidence and the current-state gap
+
+### 2.1 Ground truth
+
+Every validation rule in this plan comes from the read-only, line-accurate investigation dev-rust
+completed against HEAD `f08b8241`:
+
+`.ac/wg-11-dev-v4-team/__agent_dev-rust/findings/skill-md-validation-rules.md`
+
+That artifact is authoritative and Rule IDs used throughout (`R1`, `E1`, `F1`, `Y1`, `N1`, `D1`,
+`W1`, `X1`) are its IDs, so every finding code below is traceable to a line of Rust.
+
+**One correction, made in Step 5 by the artifact's own author:** its hard-error table is one entry
+short, so its count of 22 should read 23. The missing condition and the reasoning are in
+Section 14.4. Its single self-declared unknown, duplicate-key behaviour, is resolved in Section 12.1.
+Everything else in it was re-checked against `f08b8241` during Step 5 and holds.
+
+Headline facts this plan is built on:
+
+- The whole indexer is one module: `src-tauri/src/config/session_context.rs:206-909`. The rules the
+  checker mirrors live in `:206-714`.
+- 23 hard-error conditions (skill not indexed; the artifact says 22 and is one short, see
+  Section 14.4), 3 soft warnings (skill indexed but flagged), and 4
+  rendering-time degradations that are **not** validation outcomes and are therefore out of scope.
+- `SKILL.md` is compared byte-exactly at `:401`
+  (`entry.file_name() != OsStr::new(SKILL_MD_FILENAME)`), so wrong casing fails on **every** platform
+  including Windows. Pinned by `discover_skill_index_wrong_case_skill_md_warns_on_windows_too`
+  (`:8402-8418`).
+- Depth is fixed at one: `<owner-root>/skills/<skill-name>/SKILL.md`. Exactly one root is scanned per
+  session. `__agent_*` replica directories are never scanned; only `_agent_*` matrices are
+  (`:1437-1442`).
+- `name` is optional and falls back to the containing directory name. The resolved name must match
+  `^[a-z0-9-]{1,64}$` or the skill is hard-rejected, **including when the name came from the folder
+  fallback** (`:464-470`, `:652-660`).
+- A missing, empty or wrongly typed `description` is the only metadata problem that keeps a skill
+  alive. Everything about `name`, the entrypoint, the delimiters and the YAML shape is fatal.
+
+### 2.2 The gap
+
+Verified at `f08b8241` by the same investigation:
+
+- `scripts/` holds 8 `.mjs`, 4 `.ps1` and 1 `.sh`. None touches skills.
+- No workflow in `.github/workflows/` validates skills.
+- The only existing verification is the Rust unit module at `session_context.rs:8329-8707`, which
+  validates the indexer against `tempfile` fixtures, never the skill files that ship on disk.
+
+So a malformed skill is silent at authoring time: it simply never appears in the agent's context, and
+the author learns about it only by reading startup warnings. A live instance exists in this workspace
+right now: ``Skipped skill directory `tiktok-news-publisher`: missing exact SKILL.md entrypoint``.
+
+### 2.3 Repo conventions the script must follow
+
+Verified at `f08b8241`:
+
+- Cross-platform tooling is `.mjs` run through `node` and wired to `package.json`
+  (`scripts/check-version-sync.mjs`, `scripts/validate-branch-name.mjs`,
+  `scripts/check-test-debt.mjs`). `.ps1` and `.sh` appear only for platform-specific work.
+- Script header shape (`scripts/check-version-sync.mjs:1-13`): `#!/usr/bin/env node`, a one-line
+  purpose naming the issue, a short rationale, a `Usage:` block, an `Exit codes:` block.
+- Output is prefixed with a bracketed tag, for example `[check-version-sync] OK ...`.
+- Arguments are parsed by a hand-rolled `parseArgs(process.argv.slice(2))`
+  (`validate-branch-name.mjs:30-37`, `check-test-debt.mjs:860-877`).
+- A `.mjs` script is self-tested through a `--self-test` flag with runtime `mkdtemp` fixtures, not
+  through vitest (`check-test-debt.mjs:702-858`, wired as `test:debt:self`).
+- CI pins Node 22 in every workflow (`actions/setup-node@v5`, `node-version: 22`).
+- `vitest.config.ts:12` collects `['src/**/*.test.ts', 'src/**/*.test.tsx']` only. Nothing under
+  `scripts/` is collected today.
+- `plans/` is gitignored (`.gitignore:11`), so this plan file needs `git add -f`.
+
+## 3. Scope
+
+### In scope
+
+| # | Deliverable |
+| --- | --- |
+| 1 | New file `scripts/01-skills-checker.mjs`. |
+| 2 | Two new entries in `package.json` `scripts` (Section 5.2). |
+| 3 | This plan file, force-added (Section 8, step 0). |
+
+Zero new dependencies. `package-lock.json` is not touched. The script must run via
+`node scripts/01-skills-checker.mjs` in a fresh checkout with no `npm install`.
+
+### Out of scope
+
+Taken from the issue's own out-of-scope list and from the evidence artifact:
+
+- Any change to the Rust indexer or its behaviour.
+- Auto-fixing malformed skill files. The checker never writes to disk outside its own temp fixtures.
+- Wiring the check into CI or the husky `pre-push` hook. The `package.json` entry makes it
+  attachable; attaching it is a separate issue.
+- The rendering-time degradations (evidence artifact section 2, "Rendering-time degradation"): the
+  1536-char trigger truncation and the 65536-byte context budget. They are not validation outcomes
+  and cannot make a valid skill invalid.
+- Root-resolution rules `R1` and `R2` beyond the directory-name shape: matrix canonicalization, the
+  symlink test on the matrix directory, and the "canonical parent must be a workspace dir" test
+  (`:1437-1479`). The checker classifies position by directory name only (Section 6.7) and never
+  fails a run on it.
+- Keys the indexer never reads: `allowed-tools`, `license`, `metadata`, `version` (evidence `X1`).
+- Anything in the `SKILL.md` body after the closing delimiter. The indexer returns at the closing
+  delimiter (`:366-368`) and imposes no body rule at all (evidence 3.4).
+
+## 4. The decided solution
+
+One file, `scripts/01-skills-checker.mjs`. The name and the `01-` prefix are the user's decision and
+are settled.
+
+The script walks a tree, finds every `SKILL.md` **case-insensitively**, validates each one against
+the indexer's rules, classifies each one's indexability by position, and reports. Discovery is
+case-insensitive so that a wrongly cased entrypoint is found rather than missed; validation is
+byte-exact so that a wrongly cased entrypoint is still reported as a hard error, because the indexer
+rejects it on every platform.
+
+Decisions taken here, so that none is left to the implementer:
+
+| # | Decision | Taken | Why |
+| --- | --- | --- | --- |
+| 1 | Entrypoint discovery | `fs.readdirSync(dir, { withFileTypes: true })`, then `entry.name.toLowerCase() === 'skill.md'` to discover, then `entry.name === 'SKILL.md'` to validate | `fs.existsSync(path.join(dir, 'SKILL.md'))` passes on Windows for `skill.md` and would produce a checker that accepts files the app rejects. User decision, restated as an implementation constraint. |
+| 2 | Wrong casing | Hard error, and validation continues | It is fatal on every platform (`:401`). Continuing means the author gets one complete report instead of a fix-one-find-another loop. |
+| 3 | Root argument | Positional, optional, defaults to `process.cwd()`. No `--root` alias | The issue says "takes a root as an argument". One way to say one thing. |
+| 4 | Traversal | Recursive, no depth limit, skipping `.git`, `node_modules`, `target` **except inside a `skills/` directory, where no name filter applies at all** (6.2 step 3) | User decision 4. The checker is generic over any tree and is not limited to Agent Matrix roots. The carve-out exists because the indexer applies no name filter, so `skills/target/` is a legal skill directory (Step 6 defect G2). |
+| 5 | Exit codes | `0` no error findings, `1` at least one error finding, `2` usage or IO failure | User decision 3. Warnings and informational findings never change the exit code, mirroring the indexer, where a soft warning still indexes the skill. |
+| 6 | Position findings | Always severity `info`, never affect the exit code | Decides the question the coordinator left open. The checker is generic over any tree and cannot know whether a given tree is an Agent Matrix; making position fatal would fail every run over an ordinary repository. |
+| 7 | YAML | Hand-written mini-parser over a fixed subset, zero dependencies | User decision 5. Anything outside the subset becomes an explicit `W-YAML-UNDECIDABLE` finding and is never silently approved. |
+| 8 | Testing | In-script `--self-test` with runtime `mkdtemp` fixtures, not vitest | Section 9.1 gives the four reasons. |
+| 9 | Streams | The whole report goes to stdout; only exit-2 failures write to stderr | A report is data. CI must not have to merge two streams to read it. |
+
+### 4.1 Severity model
+
+Three severities, and one rule that decides which applies.
+
+| Severity | Meaning | Exit code effect |
+| --- | --- | --- |
+| `error` | The indexer would not index this skill | Forces exit `1` |
+| `warning` | The indexer would index it but flag it, or the checker cannot judge it with certainty | None |
+| `info` | Position and indexability notes; never a validation outcome | None |
+
+**Severity assignment rule, applied uniformly:**
+
+1. A finding about a **present entrypoint file** (its name, its type, its frontmatter, its YAML, its
+   fields) takes the severity of the matching indexer outcome, **regardless of where the file sits**.
+   A file named `SKILL.md` declares itself to be a skill, so it is held to the rules everywhere.
+   Codes governed by rule 1: `E-ENTRYPOINT-CASE`, `E-ENTRYPOINT-LINK`, `E-ENTRYPOINT-NOT-FILE`,
+   `E-ENTRYPOINT-UNREADABLE`, every `E-FM-*`, every `E-YAML-*`, every `E-NAME-*`, `W-ENTRYPOINT-CASE-SHADOWED`,
+   `W-DESC-*`, `W-WHEN-NOT-STRING`, `W-YAML-UNDECIDABLE`, `W-NAME-UNDECIDABLE`, `I-KEY-HYPHEN-VARIANT`.
+2. **Every other finding is gated on canonical position** (Section 6.7): `error` inside it, `warning`
+   or `info` outside it. Outside canonical position the checker cannot distinguish a skills root from
+   a coincidentally named folder, so it must not fail the run. This covers two kinds of finding that
+   Step 4 stated as one, and the distinction matters because Step 6 added codes of the second kind:
+   - **Absence-type**, where the checker cannot see what it needs: `I-NO-ENTRYPOINT` promoting to
+     `E-NO-ENTRYPOINT`, and `W-DIR-UNREADABLE` promoting to `E-SKILLS-DIR-UNREADABLE` or
+     `E-SKILL-DIR-UNREADABLE`.
+   - **Present-entry shape**, where a directory entry exists but is the wrong kind of thing:
+     `W-SKILL-DIR-LINK` promoting to `E-SKILL-DIR-LINK`, and `E-SKILLS-NOT-DIR`, which is emitted
+     only inside the gate and has no ungated counterpart.
+
+   These are not entrypoint files, so rule 1 does not reach them; they are not absences either, which
+   is why Step 4's wording left them uncovered and 6.2 step 3 had to invoke a rule that did not yet
+   describe its own case.
+
+   **The `skills` name test inside the gate is deliberately not uniform**, and this is the one place
+   where the two kinds diverge. Absence-type findings test `skills` **byte-exactly** (6.2 step 1), so
+   a case-variant `Skills/` stays a warning: promoting it would make the same tree exit 1 on Windows
+   and 0 on Linux, and Section 12.4 established that the `skills` path is a join, so its casing really
+   is platform-dependent. Present-entry findings test `skills` **ASCII case-insensitively** (6.2
+   steps 3 and 4), so a case-variant `Skills/` still yields the error on both platforms, which keeps
+   the report stable rather than silently different. Both choices serve cross-platform stability and
+   reach it from opposite directions because the failure modes are opposite: a missed absence is a
+   false negative on one OS, a reported shape error is the same finding on both. Neither is an
+   accident and neither may be "harmonized" by an implementer.
+3. Position itself is always `info` (decision 6 above).
+
+## 5. Affected surfaces: exact files and symbols
+
+### 5.1 `scripts/01-skills-checker.mjs` (new, the only production file)
+
+Module layout, in file order. These are the exact function names to implement; the self-test and the
+acceptance criteria reference them.
+
+| Symbol | Responsibility | Section |
+| --- | --- | --- |
+| header comment | Purpose, issue, **source of truth `src-tauri/src/config/session_context.rs:206-714`**, usage, exit codes | 5.1.1 |
+| `SKILL_MD = 'SKILL.md'`, `SKILLS_DIR = 'skills'`, `FRONTMATTER_MAX_BYTES = 16384`, `FIRST_LINE_MAX_BYTES = 1024`, `NAME_RE = /^[a-z0-9-]{1,64}$/`, `SKIP_DIRS = new Set(['.git', 'node_modules', 'target'])` | Constants mirroring `session_context.rs:206-211` and `:464-470` | 6 |
+| `parseArgs(argv)` | CLI parsing | 6.1 |
+| `printUsage()` | `--help` text | 6.1 |
+| `walk(root)` | Iterative directory walk, returns candidate records and traversal findings | 6.2 |
+| `readFrontmatter(filePath)` | Byte-level frontmatter extraction | 6.4 |
+| `isFrontmatterDelimiter(lineBytes, allowBom)` | Exact port of `session_context.rs:276-302` | 6.4.1 |
+| `parseMiniYaml(text)` | The mini-parser | 6.5 |
+| `validateEntrypoint(record)` | Entrypoint-layer rules `E1`-`E4` | 6.3 |
+| `validateFields(mapping, dirName)` | Field-layer rules `N1`-`N5`, `D1`-`D2`, `W1`-`W2` | 6.6 |
+| `classifyPosition(filePath)` | Indexability verdict | 6.7 |
+| `detectDuplicates(candidates)` | Rule `N5`, scoped per `skills/` directory | 6.6.4 |
+| `renderHuman(report)` | Default output | 6.9 |
+| `renderJson(report)` | `--json` output | 6.10 |
+| `selfTest()` | Section 9 | 9 |
+| `main()` | Orchestration and exit code | 6.1 for the CLI and the exit-2 cases, 6.8 for the exit-code mapping |
+
+**Step 7 correction to this table.** Step 4 wrote the last three rows as 6.8, 6.9 and 6.10, which is
+off by one: 6.8 is the finding taxonomy, 6.9 is the human report and 6.10 is the JSON format, and
+there is no section that owns `main()` alone. The error survived both enrichment passes because
+Section 8 step 6 cites the correct sections and nobody compared the two. Corrected above. This table
+is a locator, not a normative section; where it and a numbered section disagree, the numbered section
+wins.
+
+Helper functions the constraints above imply, named here so they are not improvised. Each is used in
+more than one place and each has a correctness requirement in 5.1.2 or Section 7:
+
+| Helper | Requirement |
+| --- | --- |
+| `trimYamlValue(s)` | The explicit Unicode `White_Space` set of 5.1.2. Never `String.prototype.trim()` |
+| `asciiLower(s)` | A-Z to a-z only, mirroring Rust `to_ascii_lowercase()` |
+| `compareUtf8(a, b)` | `Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))` |
+| `sanitizeForReport(s)` | Collapse C0 controls and Unicode whitespace runs to one U+0020, then truncate to 200 characters (Section 7). Presentation only; never feeds a verdict |
+
+#### 5.1.1 Required header
+
+The header must name the source-of-truth range verbatim, because the drift risk is the reason the
+coordinator asked for it:
+
+```js
+#!/usr/bin/env node
+// Validates SKILL.md structure the way AgentsCommander's indexer does, for issue #1213.
+//
+// SOURCE OF TRUTH: src-tauri/src/config/session_context.rs:206-714
+// This script is a second, independent implementation of the rules that module enforces.
+// If that range changes, this file is stale until it is changed to match.
+//
+// Discovery is case-insensitive so a wrongly cased entrypoint is FOUND; validation is
+// byte-exact because session_context.rs:401 compares entry.file_name() against "SKILL.md"
+// byte-for-byte, so wrong casing fails on every platform including Windows.
+//
+// The two path constants are NOT symmetric, and this is the surface's biggest trap:
+//   "SKILL.md" (:401) is an entry-name comparison  -> case-sensitive on EVERY platform.
+//   "skills"   (:509) is a path join               -> case-INsensitive on Windows only.
+// So `_agent_x/Skills/y/SKILL.md` is indexed on Windows and invisible on Linux, while
+// `_agent_x/skills/y/skill.md` is rejected on both.
+//
+// YAML semantics below are pinned to serde_yaml 0.9.34+deprecated (Cargo.lock:5483-5486):
+// duplicate mapping keys are a HARD parse error (mapping.rs:813-822), and plain
+// yes/no/on/off resolve as STRINGS, not booleans (de.rs:932-938, YAML 1.2 core schema).
+// A serde_yaml bump invalidates both.
+//
+// Usage:
+//   node scripts/01-skills-checker.mjs [root] [--json]
+//   node scripts/01-skills-checker.mjs --help
+//   node scripts/01-skills-checker.mjs --self-test
+//
+// Exit codes:
+//   0 → no error findings (warnings and notes may still be present)
+//   1 → at least one error finding: one or more skills would not be indexed
+//   2 → usage error, or the root does not exist / is not a directory / cannot be read
+```
+
+#### 5.1.2 Node API constraints
+
+These are correctness requirements, not style:
+
+- Only `node:fs`, `node:path`, `node:os`, `node:url`, `node:util` (for `TextDecoder`, which is also
+  global). No dependency, no dynamic import.
+- Frontmatter bytes are decoded with `new TextDecoder('utf-8', { fatal: true })` inside a
+  `try`/`catch`. **`buffer.toString('utf8')` is forbidden**: it replaces invalid sequences with
+  U+FFFD and would silently pass a file the indexer rejects under `F8`.
+- Name length is counted in Unicode scalar values, `[...name].length`, mirroring Rust
+  `chars().count()` (`:465`). `name.length` counts UTF-16 code units and is wrong.
+- **`String.prototype.trim()` is forbidden for field values.** `yaml_field_string` trims with Rust
+  `str::trim` (`:453`), which uses the Unicode `White_Space` property. JS `trim()` uses a different
+  set, and the two disagree in both directions:
+  - **U+FEFF (ZWNBSP)**: JS trims it, Rust does not. `name: "﻿abc"` would trim to `abc` and pass
+    the charset test in the checker, while the indexer keeps the U+FEFF, fails
+    `is_valid_skill_name` and hard-rejects the skill. This is a **false pass** and it is the reason
+    this constraint is not a style note.
+  - **U+0085 (NEL)**: Rust trims it, JS does not. This direction only costs a false failure.
+
+  Implement the trim against this explicit set, which is Unicode `White_Space` exactly:
+  `U+0009`-`U+000D`, `U+0020`, `U+0085`, `U+00A0`, `U+1680`, `U+2000`-`U+200A`, `U+2028`, `U+2029`,
+  `U+202F`, `U+205F`, `U+3000`. Note `U+180E` is **not** in it: it was removed from `White_Space` in
+  Unicode 6.3 and current Rust follows current Unicode.
+- **String ordering must be UTF-8 byte order, not JS code-unit order**, wherever a comparison mirrors
+  Rust (`:588-591` and `:449-450`). Rust `String: Ord` compares UTF-8 bytes, which equals code-point
+  order; JS `<` compares UTF-16 code units, which sorts astral characters (U+10000 and above, stored
+  as surrogates in the D800-DFFF range) **below** U+E000-U+FFFF. Use
+  `Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))`. This only bites on exotic
+  directory names, but the candidate sort decides who wins a duplicate-name clash, so a divergence
+  there silently blames the wrong skill.
+- ASCII lowercasing for sort keys and for the `skills` directory-name comparison uses an explicit
+  A-Z to a-z map, not `String.prototype.toLowerCase()`, which is locale- and Unicode-aware and would
+  diverge from Rust `to_ascii_lowercase()` (`:588-591`). The single exception is entrypoint
+  **discovery** (`entry.name.toLowerCase() === 'skill.md'`), where over-matching is harmless because
+  the byte-exact test immediately follows.
+- Target runtime is Node 22, matching CI. No API newer than Node 18 is used.
+
+### 5.2 `package.json`
+
+Insert exactly two entries, immediately after the existing `"test:debt:self"` line
+(`package.json:23`):
+
+```diff
+     "test:debt:self": "node scripts/check-test-debt.mjs --self-test",
++    "check:skills": "node scripts/01-skills-checker.mjs",
++    "check:skills:self": "node scripts/01-skills-checker.mjs --self-test",
+     "test:watch": "vitest",
+```
+
+No dependency is added, so `package-lock.json` does not change and the `lockfile-check.yml` workflow
+is unaffected. `scripts/check-version-sync.mjs:37` anchors on the adjacency of `"name"` and
+`"version"` at the top of the file, which these edits do not disturb.
+
+### 5.3 Files deliberately not touched
+
+`vitest.config.ts` (Section 9.1 explains why the include list is not extended), `package-lock.json`,
+`.husky/pre-push`, everything in `.github/workflows/`, and every file under `src-tauri/` and `src/`.
+If the implementation needs any of them, the change was misunderstood.
+
+## 6. Required behaviour, edge cases and failure behaviour
+
+### 6.1 CLI surface
+
+```
+node scripts/01-skills-checker.mjs [root] [--json]
+node scripts/01-skills-checker.mjs --help | -h
+node scripts/01-skills-checker.mjs --self-test
+```
+
+| Input | Behaviour | Exit |
+| --- | --- | --- |
+| No arguments | Root is `process.cwd()`, human report | 0 or 1 |
+| One positional | That positional is the root, resolved with `path.resolve()` | 0 or 1 |
+| `--json` | JSON document to stdout, nothing else on stdout | 0 or 1 |
+| `--help` or `-h`, anywhere in argv | Usage to stdout. Wins over every other argument, including an invalid one | 0 |
+| `--self-test` | Runs the self-test (Section 9). May not be combined with any other argument | 0 or 1 |
+| `--` | Terminates flag parsing; every token after it is positional. Allows a root beginning with `-` | as above |
+| A second positional | `usage: at most one root may be given` to stderr | 2 |
+| An unknown flag | `usage: unknown option '<flag>'` to stderr | 2 |
+| `--json` given twice | Accepted, idempotent | as above |
+| Root does not exist | `cannot read root '<path>': ENOENT` to stderr | 2 |
+| Root is a file | `root '<path>' is not a directory` to stderr | 2 |
+| Root exists but `readdirSync` on it throws | `cannot read root '<path>': <code>` to stderr | 2 |
+| Any uncaught exception | `internal error: <message>` plus the stack to stderr | 2 |
+
+Exit 2 is only ever about the invocation and the root itself. A directory that cannot be read
+**inside** the walk is a finding, not an exit-2 failure (Section 6.2), because failing an entire run
+because one unrelated subtree is permission-protected would make the checker unusable on a real
+machine.
+
+In `--json` mode an exit-2 failure writes a JSON object to **stderr** and nothing to stdout:
+
+```json
+{ "tool": "01-skills-checker", "version": 1, "error": "root '/x' is not a directory", "exitCode": 2 }
+```
+
+`--help` output is stdout in both modes and is never JSON.
+
+### 6.2 Traversal
+
+Iterative, using an explicit stack, not recursion, so a deep tree cannot exhaust the JS stack.
+
+For each directory `D` popped from the stack:
+
+1. `entries = fs.readdirSync(D, { withFileTypes: true })`. If it throws, in this order:
+   - If `basename(D)` is `skills` byte-exactly and `basename(dirname(D))` matches `/^_agent_.+$/`,
+     that is `D` is itself a canonical skills root: emit `E-SKILLS-DIR-UNREADABLE` (error), mirroring
+     ``skills` directory could not be read`` and ``skills` could not be inspected``
+     (`:527-530`, `:545-548`).
+
+     **Step 6 note on the byte-exact test, because 14.5.5 argues the opposite for step 4.** Section
+     12.4 established that `skills` is reached by a path **join**, so on Windows `_agent_x/Skills/`
+     *is* the indexer's skills root, and an unreadable `Skills/` is a hard error there while this
+     rule gives `W-DIR-UNREADABLE`. Byte-exact is kept anyway, and deliberately: promoting on a
+     case variant would make the same tree exit 1 on Windows and 0 on Linux, and the absence-type
+     findings are exactly the category Section 4.1 rule 2 says must not fail a run the checker
+     cannot verify is a skills tree. Step 4 of this section takes the opposite call for
+     `E-SKILLS-NOT-DIR`, and steps 3 and 4 both test `skills` case-insensitively, because those are
+     **present-entry shape** findings rather than absence-type ones.
+
+     **Step 7 correction.** Step 6's wording here said "so rule 1 governs it instead", which
+     contradicts step 3 four paragraphs below, where the same gating is called "severity rule 2 of
+     Section 4.1 applied consistently with `E-SKILLS-NOT-DIR` in step 4". Both cannot be true:
+     `E-SKILLS-NOT-DIR` is emitted only when the parent matches `/^_agent_.+$/`, which is a canonical
+     gate, and rule 1 is by definition ungated. Rule 2 governs it. What actually differs between
+     step 1 and steps 3 and 4 is **not** whether the gate applies but how the `skills` name is
+     matched inside it, byte-exact versus ASCII case-insensitive. Section 4.1 rule 2 now states both
+     axes explicitly. The `W-DIR-UNREADABLE` message must still say that a case-variant `skills`
+     directory may be the live skills root on Windows.
+   - **Else if `D` is a skill directory in canonical position**, that is `D` satisfies both tests of
+     Section 6.7 (`basename(dirname(D))` is `skills` and `basename(dirname(dirname(D)))` matches
+     `/^_agent_.+$/`): emit `E-SKILL-DIR-UNREADABLE` (error). This is the indexer's
+     ``Skipped skill directory `{folder}`: unable to read skill directory: {err}`` (`:396-397`),
+     which is a hard error for that skill. Step 4 wrote the first test as "Section 6.7 test 1 applied
+     to `D` itself", which only ever matches the `skills/` root and therefore downgraded this real
+     hard error to a warning. Step 5 promoted it but reused `E-SKILLS-DIR-UNREADABLE`; Step 6 split
+     the code so `indexerMessage` stays truthful (6.8).
+   - Otherwise: emit `W-DIR-UNREADABLE` (warning) carrying the errno code. The walk continues.
+2. Discover entrypoints in `entries` (Section 6.3).
+3. For **every** entry, in this order. **The order and the guard shape are load-bearing and Step 6
+   rewrote this step: the Step 4/5 wording opened with "For each entry that is a directory", which
+   made the symlink branch below unreachable.** In Node, `readdirSync(D, { withFileTypes: true })`
+   returns `Dirent`s with **lstat semantics**: for a symlink, `isDirectory()` is `false` and
+   `isSymbolicLink()` is `true`. The two are mutually exclusive, so any symlink test nested under an
+   `isDirectory()` guard never runs. Mirror the indexer's own order at `:578-585`, which is
+   `if is_symlink() { warn } else if is_dir() { candidate }`:
+
+   - **First, `entry.isSymbolicLink()`.** If true, **do not descend**, and do not apply any
+     directory test to it. Node reports Windows junctions and reparse points as symbolic links, so
+     this covers both platforms. Then:
+     - If `D` is a `skills` directory **in canonical position** — `path.basename(D)` is `skills`
+       (ASCII case-insensitive) **and** `path.basename(path.dirname(D))` matches `/^_agent_.+$/` —
+       emit `E-SKILL-DIR-LINK` (error), mirroring ``Skipped linked skill directory `{folder}`:
+       linked/reparse-point directories are not followed`` (`:579-581`). Note the indexer warns for
+       **any** symlink entry directly under `skills/`, including a symlink whose target is a file or
+       is missing: `:578` tests only `file_type.is_symlink()` and never inspects the target. So this
+       finding does **not** depend on what the link points at.
+     - Else if `path.basename(D)` is `skills` (ASCII case-insensitive) but the grandparent test
+       fails, emit `W-SKILL-DIR-LINK` (warning). The indexer never scans that tree, so a hard error
+       there would fail a run over an ordinary repository that happens to contain a `docs/skills/`
+       folder. This is severity rule 2 of Section 4.1 applied consistently with `E-SKILLS-NOT-DIR`
+       in step 4, which was already gated this way. Step 4/5 emitted the **error** unconditionally.
+     - Otherwise emit nothing. Not descending into arbitrary links is traversal policy, not a
+       finding.
+   - **Else if `entry.isDirectory()`:**
+     - If `path.basename(D)` is `skills` (ASCII case-insensitive), **never apply `SKIP_DIRS`**: push
+       it. The indexer applies no name filter at all (evidence 3.1), and `target`, like any string
+       matching `^[a-z0-9-]{1,64}$`, is a legal skill name. Skipping it would hide a real skill
+       directory from the checker entirely while the indexer still rejects or indexes it. Step 4/5
+       applied `SKIP_DIRS` unconditionally; see Step 6 defect G2.
+     - Otherwise, if the ASCII-lowercased name is in `SKIP_DIRS` (`.git`, `node_modules`, `target`),
+       skip it and do not descend. The skip list is a checker-side choice, not an indexer rule.
+       Comparison is case-insensitive so `Node_Modules` is also skipped.
+     - Otherwise push it onto the stack.
+   - **Else** (a regular file, or anything that is neither) it is not traversed. A plain file sitting
+     directly inside `skills/` produces no finding, which agrees with the indexer: `:583` is
+     `else if file_type.is_dir()`, so a non-directory, non-symlink entry is silently ignored there.
+     The single exception is an entry named `skills` itself, handled in step 4.
+4. For each entry named `skills` (ASCII case-insensitive) whose parent matches `^_agent_.+$` and
+   which is **not** a directory: emit `E-SKILLS-NOT-DIR` (error), mirroring
+   ``skills` exists but is not a directory`` (`:535-538`).
+
+   **Exception, verified in Step 5: a broken symlink is silent.** `:520` gates everything on
+   `skills_path.exists()`, and Rust `Path::exists` follows symlinks, so a `skills` symlink whose
+   target is missing makes `exists()` false and `discover_skill_index` returns at `:521` with **no
+   warning at all**. The three cases are therefore:
+   - `skills` is a file, or a symlink resolving to anything that exists: `E-SKILLS-NOT-DIR`. A
+     resolving symlink reaches `:524`, and `:534` rejects it on `is_symlink()` even when the target
+     is a directory.
+   - `skills` is a **broken** symlink: emit nothing. The indexer is silent here and the checker must
+     be too, or it invents a failure the app never reports.
+   - `skills` is absent: emit nothing (`:520-522`).
+
+   Detecting the broken-symlink case needs an explicit `fs.statSync(p, { throwIfNoEntry: false })`
+   on the entry, because `Dirent.isSymbolicLink()` alone cannot tell a resolving link from a broken
+   one. That single `statSync` is the only place in the walk that follows a link.
+
+**Loop protection.** Symlinked directories are never descended into, so a symlink cycle is
+unreachable. As unconditional insurance, the walker keeps a `Set` of `path.resolve(D)` strings and
+refuses to push a directory already in it. If that guard ever fires it emits nothing and simply skips
+the directory; it exists so that no filesystem quirk can hang the walk.
+
+The walk counts every directory it lists into `summary.directoriesScanned`.
+
+### 6.3 Entrypoint discovery and the casing rule
+
+Within directory `D`, from the same listing:
+
+```
+matches = entries.filter(e => e.name.toLowerCase() === 'skill.md')
+```
+
+| Situation | Behaviour |
+| --- | --- |
+| `matches` is empty and `D`'s parent is named `skills` (ASCII case-insensitive) | `I-NO-ENTRYPOINT` (info), promoted to `E-NO-ENTRYPOINT` (error) when `D` is in canonical position (Section 6.7). Mirrors ``missing exact SKILL.md entrypoint`` (`:417`). This is the `tiktok-news-publisher` case from the issue. |
+| `matches` is empty and `D`'s parent is not named `skills` | Nothing. `D` is an ordinary directory. |
+| Exactly one match, and `e.name === 'SKILL.md'` | Validate fully. No casing finding. |
+| Exactly one match, and `e.name !== 'SKILL.md'` | `E-ENTRYPOINT-CASE` (error), **then validate fully**. The author gets the casing verdict and the frontmatter verdict in one run. |
+| Two or more matches (only reachable on a case-sensitive filesystem), one of them byte-exact | Validate the byte-exact one fully. Each other one gets `W-ENTRYPOINT-CASE-SHADOWED` (warning) and is not validated further: the skill does work today, and the stray file is a hazard, not an indexer rejection. |
+| Two or more matches, none byte-exact | Each gets `E-ENTRYPOINT-CASE` and each is validated fully. |
+
+For each match selected for validation, before reading it:
+
+| Test | Finding | Indexer counterpart |
+| --- | --- | --- |
+| `e.isSymbolicLink()` | `E-ENTRYPOINT-LINK` (error), stop validating this file | ``exact SKILL.md entrypoint is linked/reparse-point`` (`:409`) |
+| `e.isDirectory()`, or neither file nor symlink nor directory | `E-ENTRYPOINT-NOT-FILE` (error), stop | ``exact SKILL.md entrypoint is not a regular file`` (`:412`) |
+| `fs.openSync` or `fs.readSync` throws | `E-ENTRYPOINT-UNREADABLE` (error) carrying the errno, stop | ``failed to open/read SKILL.md frontmatter`` (`:324-325`, `:332-334`) |
+
+`E-ENTRYPOINT-LINK`, `E-ENTRYPOINT-NOT-FILE` and `E-ENTRYPOINT-UNREADABLE` are errors regardless of
+position, per the severity rule 1: the file declares itself to be a skill.
+
+### 6.4 Frontmatter extraction
+
+Byte-level, streaming, bounded. Open the file, read in 64 KiB chunks with `fs.readSync`, and scan for
+line terminators. **Never** read the whole file: a `SKILL.md` may have an arbitrarily large body and
+the indexer never reads past the closing delimiter (`:366-368`).
+
+State machine:
+
+1. **First line.** Accumulate bytes until the first `\n` **inclusive**, or until EOF.
+   - **The first line including its terminator must be at most 1024 bytes.** Count bytes as they are
+     appended and fail the moment the running length exceeds 1024, exactly as `:340-345` does: the
+     length test runs after the byte is pushed and before the `\n` short-circuit at `:353`, so the
+     terminator is counted. 1020 spaces plus `---\n` is 1024 bytes and is valid; 1021 spaces plus
+     `---\n` is 1025 bytes and fails. Do **not** implement this as "find `\n` within the first 1024
+     bytes": that is off by the terminator byte and accepts a line the indexer rejects.
+   - On exceeding it: `E-FM-FIRST-LINE-TOO-LONG` (error), stop. Mirrors rule `F7` (`:342-345`), which
+     the indexer reports as ``missing opening frontmatter delimiter``; the checker gives it a distinct
+     code because the cause is different and the fix is different.
+   - If EOF is reached with no `\n` and the accumulated length never exceeded 1024, the whole file is
+     line 1. Continue. Note this makes the limit a ceiling on whitespace padding around the opening
+     `---` as well (Section 12.2).
+   - A file whose line endings are bare `\r` with no `\n` has no line terminator by this definition,
+     so the whole file is line 1. It will fail as `E-FM-NO-OPEN` (or `E-FM-FIRST-LINE-TOO-LONG` past
+     1024 bytes) because `is_frontmatter_delimiter` strips at most one trailing `\r`. Classic-Mac
+     line endings are **not** supported; rule `F3` covers `\r\n` only.
+2. **Opening delimiter.** Apply `isFrontmatterDelimiter(line1, allowBom = true)` (`:358`).
+   If false: `E-FM-NO-OPEN` (error), stop. Mirrors `F1` and `F2`.
+3. **Body lines.** Read line by line. **Two size guards apply, and both are required.**
+
+   **Guard A, mid-line** (`:346-351`). While accumulating the bytes of any line after the opening
+   delimiter, and **before** deciding whether that line is the closing delimiter, fail with
+   `E-FM-TOO-LARGE` the moment
+
+   ```
+   currentLineBytes.length > (16384 - frontmatterBuffer.length) + 8
+   ```
+
+   The `+ 8` is verbatim from `remaining.saturating_add(8)` at `:348`. This guard also covers the
+   **closing delimiter line**, which never reaches the append path, so a `---` padded with enough
+   leading whitespace to exceed the budget is rejected as an over-size frontmatter rather than
+   accepted as a valid close. Omitting Guard A makes the checker accept a file the indexer rejects
+   (Section 12.3).
+
+   **Guard B, on append** (`:311-317`). Only after Guard A passes and the line proves not to be the
+   closing delimiter, test `frontmatterBuffer.length + lineBytes.length > 16384` before appending.
+
+   With both guards in place, apply `isFrontmatterDelimiter(line, allowBom = false)` (`:366`, `:382`):
+   - True: the frontmatter block is complete. Stop reading the file. Nothing after this point is ever
+     inspected: the checker imposes **no body rule at all** (evidence 3.4).
+   - False: append the line's raw bytes, **including its line terminator exactly as read**, to the
+     frontmatter buffer. Terminators are counted and `\r\n` costs two bytes; both delimiter lines are
+     excluded. Confirmed in Section 12.3. On Guard B failing: `E-FM-TOO-LARGE` (error), stop.
+     Mirrors `F6` (`:304-309`, `:313`, `:349`).
+   - EOF before a closing delimiter: `E-FM-NO-CLOSE` (error), stop. Mirrors `F5` (`:388-392`).
+
+   **EOF with an unterminated final line: `:374-386`, and it is not symmetric. Step 6 promoted this
+   from a passing citation to its own rule, because the common half of it was never stated.** When
+   the read loop ends with `current_line` non-empty — that is, the file does not end with `\n` — the
+   indexer does **not** discard that tail. It runs the same tests on it, in this order:
+
+   | State at EOF | Tail is a delimiter? | Indexer outcome | Checker |
+   | --- | --- | --- | --- |
+   | Opening never seen | yes (`allowBom = true`, `:376`) | ``missing closing frontmatter delimiter`` | `E-FM-NO-CLOSE` |
+   | Opening never seen | no | ``missing opening frontmatter delimiter`` | `E-FM-NO-OPEN` |
+   | Opening seen | yes (`allowBom = false`, `:382`) | **success**: returns the frontmatter | **valid, no finding** |
+   | Opening seen | no | append the tail (Guard B, `:385`), then ``missing closing frontmatter delimiter`` | `E-FM-TOO-LARGE` if the append overflows, else `E-FM-NO-CLOSE` |
+
+   Row 3 is the one that matters and the one Step 4/5 left implicit: **`---\nname: ok-name\n---`
+   with no trailing newline is a fully valid skill.** Files without a final newline are produced by
+   every editor that does not force one, so this is not an exotic shape. The natural
+   implementations — `split('\n')` and iterate, or "a line is complete only when a `\n` is seen" —
+   either drop the unterminated tail or never test it, and report `E-FM-NO-CLOSE` on a file the app
+   indexes cleanly. That is a false positive on a very common file. Self-test cases 29a and 29b pin
+   both halves.
+
+   Row 4 also fixes an ordering detail: the append at `:385` happens **before** the
+   ``missing closing`` return at `:389`, so an unterminated final body line that overflows the
+   budget yields `E-FM-TOO-LARGE`, not `E-FM-NO-CLOSE`. Guard A has already been applied to that
+   line byte by byte during accumulation, so it is Guard B that decides here.
+4. **UTF-8.** Decode the accumulated buffer with `new TextDecoder('utf-8', { fatal: true })`. On
+   throw: `E-FM-NOT-UTF8` (error), stop. Mirrors `F8` (`:319-321`).
+   Only the frontmatter block is required to be valid UTF-8. The body may be arbitrary bytes.
+
+#### 6.4.1 `isFrontmatterDelimiter`: exact port of `session_context.rs:276-302`
+
+Operating on the raw line bytes, in this order. The order is load-bearing and the self-test pins it.
+
+1. If the last byte is `\n` (0x0A), drop it.
+2. Then if the last byte is `\r` (0x0D), drop it.
+3. If `allowBom` is true **and** the remaining bytes start with `EF BB BF`, drop those three bytes.
+4. Trim leading and trailing ASCII whitespace, defined exactly as Rust `trim_ascii`:
+   `\t` (0x09), `\n` (0x0A), `\x0C` (0x0C), `\r` (0x0D), `space` (0x20).
+5. Return true if and only if the remainder is exactly the three bytes `2D 2D 2D`.
+
+**Step 5 verification: this port is correct, step for step.** `:278-280` strips `\n`, `:281-283`
+strips `\r`, `:284-286` strips the BOM under `allow_bom`, `:287-293` trims leading ASCII whitespace,
+`:294-300` trims trailing, `:301` compares to `b"---"`. The load-bearing claim holds: **the BOM is
+stripped before the trim** (`:284-286` precedes `:287`), which is what makes `  <BOM>---` false and
+`<BOM>  ---` true. The whitespace set is also exact: Rust `u8::is_ascii_whitespace` is
+`\t` `\n` `\x0C` `\r` and space, and it does **not** include vertical tab `\x0B`, so a `\x0B`-padded
+delimiter is correctly rejected. Do not reach for a JS regex like `\s` or `String.prototype.trim()`
+here: both include Unicode whitespace and `\x0B`, and both would accept delimiters the indexer
+rejects. Compare bytes, not characters.
+
+Consequences the self-test pins:
+
+| Input line | `allowBom` | Result |
+| --- | --- | --- |
+| `---\n` | either | true |
+| `---\r\n` | either | true (`F3`) |
+| `  ---  \n` | either | true (`F4`) |
+| `<BOM>---\n` | true | true (`F2`) |
+| `<BOM>---\n` | false | **false**. A BOM is tolerated on the opening delimiter only (`F5`) |
+| `  <BOM>---\n` | true | **false**. Step 3 requires the BOM to be leading; leading spaces defeat it |
+| `----\n` | either | false. Longer fences are rejected |
+| `+++\n` | either | false. TOML delimiters are rejected |
+| `\n---\n` as the file's first two lines | true | false on line 1: leading blank lines are not tolerated (`F1`) |
+
+### 6.5 The YAML mini-parser
+
+The parser answers exactly two questions per key: *is this key present*, and *is its value a YAML
+string*. Nothing else about the value matters to the indexer, because `yaml_field_string`
+(`:448-462`) only accepts `Value::String`, trims it, and maps an empty result to absent.
+
+#### 6.5.1 The supported subset
+
+A top-level block mapping and nothing else.
+
+| Construct | In subset | Resolution |
+| --- | --- | --- |
+| Blank line (only ASCII whitespace) | yes | ignored |
+| Comment line (first non-space character is `#`) | yes | ignored |
+| `key: value` at column 0 | yes | mapping entry |
+| `key:` at column 0 with nothing after it | yes | value is YAML `null`, therefore **not a string** |
+| `key: # comment` | yes | value is `null`. An unquoted ` #` preceded by whitespace starts a comment |
+| Single-quoted scalar `'...'`, opening and closing quote on the same line, `''` as the escaped quote | yes | string |
+| Double-quoted scalar `"..."`, both quotes on the same line, escapes `\\` `\"` `\/` `\n` `\r` `\t` `\uXXXX` | yes | string |
+| Quoted key, `'name': x` or `"name": x` | yes | mapping entry, key is the unquoted text |
+| Block scalar `key: \|`, `\|-`, `\|+`, `>`, `>-`, `>+`, and the explicit-indentation forms `\|2`, `>2`, `\|2-`, `>2+` and so on, followed by an indented block | yes | string. Literal blocks join with `\n`; folded blocks join with a space and keep blank lines as `\n`. Exact folded whitespace is never load-bearing: no checker outcome depends on anything but whether the value trims to empty, and both foldings agree on that |
+| Plain scalar (unquoted) resolving as a YAML 1.2 core-schema string | yes | string |
+| `true` `True` `TRUE` `false` `False` `FALSE` | yes | boolean, **not a string**. This is the complete bool set: `de.rs:932-938` matches these six spellings and nothing else |
+| `null` `Null` `NULL` `~` | yes | null, **not a string**. Complete null set: `de.rs:925-930` |
+| `yes` `no` `on` `off` `y` `n`, any casing | yes | **string.** `serde_yaml` 0.9.34 applies the YAML 1.2 core schema, so these are not booleans (Section 12.5). `description: yes` is clean and produces no finding |
+| An empty value after `key:` where the key is followed only by whitespace | yes | null, **not a string**. Distinct from `key: ''`, which is an empty string and is therefore treated as absent by `Y5`, not as a type error |
+| Integer `^[-+]?[0-9]+$`, `0x...`, `0o...` | yes | number, **not a string** |
+| Float `^[-+]?[0-9]*\.[0-9]*([eE][-+]?[0-9]+)?$`, `.inf` `-.inf` `.nan` and case variants | yes | number, **not a string** |
+
+#### 6.5.1a The line grammar, stated exactly
+
+**Step 6 addition.** The table above names the constructs but never defines how a line is split into
+a key and a value, and the mini-parser's whole behaviour turns on that. Left unstated, an implementer
+reaches for `line.split(': ')`, and every legal spelling the split misses falls through to
+`W-YAML-UNDECIDABLE` — which, under 6.6.1, used to become a hard `E-NAME-INVALID`. Fix the grammar:
+
+- **Key/value separator.** A mapping entry is a key, then `:`, then **either** end of line, **or** at
+  least one space or **tab** (0x09). YAML permits a tab as separation whitespace, so `name:<TAB>x` is
+  an ordinary mapping entry, not an undecidable line and not a parse error.
+- **Trailing comments.** An unquoted `#` that is preceded by at least one space or tab starts a
+  comment and terminates the value, for **every** scalar form, not only the empty one already listed
+  in the table. So `name: my-skill  # renamed` has the value `my-skill`, and
+  `name: "my-skill"  # renamed` has the value `my-skill`. A `#` not preceded by whitespace is an
+  ordinary character: `name: a#b` is the string `a#b`.
+- **Block scalar indentation.** The block's indentation is the explicit indicator when one is given
+  (`|2`), otherwise the indentation of the block's first non-empty line. Every subsequent line
+  indented at least that far is content, **whatever it contains**, and is consumed by the block. This
+  is stated because getting it wrong is not a cosmetic error: a `description: |` block whose body
+  contains a line like `name: x` would otherwise be read as a second top-level `name` key and emit a
+  spurious `E-YAML-DUPLICATE-KEY`, which is an **error** and exits 1 on a completely ordinary file.
+- **Tabs inside a block scalar are content, not indentation.** See the corrected rule in 6.5.3.
+
+#### 6.5.2 Outside the subset: `W-YAML-UNDECIDABLE`
+
+Every construct below produces `W-YAML-UNDECIDABLE` (warning) naming the line number and the
+construct, and the affected key's value is recorded as `undecidable`. This is the category the user
+required: the parser must never approve silently what it cannot judge.
+
+- A line indented at top level that is not part of a block scalar (a nested mapping or sequence).
+- Flow collections: a value beginning with `{` or `[`.
+- Anchors `&`, aliases `*`, tags `!`, directives `%`, explicit keys `? `, merge keys `<<`, the
+  document-end marker `...`.
+- A quoted scalar whose closing quote is not on the same line (a legal multi-line quoted scalar).
+- A double-quoted scalar containing a backslash escape outside the supported set.
+- Any other line at column 0, not blank and not a comment, that the parser cannot reduce to a
+  `key:` form and that is not one of the certain-error shapes in 6.5.3.
+
+**An `undecidable` value may never produce an `error` finding. Step 6 changed this.** Step 4/5 said
+the charset check is applied to the literal text of an undecidable `name` and, through 6.6.1 step 3,
+that check emits `E-NAME-INVALID`, an error, exit 1. That inverts the whole point of the category and
+contradicts Section 4.1, which defines `warning` as precisely "the checker cannot judge it with
+certainty". Three concrete false positives it produces, all on skills the indexer indexes cleanly:
+
+- `name: !!str my-skill` — `serde_yaml` resolves the tag to the string `my-skill`, a valid name. The
+  checker sees the literal `!!str my-skill`, fails the charset test and exits 1.
+- `name: &anchor my-skill` — same, via an anchor.
+- `name: "my-skill"  # renamed` — a trailing comment. Under the Step 4/5 subset the quoted-scalar
+  rule ("both quotes on the same line") does not match the whole remainder, so the line is
+  undecidable and the literal fails the charset test. 6.5.1a now puts this back inside the subset,
+  but the severity rule below is what stops the next unlisted-but-legal spelling from exiting 1.
+
+So: when `name`'s value is `undecidable`, run the charset check for the author's benefit and report
+it as **`W-NAME-UNDECIDABLE` (warning)**, never `E-NAME-INVALID`. Its message states both possible
+indexer outcomes — the skill may be indexed under a name the checker could not resolve, or the
+indexer may reject it with ``name must be a string`` — and says the checker cannot tell which. The
+run is not failed on a value the checker has declared itself unable to judge.
+
+An undecidable `description` or `when_to_use` needs no equivalent rule: every outcome on those two
+keys is already a warning on both sides, so the severities agree whatever the value resolves to.
+
+#### 6.5.3 Certain errors
+
+Only these three, because each is invalid under any reading:
+
+| Condition | Finding | Indexer counterpart |
+| --- | --- | --- |
+| A tab character (0x09) appears in the leading whitespace of a frontmatter line that the parser is treating as a **mapping entry**, that is, a line **not** consumed as block-scalar content | `E-YAML-PARSE` (error) | ``YAML parse error: {err}`` (`:624-628`). YAML forbids tabs in indentation |
+| The frontmatter body is empty or contains only blank and comment lines | `E-YAML-NOT-MAPPING` (error) | ``frontmatter must be a YAML mapping`` (`:634-637`). `---\n---\n` parses to `Null` and fails here, which the evidence states explicitly under `Y2` |
+| The first significant line at column 0 is `-` or starts with `- ` | `E-YAML-NOT-MAPPING` (error) | as above: the root is a sequence |
+| **The parser recognized zero top-level mapping entries and the body has at least one significant line**, unless the exception below applies | `E-YAML-NOT-MAPPING` (error) | as above: the root is a scalar |
+
+**Step 6 corrected rows 1 and 4.**
+
+Row 1 was ``a tab appears in the indentation of any frontmatter line``. That fires inside block
+scalars, where a tab after the block's indent is ordinary content that libyaml accepts:
+
+```yaml
+description: |
+  <TAB>tab-indented example line
+```
+
+The block's indentation is two spaces; the tab is content. Under the old rule a naive `^[ \t]*`
+leading-run test flags it and exits 1 on a valid file, and tab-indented content inside a
+`description: |` block is common. Restricting the rule to lines the parser is treating as mapping
+entries removes the false positive without weakening the real case, because a tab in the indentation
+of an actual mapping line is still a certain error.
+
+Row 4 replaces ``the whole body is a **single line** with no `:` at all``, which was a **false
+pass**. A body of two or more colon-free lines is a multi-line plain scalar, so `as_mapping()` at
+`:633` is `None` and the indexer hard-rejects the skill — but under the old wording neither line
+reduces to a `key:` form, no row matched, and the catch-all in 6.5.2 emitted `W-YAML-UNDECIDABLE`, a
+**warning**: exit 0, and the skill counted in `summary.skillsIndexable`. The shape is one an author
+reaches for naturally:
+
+```
+---
+This skill helps with X.
+It does Y.
+---
+```
+
+Restating the rule as "zero recognized entries plus significant content" catches every arity, one
+line or many.
+
+**The exception, and why row 4 needs one.** If any significant line began with `{` (a flow
+collection) or with `%`, `!`, `&`, `*` or `? ` (a directive, tag, anchor, alias or explicit key),
+that construct can itself resolve to a mapping — `---\n{name: x}\n---` is a perfectly good mapping
+that the mini-parser cannot reduce to a `key:` form. In that case emit `W-YAML-UNDECIDABLE` and not
+`E-YAML-NOT-MAPPING`. Zero recognized entries alone is not proof the root is a scalar; zero
+recognized entries **and** nothing that could be a mapping is.
+
+#### 6.5.4 Duplicate keys: a hard error
+
+Step 4 left this open and chose a warning. **Step 5 resolved it: `serde_yaml` 0.9.34 rejects
+duplicate mapping keys, so this is a hard error.** The evidence chain is in Section 12.1.
+
+- A top-level key whose resolved name was already seen produces `E-YAML-DUPLICATE-KEY` (**error**),
+  naming both line numbers, and validation of that entrypoint **stops**. The indexer never gets past
+  `serde_yaml::from_str` (`:621`), so no field of that skill is ever resolved and no field-level
+  finding about it would be truthful.
+- `indexerMessage` is
+  ``Skipped skill `{folder}`: YAML parse error: duplicate entry with key "{key}"``. `serde_yaml`
+  appends a position suffix of its own, so the checker's string is a prefix of the real log line
+  rather than a byte-exact copy. That is the only code in the taxonomy where this is true and it is
+  called out here so nobody tries to match the two exactly.
+- **There is no "first occurrence wins" rule.** Deleting it is the point: the previous wording
+  implied the skill still resolves fields, and it does not.
+- **Scope: every top-level key, not just the three the indexer reads.** The duplicate test lives in
+  `Mapping`'s deserializer (`mapping.rs:813-822`), which runs before any field lookup, so `foo: 1`
+  written twice is fatal even though `foo` is otherwise ignored under `Y6`. A checker that only
+  deduped `name`, `description` and `when_to_use` would miss it.
+
+Key identity for the comparison is the **unquoted key text**, byte-exact and case-sensitive, matching
+`Value::String` equality at `:449-450`. `name` and `'name'` are the same key and collide; `name` and
+`Name` do not.
+
+#### 6.5.5 Unknown keys
+
+Ignored with no finding, matching `Y6` and `X1` exactly (`:641-694`, test `:8501`).
+
+One exception: a key spelled `when-to-use` (hyphenated) produces `I-KEY-HYPHEN-VARIANT` (info). The
+evidence calls this out specifically: a repo-wide grep for `when-to-use` returns zero matches, only
+the underscore form is read (`:687`), so the hyphenated spelling is silently ignored. Surfacing
+silent traps is the entire point of this tool. No other near-miss spelling is special-cased.
+
+### 6.6 Field validation
+
+#### 6.6.1 `name`
+
+Order of operations, mirroring `:641-660`:
+
+1. Key absent → resolved name is `path.basename(skillDir)`, source `folder`. **The folder fallback is
+   never trimmed**: `:652` uses `folder_name.clone()` straight from the directory entry, while only
+   the `name:` value goes through `str::trim` at `:453`. On a filesystem that permits it, a directory
+   named `" x "` resolves to `" x "`, fails the charset test and hard-rejects the skill. Trimming the
+   fallback would hide that.
+2. Key present, value not a string and not `undecidable` → `E-NAME-NOT-STRING` (error). Stop; the
+   indexer skips the skill. Mirrors `N2` and ``name must be a string`` (`:460` via `:644-648`).
+3. Key present, value `undecidable` → `W-YAML-UNDECIDABLE` already emitted. Run the charset check on
+   the literal text, source `name-undecidable`, but report any violation as **`W-NAME-UNDECIDABLE`
+   (warning), never `E-NAME-INVALID`** — see 6.5.2. This entrypoint does not participate in the
+   duplicate-name race of 6.6.4 either, because the checker does not know what name it resolves to.
+   Do **not** fall through to step 5.
+4. Key present, value is a string → trim it (`:453`) **using the explicit Unicode `White_Space` set
+   in Section 5.1.2, not `String.prototype.trim()`**. If the trimmed result is empty, treat the key
+   as **absent** (`Y5`, `:452-459`) and fall back to the directory name, source `folder`.
+5. Charset and length: the resolved name must satisfy `^[a-z0-9-]{1,64}$`, with the length counted as
+   `[...name].length`. Violation → `E-NAME-INVALID` (error). Mirrors `N3` (`:464-470`, `:653-660`).
+
+`E-NAME-INVALID`'s message **must state the source**, because the fallback is the trap the evidence
+names: a directory called `My_Skill` with no `name:` key resolves to `My_Skill`, fails the charset
+test, and the skill is hard-rejected even though nothing in the file looks wrong.
+
+- source `key`: "the `name:` key on line N".
+- source `folder`: "the containing directory name, because no usable `name:` key is present. Either
+  rename the directory or add a valid `name:` key."
+
+There is **no** requirement that `name` match the directory name (`N4`, `:652`). The checker never
+reports a mismatch.
+
+#### 6.6.2 `description`
+
+| Situation | Finding | Indexer counterpart |
+| --- | --- | --- |
+| Absent, or a string that trims to empty (including `description: ''`) | `W-DESC-MISSING` (warning) | `description metadata is missing; inspect SKILL.md before use.` (`:677-679`) |
+| Present, value not a string | `W-DESC-NOT-STRING` (warning) | `description must be a string; inspect SKILL.md before use.` (`:683`) |
+| Present, non-empty string | none | skill indexed cleanly |
+
+The skill is still counted as valid in the summary. This asymmetry is deliberate and is the single
+most important thing for an author to understand: a bad `description` is the **only** metadata
+problem that keeps a skill alive.
+
+#### 6.6.3 `when_to_use`
+
+| Situation | Finding |
+| --- | --- |
+| Absent | none (`W1`) |
+| Present, value not a string | `W-WHEN-NOT-STRING` (warning), mirroring `when_to_use must be a string; omitted when_to_use metadata.` (`:691`) |
+| Present, a string, including one that trims to empty | none. `Y5` maps an empty trim to absent, and absent is legal |
+
+#### 6.6.4 Duplicate names: `N5`, and the scope question
+
+The indexer dedupes only within one `skills/` directory, because that is the only directory it ever
+lists. A recursive checker may see many. **The checker's comparison scope is one `skills/`
+directory**, and nothing wider.
+
+Algorithm:
+
+1. Group every validated candidate by `path.dirname(skillDir)`, that is, by its parent directory.
+2. Discard every group whose parent directory is not named `skills` (ASCII case-insensitive).
+   Outside a `skills/` directory the indexer never compares those names at all, so a clash there is
+   meaningless and no finding is emitted.
+3. Within a group, sort the **skill directories** by ASCII-lowercased directory name, with the
+   original directory name as tiebreak. This is the exact port of `:588-591` and it is what decides
+   who wins a clash. **Step 5 verified the port against the source**, which is a two-element tuple
+   comparison, `(left.to_ascii_lowercase(), left).cmp(&(right.to_ascii_lowercase(), right))`. Two
+   details are load-bearing and neither is the JS default:
+   - `to_ascii_lowercase` maps **A-Z only**. Section 5.1.2 already bans
+     `String.prototype.toLowerCase()` here; this is the comparison it was banned for.
+   - Both tuple elements compare as Rust `String`, that is in **UTF-8 byte order**. Use the
+     `Buffer.compare` form from Section 5.1.2, not `<` or `localeCompare`.
+   Sort the directories, not the resolved names: `:588-591` runs on `folder_name` before any
+   frontmatter is read.
+4. Walk the sorted list. The first directory to claim a resolved name keeps it. Every later directory
+   resolving to the same name gets `E-NAME-DUPLICATE` (error), naming the winner, mirroring
+   ``duplicate skill name `{name}` already used by `{first}` `` (`:663-668`).
+
+**A candidate carrying ANY hard error does not participate**, not only a name-resolution failure.
+`:595-670` is a single loop in which every failure path is a `continue`, and `seen_skill_names` is
+only written at `:671`, after the entrypoint check, the frontmatter extraction, the YAML parse, the
+mapping check, the `name` type check and the charset check have all passed. So a directory that fails
+at any earlier layer never claims its name, and a later directory resolving to the same name is
+indexed cleanly with no duplicate finding at all.
+
+Worked example, because getting this backwards produces a finding the app would never emit: in one
+`skills/` directory, `aaa/SKILL.md` has a broken frontmatter and would have resolved to `shared`, and
+`bbb/SKILL.md` resolves to `shared` cleanly. The indexer skips `aaa` at the frontmatter layer and
+indexes `bbb` without complaint. The checker must therefore report `E-FM-*` on `aaa` and **nothing**
+on `bbb`. Step 4's wording ("every validated candidate", failing only on `E-NAME-*`) would have
+reported a spurious `E-NAME-DUPLICATE` on `bbb`.
+
+Practical rule for the implementer: build the `seen` map in sorted order and insert a name only when
+the candidate reached the end of field validation with zero `error`-severity findings.
+
+If two identical `skills/` trees exist in different matrices under the same root, they are separate
+groups and neither reports a duplicate. That is correct: they are never in the same index.
+
+### 6.7 Position and indexability
+
+Exactly one verdict per validated entrypoint. Given an entrypoint at
+`<...>/<A>/<B>/<C>/SKILL.md`, where `C` is the skill directory, `B` is its parent and `A` is `B`'s
+parent:
+
+**Canonical** requires both:
+
+1. `path.basename(B) === 'skills'`, byte-exact.
+2. `path.basename(A)` matches `/^_agent_.+$/`. A single leading underscore, so `__agent_x` fails.
+
+Canonical produces no finding. Otherwise `I-NOT-INDEXABLE` (info) with one `reason`:
+
+| `reason` | Condition | Message |
+| --- | --- | --- |
+| `not-under-skills-dir` | `basename(B)` is not `skills` in any casing | Depth is fixed at one, `<owner-root>/skills/<skill-name>/SKILL.md`. This file is structurally checkable but is never indexed |
+| `skills-dir-case` | `basename(B)` equals `skills` only after ASCII lowercasing | Platform-dependent. The indexer builds this path by joining the constant `skills`, so a differently cased directory may still resolve on Windows and will not on Linux. See Section 12.4 |
+| `replica-root` | `basename(A)` starts with `__agent_` | A `__agent_*` replica's own `skills/` directory is never scanned. `has_agent_matrix_dir_name` tests `starts_with("_agent_")` and `"__agent_x"` fails it (`:1437-1442`) |
+| `owner-root-not-recognized` | Anything else | The owner root is not an `_agent_*` matrix directory. The Root Agent directory is a third legal owner root (`root_agent.rs:633-639`) that this checker does not attempt to identify, so this note may be a false positive there. It is informational only and never affects the exit code |
+
+Position findings are **always `info`** and **never affect the exit code**. This closes the question
+the coordinator left open. The reasoning is in decision 6 of Section 4: user decision 4 makes the
+checker generic over any tree, and a generic tool cannot fail a build over a shape it cannot verify
+is meant to be a skills tree.
+
+**Canonical position for a directory, not an entrypoint.** Three findings are gated on canonical
+position without any `SKILL.md` to anchor the test: `I-NO-ENTRYPOINT` (6.3), `W-DIR-UNREADABLE`
+(6.2 step 1) and `W-SKILL-DIR-LINK` (6.2 step 3). For a directory `D` the same test reads: `D` is a
+**skill directory** in canonical position when `path.basename(path.dirname(D))` is `skills` and
+`path.basename(path.dirname(path.dirname(D)))` matches `/^_agent_.+$/`; `D` is a **skills root** in
+canonical position when `path.basename(D)` is `skills` and `path.basename(path.dirname(D))` matches
+`/^_agent_.+$/`. Whether the `skills` comparison is byte-exact or ASCII case-insensitive depends on
+the finding, per Section 4.1 rule 2. Step 4 stated this form only inside 6.2 step 1 and left 6.3
+pointing at a definition written for entrypoints; it is stated here once so both callers resolve.
+
+The `canonical` flag is what promotes every rule-2 finding to an error. **Step 7 correction:** Step 4
+wrote "the two absence-type findings (`I-NO-ENTRYPOINT` and `W-DIR-UNREADABLE`)", which Step 6 left
+stale when it added `W-SKILL-DIR-LINK` (G5) and split `E-SKILL-DIR-UNREADABLE` out of
+`E-SKILLS-DIR-UNREADABLE` (G16). There are now three promotion routes and one gated-only code, and
+`W-SKILL-DIR-LINK` is not an absence-type finding at all. The complete list is in Section 4.1 rule 2.
+
+### 6.8 The complete finding taxonomy
+
+Every code, its severity, its rule ID in the evidence artifact, and the indexer message it mirrors.
+Exit-code column: `1` means the code forces exit 1; a dash means it does not.
+
+**Errors (force exit 1)**
+
+| Code | Rule | Indexer message | Exit |
+| --- | --- | --- | --- |
+| `E-SKILLS-DIR-UNREADABLE` | `R4`, `R6` | `` `skills` could not be inspected: {err} `` / `` `skills` directory could not be read: {err} `` | 1 |
+| `E-SKILL-DIR-UNREADABLE` | `R4` | ``Skipped skill directory `{folder}`: unable to read skill directory: {err}`` | 1 |
+| `E-SKILLS-NOT-DIR` | `R5` | `` `skills` exists but is not a directory: {path} `` | 1 |
+| `E-SKILL-DIR-LINK` | `R8` | ``Skipped linked skill directory `{folder}`: linked/reparse-point directories are not followed`` | 1 |
+| `E-NO-ENTRYPOINT` | `E1` | ``Skipped skill directory `{folder}`: missing exact SKILL.md entrypoint`` | 1 |
+| `E-ENTRYPOINT-CASE` | `E1` | as above | 1 |
+| `E-ENTRYPOINT-LINK` | `E2` | ``exact SKILL.md entrypoint is linked/reparse-point`` | 1 |
+| `E-ENTRYPOINT-NOT-FILE` | `E3` | ``exact SKILL.md entrypoint is not a regular file`` | 1 |
+| `E-ENTRYPOINT-UNREADABLE` | `E4`, `F9` | ``failed to open SKILL.md frontmatter: {err}`` / ``failed to read SKILL.md frontmatter: {err}`` | 1 |
+| `E-FM-NO-OPEN` | `F1` | ``missing opening frontmatter delimiter`` | 1 |
+| `E-FM-FIRST-LINE-TOO-LONG` | `F7` | ``missing opening frontmatter delimiter`` | 1 |
+| `E-FM-NO-CLOSE` | `F5` | ``missing closing frontmatter delimiter`` | 1 |
+| `E-FM-TOO-LARGE` | `F6` | ``frontmatter exceeds 16384 byte limit`` | 1 |
+| `E-FM-NOT-UTF8` | `F8` | ``frontmatter is not valid UTF-8: {err}`` | 1 |
+| `E-YAML-PARSE` | `Y1` | ``YAML parse error: {err}`` | 1 |
+| `E-YAML-DUPLICATE-KEY` | `Y1` | ``YAML parse error: duplicate entry with key "{key}"`` (position suffix appended by `serde_yaml`) | 1 |
+| `E-YAML-NOT-MAPPING` | `Y2` | ``frontmatter must be a YAML mapping`` | 1 |
+| `E-NAME-NOT-STRING` | `N2` | ``name must be a string`` | 1 |
+| `E-NAME-INVALID` | `N3` | ``invalid skill name `{name}`; expected 1-64 lowercase ASCII letters, digits, or hyphens`` | 1 |
+| `E-NAME-DUPLICATE` | `N5` | ``duplicate skill name `{name}` already used by `{first}` `` | 1 |
+
+**Warnings (never change the exit code)**
+
+| Code | Rule | Indexer counterpart |
+| --- | --- | --- |
+| `W-DESC-MISSING` | `D1` | `description metadata is missing; inspect SKILL.md before use.` |
+| `W-DESC-NOT-STRING` | `D2` | `description must be a string; inspect SKILL.md before use.` |
+| `W-WHEN-NOT-STRING` | `W2` | `when_to_use must be a string; omitted when_to_use metadata.` |
+| `W-YAML-UNDECIDABLE` | none | none. Checker-only: the mini-parser refuses to judge |
+| `W-NAME-UNDECIDABLE` | `N3` | possibly ``invalid skill name `{name}` …`` or possibly ``name must be a string``, or possibly nothing at all. The checker states all three and asserts none (6.5.2) |
+| `W-ENTRYPOINT-CASE-SHADOWED` | none | none. The working `SKILL.md` exists; the stray variant is a hazard |
+| `W-SKILL-DIR-LINK` | `R8` outside canonical position | none. The indexer never scans that tree (6.2 step 3) |
+| `W-DIR-UNREADABLE` | `R4`, `R6` outside canonical position | none |
+
+**Informational (never change the exit code)**
+
+| Code | Rule | Meaning |
+| --- | --- | --- |
+| `I-NOT-INDEXABLE` | `R1`, `R3`, `R7` | Structurally checkable, never indexable. Carries `reason` (Section 6.7) |
+| `I-NO-ENTRYPOINT` | `E1` outside canonical position | A directory under some `skills/` folder with no entrypoint in any casing |
+| `I-KEY-HYPHEN-VARIANT` | `X1` | A `when-to-use` key, which the indexer never reads |
+
+**Indexer conditions with no exact one-to-one code**, recorded so the mapping is complete rather than
+silently partial. Step 5 re-enumerated the indexer's hard errors directly from `:311-418` and
+`:489-670` and found **five**, not four:
+
+- `Skipped a skills directory entry: {err}` (`:558-561`) and
+  ``unable to read skill directory entry: {err}`` (`:400`) are per-`DirEntry` iteration failures.
+  Node's `readdirSync(dir, { withFileTypes: true })` throws for the whole call rather than per entry,
+  so both surface as `E-SKILLS-DIR-UNREADABLE` or `W-DIR-UNREADABLE` on the parent directory.
+- ``could not inspect entry type: {err}`` (`:569-573`) is `entry.file_type()` failing on a skill
+  directory. Node resolves the `Dirent` type inside `readdirSync`, so there is no separate per-entry
+  call that can fail; the same two codes cover it.
+- **``could not inspect exact SKILL.md entrypoint: {err}`` (`:405-407`)** is the same failure on the
+  `SKILL.md` entry itself, and it is unmappable for the same reason. **This condition was missing
+  from the evidence artifact's hard-error table and therefore from Step 4's count.** See
+  Section 14.4.
+- ``unable to read skill directory: {err}`` (`:396-397`) is `read_dir` on a skill directory failing.
+  This one **is** mappable and is now mapped: Section 6.2 step 1 emits `E-SKILL-DIR-UNREADABLE` for
+  a skill directory in canonical position. It is listed here only to record that it left this bucket.
+  **Step 6 gave it its own code.** Step 5 routed it to `E-SKILLS-DIR-UNREADABLE`, which carries the
+  two `` `skills` ``-root message variants. Since 6.10 promises that `indexerMessage` "reproduces the
+  exact string that would appear in the startup log", one code covering two structurally different
+  indexer errors guarantees the wrong string for one of them, and leaves a JSON consumer unable to
+  tell a broken skills root from a broken single skill.
+
+Corrected count: the indexer has **23** hard-error conditions, not 22, and 3 soft warnings. After
+Step 5 added `E-YAML-DUPLICATE-KEY` and removed `W-YAML-DUPLICATE-KEY`, and Step 6 added
+`E-SKILL-DIR-UNREADABLE`, `W-NAME-UNDECIDABLE` and `W-SKILL-DIR-LINK`, the taxonomy is **20 error
+codes, 8 warning codes and 3 informational codes, 31 in total**. It accounts for all 23 hard errors
+and all 3 soft warnings; the three codes Step 6 added are severity- and message-fidelity splits of
+conditions that were already covered, not new indexer conditions.
+
+### 6.9 Human report format
+
+Written entirely to stdout.
+
+```
+[skills-check] root: C:\Users\x\0_repos\Project\.ac
+[skills-check] scanned 412 directories, found 7 SKILL.md entrypoints
+
+ERROR  _agent_architect/skills/my_skill/SKILL.md:2  E-NAME-INVALID  (rule N3)
+       Resolved name `my_skill` is not valid; expected 1-64 characters from [a-z0-9-].
+       Source: the `name:` key on line 2.
+       Indexer: Skipped skill `my_skill`: invalid skill name `my_skill`; expected 1-64 lowercase
+       ASCII letters, digits, or hyphens
+
+ERROR  _agent_writer/skills/notes/skill.md  E-ENTRYPOINT-CASE  (rule E1)
+       Entrypoint is named `skill.md`; the indexer compares byte-exactly against `SKILL.md` and
+       rejects this on every platform, Windows included.
+       Indexer: Skipped skill directory `notes`: missing exact SKILL.md entrypoint
+
+WARN   _agent_writer/skills/notes/skill.md:3  W-DESC-MISSING  (rule D1)
+       `description` is missing or empty. The skill is still indexed, and flagged at startup.
+
+NOTE   docs/examples/SKILL.md  I-NOT-INDEXABLE  (reason: not-under-skills-dir)
+       Depth is fixed at one: <owner-root>/skills/<skill-name>/SKILL.md. This file is structurally
+       checkable but is never indexed.
+
+[skills-check] 2 errors, 1 warning, 1 note across 7 entrypoints
+[skills-check] FAIL: 2 skills would not be indexed
+```
+
+Rules for the format:
+
+- Paths in findings are relative to the root, with `/` separators on every platform. The absolute
+  root is printed once, in the header.
+- `:N` is appended when the finding is anchored to a line in `SKILL.md`, and omitted otherwise.
+- Severity labels are the fixed-width tokens `ERROR`, `WARN`, `NOTE`.
+- The `Indexer:` line is printed only when the finding has an indexer counterpart, and reproduces the
+  exact string that would appear in the startup log. This is what makes a startup warning searchable
+  back to a checker finding.
+- The final line is `[skills-check] OK: N skills would be indexed` on exit 0 and
+  `[skills-check] FAIL: N skills would not be indexed` on exit 1. `N` counts distinct entrypoints
+  carrying at least one error, not the number of error findings.
+  **Step 6 exception, because that rule can print `FAIL: 0`.** Five error codes are not attached to
+  any entrypoint at all: `E-SKILLS-DIR-UNREADABLE`, `E-SKILL-DIR-UNREADABLE`, `E-SKILLS-NOT-DIR`,
+  `E-SKILL-DIR-LINK` and `E-NO-ENTRYPOINT`. A tree whose only fault is a `skills` file where a
+  directory belongs exits 1 with zero entrypoints implicated, and the report would read
+  `FAIL: 0 skills would not be indexed`, which flatly contradicts the exit code. So: when `N` is 0
+  and error findings exist, print `[skills-check] FAIL: M error findings, no entrypoint implicated`
+  where `M` is the error count. When both are non-zero, print
+  `[skills-check] FAIL: N skills would not be indexed, and M error findings in total`.
+- With zero entrypoints found the report is the two header lines plus
+  `[skills-check] OK: no SKILL.md entrypoints found`, exit 0. An empty tree is not a failure.
+
+### 6.10 JSON output format
+
+`--json` writes exactly one JSON document to stdout, `JSON.stringify(report, null, 2)` followed by a
+single `\n`, and writes nothing else to stdout.
+
+```json
+{
+  "tool": "01-skills-checker",
+  "version": 1,
+  "sourceOfTruth": "src-tauri/src/config/session_context.rs:206-714",
+  "root": "C:\\Users\\x\\0_repos\\Project\\.ac",
+  "summary": {
+    "directoriesScanned": 412,
+    "entrypointsFound": 7,
+    "skillsIndexable": 5,
+    "errors": 2,
+    "warnings": 1,
+    "infos": 1
+  },
+  "findings": [
+    {
+      "code": "E-NAME-INVALID",
+      "severity": "error",
+      "rule": "N3",
+      "path": "_agent_architect/skills/my_skill/SKILL.md",
+      "absolutePath": "C:\\Users\\x\\0_repos\\Project\\.ac\\_agent_architect\\skills\\my_skill\\SKILL.md",
+      "skillDirectory": "_agent_architect/skills/my_skill",
+      "skillName": "my_skill",
+      "line": 2,
+      "reason": null,
+      "message": "Resolved name `my_skill` is not valid; expected 1-64 characters from [a-z0-9-]. Source: the `name:` key on line 2.",
+      "indexerMessage": "Skipped skill `my_skill`: invalid skill name `my_skill`; expected 1-64 lowercase ASCII letters, digits, or hyphens"
+    }
+  ],
+  "exitCode": 1
+}
+```
+
+Field contract, fixed:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `tool` | string | Always `"01-skills-checker"` |
+| `version` | number | Output-format version. `1` for this implementation. Bump on any breaking field change |
+| `sourceOfTruth` | string | Constant. Makes the drift risk visible to any consumer |
+| `root` | string | Absolute, `path.resolve()`d, native separators |
+| `summary.entrypointsFound` | number | **Every** discovered `skill.md` match in any casing, including a shadowed casing variant that was never validated (6.3 row 5). Step 6 wrote this row: 14.5.1 fixed the definition and the fix was never applied here |
+| `summary.skillsIndexable` | number | Entrypoints that reached the end of field validation with zero error findings. Warnings do not disqualify, mirroring the indexer. **A shadowed casing variant is excluded**: it carries only `W-ENTRYPOINT-CASE-SHADOWED`, so the Step 4/5 wording "entrypoints with zero error findings" counted one directory as two indexable skills and `summary` could not reconcile with `findings` |
+| `findings` | array | Always present, possibly empty |
+| `findings[].code` | string | From Section 6.8 |
+| `findings[].severity` | `"error"` &#124; `"warning"` &#124; `"info"` | |
+| `findings[].rule` | string &#124; null | Evidence-artifact rule ID, or `null` for checker-only findings |
+| `findings[].path` | string | Relative to `root`, always `/`-separated. This is the stable key |
+| `findings[].absolutePath` | string | Native separators |
+| `findings[].skillDirectory` | string &#124; null | Relative, `/`-separated. `null` when the finding is not about a skill directory |
+| `findings[].skillName` | string &#124; null | The resolved name, or `null` when resolution did not complete |
+| `findings[].line` | number &#124; null | 1-based line in `SKILL.md`, `null` when not line-anchored |
+| `findings[].reason` | string &#124; null | Only populated for `I-NOT-INDEXABLE` (Section 6.7) |
+| `findings[].message` | string | Human sentence. Not a stable contract; consumers key on `code` |
+| `findings[].indexerMessage` | string &#124; null | The exact indexer string, or `null` |
+| `exitCode` | number | Duplicates the process exit code so a consumer reading only stdout knows the verdict |
+
+**Ordering is deterministic**, so the output is snapshot-comparable: sort by `path` (raw string,
+code-unit order), then `line` ascending with `null` treated as `0`, then `code` ascending, then
+**emission order** as the final tiebreak. The last key is required and Step 6 moved it here from
+14.5.2, where it was recorded and never applied: `path`/`line`/`code` still ties for two
+`W-YAML-UNDECIDABLE` findings reported against the same line, and without a total order
+`Array.prototype.sort` gives no guarantee beyond stability, so self-test case 71 does not actually
+pin what it claims to. Note this sort is presentation-only and is deliberately **not** the
+Rust-fidelity comparison of 5.1.2: nothing in the indexer depends on it, so plain code-unit order is
+correct here.
+
+**What is and is not byte-identical across platforms. Step 6 corrected this claim.** Step 4/5 said
+`path` uses `/` on every platform "specifically so a fixture snapshot is byte-identical on Windows,
+Linux and macOS". The separator normalization is real, but the guarantee as stated is false: the same
+document also carries `root` and `findings[].absolutePath`, both defined two rows above as **native
+separators** and both absolute, plus `summary.directoriesScanned`, plus every `indexerMessage` whose
+template embeds `{err}`, where the errno text is OS-specific. Self-test case 71 only asserts that two
+runs on one machine agree, so nothing tests the cross-platform claim at all. The guarantee is
+therefore scoped to exactly two fields: **`findings[].path` and `findings[].skillDirectory` are
+`/`-separated and root-relative on every platform, and a snapshot keyed on `code` plus those two
+fields is portable.** Any consumer wanting a portable snapshot of the whole document must exclude
+`root`, `absolutePath`, `summary.directoriesScanned` and `indexerMessage`.
+
+### 6.11 Windows and POSIX specifics
+
+- Junctions and reparse points: `Dirent.isSymbolicLink()` returns true for them on Windows, so the
+  symlink rules in 6.2 and 6.3 cover both platforms with one code path.
+- Case sensitivity: every validity comparison uses `===` on the string `readdirSync` returned.
+  `fs.existsSync(path.join(dir, 'SKILL.md'))` is forbidden anywhere in the file.
+- Separators: comparisons go through `path.basename` and `path.dirname`; only the report normalizes
+  `\` to `/`.
+- Long paths: not special-cased. A `readdirSync` failure from a path-length limit becomes
+  `W-DIR-UNREADABLE`, which is reported and does not abort the run.
+- The script is never made executable-bit dependent: it is always invoked as `node scripts/...`.
+
+## 7. Compatibility and security
+
+- **IPC, persistence, config.** None touched. No Tauri command, event, type or TOML shape changes.
+- **Runtime coupling.** The script is not imported by the app and does not run at app runtime. It
+  cannot affect a session.
+- **Dependencies.** Zero added. `package-lock.json` unchanged, so `lockfile-check.yml` is unaffected.
+- **Filesystem writes.** The checker only ever writes inside its own `mkdtemp` directory during
+  `--self-test`, and removes it in a `finally` (Section 9.2). In normal operation it opens files
+  read-only and writes nothing.
+- **Symlink safety.** Never following a symlinked directory means the walk cannot be redirected out
+  of the given root by a crafted link, and cannot be trapped in a cycle.
+- **Untrusted content.** `SKILL.md` files are untrusted input. Three consequences, all required:
+  - Reads are bounded: at most 1024 bytes for the first line and 16384 bytes of frontmatter body,
+    with a hard stop at the closing delimiter. A multi-gigabyte `SKILL.md` costs a bounded read.
+  - No content is ever `eval`'d, imported, or passed to a shell. The mini-parser is pure string work.
+  - Report text embeds file content (names, values). **Step 6 corrected the mitigation, which did
+    not achieve its stated goal.** Step 4/5 said values are "printed as-is inside backticks and
+    truncated to 200 characters ... so a long or **line-broken** value cannot scramble the report".
+    Truncation bounds length and does nothing whatever about a `\n` at offset 10, or about a `\r`, a
+    `\x1b` escape introducer, or any other C0 control character — all of which are legal inside a
+    YAML double-quoted scalar or a folder name. So the required order is: first **collapse** every
+    run of C0 controls and Unicode whitespace to a single U+0020 and drop the rest, then truncate to
+    200 characters. That is exactly what the indexer does before rendering the same strings
+    (`sanitize_skill_metadata_for_context`, `:420-446`, which ends in a `trim()`), so mirroring it
+    costs nothing and keeps the two outputs comparable. Both steps are presentation only and never
+    affect a verdict; in particular the charset test in 6.6.1 runs on the raw value, never on the
+    sanitized one.
+- **Rollback.** Deleting the script and reverting the two `package.json` lines restores the previous
+  state exactly. Nothing else has to be undone.
+
+## 8. Implementation order
+
+0. **Commit this plan first, as its own commit.** `plans/` is gitignored (`.gitignore:11`), so it
+   needs `git add -f plans/1213-skills-checker.md`; a plain `git add` silently adds nothing and the
+   plan never reaches the branch.
+1. Create `scripts/01-skills-checker.mjs` with the header (5.1.1), the constants, `parseArgs`,
+   `printUsage` and a `main()` that resolves the root and exits 2 on every case in Section 6.1.
+   Verifiable on its own: `--help`, a missing root, and a root that is a file.
+2. Add `walk()` (6.2) plus entrypoint discovery (6.3), reporting only `E-ENTRYPOINT-CASE`,
+   `E-NO-ENTRYPOINT`/`I-NO-ENTRYPOINT` and the symlink codes. At this point the script already
+   catches the `tiktok-news-publisher` bug from the issue.
+3. Add `isFrontmatterDelimiter` and `readFrontmatter` (6.4). All `E-FM-*` codes.
+4. Add `parseMiniYaml` (6.5). `E-YAML-*`, `W-YAML-*`.
+5. Add `validateFields` (6.6.1 to 6.6.3), `detectDuplicates` (6.6.4) and `classifyPosition` (6.7).
+6. Add `renderHuman` (6.9) and `renderJson` (6.10), and wire the exit code.
+7. Add `selfTest` (Section 9).
+8. Add the two `package.json` entries (5.2).
+9. Run the gates in Section 9.3.
+10. Commit, then **push before doing anything that needs Codebase Memory**. See the note below.
+
+Steps 1 to 8 are one commit. Splitting them would put a half-implemented checker on the branch, and a
+checker that reports fewer rules than it appears to is worse than none: an author would read a clean
+run as proof the skill is valid.
+
+### 8.1 Codebase Memory after a commit: the order is commit, push, re-index, gate
+
+**Step 7 moved this here from Section 15.2, where the implementer would not have looked for it.** It
+is an operational instruction about the tooling the implementer must use, so it belongs in the
+implementation order, not in a review record.
+
+The gate asserts `base_sha == HEAD` (`cbm.ps1:2317`), and `base_sha` derives from upstream resolution.
+Under either reading of that derivation a local commit that has not been pushed leaves `base_sha`
+behind HEAD, so the gate throws `Codebase Memory Git state is stale`. The full argument is in
+Section 15.2.
+
+So, whenever a commit lands on this branch:
+
+```
+git commit  →  git push  →  re-index  →  gate
+```
+
+**A gate failure between the commit and the push is expected and is not a regression.** Do not
+re-diagnose it, do not change the refspec, and do not change branch state. The refspec was already
+repaired once for this branch (`git remote set-branches --add`, Section 15.1); the branch's fetch
+refspec is not the cause of this particular failure and touching it again will not help.
+
+This applies to step 0 as well: the plan commit is a commit like any other.
+
+## 9. Tests and acceptance criteria
+
+### 9.1 Where the tests live, and why not vitest
+
+Tests live inside `scripts/01-skills-checker.mjs` behind `--self-test`, wired as
+`npm run check:skills:self`. Fixtures are created at runtime under
+`fs.mkdtempSync(path.join(os.tmpdir(), 'ac-skills-check-'))` and removed in a `finally`, exactly as
+`scripts/check-test-debt.mjs:703` and `:855-857` do. **No fixture file is committed.**
+
+Four reasons, all decisive:
+
+1. **Precedent.** `check-test-debt.mjs` is the repo's existing answer to "how do you test a `.mjs`
+   script", and it is already wired as `test:debt:self`. This follows it rather than inventing a
+   second pattern.
+2. **The script's own guarantee.** User decision 5 requires the script to run in a fresh checkout
+   with no `npm install`. A vitest test could only be run after `npm install`, so the thing verifying
+   the portability guarantee would itself depend on what the guarantee excludes.
+3. **Blast radius.** `vitest.config.ts:12` collects `src/**/*.test.ts(x)` only. Collecting a test
+   under `scripts/` means editing shared test configuration for one file. Section 5.3 keeps that file
+   untouched.
+4. **Fixtures that cannot be committed.** Several required fixtures do not survive a git checkout
+   portably: a wrongly cased `skill.md` beside `SKILL.md`, a symlinked `SKILL.md`, invalid UTF-8
+   bytes, a 16 KiB frontmatter, a file with no trailing newline, and a leading BOM. Generating them
+   at runtime is the only portable way to test the rules that matter most.
+
+### 9.2 The self-test
+
+`selfTest()` returns `0` when every case passes and `1` on the first failure, printing the failing
+case name. It uses an `assertSelf(condition, message)` helper, mirroring `check-test-debt.mjs`.
+
+Each case builds a fixture tree, runs the checker's own pipeline in-process against it, and asserts
+on the resulting finding codes. Cases that cannot be constructed on the running platform wrap
+creation in `try`/`catch` and skip with a printed `SKIP` line naming the reason. A skip is not a
+failure; the case list prints how many were skipped and which.
+
+#### 9.2.1 Which cases skip, and how to stop most of them skipping
+
+**Step 6 wrote this subsection.** Step 4/5 named exactly one skippable case (11) and 14.5.4 flagged
+it as the one that matters. That undercounts, and one of the omissions is not a skip at all but a
+hard failure on the team's own platform.
+
+| Case | Needs | Without the fix |
+| --- | --- | --- |
+| 11, 12, 63e, 63f | a **directory** link | skips on unprivileged Windows without Developer Mode |
+| 19 | a **file** symlink to `SKILL.md` | skips on unprivileged Windows without Developer Mode |
+| 20 | `SKILL.md` **and** `skill.md` in one directory | **FAILS**, not skips, on any case-insensitive filesystem |
+| 63c, 63g | a directory whose listing throws | not reliably constructible as the owning user |
+
+**Case 20 is the serious one.** 6.3 row 5 says two matches are "only reachable on a case-sensitive
+filesystem", and default Windows and default macOS are not. The second `writeFileSync` overwrites the
+first, the directory ends up with one entry, and the assertion for `W-ENTRYPOINT-CASE-SHADOWED` fails.
+Since it was never listed as skippable, `npm run check:skills:self` exits 1 on the primary
+development platform, which breaks acceptance criterion 2 outright. Case 20 must probe first — create
+`SKILL.md`, then `skill.md`, then re-list the directory and skip unless two entries came back — and
+print `SKIP (case-insensitive filesystem)`.
+
+**Cases 63c, 63g and 79** must skip the same way: attempt the permission change, re-list, and skip
+unless the listing actually throws. `icacls` denials do not bind the owner on Windows and `chmod 000`
+does not bind root on Linux. All three share one probe, so implement the probe once and let the three
+cases consume its result.
+
+**The four directory-link cases should not skip at all.** On win32, create directory links with
+
+```js
+fs.symlinkSync(path.resolve(target), linkPath, 'junction')
+```
+
+A junction requires **no** Developer Mode and no elevation, works for directories, and Node reports
+it through `Dirent.isSymbolicLink()`. That converts cases 11, 12, 63f and 63e (create the junction,
+then delete its target) from skips into real assertions on ordinary Windows — and doing so is
+precisely the evidence 14.5.4 says is missing, since it exercises the junction behaviour the plan
+leans on in three places rather than assuming it. Only case 19 still needs a file symlink and
+therefore still skips.
+
+Without this, `E-SKILL-DIR-LINK`, `W-SKILL-DIR-LINK`, `E-ENTRYPOINT-LINK`, `E-SKILLS-NOT-DIR` and
+`W-ENTRYPOINT-CASE-SHADOWED` are all unverified on the platform the team develops on — five codes,
+four of them errors, silently untested behind a green run.
+
+#### 9.2.2 Codes with no case at all
+
+Acceptance criterion 12 requires every code in 6.8 to be emitted by at least one case. Three codes had
+none: `E-ENTRYPOINT-UNREADABLE` (nothing makes `openSync` or `readSync` throw), `W-DIR-UNREADABLE`
+(63c covers only the canonical error variant), and the `skills`-root variant of
+`E-SKILLS-DIR-UNREADABLE`.
+
+**Step 7 correction.** Step 6 wrote that "cases 76-79 below close three of them". They do not. Case 79
+closes the `E-SKILLS-DIR-UNREADABLE` skills-root variant; cases 76, 77 and 78 close the FAIL-line
+wording, the `entrypointsFound`/`skillsIndexable` split and the ordering tiebreak respectively, none
+of which is an unreadable-directory code. `W-DIR-UNREADABLE` was left with no case at all, so
+criterion 12 remained unsatisfiable with a single named exemption. **Case 63g now closes it.**
+`E-ENTRYPOINT-UNREADABLE` shares case 63c's constructibility problem and stays an explicit exemption
+in criterion 12.
+
+Full accounting, so this is checkable rather than asserted: `E-SKILLS-DIR-UNREADABLE` is case 79,
+`E-SKILL-DIR-UNREADABLE` is case 63c, `W-DIR-UNREADABLE` is case 63g, and `E-ENTRYPOINT-UNREADABLE`
+is exempt. Every other code in 6.8 has at least one case in the tables below; criterion 12's grep is
+what verifies that claim rather than this sentence.
+
+Required cases, by section:
+
+**CLI (6.1)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 1 | `--help` | usage on stdout, exit 0 |
+| 2 | Nonexistent root | exit 2, message names the path |
+| 3 | Root is a file | exit 2 |
+| 4 | Two positionals | exit 2 |
+| 5 | Unknown flag | exit 2 |
+| 6 | `--` followed by a root starting with `-` | treated as the root, not a flag |
+| 7 | Empty directory as root | exit 0, `entrypointsFound: 0` |
+
+**Traversal (6.2)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 8 | A `SKILL.md` inside `node_modules/`, `.git/` and `target/` | not discovered; `entrypointsFound: 0` |
+| 9 | Same, in a directory named `Node_Modules` | not discovered (case-insensitive skip) |
+| 10 | A valid skill nested five levels below the root | discovered (no depth limit) |
+| 11 | A linked directory under `_agent_x/skills/` (junction on win32, see 9.2.1) | `E-SKILL-DIR-LINK`, walk does not descend |
+| 11a | A linked directory under `docs/skills/`, that is a `skills/` folder **outside** canonical position | `W-SKILL-DIR-LINK`, **exit 0**. Step 6 added this. Under Step 4/5 this was an unconditional `E-SKILL-DIR-LINK` and any repository containing a `docs/skills/` link exited 1, which also breaks acceptance criterion 4 |
+| 11b | A link under `_agent_x/skills/` whose target is a **file**, and one whose target is **missing** | `E-SKILL-DIR-LINK` in both cases. `:578` tests only `is_symlink()` and never inspects the target |
+| 12 | A linked directory elsewhere (not under any `skills/`) | no finding, not descended |
+| 12a | `_agent_x/skills/target/SKILL.md` with a broken frontmatter, and the same under `node_modules` and `.git` names | `E-FM-*` reported for all three. Step 6 added this. `SKIP_DIRS` must not apply inside a `skills/` directory: `target` matches `^[a-z0-9-]{1,64}$` and is a legal skill name, and under Step 4/5 the checker skipped the directory and reported **nothing** while the indexer rejects it |
+| 12b | A directory link **directly named** `skills` under `_agent_x`, resolving to a real directory | `E-SKILLS-NOT-DIR` (6.2 step 4), and **not** `E-SKILL-DIR-LINK`: the symlink branch of step 3 must not claim it first |
+
+**Entrypoint (6.3)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 13 | `skills/x/SKILL.md`, valid | no error, `skillsIndexable: 1` |
+| 14 | `skills/x/skill.md`, otherwise valid | `E-ENTRYPOINT-CASE`, exit 1 |
+| 15 | `skills/x/Skill.md` with a broken name too | both `E-ENTRYPOINT-CASE` and `E-NAME-INVALID`, proving validation continues after a casing error |
+| 16 | `skills/x/` with no entrypoint at all, in canonical position | `E-NO-ENTRYPOINT` |
+| 17 | Same, outside canonical position | `I-NO-ENTRYPOINT`, exit 0 |
+| 18 | `SKILL.md` is a directory | `E-ENTRYPOINT-NOT-FILE` |
+| 19 | `SKILL.md` is a symlink | `E-ENTRYPOINT-LINK` |
+| 20 | Both `SKILL.md` and `skill.md` present | `W-ENTRYPOINT-CASE-SHADOWED`, exit 0 |
+
+**Frontmatter (6.4)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 21 | No frontmatter at all | `E-FM-NO-OPEN` |
+| 22 | One blank line before `---` | `E-FM-NO-OPEN` (`F1`) |
+| 23 | CRLF on both delimiters | valid |
+| 24 | BOM on the opening delimiter | valid (`F2`) |
+| 25 | BOM on the closing delimiter | `E-FM-NO-CLOSE` (`F5`) |
+| 26 | `  ---  ` with surrounding spaces | valid (`F4`) |
+| 27 | `----` as the opening fence | `E-FM-NO-OPEN` |
+| 28 | `+++` as the opening fence | `E-FM-NO-OPEN` |
+| 29 | File is exactly `---` with no trailing newline | `E-FM-NO-CLOSE`, not `E-FM-NO-OPEN` (`:374-386`) |
+| 29a | `---\nname: ok-name\n---` with **no trailing newline**, so the closing delimiter is the unterminated final line | **valid, zero findings, exit 0** (`:382-383`). Step 6 added this. It is the shape every editor without "insert final newline" produces, and the obvious implementations (`split('\n')`, or "a line is complete only when a `\n` is seen") report `E-FM-NO-CLOSE` on it. Without this case that false positive ships |
+| 29b | `---\nname: ok-name\ndescription: x` with no trailing newline, so the unterminated final line is a **body** line | `E-FM-NO-CLOSE` (`:385` appends, then `:389` returns). Pins the other half of the EOF branch |
+| 29c | Same as 29b but the unterminated final body line is large enough to overflow the 16384 budget | `E-FM-TOO-LARGE`, not `E-FM-NO-CLOSE`. Pins that the append at `:385` runs before the ``missing closing`` return at `:389` |
+| 29d | Zero-byte file | `E-FM-NO-OPEN` (`:390-392`, `current_line` empty so the `:374` branch is skipped) |
+| 30 | Opening `---` present, EOF before a closing one | `E-FM-NO-CLOSE` |
+| 31 | Frontmatter body of 16385 bytes | `E-FM-TOO-LARGE` |
+| 32 | Frontmatter body of 16000 bytes | valid |
+| 33 | Invalid UTF-8 byte inside the frontmatter | `E-FM-NOT-UTF8` |
+| 34 | Invalid UTF-8 bytes only in the body, after the closing delimiter | valid; the body is never read |
+| 35 | First line of 2000 bytes with no newline, file longer | `E-FM-FIRST-LINE-TOO-LONG` |
+| 35a | Opening line of 1020 spaces then `---\n`, exactly 1024 bytes | **valid**. Pins the inclusive side of the 1024 boundary (Section 12.2) |
+| 35b | Opening line of 1021 spaces then `---\n`, exactly 1025 bytes | `E-FM-FIRST-LINE-TOO-LONG`. Pins the exclusive side, and proves the terminator is counted |
+| 35c | Valid frontmatter whose **closing** `---` is padded with enough leading spaces to exceed `(16384 - body) + 8` | `E-FM-TOO-LARGE`, not a successful close. Pins Guard A (Section 12.3). Without Guard A the checker passes a file the indexer rejects |
+| 35d | Frontmatter using `\r\n` throughout, sized so the body is 16384 bytes counting both terminator bytes per line | valid; adding one more line tips it to `E-FM-TOO-LARGE`. Pins that `\r\n` costs two bytes |
+| 35e | A file whose only line endings are bare `\r` | `E-FM-NO-OPEN`. Classic-Mac endings are not supported (6.4 step 1) |
+| 35f | Opening delimiter line padded with `\x0B` (vertical tab) around `---` | `E-FM-NO-OPEN`. `\x0B` is not ASCII whitespace in Rust, so a JS `\s` or `trim()` port would wrongly accept it (6.4.1) |
+
+**YAML (6.5)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 36 | `---\n---\n`, empty frontmatter | `E-YAML-NOT-MAPPING` (`Y2`) |
+| 37 | Root is a sequence (`- a`) | `E-YAML-NOT-MAPPING` |
+| 38 | A tab in a line's indentation | `E-YAML-PARSE` |
+| 39 | Single- and double-quoted values | parsed as strings |
+| 40 | Literal (`\|`) and folded (`>`) block scalars for `description` | parsed as strings, no finding |
+| 41 | `name: 42`, `name: true`, `name: null`, `name:` with no value | each `E-NAME-NOT-STRING` |
+| 42 | `description: yes`, and `description: on` | **no finding**, exit 0, both are plain strings under the YAML 1.2 core schema (Section 12.5) |
+| 42a | Body of two colon-free lines, e.g. `This skill helps with X.` then `It does Y.` | `E-YAML-NOT-MAPPING`, **exit 1**. Step 6 added this. The root is a multi-line plain scalar and the indexer hard-rejects it at `:633`; the Step 4/5 rule only caught the single-line form, so this exited 0 as a warning (6.5.3 row 4) |
+| 42b | Body is the single line `{name: ok-name}` (a flow mapping at the root) | `W-YAML-UNDECIDABLE`, exit 0. Pins the exception to row 4: zero recognized entries is not proof the root is a scalar |
+| 42c | `name: "ok-name"  # renamed`, and `name:<TAB>ok-name` | **each valid, zero findings, exit 0** (6.5.1a). Pins the separator and trailing-comment grammar |
+| 42d | `description: \|` whose block content is indented two spaces and whose lines begin with a tab **after** that indent | **valid, zero findings**. Pins that a tab inside block-scalar content is not `E-YAML-PARSE` (6.5.3 row 1) |
+| 42e | `description: \|` whose block content includes the line `name: shadowed`, with a real `name` key elsewhere | **no `E-YAML-DUPLICATE-KEY`**: the block consumes it as content (6.5.1a) |
+| 42f | `name: !!str ok-name` (a tag), and `name: &a ok-name` (an anchor) | `W-YAML-UNDECIDABLE` plus `W-NAME-UNDECIDABLE`, **exit 0**. Step 6 added this. Both resolve to the valid name `ok-name` and the indexer indexes them cleanly; under Step 4/5 the charset check on the literal text emitted `E-NAME-INVALID` and exited 1 (6.5.2) |
+| 43 | Nested mapping under a key | `W-YAML-UNDECIDABLE` |
+| 44 | Flow mapping `{a: 1}` as a value | `W-YAML-UNDECIDABLE` |
+| 45 | An anchor, an alias and a tag | each `W-YAML-UNDECIDABLE` |
+| 46 | `name` given twice | `E-YAML-DUPLICATE-KEY`, **exit 1**, no field-level finding emitted for that entrypoint (Section 12.1) |
+| 46b | An **ignored** key such as `foo` given twice | `E-YAML-DUPLICATE-KEY`, exit 1. Duplicate detection covers every top-level key, not just the three the indexer reads |
+| 46c | `name` once and `'name'` once (quoted) | `E-YAML-DUPLICATE-KEY`: same key after unquoting |
+| 46d | `name` and `Name` | no duplicate finding: key matching is case-sensitive (`:449-450`) |
+| 47 | Unknown key `foo: bar` | no finding (`Y6`) |
+| 48 | `when-to-use` key | `I-KEY-HYPHEN-VARIANT`, exit 0 |
+| 49 | Comment-only and blank lines mixed in | ignored |
+
+**Fields (6.6)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 50 | No `name`, directory `my-skill` | valid, resolved name `my-skill` (`N1`) |
+| 51 | No `name`, directory `My_Skill` | `E-NAME-INVALID`, message names the folder fallback as the source (the `N3` trap) |
+| 52 | `name: ''` in directory `ok-name` | falls back to `ok-name`, valid (`Y5`) |
+| 53 | `name` differing from the directory name, both valid | no finding (`N4`) |
+| 54 | 64-character valid name | valid |
+| 55 | 65-character name | `E-NAME-INVALID` |
+| 56 | `name: Café` | `E-NAME-INVALID`, and the length must be counted in scalar values |
+| 57 | Two directories in one `skills/` resolving to the same name | `E-NAME-DUPLICATE` on the second in sort order, and the message names the winner |
+| 58 | Same clash across two different `skills/` directories | no finding (6.6.4 step 2) |
+| 59 | `description` absent | `W-DESC-MISSING`, exit 0, counted in `skillsIndexable` |
+| 60 | `description: ''` | `W-DESC-MISSING` (`D1`) |
+| 61 | `description: 42` | `W-DESC-NOT-STRING`, exit 0 |
+| 62 | `when_to_use: 42` | `W-WHEN-NOT-STRING`, exit 0 |
+| 63 | `when_to_use` absent | no finding |
+| 63a | `name: "﻿ok-name"` (a leading U+FEFF inside the quoted value) | `E-NAME-INVALID`. `String.prototype.trim()` would strip the U+FEFF and wrongly pass it; Rust `str::trim` does not (Section 5.1.2) |
+| 63b | `name: "ok-name"` (a leading U+0085 NEL) | **valid**, resolved name `ok-name`. Rust trims U+0085 and JS `trim()` does not, so a naive port fails this one |
+| 63c | A skill directory in canonical position whose listing throws (permissions, or a path-length failure) | `E-SKILL-DIR-UNREADABLE`, exit 1, not `W-DIR-UNREADABLE` (6.2 step 1). **Step 7 corrected the code**: this row still named `E-SKILLS-DIR-UNREADABLE`, which G16 split away from it. Case 79 already refers to "case 63c's `E-SKILL-DIR-UNREADABLE`", so the two rows contradicted each other and an implementer writing the test from this row would have asserted the wrong code against a correct implementation |
+| 63g | The **same** fixture as 63c but placed outside canonical position, for example `docs/skills/x/` | `W-DIR-UNREADABLE`, **exit 0**. **Step 7 added this case.** 9.2.2 stated that `W-DIR-UNREADABLE` had no case and that cases 76-79 closed it; none of them does, so acceptance criterion 12 was still unsatisfiable for that code with only one named exemption. It also pins the rule-2 gate from the warning side, which nothing else does. Skips exactly like 63c and for the same reason |
+| 63d | In one `skills/`, dir `aaa` with broken frontmatter that would resolve to `shared`, and dir `bbb` resolving to `shared` cleanly | `E-FM-*` on `aaa` and **no finding on `bbb`**. Pins that a candidate with any earlier hard error never claims its name (6.6.4) |
+| 63e | `_agent_x/skills` is a **broken** symlink | no finding at all, exit 0 (6.2 step 4) |
+| 63f | `_agent_x/skills` is a symlink resolving to a real directory | `E-SKILLS-NOT-DIR`, exit 1 |
+
+**Position (6.7)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 64 | `_agent_x/skills/y/SKILL.md` | canonical, no `I-NOT-INDEXABLE` |
+| 65 | `__agent_x/skills/y/SKILL.md` | `I-NOT-INDEXABLE`, `reason: replica-root`, exit 0 |
+| 66 | `_agent_x/skills/y/z/SKILL.md` | `reason: not-under-skills-dir` |
+| 67 | `_agent_x/Skills/y/SKILL.md` | `reason: skills-dir-case` |
+| 68 | `docs/examples/SKILL.md` | `reason: owner-root-not-recognized` |
+| 69 | A structurally broken skill in a non-canonical position | still `E-*`, exit 1 (severity rule 1) |
+
+**Output (6.9, 6.10)**
+
+| # | Case | Expect |
+| --- | --- | --- |
+| 70 | `--json` on a tree with findings of all three severities | parses as JSON; `exitCode` matches the process exit; `summary` counts match the array |
+| 71 | `--json` ordering | findings sorted by `path`, then `line`, then `code`, and running twice gives byte-identical output |
+| 72 | `path` separators | every `path` and `skillDirectory` contains no `\` |
+| 73 | A clean tree | exit 0, `errors: 0`, human report ends with `OK:` |
+| 74 | A tree with only warnings and notes | exit 0 |
+| 75 | A tree with one error | exit 1 |
+| 76 | A tree whose **only** fault is `_agent_x/skills` being a plain file | exit 1, and the final human line is `FAIL: M error findings, no entrypoint implicated`, never `FAIL: 0 skills would not be indexed` (6.9). Step 6 added this |
+| 77 | A directory with both `SKILL.md` and `skill.md` (skips per 9.2.1) | `entrypointsFound: 2`, `skillsIndexable: 1`. Pins the 14.5.1 definitions, which 6.10 now carries |
+| 78 | Two `W-YAML-UNDECIDABLE` findings on the same line of the same file | the two orderings are stable across runs, pinning the emission-order tiebreak (6.10) |
+| 79 | `_agent_x/skills/` itself unreadable (skips like 63c) | `E-SKILLS-DIR-UNREADABLE` with the `` `skills` directory could not be read `` message, distinct from case 63c's `E-SKILL-DIR-UNREADABLE`. Pins the code split (6.8) |
+| 80 | A `SKILL.md` whose `name` value contains an embedded `\n` and a `\x1b`, long enough to truncate | the human report stays on the finding's own lines and contains no raw control character (Section 7) |
+
+### 9.3 Acceptance criteria
+
+Objective and individually checkable at `f08b8241` plus this change:
+
+1. `node scripts/01-skills-checker.mjs --help` exits 0 and prints the usage block, **in a checkout
+   where `node_modules/` does not exist**. This is the zero-dependency guarantee and it must be
+   tested exactly that way.
+2. `npm run check:skills:self` exits 0 and prints a pass line naming the number of cases run and the
+   number skipped.
+3. `npm run check:skills -- <path-to-a-matrix-with-a-wrongly-cased-entrypoint>` exits 1 and reports
+   `E-ENTRYPOINT-CASE` for it. Run against the live `tiktok-news-publisher` case from the issue if it
+   is still present; otherwise against a fixture reproducing it.
+4. `npm run check:skills` from the repo root exits 0. The repo tree contains no `SKILL.md`, so this
+   verifies the clean path and that the walk does not choke on `src-tauri/target/` or `node_modules/`.
+5. `npm run check:skills -- --json .` produces output that `JSON.parse` accepts and whose
+   `summary.errors` equals the number of `findings` with `severity === "error"`.
+6. `npm run typecheck` exits 0, `npm test` is green with the same test count as at `f08b8241`, and
+   `npm run test:debt` exits 0. None of the three should be affected; if any changes, the blast
+   radius was exceeded.
+7. `npm run version:check` exits 0, confirming the `package.json` edit did not disturb the anchors in
+   `scripts/check-version-sync.mjs:37`.
+8. `git diff --stat f08b8241..HEAD` touches exactly three files: `plans/1213-skills-checker.md`
+   (force-added, Section 8 step 0), `scripts/01-skills-checker.mjs` and `package.json`. If
+   `package-lock.json` appears, a dependency was added and user decision 5 was broken.
+9. `grep -n "existsSync" scripts/01-skills-checker.mjs` returns nothing. The forbidden call
+   (Section 5.1.2) must not be present in any form.
+10. `grep -n "toString('utf8')\|toString(\"utf8\")" scripts/01-skills-checker.mjs` returns nothing,
+    for the same reason under `F8`.
+11. `grep -n "session_context.rs:206-714" scripts/01-skills-checker.mjs` returns at least one hit, in
+    the header. This is the drift control the coordinator required.
+12. Every code in Section 6.8 is emitted by at least one self-test case, **with one named exemption:
+    `E-ENTRYPOINT-UNREADABLE`**, which needs a file whose `open`/`read` throws and is not reliably
+    constructible as the owning user on Windows or as root on Linux (9.2.2). Verifiable by grepping
+    the code list against the self-test body; the exemption must appear as a comment naming this
+    criterion, so a future reader does not mistake it for an oversight.
+13. **`npm run check:skills:self` exits 0 on Windows without Developer Mode**, and its skip line
+    names only cases 19, 20, 63c, 63g and 79. Step 6 added this criterion: it is the one that proves
+    9.2.1 was implemented, since the failure it guards against, case 20 hard-failing on a
+    case-insensitive filesystem, makes criterion 2 fail on the team's own machines. **Step 7 corrected
+    the list**: it named "only cases 19 and 63c", which omits case 20 (which skips on Windows by
+    9.2.1's own probe, so a run that does not name it has not implemented the probe), case 79 (which
+    shares 63c's unreadable-directory probe) and case 63g (added in Step 7). The parenthetical "plus
+    `E-ENTRYPOINT-UNREADABLE`'s" is dropped because that code has no case to skip; it is an exemption
+    under criterion 12, not a skip.
+14. The self-test prints, for each skipped case, the case number and the reason. A run that skips
+    silently is indistinguishable from a run that passed, which is the same false confidence this
+    whole tool exists to remove.
+
+## 10. Adjacent findings, reported and not changed
+
+1. **The `tiktok-news-publisher` skill is broken right now** in this workspace, with exactly the
+   failure this checker is built to catch. Fixing it is not part of this issue; the checker only has
+   to report it.
+2. **`vitest.config.ts` collects nothing outside `src/`.** Any future `.mjs` script that wants a real
+   vitest suite hits the same wall this plan routes around. Worth a decision of its own, not a
+   side effect of this issue.
+3. **The checker cannot recognize the Root Agent directory** as a legal owner root, because that name
+   is a runtime value in `root_agent.rs:633-639`. The consequence is confined to an `info` finding
+   (Section 6.7, `owner-root-not-recognized`) and never a false failure. If it becomes noisy, the fix
+   is a `--matrix-root-pattern` flag, which this issue does not add.
+4. **Drift has no automatic detector.** The header comment naming `session_context.rs:206-714` is a
+   convention, not a gate. A CI job asserting that the Rust and the `.mjs` agree on a shared fixture
+   corpus would close it, and is a separate issue.
+
+## 11. Risks
+
+| Risk | Mitigation in this plan |
+| --- | --- |
+| The `.mjs` duplicates rules owned by `session_context.rs:206-714` and silently drifts | Mandatory header naming the range (5.1.1), acceptance criterion 11, rule IDs on every finding (6.8), and `indexerMessage` on every mirrored code so a startup warning is searchable back to a checker finding |
+| The mini-parser disagrees with `serde_yaml` and passes a file the app rejects | Anything outside the fixed subset becomes `W-YAML-UNDECIDABLE` (6.5.2) rather than a silent pass. The three certain-error shapes (6.5.3) are the only cases where the parser asserts a hard failure |
+| Case-insensitive discovery accidentally becomes case-insensitive validation | `===` on the listing name (5.1.2), `existsSync` banned, acceptance criterion 9, self-test cases 14, 15, 20 |
+| A generic run over an ordinary repository fails the build on position findings | Position is always `info` (6.7), absence-type findings are promoted to `error` only in canonical position (4.1 rule 2) |
+| An unverified rule (Section 12) turns into a false CI failure | Half closed. Step 5 resolved all five Section 12 items against pinned source, so no finding rests on an unverified *fact*. But Step 6 then found **six false positives** that came from elsewhere — an over-eager severity on undecidable values, an ungated symlink error, two under-specified YAML rules, and a valid file shape nobody had written down (Section 15.3, G4-G7, G13-G14). The lesson is that "every cited fact is verified" is not the same as "every rule is safe": the risk lives in the rules the plan states *without* citing a fact. Each is now corrected, and the self-test cases that pin them are 11a, 29a, 42a-42f and 76 |
+| The pinned `serde_yaml` version changes and takes YAML semantics with it | Two rules in this plan are facts about `0.9.34+deprecated` specifically, not about YAML: duplicate keys are fatal (12.1) and plain `yes`/`no`/`on`/`off` are strings (12.5). Both cite the crate file and line. A `serde_yaml` bump is a reason to re-read Section 12, and the crate is deprecated upstream, so that bump will come |
+
+## 12. Formerly unverified items: all five RESOLVED in Step 5
+
+Step 4 could not confirm these five facts and fixed the checker's behaviour conservatively. Step 5
+(dev-rust) settled every one of them against pinned source. Nothing in this section is open any more.
+Where the resolved fact contradicts the Step 4 behaviour, the owning section has been corrected and
+the change is named below.
+
+The `serde_yaml` version is pinned at **0.9.34+deprecated** (`src-tauri/Cargo.toml:12` declares
+`serde_yaml = "0.9"`; `Cargo.lock:5483-5486` resolves it to `0.9.34+deprecated`, on
+`unsafe-libyaml 0.2.11` at `Cargo.lock:6893-6896`). Items 1 and 5 are answered from that crate's
+vendored source, so they are facts about the version this repo actually builds, not about the family.
+
+### 12.1 YAML duplicate keys: RESOLVED. They are REJECTED, so this is a hard error.
+
+`serde_yaml` 0.9.34 rejects duplicate mapping keys. The chain is three hops and every one is source:
+
+1. `session_context.rs:621` parses with `serde_yaml::from_str::<serde_yaml::Value>`.
+2. `Value`'s map visitor delegates the whole mapping to `Mapping::deserialize`
+   (`serde_yaml-0.9.34/src/value/de.rs:100-107`).
+3. `Mapping`'s visitor walks entries and returns `Err(DuplicateKeyError)` the moment
+   `mapping.entry(key)` is `Entry::Occupied` (`serde_yaml-0.9.34/src/mapping.rs:813-822`).
+
+The rendered message for a string key is `duplicate entry with key "name"`
+(`mapping.rs:840` writes the prefix, `:845` formats a `Value::String` key with `{:?}`); `serde_yaml`
+appends its own position suffix. It surfaces through `session_context.rs:624-628` as a hard error.
+
+**Change applied:** Section 6.5.4 now emits `E-YAML-DUPLICATE-KEY` (**error**), not
+`W-YAML-DUPLICATE-KEY` (warning). Section 6.8 gains the code and loses the warning. The
+"first occurrence wins" resolution rule is deleted: the indexer never resolves any field, because the
+parse itself fails and the skill is skipped outright. Self-test case 46 is corrected.
+
+Note the scope: the check is on the deserialized mapping, so it applies to **any** duplicated
+top-level key, including keys the indexer never reads. `foo: 1` twice is fatal even though `foo` is
+otherwise ignored under `Y6`. The checker must therefore run duplicate detection over every key, not
+only over `name`, `description` and `when_to_use`.
+
+### 12.2 The 1024-byte limit: RESOLVED. First line only, CONFIRMED, with a boundary correction.
+
+`session_context.rs:342-351` is an if/else on `saw_opening`:
+
+```rust
+if !saw_opening {
+    if current_line.len() > 1024 { return Err("missing opening frontmatter delimiter"); }
+} else {
+    let remaining = SKILL_FRONTMATTER_MAX_BYTES.saturating_sub(frontmatter.len());
+    if current_line.len() > remaining.saturating_add(8) { return Err(frontmatter_limit_error()); }
+}
+```
+
+The 1024 test is unreachable once the opening delimiter has been seen, so the plan's assumption holds:
+**no per-line limit applies to body lines**, only the frontmatter-total guard in the `else` arm.
+
+Two corrections, both boundary-exact:
+
+- The limit **includes the line terminator**. The check runs after `current_line.push(*byte)`
+  (`:340`) and before the `if *byte != b'\n'` short-circuit (`:353`), so the `\n` itself is counted.
+  A first line of 1020 spaces plus `---\n` is 1024 bytes and is **valid**; 1021 spaces plus `---\n`
+  is 1025 bytes and fails. The rule is: **the first line including its terminator must be at most
+  1024 bytes.** Section 6.4 step 1 has been restated in those terms; its previous wording
+  ("scan for the first `\n` within the first 1024 bytes") is off by the terminator byte.
+- A corollary worth stating because rule `F4` invites the opposite conclusion: whitespace padding
+  around the opening `---` is tolerated by the trim, but only up to this 1024-byte ceiling. Past it
+  the file fails, and it fails as ``missing opening frontmatter delimiter``, not as a size error.
+
+### 12.3 What the 16384-byte count includes: RESOLVED. Terminators counted, CONFIRMED, plus a missed rule.
+
+`append_frontmatter_line` (`:311-317`) tests `frontmatter.len() + line.len() > 16384` and then
+appends `line` verbatim. `line` is `&current_line`, and `current_line` accumulates every byte
+including the `\n` (`:340`) and is only cleared after the append (`:370`). So terminators **are**
+counted, `\r\n` costs two bytes, and both delimiter lines are excluded: the opening line is cleared
+without appending (`:362`) and the closing line returns before the append (`:366-367`). The plan's
+assumption is confirmed exactly.
+
+**But Step 4 missed a second, independent limit** in the same `else` arm quoted in 12.2: a
+**mid-line** guard that fires while a line is still being read, at
+`current_line.len() > (16384 - frontmatter.len()) + 8`.
+
+For an ordinary body line this only stops the read a few bytes earlier and produces the same message,
+so it changes nothing. It matters in exactly one place: **it also applies to the closing delimiter
+line**, which `append_frontmatter_line` never sees. A closing `---` padded with enough leading
+whitespace to exceed `remaining + 8` is rejected with ``frontmatter exceeds 16384 byte limit``
+instead of closing the block, even though `is_frontmatter_delimiter` would have accepted it.
+
+**Change applied:** Section 6.4 step 3 now applies the guard to every post-opening line before
+deciding whether that line is the closing delimiter. Without it the checker would accept a file the
+indexer rejects. This is one of the two false passes named in Section 14.3.
+
+### 12.4 How `skills` is matched: RESOLVED. It is a path join. The platform divergence is real.
+
+`session_context.rs:509` is `let skills_path = matrix_path.join(SKILLS_DIR_NAME);`, and every
+subsequent operation takes that joined path: `:520` `skills_path.exists()`, `:524`
+`symlink_metadata(&skills_path)`, `:542` `read_dir(&skills_path)`. There is **no** directory listing
+of the matrix root and **no** entry-name comparison anywhere in this path. So the plan is right on
+both counts: it is a join, and it is the only genuinely platform-divergent rule in the surface.
+`_agent_x/Skills/` resolves on Windows and does not on Linux. `reason: skills-dir-case` stays
+informational, which is the correct call for a rule whose outcome depends on the reader's OS.
+
+Contrast this with the entrypoint at `:401`, which **is** an entry-name comparison
+(`entry.file_name() != OsStr::new("SKILL.md")`) and is therefore uniform on every platform. The two
+constants look symmetric in the source and behave differently. That asymmetry is the single most
+counter-intuitive fact in the whole surface and belongs in the script's header comment.
+
+**Change applied:** none to behaviour. Section 6.7 `skills-dir-case` was already correct.
+
+### 12.5 YAML 1.1 vs 1.2 scalar resolution: RESOLVED. It is YAML 1.2 core schema.
+
+`serde_yaml-0.9.34/src/de.rs:932-938`:
+
+```rust
+fn parse_bool(scalar: &str) -> Option<bool> {
+    match scalar {
+        "true" | "True" | "TRUE" => Some(true),
+        "false" | "False" | "FALSE" => Some(false),
+        _ => None,
+    }
+}
+```
+
+and `:925-930`, `parse_null`, accepts only `null`, `Null`, `NULL`, `~`. Nothing else resolves to a
+bool or a null. `yes`, `no`, `on`, `off`, `y`, `n` and every case variant resolve as **plain
+strings**. This is the YAML 1.2 core schema, not YAML 1.1.
+
+`de.rs:895-896` confirms the dispatch: only `ScalarStyle::Plain` reaches `visit_untagged_scalar`,
+which is where `parse_null` and `parse_bool` are consulted. Single-quoted, double-quoted, literal and
+folded scalars fall through to `visitor.visit_str` (`:898-902`) and are **always** strings. The
+plan's 6.5.1 table was already right about quoted and block scalars; it is now also settled for
+plain ones.
+
+**Change applied:** `yes` / `no` / `on` / `off` / `y` / `n` are removed from the
+`W-YAML-UNDECIDABLE` list in 6.5.2 and added to 6.5.1 as strings. `description: yes` is a clean
+string and produces **no finding at all**. Self-test case 42 is corrected. Emitting a warning there
+would have been a false positive on a spelling authors use routinely.
+
+## 13. Open decisions
+
+None. The CLI surface, the exit-code mapping, the full finding taxonomy, the severity of the position
+category, the JSON schema and its ordering, the YAML subset and its out-of-subset behaviour,
+duplicate-key handling, duplicate-name comparison scope, symlink and loop handling, the test location
+and the fixture strategy are all fixed above. The five items in Section 12 are no longer unverified:
+Step 5 resolved every one against pinned source, and the two that contradicted Step 4's conservative
+choice have been corrected in the sections that own them.
+
+**Step 6 opened none either.** All seventeen of its findings (Section 15.3) were decided from source
+already pinned in this plan, and each was corrected in place rather than escalated. Three of them do
+change decisions Step 4 recorded: `SKIP_DIRS` no longer applies inside a `skills/` directory,
+`E-SKILL-DIR-LINK` is now gated on canonical position, and an undecidable value may never produce an
+error. All three are narrowings of checker-side policy, not reversals of a user decision.
+
+**Step 7 opened none either, and closed eight internal gaps.** None needed new evidence and none
+changed a rule the indexer imposes; all eight were contradictions or omissions inside this document,
+listed in Section 16.2. The one that changes behaviour an implementer would write is the corrected
+finding code on self-test case 63c. The rest make the normative text say what the plan already
+decided.
+
+**Nothing in this file is unresolved, deferred, pending a later decision, offered as a competing
+alternative, or left to the implementer's judgement.** Verified in Step 7 by reading every section
+start to finish, not by grep. The wording here deliberately avoids the placeholder tokens themselves
+so that a mechanical audit of this file for those tokens comes back empty.
+
+## 14. Step 5 record (dev-rust)
+
+### 14.1 Codebase Memory gate: DOWN, diagnosed, not worked around
+
+The gate was run three times against `repo-AgentsCommander` and failed identically every time:
+
+```
+{"operation":"gate","error":"status.git.base_sha must be a string"}
+```
+
+**The message is misleading. `base_sha` IS a string; it is the empty string.** `index_status` for
+this project returns `"base_sha": ""` alongside a correct `"head_sha":
+"f08b82419b7943d694965af000630bf053e2922a"`, `"status": "ready"`, 20185 nodes and 107234 edges. The
+gate's `Assert-String` rejects a whitespace-only string unless `-AllowEmpty` is passed, and the
+`base_sha` assertion does not pass it. So the index itself is healthy and fresh at branch HEAD; only
+the gate's precondition fails.
+
+**Why `base_sha` is empty.** Codebase Memory populates it only when the branch's upstream resolves.
+A three-arm comparison across sibling clones on this machine settles it:
+
+| Clone | Branch | `remote.origin.fetch` | `@{u}` resolves | `base_sha` |
+| --- | --- | --- | --- | --- |
+| `wg-11/repo-agentscommander_webpage` | `main` | main only | yes | `6a7d3ae2`, equals head |
+| `wg-2/repo-AgentsCommander` | `fix/1206-flaky-tests-parallel-load` | main **plus that branch** | yes | `f08b8241`, equals head |
+| `wg-7/repo-AgentsCommander` | `feature/1173-...` | main only, no upstream configured | no | **empty** |
+| `wg-11/repo-AgentsCommander` (this one) | `feature/1213-skills-checker` | main only | no | **empty** |
+
+The wg-2 arm is the decisive one: it is on a feature branch and its gate precondition is satisfied,
+so the predictor is not "the branch must be `main`". It is upstream resolvability, and wg-2 has an
+extra explicit refspec line for its branch.
+
+**The architect's hypothesis was directionally right but imprecise, and the tech lead's fix could not
+have worked.** The upstream *is* configured here: `branch.feature/1213-skills-checker.remote=origin`
+and `.merge=refs/heads/feature/1213-skills-checker`. The remote-tracking ref also exists;
+`git rev-parse --verify refs/remotes/origin/feature/1213-skills-checker` returns `f08b8241`. Git
+still refuses:
+
+```
+fatal: upstream branch 'refs/heads/feature/1213-skills-checker' not stored as a remote-tracking branch
+```
+
+because git resolves `@{u}` by mapping `branch.<name>.merge` **through the remote's fetch refspec**,
+not by testing whether a ref file exists. With `remote.origin.fetch =
++refs/heads/main:refs/remotes/origin/main`, `refs/heads/feature/1213-skills-checker` maps to nothing.
+Pushing the branch and fetching its ref cannot fix that, which is exactly what was observed.
+
+The remedy is one refspec line, the shape wg-2 already has. **It was not applied**: the instruction
+was to diagnose, not to work around, and no git config, refspec or branch was changed.
+
+There is also a latent second blocker behind this one. Even with `base_sha` populated, the gate
+requires `base_sha == head_sha`. That holds today only because this branch has no commits of its own
+(`git merge-base HEAD origin/main` returns `f08b8241`, which is HEAD). Once a real commit lands here,
+whether the gate passes depends on whether Codebase Memory sets `base_sha` to HEAD or to the
+merge-base. Worth knowing before anyone treats the refspec as a complete fix.
+
+### 14.2 Method and what the gate outage costs
+
+With the gate down, Section 12 and the fidelity review were settled by direct reads, which the Step 5
+brief explicitly authorised. Sources read, all read-only:
+
+- `src-tauri/src/config/session_context.rs`, ranges `:204-418`, `:446-490`, `:489-698`.
+- `src-tauri/Cargo.toml:12` and `Cargo.lock:5482-5496`, `:6892-6896` for the pins.
+- Vendored `serde_yaml-0.9.34+deprecated`: `src/de.rs:846-938`, `src/value/de.rs:100-107`,
+  `src/mapping.rs:813-851`.
+
+**Confidence cost, stated plainly.** The gate provides breadth, not depth: it certifies that the
+graph is complete and fresh so that a "no other caller exists" claim is trustworthy. Everything in
+Section 12 and Sections 14.3 and 14.4 is a *local* fact about code that was read line by line, and
+those are unaffected. What is weaker is the negative claim inherited from the evidence artifact that
+`session_context.rs` is the **only** module implementing these rules and that no second call site
+enforces anything additional. That claim was verified under a clean gate during the original
+investigation at this same HEAD `f08b8241`, and nothing has been committed to the branch since, so it
+still holds by provenance rather than by re-verification. If a reviewer wants that re-established
+independently, the refspec has to be fixed first.
+
+### 14.3 Fidelity defects found and corrected
+
+Seven. Two would have made the checker approve a file the indexer rejects, which is the failure mode
+this tool exists to prevent.
+
+| # | Defect | Section | Corrected to | Impact |
+| --- | --- | --- | --- | --- |
+| 1 | The mid-line frontmatter guard at `:346-351` was missed entirely, so a whitespace-padded closing `---` would close the block instead of failing | 6.4 step 3 | Guard A added, applied before the closing-delimiter test | **False pass** |
+| 2 | `String.prototype.trim()` strips U+FEFF and Rust `str::trim` does not | 5.1.2, 6.6.1 | Explicit Unicode `White_Space` set, JS `trim()` banned for field values | **False pass** |
+| 3 | Duplicate YAML keys specified as a warning; `serde_yaml` 0.9.34 rejects them | 6.5.4, 6.8, 12.1 | `E-YAML-DUPLICATE-KEY`, error, scoped to every top-level key | False negative |
+| 4 | An unreadable skill directory in canonical position was routed to `W-DIR-UNREADABLE`; the indexer treats it as a hard error (`:396-397`) | 6.2 step 1 | Promoted to `E-SKILLS-DIR-UNREADABLE` | False negative |
+| 5 | Duplicate-name participation limited to `E-NAME-*` failures; any earlier hard error also removes a candidate | 6.6.4 | Rewritten with a worked example | **False positive**: blames an innocent skill |
+| 6 | `yes` / `no` / `on` / `off` listed as undecidable; 0.9.34 resolves them as plain strings | 6.5.1, 6.5.2, 12.5 | Removed from the undecidable list, added as strings | False positive on common spellings |
+| 7 | The 1024-byte first-line rule stated as "find `\n` within the first 1024 bytes"; the terminator is counted, so the real ceiling is 1024 **including** it | 6.4 step 1, 12.2 | Restated as a running-length test, with boundary cases 35a and 35b | Off by one byte |
+
+Also corrected without changing behaviour: a broken `skills` symlink is silent rather than
+`E-SKILLS-NOT-DIR`, because `:520` gates on `Path::exists`, which follows links (6.2 step 4). And two
+Rust-versus-JS comparison hazards are now spelled out in 5.1.2: `u8::is_ascii_whitespace` excludes
+`\x0B`, and Rust `String` ordering is UTF-8 byte order rather than JS UTF-16 code-unit order.
+
+### 14.4 Correction to the evidence artifact
+
+`__agent_dev-rust/findings/skill-md-validation-rules.md` states 22 hard-error conditions. **The
+correct number is 23.** Its hard-error table omits
+
+``Skipped skill directory `{folder}`: could not inspect exact SKILL.md entrypoint: {err}``
+
+emitted when `entry.file_type()` fails on the `SKILL.md` entry at `session_context.rs:405-407`,
+wrapped by `:600-606`. The artifact documents the sibling failure at `:569-573` for skill directories
+but not this one for the entrypoint. The error is mine and it propagated into this plan's
+Section 6.8, which claimed to account for "all 22 hard errors". Section 6.8 now says 23 and lists the
+condition in the unmappable bucket, where it belongs: Node resolves `Dirent` types inside
+`readdirSync`, so there is no separate per-entry call that can fail.
+
+Nothing else in the artifact was found to be wrong. Every other rule, message string and `file:line`
+in it that this plan depends on was re-checked against `f08b8241` during this pass and holds. The
+artifact's single self-declared unknown, duplicate-key behaviour, is now resolved in Section 12.1.
+
+### 14.5 Implementability flags
+
+Not defects in the rules, but places where an implementer would otherwise have to guess.
+
+1. **`entrypointsFound` needs a definition.** With a shadowed casing variant (6.3 row 5) one
+   directory yields two matches, one validated and one not. Fix the contract: `entrypointsFound`
+   counts **every** discovered match including shadowed ones, `skillsIndexable` counts only
+   fully validated entrypoints with zero `error` findings. Otherwise `summary` numbers will not
+   reconcile with the findings array and self-test case 70 is untestable.
+2. **JSON ordering needs a final tiebreak.** `path`, then `line`, then `code` can still tie, for
+   example two `W-YAML-UNDECIDABLE` findings reported for the same line. Append emission order as
+   the last key so the sort is total and case 71's byte-identical guarantee actually holds.
+3. **`statSync` is required and must not be refactored away.** 6.2 step 4 needs one link-following
+   `fs.statSync(p, { throwIfNoEntry: false })` to separate a broken symlink from a resolving one.
+   Acceptance criterion 9 bans `existsSync` and this is not that, but the two look alike enough that
+   the ban should be read as naming `existsSync` only.
+4. **`Dirent.isSymbolicLink()` on Windows junctions should be proven, not assumed.** The plan leans
+   on it in three places. libuv reports reparse points as `UV_DIRENT_LINK`, so it should hold, but
+   nothing in this repo pins it. Self-test case 11 covers it only where the platform lets the test
+   create a junction, and unprivileged Windows without Developer Mode will skip exactly the case that
+   matters. Recommend the implementer run case 11 on a Windows box with Developer Mode on and record
+   the result, rather than shipping on a skipped test.
+5. **Case-variant `skills` in step 4 of 6.2 is platform-divergent** in the same way as 12.4. A file
+   named `Skills` under an `_agent_*` directory is `E-SKILLS-NOT-DIR` on Windows and invisible on
+   Linux. Emitting the error on both keeps the report stable across platforms and is the right call,
+   but the message should say so rather than implying a universal rule.
+6. **Node's `readdirSync` lossily converts unpaired surrogates in filenames**, and Rust's
+   `to_string_lossy` at `:565` does the same, so the two agree. Worth a one-line comment at the call
+   site so a future reader does not "fix" it toward a buffer-based listing and silently diverge.
+
+**Step 6 note on this section.** Items 1 and 2 above were recorded here and **never written into the
+sections that own them**. Section 6.10's field table still carried the superseded definition of
+`skillsIndexable`, never defined `entrypointsFound` at all, and its ordering paragraph still stopped
+at `code` with no emission-order tiebreak. Unlike Section 14.3, whose seven defects say "corrected in
+place in the section that owns it", Section 14.5 is a record only — and an implementer working from
+the normative sections would have followed 6.10 and shipped both bugs. Both are now applied in 6.10.
+Item 3's `statSync` carve-out is restated in acceptance criterion 9's own wording, item 4 is answered
+constructively in 9.2.1 (use a junction on win32 and stop skipping the case), and item 5 is answered
+in 6.2 step 1. Item 6 stands as written.
+
+## 15. Step 6 record (dev-rust-grinch)
+
+### 15.1 Method, and the Codebase Memory gate
+
+**The gate is green.** Run against `repo-AgentsCommander`, it returned
+`{"operation":"gate","status":"ready", ... "nodes":20185,"edges":107234,`
+`"git":{"is_git":true,"head_sha":"f08b8241…","base_sha":"f08b8241…"}}`. The tech lead's
+`git remote set-branches --add` fix worked: `@{u}` now resolves and `base_sha` is populated. Section
+14.1's diagnosis is confirmed correct in full, including the part about the refspec being the actual
+cause rather than the missing remote-tracking ref.
+
+Graph operations used: `name` over `(?i)(skill|frontmatter|yaml_field|is_valid_skill)`, and `trace`
+on `discover_skill_index`. The trace settles the negative claim Section 14.2 could only carry by
+provenance: `discover_skill_index` has exactly **one** production caller,
+`ensure_session_context_with_config`; every other inbound edge is a test. Its callee set is closed
+and is exactly the surface this plan mirrors — `find_exact_skill_entrypoint`,
+`extract_skill_frontmatter`, `is_frontmatter_delimiter`, `append_frontmatter_line`,
+`frontmatter_utf8`, `yaml_field_string`, `is_valid_skill_name`. No second module implements these
+rules at `f08b8241`. That claim is now re-established independently rather than inherited.
+
+Direct reads then went past the skill's one-fallback allowance, deliberately and with the Step 6
+brief's explicit authorisation: `session_context.rs:204-423` and `:440-719` were read line by line,
+because a fidelity pass over a pinned range is verification of exact text, not exploration. Every
+finding below cites the line it came from.
+
+### 15.2 The open question about the gate after a real commit lands
+
+Section 14.1 flagged this and nobody had settled it. `cbm.ps1:2317` is
+
+```powershell
+if ($git['head_sha'] -cne $head -or $git['base_sha'] -cne $head) { throw 'Codebase Memory Git state is stale' }
+```
+
+so the gate requires `base_sha == HEAD`, not `base_sha == merge-base`. `base_sha` is derived from
+upstream resolution. **Under either reading of that derivation the answer is the same:** if
+`base_sha` is `rev-parse @{u}`, an unpushed local commit leaves it at the remote ref while `head_sha`
+advances; if it is `merge-base(HEAD, @{u})`, an unpushed commit leaves it at the old head. Both
+diverge from HEAD, and the gate throws `Codebase Memory Git state is stale`.
+
+**Operational consequence for Step 8: commit, push, then re-index and re-gate.** Pushing advances the
+remote ref, which repairs `base_sha` under both readings. A gate failure between the commit and the
+push is expected and is not a regression of the refspec fix.
+
+This is settled by the assertion plus the derivation, not by experiment: no clone on this machine is
+currently ahead of its upstream (all 35 sibling repos surveyed read `ahead = 0`), so there was no way
+to observe the failing state directly without changing branch state, which Step 6 was told not to do.
+
+### 15.3 Defects found and corrected
+
+Seventeen. Three are false passes, the class the brief named as the one that matters most, and six
+are false positives that would fail a run over a healthy tree.
+
+| # | Defect | Section | Corrected to | Impact |
+| --- | --- | --- | --- | --- |
+| G1 | Step 3 of the walk opened "For each entry that is a directory", so the nested `isSymbolicLink()` branch is **unreachable**: Node `Dirent`s use lstat semantics, and `isDirectory()` is false for every symlink | 6.2 step 3 | Rewritten to test `isSymbolicLink()` first, mirroring `:578-585` | **False pass** |
+| G2 | `SKIP_DIRS` applied unconditionally, so `_agent_x/skills/target/` is never scanned; `target` is a legal skill name and the indexer applies no name filter | 6.2 step 3 | `SKIP_DIRS` never applies inside a `skills/` directory | **False pass** |
+| G3 | `E-YAML-NOT-MAPPING` required "a **single** line with no `:`"; a two-line colon-free body is a multi-line plain scalar the indexer hard-rejects at `:633`, and fell through to a warning | 6.5.3 | Restated as "zero recognized entries plus significant content", with an exception for flow/tag/anchor lines | **False pass** |
+| G4 | An `undecidable` `name` still ran the charset check at **error** severity, so `name: !!str ok-name` exited 1 on a skill the indexer indexes cleanly | 6.5.2, 6.6.1 | `W-NAME-UNDECIDABLE` (warning); an undecidable value may never yield an error | False positive |
+| G5 | `E-SKILL-DIR-LINK` was not gated on canonical position, unlike its sibling `E-SKILLS-NOT-DIR` in the very next step | 6.2 step 3 | Gated; `W-SKILL-DIR-LINK` outside canonical position | False positive |
+| G6 | "A tab in the indentation of any frontmatter line" fires on tab-indented content **inside** a `description: \|` block, which libyaml accepts | 6.5.3 | Restricted to lines treated as mapping entries | False positive |
+| G7 | A file with no trailing newline whose last line is the closing `---` is **valid** (`:382-383`), and neither the prose nor any self-test said so | 6.4 step 3 | EOF branch given its own four-row table; cases 29a-29d | False positive |
+| G8 | The self-test's skip list named only case 11. Case **20 hard-FAILS** on any case-insensitive filesystem, so `check:skills:self` exits 1 on Windows and macOS, breaking acceptance criterion 2 | 9.2.1 | Full skip table, probe-then-skip for 20 and 63c, and win32 junctions to stop 11/12/63e/63f skipping at all | Broken acceptance |
+| G9 | `E-ENTRYPOINT-UNREADABLE` and `W-DIR-UNREADABLE` have no case, so acceptance criterion 12 was unsatisfiable | 9.2.2, 9.3 | Cases 76-80 added; one named exemption. **Step 7: only half closed.** None of cases 76-80 emits `W-DIR-UNREADABLE`, so that code still had no case and criterion 12 was still unsatisfiable with one exemption. Case 63g closes it (9.2.2) | Broken acceptance |
+| G10 | The FAIL line counts entrypoints, but five error codes attach to no entrypoint, so a real failure prints `FAIL: 0 skills would not be indexed` | 6.9 | Explicit no-entrypoint wording | Incoherent output |
+| G11 | Section 14.5 items 1 and 2 were recorded and never applied to Section 6.10, which an implementer would follow | 6.10, 14.5 | Both applied; 14.5 annotated | Two latent bugs |
+| G12 | 6.10 claimed the JSON is byte-identical across platforms; `root`, `absolutePath`, `directoriesScanned` and `{err}`-bearing `indexerMessage` are all platform-dependent, and case 71 only tests idempotence on one machine | 6.10 | Guarantee scoped to `path` and `skillDirectory` | False guarantee |
+| G13 | The `key: value` separator grammar was never defined: YAML allows a **tab** as separation space and a trailing ` # comment` after any scalar, and neither was in the subset | 6.5.1a | Grammar stated | False positive, via G4 |
+| G14 | Block-scalar indentation detection was unspecified, and the explicit indicators `\|2`, `>2` were absent from the subset. A `description: \|` block containing `name: x` would emit a spurious `E-YAML-DUPLICATE-KEY` | 6.5.1, 6.5.1a | Indent rule stated; indicators added | False positive |
+| G15 | 6.2 step 1 tests `skills` byte-exactly while 14.5.5 argues the opposite for step 4, with no statement of why | 6.2 step 1 | Both kept, and the severity rule that separates them made explicit | Internal contradiction |
+| G16 | `E-SKILLS-DIR-UNREADABLE` covered two structurally different indexer errors, so `indexerMessage` is wrong for one of them despite 6.10 promising the exact log string | 6.8, 6.2 step 1 | Split into `E-SKILL-DIR-UNREADABLE` | Wrong `indexerMessage` |
+| G17 | Section 7 claimed 200-character truncation stops a "line-broken" value scrambling the report; truncation does nothing about a `\n` at offset 10 | 7 | Collapse controls and whitespace first, then truncate, mirroring `:420-446` | Unmet claim |
+
+### 15.4 What was attacked and held
+
+Reported because a negative result is evidence too, and because re-attacking these in Step 7 is
+wasted effort.
+
+- **`isFrontmatterDelimiter` is a correct port.** Verified byte for byte against `:276-302`: the
+  `\n`-then-`\r` strip order, the BOM strip **before** the trim, the `trim_ascii` set as exactly
+  `\t \n \x0C \r space` with `\x0B` excluded, and the final `== b"---"`. All nine rows of the
+  consequence table in 6.4.1 are right, including the subtle `  <BOM>---` = **false** and
+  `<BOM>  ---` = true pair.
+- **The 1024-byte first-line boundary.** `:339-345` pushes the byte then tests, and the test precedes
+  the `\n` short-circuit at `:353`, so the terminator counts. 1020 spaces + `---\n` = 1024 is valid;
+  1021 + `---\n` = 1025 fails. Cases 35a/35b are exact. The 1024-byte `read_buffer` at `:326` is
+  chunking only and carries no semantics, so the plan's 64 KiB chunk is free to differ.
+- **Guard A and Guard B.** `remaining.saturating_add(8)` at `:347-350`, the placement before the
+  closing-delimiter test, and Guard B's exclusion of both delimiter lines (`:362` clears the opening,
+  `:366` returns before the append) all match `:311-317` and `:346-351`. The `saturating_sub` cannot
+  underflow in JS because the append guard keeps the buffer at or below 16384.
+- **The duplicate-name sort.** `:588-591` is a two-element tuple compare of
+  `(to_ascii_lowercase(), original)`, both as Rust `String`, that is UTF-8 byte order. The plan's
+  `Buffer.compare` plus an explicit A-Z map is the correct port, the comparison is total because two
+  entries in one directory cannot share a name, and both Rust `sort_by` and `Array.prototype.sort`
+  are stable. Nothing to break here.
+- **"Any hard error removes a candidate from the name race."** `:595-671` is one loop whose every
+  failure path is a `continue`, and the `seen_skill_names.insert` at `:671` is strictly after the
+  entrypoint, frontmatter, parse, mapping, name-type and charset checks. `description` (`:674`) and
+  `when_to_use` (`:687`) run **after** the insert and can only ever produce warnings, so 6.6.4's
+  "zero error findings at the end of field validation" is equivalent to the Rust. The worked example
+  is correct.
+- **`is_valid_skill_name`** (`:464-470`) is `chars().count()` in `1..=64` plus
+  `is_ascii_lowercase() || is_ascii_digit() || '-'`. `[...name].length` with `/^[a-z0-9-]{1,64}$/` is
+  faithful, and JS `$` without the `m` flag does **not** match before a trailing newline, so
+  `"ok-name\n"` is correctly rejected. No gap.
+- **A plain file directly inside `skills/` is silently ignored** by `:583`'s `else if is_dir()`, and
+  the checker emits nothing for it either. The two agree.
+- **The exit-code contract holds across all 31 codes.** Traced every one: no `error` code fails to
+  force exit 1, no `warning` or `info` code can reach it, position findings never do, and there is no
+  path producing exit 1 with zero findings. The only incoherence found was in the *reporting* of that
+  verdict, which is G10, not in the verdict itself.
+- **The `skills` broken-symlink silence** (6.2 step 4) is right: `:520` gates on `Path::exists`, which
+  follows links, so `:524` is unreachable for a broken link and the indexer says nothing. Also worth
+  recording: `Path::exists` returns false on **any** stat error, so an EACCES on `skills/` itself also
+  returns silently at `:521` and `` `skills` could not be inspected `` (`:527-530`) is reachable only
+  in the narrow window where `metadata` succeeds and `symlink_metadata` then fails. The plan's mapping
+  is still correct; the message is simply rarer than it looks.
+
+### 15.5 Verdict
+
+The plan is implementable, and after these corrections I believe it is implementable **correctly**.
+Before them it was not: an implementer following Sections 6.2, 6.5 and 6.10 to the letter would have
+shipped three false passes and six false positives, and would have read a green
+`npm run check:skills:self` on Windows as proof of behaviour that five codes' worth of cases never
+actually exercised. None of the seventeen required new evidence — every one is decided by the pinned
+source already cited in this plan — which is why they belong in Step 6 rather than in a rework.
+
+Two things I would still not call closed, neither of them blocking:
+
+1. **Drift remains uncontrolled**, as Section 10 item 4 already says. Seventeen fidelity defects
+   surviving two review passes over a 500-line Rust surface is the measurement of how expensive a
+   hand-maintained second implementation is. The shared-fixture CI job named there is worth opening as
+   its own issue now, not later.
+2. **`Dirent.isSymbolicLink()` on Windows junctions** is still asserted rather than proven. 9.2.1 now
+   makes the self-test prove it on ordinary Windows instead of skipping, which is the cheapest
+   available proof, but it becomes real evidence only once someone runs it. Step 8 should report that
+   run's output.
+
+## 16. Step 7 record (architect): certification
+
+### 16.1 What Step 7 did and did not do
+
+Step 7 is a Plan Contract audit, not a third fidelity pass. Section 15.4 lists what Step 6 attacked
+and could not break, and re-attacking it here would have spent the round without improving the
+answer, so it was not re-attacked. No Rust source was read in this pass and the Codebase Memory gate
+was not run: nothing in Step 7 rests on a new fact about the codebase.
+
+What was audited instead is the property the two enrichment passes could not audit for themselves:
+**whether the normative sections of this file agree with each other and with the records that claim to
+have corrected them.** That is the class Step 6 named as G11, where 14.5 items 1 and 2 were recorded
+and never written into 6.10. Step 6 fixed its two instances; Step 7 was asked to check whether the
+class had any others. It did. Eight, listed below.
+
+Every section was read start to finish. Cross-references were checked in both directions: from each
+record row to the section it claims to have corrected, and from each normative section back to the
+codes and cases it names.
+
+### 16.2 Gaps found and closed in Step 7
+
+Numbered `A1`-`A8`, in the order they appear in the file.
+
+| # | Gap | Section | Closed by | Class |
+| --- | --- | --- | --- | --- |
+| A1 | The traversal decision in Section 4's table still read "skipping `.git`, `node_modules`, `target`" with no carve-out, after G2 made `SKIP_DIRS` inapplicable inside a `skills/` directory. A summary table an implementer skims, contradicting the normative section | 4 row 4 | Carve-out added, with the G2 reference | Recorded-not-applied (G11 class) |
+| A2 | The severity model did not cover its own instances. Rule 1 governs "a present **entrypoint file**" and rule 2 governs "something **absent or unreadable**"; `E-SKILLS-NOT-DIR` and `E-SKILL-DIR-LINK`/`W-SKILL-DIR-LINK` are neither, so no rule reached them, while 6.2 step 3 explicitly invoked "severity rule 2" for a case rule 2 did not describe | 4.1 | Rule 2 rewritten to cover every non-entrypoint finding, split into absence-type and present-entry-shape, with the complete code list for each | Normative gap |
+| A3 | 6.2 step 1 said `E-SKILLS-NOT-DIR` is governed by "rule 1", while 6.2 step 3 four paragraphs below said the same gating "is severity rule 2 applied consistently with `E-SKILLS-NOT-DIR` in step 4". `E-SKILLS-NOT-DIR` is emitted only when the parent matches `/^_agent_.+$/`, which is a canonical gate, so rule 2 governs it and step 1 was wrong. The real difference between step 1 and steps 3 and 4 is byte-exact versus ASCII case-insensitive `skills` matching, a different axis entirely | 6.2 step 1, 4.1 | Step 1 corrected; both axes stated explicitly in rule 2 | Internal contradiction |
+| A4 | The module table in 5.1 pointed `renderHuman` at 6.8 (the taxonomy), `renderJson` at 6.9 (the human report) and `main()` at 6.10 (the JSON format). Off by one throughout. Section 8 step 6 cites the correct sections, so the two disagreed | 5.1 | Corrected, plus a precedence rule and the four helper functions the 5.1.2 and Section 7 constraints imply | Wrong cross-reference |
+| A5 | 6.7 closed with "the `canonical` flag is what promotes the two absence-type findings (`I-NO-ENTRYPOINT` and `W-DIR-UNREADABLE`)". Stale after G5 added `W-SKILL-DIR-LINK`, which is not absence-type, and after G16 split `E-SKILL-DIR-UNREADABLE` out. 6.7 also defined canonical position only for an entrypoint path, while 6.3, 6.2 step 1 and 6.2 step 3 all apply it to a bare directory | 6.7 | Directory form of the test stated once; promotion list replaced by a pointer to the complete list in 4.1 | Recorded-not-applied (G11 class) |
+| A6 | **Self-test case 63c named `E-SKILLS-DIR-UNREADABLE`**, the code G16 split away from it. Case 79 already refers to "case 63c's `E-SKILL-DIR-UNREADABLE`", so the two rows contradicted each other. An implementer writing the self-test from case 63c would have asserted the wrong code and watched it fail against a correct implementation | 9.2, case 63c | Code corrected to `E-SKILL-DIR-UNREADABLE` | **Recorded-not-applied, behaviour-affecting** |
+| A7 | **`W-DIR-UNREADABLE` still had no self-test case.** 9.2.2 said so and then claimed "cases 76-79 below close three of them"; none of 76-80 emits it. Acceptance criterion 12 therefore remained unsatisfiable with a single named exemption, which is the same defect G9 was raised to fix. Criterion 13's skip list was also short by three cases | 9.2.1, 9.2.2, 9.3 criteria 12 and 13, case 63g | Case 63g added; the accounting in 9.2.2 made explicit and checkable; criterion 13's skip list corrected | **Recorded-not-applied, breaks acceptance** |
+| A8 | The self-test case count was reported as 94. The tables actually hold **109** rows after Step 6, and 110 after A7 added case 63g. Step 6's Section 15 record and the Step 6 report both carry 94, and Step 7's own summary inherited it before checking | header, 16.3 | Counted mechanically: 110 unique case ids, no duplicates, verified by extracting every row id between "Required cases, by section:" and Section 9.3. Header and 16.3 corrected | Wrong count in a record |
+
+A6 and A7 are the two that would have cost the implementer real time: one makes a correct
+implementation fail its own test, the other makes an acceptance criterion unsatisfiable. Both are the
+same shape as G11 and both were invisible from inside the pass that created them, which is the
+argument for the cross-reference audit being a distinct step rather than a habit.
+
+A8 is the mildest of the eight and is recorded anyway, because a count nobody checks is exactly how
+A6 and A7 survived: the number sounded settled, so it was carried forward instead of derived. The
+count in Section 15.3 and in the Step 6 report is left as written; those are records of what that
+pass believed, and correcting them retroactively would defeat the point of keeping records. The
+header and 16.3, which an implementer reads, carry the verified number.
+
+None of the eight needed dev-rust or dev-rust-grinch. Every one is either a correction of Step 4's own
+text or a cross-reference an enrichment pass left behind, and in every case the correct answer was
+already determined by a section of this plan or derivable by counting it. That is why Step 7 closed
+them in place instead of opening a second round.
+
+### 16.3 Plan Contract check
+
+Each of the nine required elements, with where it lives.
+
+| # | Required element | Where | Verdict |
+| --- | --- | --- | --- |
+| 1 | Issue and objective | 1 | Present. Issue, branch, baseline SHA, objective and non-objective |
+| 2 | Evidence and current-state gap | 2, 12, 14, 15 | Present. Every rule traces to a `file:line`, and the one artifact error is corrected in 14.4 |
+| 3 | In-scope and out-of-scope | 3 | Present. Three deliverables, eight exclusions |
+| 4 | The decided solution | 4, 4.1 | Present. Nine decisions plus the severity model |
+| 5 | Affected surfaces, exact files and symbols | 5.1, 5.2, 5.3 | Present. One new file with its module table, one two-line `package.json` diff, and an explicit do-not-touch list |
+| 6 | Required behaviour, edge cases, failure behaviour | 6.1-6.11 | Present. 31 codes, the full CLI table, both frontmatter size guards, the EOF table, the YAML subset and its grammar |
+| 7 | Compatibility and security | 7 | Present. Bounded reads, no `eval`, sanitize-then-truncate, rollback |
+| 8 | Implementation order | 8, 8.1 | Present. Ten steps, one commit for 1-8, and the Codebase Memory sequence |
+| 9 | Tests and objective acceptance criteria | 9.1-9.3 | Present. 110 cases, 14 criteria, every criterion mechanically checkable |
+
+Cold-start test applied deliberately: an implementer with only this file needs no other document to
+write the script. The one external dependency is the `git add -f` requirement for `plans/`, and
+Section 8 step 0 states it with the `.gitignore` line number.
+
+### 16.4 Two answers the coordinator asked for
+
+1. **The shared-fixture CI job belongs outside #1213. Agreed.** Two independent reasons: the issue's
+   own out-of-scope list excludes wiring anything into CI, and a job that runs the Rust and the `.mjs`
+   over one fixture corpus needs a Rust-side harness, which means touching `src-tauri/`, which
+   Section 5.3 forbids. It is the right follow-up and Section 15.5 is right that it should be opened
+   now rather than later; it is not this issue.
+2. **The remaining open items are correctly non-blocking.** `Dirent.isSymbolicLink()` on Windows
+   junctions is asserted rather than proven, and 9.2.1 converts the assertion into a test that runs on
+   ordinary Windows instead of skipping. That is the cheapest available proof and it is now on the
+   critical path of acceptance criterion 13, so it cannot ship unexercised. Step 8 should report that
+   run's output, as Section 15.5 asks.
+
+### 16.5 Verdict
+
+`READY_FOR_IMPLEMENTATION`.
+
+The plan is a complete cold-start specification. Every rule traces to a pinned `file:line`; the five
+Step 4 unknowns are resolved against source; the twenty-four defects the two enrichment passes found
+are corrected in the sections that own them; and the eight cross-reference gaps those passes left
+behind are closed above.
+
+Certified against the file as it stands after the Step 7 edits. Any byte change invalidates this
+certification, per the freeze gate.

--- a/scripts/01-skills-checker.mjs
+++ b/scripts/01-skills-checker.mjs
@@ -1,0 +1,2660 @@
+#!/usr/bin/env node
+// Validates SKILL.md structure the way AgentsCommander's indexer does, for issue #1213.
+//
+// SOURCE OF TRUTH: src-tauri/src/config/session_context.rs:206-714
+// This script is a second, independent implementation of the rules that module enforces.
+// If that range changes, this file is stale until it is changed to match.
+//
+// Discovery is case-insensitive so a wrongly cased entrypoint is FOUND; validation is
+// byte-exact because session_context.rs:401 compares entry.file_name() against "SKILL.md"
+// byte-for-byte, so wrong casing fails on every platform including Windows.
+//
+// The two path constants are NOT symmetric, and this is the surface's biggest trap:
+//   "SKILL.md" (:401) is an entry-name comparison  -> case-sensitive on EVERY platform.
+//   "skills"   (:509) is a path join               -> case-INsensitive on Windows only.
+// So `_agent_x/Skills/y/SKILL.md` is indexed on Windows and invisible on Linux, while
+// `_agent_x/skills/y/skill.md` is rejected on both.
+//
+// YAML semantics below are pinned to serde_yaml 0.9.34+deprecated (Cargo.lock:5483-5486):
+// duplicate mapping keys are a HARD parse error (mapping.rs:813-822), and plain
+// yes/no/on/off resolve as STRINGS, not booleans (de.rs:932-938, YAML 1.2 core schema).
+// A serde_yaml bump invalidates both.
+//
+// Usage:
+//   node scripts/01-skills-checker.mjs [root] [--json]
+//   node scripts/01-skills-checker.mjs --help
+//   node scripts/01-skills-checker.mjs --self-test
+//
+// Exit codes:
+//   0 → no error findings (warnings and notes may still be present)
+//   1 → at least one error finding: one or more skills would not be indexed
+//   2 → usage error, or the root does not exist / is not a directory / cannot be read
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TOOL = '01-skills-checker';
+const TAG = '[skills-check]';
+const SOURCE_OF_TRUTH = 'src-tauri/src/config/session_context.rs:206-714';
+const OUTPUT_VERSION = 1;
+
+const SKILL_MD = 'SKILL.md';
+const SKILLS_DIR = 'skills';
+const FRONTMATTER_MAX_BYTES = 16384;
+const FIRST_LINE_MAX_BYTES = 1024;
+const NAME_RE = /^[a-z0-9-]{1,64}$/;
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'target']);
+
+const MATRIX_DIR_RE = /^_agent_.+$/;
+const REPLICA_PREFIX = '__agent_';
+const READ_CHUNK_BYTES = 65536;
+
+// ---------------------------------------------------------------------------
+// Primitive helpers (Section 5.1.2 constraints; each is a correctness rule)
+// ---------------------------------------------------------------------------
+
+// Unicode White_Space exactly, mirroring Rust str::trim used by yaml_field_string (:453).
+// U+180E is deliberately absent: removed from White_Space in Unicode 6.3.
+// String.prototype.trim() is NOT equivalent (it strips U+FEFF, which Rust keeps, and
+// keeps U+0085, which Rust strips) and is banned for field values.
+function isUnicodeWhitespace(code) {
+  return (
+    (code >= 0x0009 && code <= 0x000d) ||
+    code === 0x0020 ||
+    code === 0x0085 ||
+    code === 0x00a0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000
+  );
+}
+
+function trimYamlValue(value) {
+  const chars = [...value];
+  let start = 0;
+  let end = chars.length;
+  while (start < end && isUnicodeWhitespace(chars[start].codePointAt(0))) start += 1;
+  while (end > start && isUnicodeWhitespace(chars[end - 1].codePointAt(0))) end -= 1;
+  return chars.slice(start, end).join('');
+}
+
+// A-Z to a-z only, mirroring Rust to_ascii_lowercase(). String.prototype.toLowerCase()
+// is locale- and Unicode-aware and would diverge (:588-591).
+function asciiLower(value) {
+  let out = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    out += code >= 0x41 && code <= 0x5a ? String.fromCharCode(code + 0x20) : value[i];
+  }
+  return out;
+}
+
+// Rust String: Ord compares UTF-8 bytes; JS `<` compares UTF-16 code units and sorts
+// astral characters below U+E000-U+FFFF. The duplicate-name race depends on this order.
+function compareUtf8(a, b) {
+  return Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+}
+
+// Presentation only, never a verdict. Mirrors sanitize_skill_metadata_for_context
+// (:420-446): collapse every run of C0 controls and Unicode whitespace to one U+0020,
+// drop the remaining non-printables, trim, then truncate. Truncation alone does nothing
+// about a `\n` or a `\x1b` at offset 10, which is why the collapse comes first.
+function sanitizeForReport(value) {
+  const text = String(value);
+  let out = '';
+  let pendingSpace = false;
+  for (const ch of text) {
+    const code = ch.codePointAt(0);
+    if (code <= 0x1f || isUnicodeWhitespace(code)) {
+      pendingSpace = true;
+      continue;
+    }
+    if (code === 0x7f || (code >= 0x80 && code <= 0x9f)) continue;
+    if (pendingSpace && out.length > 0) out += ' ';
+    pendingSpace = false;
+    out += ch;
+  }
+  return [...out].slice(0, 200).join('');
+}
+
+function errnoOf(err) {
+  if (err && typeof err.code === 'string' && err.code.length > 0) return err.code;
+  if (err && typeof err.message === 'string') return err.message;
+  return String(err);
+}
+
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+function relativeTo(root, target) {
+  const rel = path.relative(root, target);
+  if (rel === '') return '.';
+  return toPosix(rel);
+}
+
+function plural(count, word) {
+  return `${count} ${word}${count === 1 ? '' : 's'}`;
+}
+
+// ---------------------------------------------------------------------------
+// Finding taxonomy (Section 6.8)
+// ---------------------------------------------------------------------------
+
+const SEVERITY = { error: 'error', warning: 'warning', info: 'info' };
+
+const RULE_OF = {
+  'E-SKILLS-DIR-UNREADABLE': 'R4',
+  'E-SKILL-DIR-UNREADABLE': 'R4',
+  'E-SKILLS-NOT-DIR': 'R5',
+  'E-SKILL-DIR-LINK': 'R8',
+  'E-NO-ENTRYPOINT': 'E1',
+  'E-ENTRYPOINT-CASE': 'E1',
+  'E-ENTRYPOINT-LINK': 'E2',
+  'E-ENTRYPOINT-NOT-FILE': 'E3',
+  'E-ENTRYPOINT-UNREADABLE': 'E4',
+  'E-FM-NO-OPEN': 'F1',
+  'E-FM-FIRST-LINE-TOO-LONG': 'F7',
+  'E-FM-NO-CLOSE': 'F5',
+  'E-FM-TOO-LARGE': 'F6',
+  'E-FM-NOT-UTF8': 'F8',
+  'E-YAML-PARSE': 'Y1',
+  'E-YAML-DUPLICATE-KEY': 'Y1',
+  'E-YAML-NOT-MAPPING': 'Y2',
+  'E-NAME-NOT-STRING': 'N2',
+  'E-NAME-INVALID': 'N3',
+  'E-NAME-DUPLICATE': 'N5',
+  'W-DESC-MISSING': 'D1',
+  'W-DESC-NOT-STRING': 'D2',
+  'W-WHEN-NOT-STRING': 'W2',
+  'W-YAML-UNDECIDABLE': null,
+  'W-NAME-UNDECIDABLE': 'N3',
+  'W-ENTRYPOINT-CASE-SHADOWED': null,
+  'W-SKILL-DIR-LINK': 'R8',
+  'W-DIR-UNREADABLE': 'R4',
+  'I-NOT-INDEXABLE': 'R1',
+  'I-NO-ENTRYPOINT': 'E1',
+  'I-KEY-HYPHEN-VARIANT': 'X1',
+};
+
+function severityOf(code) {
+  if (code.startsWith('E-')) return SEVERITY.error;
+  if (code.startsWith('W-')) return SEVERITY.warning;
+  return SEVERITY.info;
+}
+
+// The `Skipped skill directory` / `Skipped skill` prefixes are the real wrappers at
+// :601 and :613; every embedded value is sanitized there too (:596, :603, :615).
+function skippedDirectory(folder, tail) {
+  return `Skipped skill directory \`${sanitizeForReport(folder)}\`: ${tail}`;
+}
+
+function skippedSkill(folder, tail) {
+  return `Skipped skill \`${sanitizeForReport(folder)}\`: ${tail}`;
+}
+
+// ---------------------------------------------------------------------------
+// Report collector
+// ---------------------------------------------------------------------------
+
+function createCollector(root) {
+  const findings = [];
+  let seq = 0;
+  return {
+    findings,
+    add(finding) {
+      const code = finding.code;
+      const absolutePath = finding.absolutePath;
+      findings.push({
+        seq: seq++,
+        code,
+        severity: severityOf(code),
+        rule: Object.prototype.hasOwnProperty.call(RULE_OF, code) ? RULE_OF[code] : null,
+        path: relativeTo(root, absolutePath),
+        absolutePath,
+        skillDirectory:
+          finding.skillDirectory === undefined || finding.skillDirectory === null
+            ? null
+            : relativeTo(root, finding.skillDirectory),
+        skillName: finding.skillName === undefined ? null : finding.skillName,
+        line: finding.line === undefined ? null : finding.line,
+        reason: finding.reason === undefined ? null : finding.reason,
+        message: finding.message,
+        indexerMessage: finding.indexerMessage === undefined ? null : finding.indexerMessage,
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 6.7 Position and indexability
+// ---------------------------------------------------------------------------
+
+function classifyPosition(entrypointPath) {
+  const skillDir = path.dirname(entrypointPath);
+  const parent = path.dirname(skillDir);
+  const grandparent = path.dirname(parent);
+  const parentName = path.basename(parent);
+  const ownerName = path.basename(grandparent);
+
+  if (asciiLower(parentName) !== SKILLS_DIR) {
+    return { canonical: false, reason: 'not-under-skills-dir' };
+  }
+  if (parentName !== SKILLS_DIR) {
+    return { canonical: false, reason: 'skills-dir-case' };
+  }
+  if (MATRIX_DIR_RE.test(ownerName)) {
+    return { canonical: true, reason: null };
+  }
+  if (ownerName.startsWith(REPLICA_PREFIX)) {
+    return { canonical: false, reason: 'replica-root' };
+  }
+  return { canonical: false, reason: 'owner-root-not-recognized' };
+}
+
+const POSITION_MESSAGE = {
+  'not-under-skills-dir':
+    'Depth is fixed at one: <owner-root>/skills/<skill-name>/SKILL.md. This file is structurally checkable but is never indexed.',
+  'skills-dir-case':
+    'The parent directory matches `skills` only after ASCII lowercasing. The indexer builds this path by joining the constant `skills`, so a differently cased directory may still resolve on Windows and will not on Linux.',
+  'replica-root':
+    'A `__agent_*` replica\'s own `skills/` directory is never scanned. has_agent_matrix_dir_name tests starts_with("_agent_") and "__agent_x" fails it (:1437-1442).',
+  'owner-root-not-recognized':
+    'The owner root is not an `_agent_*` matrix directory. The Root Agent directory is a third legal owner root that this checker does not attempt to identify, so this note may be a false positive there. It is informational only and never affects the exit code.',
+};
+
+// D is a SKILL DIRECTORY in canonical position. `skills` byte-exact: absence-type
+// findings must not fail a run differently on Windows and Linux (Section 4.1 rule 2).
+function isCanonicalSkillDir(dir) {
+  return (
+    path.basename(path.dirname(dir)) === SKILLS_DIR &&
+    MATRIX_DIR_RE.test(path.basename(path.dirname(path.dirname(dir))))
+  );
+}
+
+// D is a SKILLS ROOT in canonical position, `skills` byte-exact, same reason.
+function isCanonicalSkillsRoot(dir) {
+  return path.basename(dir) === SKILLS_DIR && MATRIX_DIR_RE.test(path.basename(path.dirname(dir)));
+}
+
+// Present-entry shape findings test `skills` ASCII case-insensitively, so a case-variant
+// `Skills/` yields the same finding on both platforms (Section 4.1 rule 2).
+function isSkillsNameCi(name) {
+  return asciiLower(name) === SKILLS_DIR;
+}
+
+// ---------------------------------------------------------------------------
+// 6.4.1 isFrontmatterDelimiter: exact port of session_context.rs:276-302
+// ---------------------------------------------------------------------------
+
+// Rust u8::is_ascii_whitespace: \t \n \x0C \r and space. Vertical tab \x0B is NOT in it,
+// so a JS \s or String.prototype.trim() port would wrongly accept a \x0B-padded fence.
+function isAsciiWhitespaceByte(byte) {
+  return byte === 0x09 || byte === 0x0a || byte === 0x0c || byte === 0x0d || byte === 0x20;
+}
+
+function isFrontmatterDelimiter(lineBytes, allowBom) {
+  let start = 0;
+  let end = lineBytes.length;
+  if (end > start && lineBytes[end - 1] === 0x0a) end -= 1;
+  if (end > start && lineBytes[end - 1] === 0x0d) end -= 1;
+  if (
+    allowBom &&
+    end - start >= 3 &&
+    lineBytes[start] === 0xef &&
+    lineBytes[start + 1] === 0xbb &&
+    lineBytes[start + 2] === 0xbf
+  ) {
+    start += 3;
+  }
+  while (start < end && isAsciiWhitespaceByte(lineBytes[start])) start += 1;
+  while (end > start && isAsciiWhitespaceByte(lineBytes[end - 1])) end -= 1;
+  return (
+    end - start === 3 &&
+    lineBytes[start] === 0x2d &&
+    lineBytes[start + 1] === 0x2d &&
+    lineBytes[start + 2] === 0x2d
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 6.4 Frontmatter extraction: byte-level, streaming, bounded
+// ---------------------------------------------------------------------------
+
+function readFrontmatter(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+  } catch (err) {
+    return { ok: false, code: 'E-ENTRYPOINT-UNREADABLE', detail: errnoOf(err), verb: 'open' };
+  }
+
+  try {
+    const chunk = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+    let chunkLength = 0;
+    let chunkPos = 0;
+    let readFailure = null;
+
+    const nextByte = () => {
+      if (chunkPos >= chunkLength) {
+        try {
+          chunkLength = fs.readSync(fd, chunk, 0, chunk.length, null);
+        } catch (err) {
+          readFailure = err;
+          return -1;
+        }
+        chunkPos = 0;
+        if (chunkLength === 0) return -1;
+      }
+      chunkPos += 1;
+      return chunk[chunkPos - 1];
+    };
+
+    let sawOpening = false;
+    let currentLine = [];
+    const frontmatter = [];
+
+    const appendLine = () => {
+      for (let i = 0; i < currentLine.length; i += 1) frontmatter.push(currentLine[i]);
+    };
+
+    for (;;) {
+      const byte = nextByte();
+      if (byte === -1) break;
+      currentLine.push(byte);
+
+      // Size guards, mirroring the if/else on saw_opening at :342-351. Both run after
+      // the byte is pushed and before the `\n` short-circuit at :353, so the terminator
+      // is counted on both arms.
+      if (!sawOpening) {
+        if (currentLine.length > FIRST_LINE_MAX_BYTES) {
+          return { ok: false, code: 'E-FM-FIRST-LINE-TOO-LONG' };
+        }
+      } else {
+        // Guard A, mid-line (:346-351). The `+ 8` is verbatim from
+        // remaining.saturating_add(8). It also covers the closing delimiter line,
+        // which never reaches the append path.
+        const remaining = Math.max(0, FRONTMATTER_MAX_BYTES - frontmatter.length);
+        if (currentLine.length > remaining + 8) {
+          return { ok: false, code: 'E-FM-TOO-LARGE' };
+        }
+      }
+
+      if (byte !== 0x0a) continue;
+
+      if (!sawOpening) {
+        if (!isFrontmatterDelimiter(currentLine, true)) {
+          return { ok: false, code: 'E-FM-NO-OPEN' };
+        }
+        sawOpening = true;
+        currentLine = [];
+        continue;
+      }
+
+      if (isFrontmatterDelimiter(currentLine, false)) {
+        return decodeFrontmatter(frontmatter);
+      }
+
+      // Guard B, on append (:311-317).
+      if (frontmatter.length + currentLine.length > FRONTMATTER_MAX_BYTES) {
+        return { ok: false, code: 'E-FM-TOO-LARGE' };
+      }
+      appendLine();
+      currentLine = [];
+    }
+
+    if (readFailure !== null) {
+      return { ok: false, code: 'E-ENTRYPOINT-UNREADABLE', detail: errnoOf(readFailure), verb: 'read' };
+    }
+
+    // EOF with an unterminated final line (:374-386). Not symmetric, and row 3 below is
+    // the common shape every editor without "insert final newline" produces.
+    if (currentLine.length > 0) {
+      if (!sawOpening) {
+        if (isFrontmatterDelimiter(currentLine, true)) return { ok: false, code: 'E-FM-NO-CLOSE' };
+        return { ok: false, code: 'E-FM-NO-OPEN' };
+      }
+      if (isFrontmatterDelimiter(currentLine, false)) {
+        return decodeFrontmatter(frontmatter);
+      }
+      // :385 appends before the `missing closing` return at :389, so an overflowing
+      // unterminated body line yields E-FM-TOO-LARGE, not E-FM-NO-CLOSE.
+      if (frontmatter.length + currentLine.length > FRONTMATTER_MAX_BYTES) {
+        return { ok: false, code: 'E-FM-TOO-LARGE' };
+      }
+      appendLine();
+      return { ok: false, code: 'E-FM-NO-CLOSE' };
+    }
+
+    if (!sawOpening) return { ok: false, code: 'E-FM-NO-OPEN' };
+    return { ok: false, code: 'E-FM-NO-CLOSE' };
+  } finally {
+    try {
+      fs.closeSync(fd);
+    } catch {
+      // Closing a descriptor we already finished with cannot change a verdict.
+    }
+  }
+}
+
+function decodeFrontmatter(bytes) {
+  // fatal: true is required. Decoding the buffer through Buffer#toString with the utf8
+  // encoding replaces invalid sequences with U+FFFD and would silently pass a file the
+  // indexer rejects under F8 (:319-321), so that call is banned anywhere in this file and
+  // acceptance criterion 10 greps for it.
+  try {
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(bytes));
+    return { ok: true, text };
+  } catch (err) {
+    return { ok: false, code: 'E-FM-NOT-UTF8', detail: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6.5 The YAML mini-parser
+// ---------------------------------------------------------------------------
+
+function splitFrontmatterLines(text) {
+  if (text === '') return [];
+  const parts = text.split('\n');
+  if (parts.length > 0 && parts[parts.length - 1] === '') parts.pop();
+  return parts.map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line));
+}
+
+function isBlankLine(line) {
+  return /^[\t\n\v\f\r ]*$/.test(line);
+}
+
+// YAML indentation is spaces only; a tab is never indentation.
+function indentWidth(line) {
+  let n = 0;
+  while (n < line.length && line[n] === ' ') n += 1;
+  return n;
+}
+
+function leadingWsRun(line) {
+  let n = 0;
+  while (n < line.length && (line[n] === ' ' || line[n] === '\t')) n += 1;
+  return line.slice(0, n);
+}
+
+function readQuotedScalar(text, start) {
+  const quote = text[start];
+  let i = start + 1;
+  let out = '';
+  if (quote === "'") {
+    while (i < text.length) {
+      const ch = text[i];
+      if (ch === "'") {
+        if (text[i + 1] === "'") {
+          out += "'";
+          i += 2;
+          continue;
+        }
+        return { ok: true, value: out, end: i + 1 };
+      }
+      out += ch;
+      i += 1;
+    }
+    return { ok: false, reason: 'a single-quoted scalar whose closing quote is not on the same line' };
+  }
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\\') {
+      const esc = text[i + 1];
+      if (esc === '\\') out += '\\';
+      else if (esc === '"') out += '"';
+      else if (esc === '/') out += '/';
+      else if (esc === 'n') out += '\n';
+      else if (esc === 'r') out += '\r';
+      else if (esc === 't') out += '\t';
+      else if (esc === 'u') {
+        const hex = text.slice(i + 2, i + 6);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+          return { ok: false, reason: 'a double-quoted scalar with a malformed \\u escape' };
+        }
+        out += String.fromCharCode(parseInt(hex, 16));
+        i += 6;
+        continue;
+      } else {
+        return { ok: false, reason: 'a double-quoted scalar with a backslash escape outside the supported set' };
+      }
+      i += 2;
+      continue;
+    }
+    if (ch === '"') return { ok: true, value: out, end: i + 1 };
+    out += ch;
+    i += 1;
+  }
+  return { ok: false, reason: 'a double-quoted scalar whose closing quote is not on the same line' };
+}
+
+// 6.5.1a. A mapping entry is a key, then `:`, then end of line or at least one space or
+// TAB. YAML permits a tab as separation whitespace, so `name:<TAB>x` is an ordinary entry.
+function parseKeyValueLine(body) {
+  let key;
+  let rest;
+  if (body[0] === "'" || body[0] === '"') {
+    const quoted = readQuotedScalar(body, 0);
+    if (!quoted.ok) return { ok: false, reason: quoted.reason };
+    if (body[quoted.end] !== ':') {
+      return { ok: false, reason: 'a quoted scalar at column 0 that is not a mapping key' };
+    }
+    key = quoted.value;
+    rest = body.slice(quoted.end + 1);
+  } else {
+    let separator = -1;
+    for (let i = 0; i < body.length; i += 1) {
+      if (body[i] !== ':') continue;
+      const next = body[i + 1];
+      if (next === undefined || next === ' ' || next === '\t') {
+        separator = i;
+        break;
+      }
+    }
+    if (separator === -1) return { ok: false, reason: 'a line that is not a `key:` mapping entry' };
+    key = body.slice(0, separator);
+    rest = body.slice(separator + 1);
+  }
+
+  const value = rest.replace(/^[ \t]+/, '');
+  const header = /^([|>])([0-9]*)([-+]?)([0-9]*)[ \t]*(?:#.*)?$/.exec(value);
+  if (header) {
+    const explicit = header[2] || header[4];
+    return {
+      ok: true,
+      key,
+      value,
+      blockScalar: true,
+      blockStyle: header[1],
+      blockIndent: explicit === '' ? null : Number(explicit),
+    };
+  }
+  return { ok: true, key, value, blockScalar: false };
+}
+
+// The block's indentation is the explicit indicator when given, otherwise the indentation
+// of the first non-empty line. Every subsequent line indented at least that far is
+// content WHATEVER it contains, so a `name: x` inside a `description: |` block is content
+// and never a second top-level key.
+function readBlockScalar(lines, startIndex, explicitIndent, style) {
+  let indent = explicitIndent;
+  if (indent === null) {
+    let probe = startIndex;
+    while (probe < lines.length && isBlankLine(lines[probe])) probe += 1;
+    if (probe >= lines.length) return { endIndex: startIndex, content: '' };
+    const width = indentWidth(lines[probe]);
+    if (width === 0) return { endIndex: startIndex, content: '' };
+    indent = width;
+  }
+  if (indent <= 0) return { endIndex: startIndex, content: '' };
+
+  const content = [];
+  let i = startIndex;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (isBlankLine(line)) {
+      content.push('');
+      i += 1;
+      continue;
+    }
+    if (indentWidth(line) < indent) break;
+    content.push(line.slice(indent));
+    i += 1;
+  }
+  while (content.length > 0 && content[content.length - 1] === '') content.pop();
+
+  // Exact folded whitespace is never load-bearing: no outcome depends on anything but
+  // whether the value trims to empty, and both foldings agree on that.
+  if (style === '>') {
+    let folded = '';
+    for (let j = 0; j < content.length; j += 1) {
+      if (j > 0) folded += content[j] === '' || content[j - 1] === '' ? '\n' : ' ';
+      folded += content[j];
+    }
+    return { endIndex: i, content: folded };
+  }
+  return { endIndex: i, content: content.join('\n') };
+}
+
+function resolveScalar(value) {
+  if (value === '') return { kind: 'null', value: null, raw: value };
+  const lead = value[0];
+  if (lead === '#') return { kind: 'null', value: null, raw: value };
+  if (lead === '{' || lead === '[') {
+    return { kind: 'undecidable', construct: 'a flow collection value', raw: value };
+  }
+  if (lead === '&') return { kind: 'undecidable', construct: 'an anchored value', raw: value };
+  if (lead === '*') return { kind: 'undecidable', construct: 'an alias value', raw: value };
+  if (lead === '!') return { kind: 'undecidable', construct: 'a tagged value', raw: value };
+  if (lead === '|' || lead === '>') {
+    return { kind: 'undecidable', construct: 'a block-scalar header outside the supported subset', raw: value };
+  }
+  if (lead === "'" || lead === '"') {
+    const quoted = readQuotedScalar(value, 0);
+    if (!quoted.ok) return { kind: 'undecidable', construct: quoted.reason, raw: value };
+    const tail = value.slice(quoted.end);
+    if (tail !== '' && !/^[ \t]+(#.*)?$/.test(tail)) {
+      return { kind: 'undecidable', construct: 'trailing text after a quoted scalar', raw: value };
+    }
+    return { kind: 'string', value: quoted.value, raw: value };
+  }
+
+  // Plain scalar. An unquoted `#` preceded by a space or tab starts a comment and
+  // terminates the value; a `#` not preceded by whitespace is an ordinary character.
+  let plain = value;
+  const comment = /[ \t]#/.exec(plain);
+  if (comment) plain = plain.slice(0, comment.index);
+  plain = plain.replace(/[ \t]+$/, '');
+  if (plain === '') return { kind: 'null', value: null, raw: value };
+
+  // de.rs:932-938 matches exactly these six bool spellings and nothing else; de.rs:925-930
+  // exactly these four nulls. yes/no/on/off/y/n are plain STRINGS under the 1.2 core schema.
+  if (
+    plain === 'true' ||
+    plain === 'True' ||
+    plain === 'TRUE' ||
+    plain === 'false' ||
+    plain === 'False' ||
+    plain === 'FALSE'
+  ) {
+    return { kind: 'bool', value: null, raw: value };
+  }
+  if (plain === 'null' || plain === 'Null' || plain === 'NULL' || plain === '~') {
+    return { kind: 'null', value: null, raw: value };
+  }
+  if (/^[-+]?[0-9]+$/.test(plain) || /^0x[0-9a-fA-F]+$/.test(plain) || /^0o[0-7]+$/.test(plain)) {
+    return { kind: 'number', value: null, raw: value };
+  }
+  if (
+    /^[-+]?[0-9]*\.[0-9]*([eE][-+]?[0-9]+)?$/.test(plain) ||
+    /^[-+]?\.(inf|Inf|INF)$/.test(plain) ||
+    /^\.(nan|NaN|NAN)$/.test(plain)
+  ) {
+    return { kind: 'number', value: null, raw: value };
+  }
+  return { kind: 'string', value: plain, raw: value };
+}
+
+function parseMiniYaml(text) {
+  const result = {
+    entries: new Map(),
+    undecidables: [],
+    duplicate: null,
+    certainError: null,
+    recognized: 0,
+    significant: 0,
+  };
+
+  const lines = splitFrontmatterLines(text);
+  let firstSignificantSeen = false;
+  let mappingCandidate = false;
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const lineNo = i + 1;
+    i += 1;
+
+    if (isBlankLine(line)) continue;
+
+    // 6.5.3 row 1, as corrected in Step 6: a tab in the leading whitespace is a certain
+    // error only on a line the parser is treating as a mapping entry, that is a line NOT
+    // consumed as block-scalar content. Block content is consumed by readBlockScalar and
+    // never reaches this point, so tab-indented text inside a `description: |` block is
+    // content and not an error.
+    if (leadingWsRun(line).includes('\t')) {
+      result.certainError = {
+        code: 'E-YAML-PARSE',
+        line: lineNo,
+        detail: 'a tab character appears in the indentation of a mapping line; YAML forbids tabs in indentation',
+      };
+      return result;
+    }
+
+    const indent = indentWidth(line);
+    const body = line.slice(indent);
+    if (body.startsWith('#')) continue;
+
+    result.significant += 1;
+
+    if (indent > 0) {
+      result.undecidables.push({
+        line: lineNo,
+        construct: 'an indented line at top level (a nested mapping or sequence)',
+      });
+      continue;
+    }
+
+    if (!firstSignificantSeen) {
+      firstSignificantSeen = true;
+      if (body === '-' || body.startsWith('- ')) {
+        result.certainError = {
+          code: 'E-YAML-NOT-MAPPING',
+          line: lineNo,
+          detail: 'the document root is a sequence, not a mapping',
+        };
+        return result;
+      }
+    }
+
+    const lead = body[0];
+    if (lead === '{') {
+      mappingCandidate = true;
+      result.undecidables.push({ line: lineNo, construct: 'a flow mapping at the document root' });
+      continue;
+    }
+    if (lead === '[') {
+      result.undecidables.push({ line: lineNo, construct: 'a flow sequence at the document root' });
+      continue;
+    }
+    if (lead === '%' || lead === '!' || lead === '&' || lead === '*') {
+      mappingCandidate = true;
+      result.undecidables.push({
+        line: lineNo,
+        construct: 'a directive, tag, anchor or alias at the document root',
+      });
+      continue;
+    }
+    if (body === '?' || body.startsWith('? ')) {
+      mappingCandidate = true;
+      result.undecidables.push({ line: lineNo, construct: 'an explicit key' });
+      continue;
+    }
+    if (body === '...' || body.startsWith('... ')) {
+      result.undecidables.push({ line: lineNo, construct: 'the document-end marker' });
+      continue;
+    }
+
+    const entry = parseKeyValueLine(body);
+    if (!entry.ok) {
+      result.undecidables.push({ line: lineNo, construct: entry.reason });
+      continue;
+    }
+    if (entry.key === '<<') {
+      result.undecidables.push({ line: lineNo, construct: 'a merge key' });
+      continue;
+    }
+
+    let resolved;
+    if (entry.blockScalar) {
+      const block = readBlockScalar(lines, i, entry.blockIndent, entry.blockStyle);
+      i = block.endIndex;
+      resolved = { kind: 'string', value: block.content, raw: entry.value };
+    } else {
+      resolved = resolveScalar(entry.value);
+    }
+    if (resolved.kind === 'undecidable') {
+      result.undecidables.push({ line: lineNo, construct: resolved.construct });
+    }
+
+    result.recognized += 1;
+
+    // 6.5.4. Key identity is the unquoted key text, byte-exact and case-sensitive,
+    // matching Value::String equality at :449-450. The check lives in Mapping's
+    // deserializer (mapping.rs:813-822) and runs before any field lookup, so it covers
+    // EVERY top-level key, not just the three the indexer reads.
+    if (result.entries.has(entry.key)) {
+      result.duplicate = {
+        key: entry.key,
+        firstLine: result.entries.get(entry.key).line,
+        line: lineNo,
+      };
+      return result;
+    }
+    result.entries.set(entry.key, {
+      line: lineNo,
+      kind: resolved.kind,
+      value: resolved.value === undefined ? null : resolved.value,
+      raw: resolved.raw === undefined ? entry.value : resolved.raw,
+    });
+  }
+
+  if (result.significant === 0) {
+    result.certainError = {
+      code: 'E-YAML-NOT-MAPPING',
+      line: null,
+      detail: 'the frontmatter block is empty or contains only blank and comment lines',
+    };
+    return result;
+  }
+
+  // 6.5.3 row 4. Zero recognized entries alone is not proof the root is a scalar; zero
+  // recognized entries AND nothing that could itself resolve to a mapping is.
+  if (result.recognized === 0 && !mappingCandidate) {
+    result.certainError = {
+      code: 'E-YAML-NOT-MAPPING',
+      line: null,
+      detail: 'the document root is a scalar, not a mapping',
+    };
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 6.2 Traversal + 6.3 entrypoint discovery
+// ---------------------------------------------------------------------------
+
+function walk(root, collector) {
+  const candidates = [];
+  const stack = [root];
+  const visited = new Set([path.resolve(root)]);
+  let directoriesScanned = 0;
+  let entrypointsFound = 0;
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      const code = errnoOf(err);
+      if (isCanonicalSkillsRoot(dir)) {
+        collector.add({
+          code: 'E-SKILLS-DIR-UNREADABLE',
+          absolutePath: dir,
+          message: `The \`skills\` directory could not be listed (${code}). The indexer treats this as a hard error and indexes no skill from this matrix.`,
+          indexerMessage: `\`skills\` directory could not be read: ${sanitizeForReport(code)}`,
+        });
+      } else if (isCanonicalSkillDir(dir)) {
+        collector.add({
+          code: 'E-SKILL-DIR-UNREADABLE',
+          absolutePath: dir,
+          skillDirectory: dir,
+          message: `The skill directory could not be listed (${code}). The indexer skips this skill.`,
+          indexerMessage: skippedDirectory(
+            path.basename(dir),
+            `unable to read skill directory: ${sanitizeForReport(code)}`,
+          ),
+        });
+      } else {
+        collector.add({
+          code: 'W-DIR-UNREADABLE',
+          absolutePath: dir,
+          message: `The directory could not be listed (${code}); it was skipped and the walk continued. If this is a case-variant \`skills\` directory it may still be the live skills root on Windows, where the indexer reaches it by joining the constant \`skills\`.`,
+        });
+      }
+      continue;
+    }
+    directoriesScanned += 1;
+
+    // 6.3 discovery. toLowerCase() is deliberate here and is the single exception to the
+    // asciiLower() rule: over-matching is harmless because the byte-exact test follows.
+    const matches = entries.filter((entry) => entry.name.toLowerCase() === 'skill.md');
+    entrypointsFound += matches.length;
+
+    if (matches.length === 0) {
+      if (isSkillsNameCi(path.basename(path.dirname(dir)))) {
+        const canonical = isCanonicalSkillDir(dir);
+        collector.add({
+          code: canonical ? 'E-NO-ENTRYPOINT' : 'I-NO-ENTRYPOINT',
+          absolutePath: dir,
+          skillDirectory: dir,
+          message: canonical
+            ? 'No `SKILL.md` entrypoint in any casing. The indexer requires an exact `SKILL.md` and skips this directory.'
+            : 'No `SKILL.md` entrypoint in any casing. This directory sits under a `skills/` folder that the indexer never scans, so it is a note only.',
+          indexerMessage: canonical
+            ? skippedDirectory(path.basename(dir), 'missing exact SKILL.md entrypoint')
+            : null,
+        });
+      }
+    } else {
+      const exact = matches.filter((entry) => entry.name === SKILL_MD);
+      for (const entry of matches) {
+        if (exact.length > 0 && entry.name !== SKILL_MD) {
+          // The skill works today; the stray variant is a hazard, not a rejection.
+          collector.add({
+            code: 'W-ENTRYPOINT-CASE-SHADOWED',
+            absolutePath: path.join(dir, entry.name),
+            skillDirectory: dir,
+            message: `\`${entry.name}\` sits beside an exact \`SKILL.md\`, which is the file the indexer uses. This stray variant is never read and is a hazard for the next reader.`,
+          });
+          continue;
+        }
+        candidates.push({
+          dir,
+          entryName: entry.name,
+          entrypoint: path.join(dir, entry.name),
+          dirent: entry,
+          casingError: entry.name !== SKILL_MD,
+        });
+      }
+    }
+
+    // Step 3. The order and the guard shape are load-bearing: readdirSync returns Dirents
+    // with lstat semantics, so isDirectory() is false for every symlink and any symlink
+    // test nested under an isDirectory() guard never runs. Mirrors :578-585.
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+
+      if (entry.isSymbolicLink()) {
+        // Never descend, and never apply a directory test. Node reports Windows junctions
+        // and reparse points as symbolic links, so one code path covers both platforms.
+        if (isSkillsNameCi(path.basename(dir))) {
+          const canonical = MATRIX_DIR_RE.test(path.basename(path.dirname(dir)));
+          if (canonical) {
+            collector.add({
+              code: 'E-SKILL-DIR-LINK',
+              absolutePath: entryPath,
+              skillDirectory: entryPath,
+              message:
+                'A linked entry directly under `skills/` is never followed. :578 tests only is_symlink() and never inspects the target, so this holds whether the link resolves to a directory, to a file, or to nothing.',
+              indexerMessage: `Skipped linked skill directory \`${sanitizeForReport(entry.name)}\`: linked/reparse-point directories are not followed`,
+            });
+          } else {
+            collector.add({
+              code: 'W-SKILL-DIR-LINK',
+              absolutePath: entryPath,
+              skillDirectory: entryPath,
+              message:
+                'A linked entry directly under a `skills/` folder that is not in canonical position. The indexer never scans this tree, so this is a note about a shape that would be fatal if the folder were a real skills root.',
+            });
+          }
+        }
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        // SKIP_DIRS never applies inside a `skills/` directory: the indexer applies no
+        // name filter at all, and `target` matches ^[a-z0-9-]{1,64}$ so it is a legal
+        // skill name. Skipping it would hide a real skill from the checker.
+        if (!isSkillsNameCi(path.basename(dir)) && SKIP_DIRS.has(asciiLower(entry.name))) continue;
+        const resolved = path.resolve(entryPath);
+        if (visited.has(resolved)) continue;
+        visited.add(resolved);
+        stack.push(entryPath);
+        continue;
+      }
+
+      // Step 4. An entry named `skills` that is not a directory, under an `_agent_*`
+      // parent. A plain file directly inside `skills/` produces nothing, agreeing with
+      // :583's `else if is_dir()`.
+      if (isSkillsNameCi(entry.name) && MATRIX_DIR_RE.test(path.basename(dir))) {
+        collector.add({
+          code: 'E-SKILLS-NOT-DIR',
+          absolutePath: entryPath,
+          message:
+            '`skills` exists but is not a directory, so the indexer finds no skills in this matrix at all.',
+          indexerMessage: `\`skills\` exists but is not a directory: ${sanitizeForReport(entryPath)}`,
+        });
+      }
+    }
+
+    // Step 4, symlink arm. Handled separately because a symlink is excluded from the
+    // isDirectory() branch above and must be probed to tell a resolving link from a
+    // broken one: :520 gates on Path::exists, which follows links, so a broken `skills`
+    // link makes exists() false and the indexer returns at :521 with NO warning at all.
+    // This statSync is the only place in the walk that follows a link.
+    for (const entry of entries) {
+      if (!entry.isSymbolicLink()) continue;
+      if (!isSkillsNameCi(entry.name)) continue;
+      if (!MATRIX_DIR_RE.test(path.basename(dir))) continue;
+      const entryPath = path.join(dir, entry.name);
+      let resolves = false;
+      try {
+        resolves = fs.statSync(entryPath, { throwIfNoEntry: false }) !== undefined;
+      } catch {
+        // Path::exists returns false on ANY stat error, and the indexer is silent there.
+        resolves = false;
+      }
+      if (!resolves) continue;
+      collector.add({
+        code: 'E-SKILLS-NOT-DIR',
+        absolutePath: entryPath,
+        message:
+          '`skills` is a symlink that resolves, and :534 rejects it on is_symlink() even when the target is a directory. The indexer finds no skills in this matrix at all.',
+        indexerMessage: `\`skills\` exists but is not a directory: ${sanitizeForReport(entryPath)}`,
+      });
+    }
+  }
+
+  return { candidates, directoriesScanned, entrypointsFound };
+}
+
+// ---------------------------------------------------------------------------
+// 6.6 Field validation
+// ---------------------------------------------------------------------------
+
+function validateFields(candidate, mapping, collector, lineOffset) {
+  const folder = path.basename(candidate.dir);
+  const entrypoint = candidate.entrypoint;
+  const fileLine = (bodyLine) => (bodyLine === null ? null : bodyLine + lineOffset);
+
+  const hyphenVariant = mapping.entries.get('when-to-use');
+  if (hyphenVariant) {
+    collector.add({
+      code: 'I-KEY-HYPHEN-VARIANT',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: fileLine(hyphenVariant.line),
+      message:
+        'The key `when-to-use` is never read. The indexer reads only the underscored `when_to_use` (:687), so this spelling is silently ignored.',
+    });
+  }
+
+  // ---- name (:641-660) ----
+  const nameEntry = mapping.entries.get('name');
+  let resolvedName = null;
+  let nameSource = 'folder';
+  let nameLine = null;
+  let nameResolved = false;
+
+  if (nameEntry === undefined) {
+    // :652 uses folder_name.clone() straight from the directory entry. The folder
+    // fallback is NEVER trimmed; trimming it would hide a directory named " x ".
+    resolvedName = folder;
+    nameSource = 'folder';
+    nameResolved = true;
+  } else if (nameEntry.kind === 'undecidable') {
+    // 6.5.2/6.6.1 step 3. W-YAML-UNDECIDABLE is already emitted. Run the charset check
+    // for the author's benefit but report any violation as a WARNING: the run is never
+    // failed on a value the checker has declared itself unable to judge, and this
+    // entrypoint does not participate in the duplicate-name race.
+    const literal = nameEntry.raw;
+    if (!NAME_RE.test(literal)) {
+      collector.add({
+        code: 'W-NAME-UNDECIDABLE',
+        absolutePath: entrypoint,
+        skillDirectory: candidate.dir,
+        line: fileLine(nameEntry.line),
+        message: `The \`name:\` value \`${sanitizeForReport(literal)}\` is outside the parser's YAML subset, so the checker cannot resolve it. The indexer may index this skill under a name the checker could not resolve, or reject it with \`name must be a string\`, or reject it as an invalid name. The checker cannot tell which.`,
+      });
+    }
+  } else if (nameEntry.kind !== 'string') {
+    collector.add({
+      code: 'E-NAME-NOT-STRING',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: fileLine(nameEntry.line),
+      message: 'The `name:` value is not a YAML string. `yaml_field_string` accepts only Value::String (:448-462).',
+      indexerMessage: skippedSkill(folder, 'name must be a string'),
+    });
+  } else {
+    // :453 trims with Rust str::trim; Y5 maps an empty result to absent (:452-459).
+    const trimmed = trimYamlValue(nameEntry.value);
+    if (trimmed === '') {
+      resolvedName = folder;
+      nameSource = 'folder';
+    } else {
+      resolvedName = trimmed;
+      nameSource = 'key';
+      nameLine = fileLine(nameEntry.line);
+    }
+    nameResolved = true;
+  }
+
+  if (nameResolved) {
+    // :464-470 is chars().count() in 1..=64 plus is_ascii_lowercase()/is_ascii_digit()/'-'.
+    // NAME_RE covers both, and for a charset-valid name the UTF-16 length equals the
+    // scalar count, so the two formulations agree; the scalar count is what the message
+    // reports, because `name.length` would misreport astral characters.
+    const scalarLength = [...resolvedName].length;
+    if (!NAME_RE.test(resolvedName)) {
+      const source =
+        nameSource === 'key'
+          ? `the \`name:\` key on line ${nameLine}.`
+          : 'the containing directory name, because no usable `name:` key is present. Either rename the directory or add a valid `name:` key.';
+      collector.add({
+        code: 'E-NAME-INVALID',
+        absolutePath: entrypoint,
+        skillDirectory: candidate.dir,
+        skillName: resolvedName,
+        line: nameLine,
+        message: `Resolved name \`${sanitizeForReport(resolvedName)}\` is not valid; expected 1-64 characters from [a-z0-9-] and this one is ${scalarLength}. Source: ${source}`,
+        indexerMessage: skippedSkill(
+          folder,
+          `invalid skill name \`${sanitizeForReport(resolvedName)}\`; expected 1-64 lowercase ASCII letters, digits, or hyphens`,
+        ),
+      });
+      nameResolved = false;
+    }
+  }
+
+  // ---- description (:674-684) ----
+  const descEntry = mapping.entries.get('description');
+  if (descEntry === undefined) {
+    collector.add({
+      code: 'W-DESC-MISSING',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      skillName: resolvedName,
+      message:
+        '`description` is missing. The skill is still indexed, and flagged at startup. A bad description is the only metadata problem that keeps a skill alive.',
+      indexerMessage: 'description metadata is missing; inspect SKILL.md before use.',
+    });
+  } else if (descEntry.kind === 'string') {
+    if (trimYamlValue(descEntry.value) === '') {
+      collector.add({
+        code: 'W-DESC-MISSING',
+        absolutePath: entrypoint,
+        skillDirectory: candidate.dir,
+        skillName: resolvedName,
+        line: fileLine(descEntry.line),
+        message:
+          '`description` trims to empty, which Y5 maps to absent. The skill is still indexed, and flagged at startup.',
+        indexerMessage: 'description metadata is missing; inspect SKILL.md before use.',
+      });
+    }
+  } else if (descEntry.kind !== 'undecidable') {
+    collector.add({
+      code: 'W-DESC-NOT-STRING',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      skillName: resolvedName,
+      line: fileLine(descEntry.line),
+      message: '`description` is present but is not a YAML string. The skill is still indexed, and flagged at startup.',
+      indexerMessage: 'description must be a string; inspect SKILL.md before use.',
+    });
+  }
+
+  // ---- when_to_use (:687-692) ----
+  const whenEntry = mapping.entries.get('when_to_use');
+  if (whenEntry !== undefined && whenEntry.kind !== 'string' && whenEntry.kind !== 'undecidable') {
+    collector.add({
+      code: 'W-WHEN-NOT-STRING',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      skillName: resolvedName,
+      line: fileLine(whenEntry.line),
+      message: '`when_to_use` is present but is not a YAML string; the indexer omits the metadata and indexes the skill.',
+      indexerMessage: 'when_to_use must be a string; omitted when_to_use metadata.',
+    });
+  }
+
+  return { resolvedName: nameResolved ? resolvedName : null, nameLine };
+}
+
+// ---------------------------------------------------------------------------
+// 6.6.4 Duplicate names
+// ---------------------------------------------------------------------------
+
+function detectDuplicates(validated, collector) {
+  const groups = new Map();
+  for (const candidate of validated) {
+    const parent = path.dirname(candidate.dir);
+    if (!isSkillsNameCi(path.basename(parent))) continue;
+    if (!groups.has(parent)) groups.set(parent, []);
+    groups.get(parent).push(candidate);
+  }
+
+  for (const group of groups.values()) {
+    // Exact port of :588-591, a two-element tuple compare of
+    // (to_ascii_lowercase(), original), both as Rust String, that is UTF-8 byte order.
+    // Sort the DIRECTORIES, not the resolved names: :588-591 runs on folder_name before
+    // any frontmatter is read.
+    group.sort((a, b) => {
+      const an = path.basename(a.dir);
+      const bn = path.basename(b.dir);
+      const byLower = compareUtf8(asciiLower(an), asciiLower(bn));
+      if (byLower !== 0) return byLower;
+      return compareUtf8(an, bn);
+    });
+
+    const seen = new Map();
+    for (const candidate of group) {
+      const name = candidate.resolvedName;
+      if (name === null) continue;
+      const first = seen.get(name);
+      if (first === undefined) {
+        seen.set(name, path.basename(candidate.dir));
+        continue;
+      }
+      collector.add({
+        code: 'E-NAME-DUPLICATE',
+        absolutePath: candidate.entrypoint,
+        skillDirectory: candidate.dir,
+        skillName: name,
+        line: candidate.nameLine,
+        message: `Resolved name \`${sanitizeForReport(name)}\` is already claimed by \`${sanitizeForReport(first)}\`, which sorts first in the same \`skills/\` directory. The indexer keeps the first and skips this one.`,
+        indexerMessage: skippedSkill(
+          path.basename(candidate.dir),
+          `duplicate skill name \`${sanitizeForReport(name)}\` already used by \`${sanitizeForReport(first)}\``,
+        ),
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+function validateEntrypoint(candidate, collector) {
+  const folder = path.basename(candidate.dir);
+  const entrypoint = candidate.entrypoint;
+
+  if (candidate.casingError) {
+    collector.add({
+      code: 'E-ENTRYPOINT-CASE',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      message: `Entrypoint is named \`${candidate.entryName}\`; the indexer compares entry.file_name() byte-exactly against \`SKILL.md\` (:401) and rejects this on every platform, Windows included.`,
+      indexerMessage: skippedDirectory(folder, 'missing exact SKILL.md entrypoint'),
+    });
+  }
+
+  // Symlink first, again for lstat semantics.
+  if (candidate.dirent.isSymbolicLink()) {
+    collector.add({
+      code: 'E-ENTRYPOINT-LINK',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      message: 'The `SKILL.md` entrypoint is a symlink or reparse point, which the indexer refuses to follow (:409).',
+      indexerMessage: skippedDirectory(folder, 'exact SKILL.md entrypoint is linked/reparse-point'),
+    });
+    return null;
+  }
+  if (!candidate.dirent.isFile()) {
+    collector.add({
+      code: 'E-ENTRYPOINT-NOT-FILE',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      message: 'The `SKILL.md` entrypoint is not a regular file (:412).',
+      indexerMessage: skippedDirectory(folder, 'exact SKILL.md entrypoint is not a regular file'),
+    });
+    return null;
+  }
+
+  const frontmatter = readFrontmatter(entrypoint);
+  if (!frontmatter.ok) {
+    const detail = frontmatter.detail === undefined ? '' : frontmatter.detail;
+    const messages = {
+      'E-ENTRYPOINT-UNREADABLE': `The entrypoint could not be ${frontmatter.verb === 'read' ? 'read' : 'opened'} (${detail}).`,
+      'E-FM-NO-OPEN':
+        'No opening frontmatter delimiter on line 1. The first line must reduce to exactly `---` after stripping one terminator, an optional leading BOM and ASCII whitespace.',
+      'E-FM-FIRST-LINE-TOO-LONG': `The first line, including its terminator, exceeds ${FIRST_LINE_MAX_BYTES} bytes. The indexer reports this as a missing opening delimiter (:342-345).`,
+      'E-FM-NO-CLOSE': 'End of file reached with no closing frontmatter delimiter.',
+      'E-FM-TOO-LARGE': `The frontmatter exceeds the ${FRONTMATTER_MAX_BYTES} byte limit. Line terminators count, and \`\\r\\n\` costs two bytes.`,
+      'E-FM-NOT-UTF8': `The frontmatter block is not valid UTF-8 (${detail}). Only the frontmatter must be valid UTF-8; the body may be arbitrary bytes.`,
+    };
+    const tails = {
+      'E-ENTRYPOINT-UNREADABLE': `failed to ${frontmatter.verb === 'read' ? 'read' : 'open'} SKILL.md frontmatter: ${sanitizeForReport(detail)}`,
+      'E-FM-NO-OPEN': 'missing opening frontmatter delimiter',
+      'E-FM-FIRST-LINE-TOO-LONG': 'missing opening frontmatter delimiter',
+      'E-FM-NO-CLOSE': 'missing closing frontmatter delimiter',
+      'E-FM-TOO-LARGE': `frontmatter exceeds ${FRONTMATTER_MAX_BYTES} byte limit`,
+      'E-FM-NOT-UTF8': `frontmatter is not valid UTF-8: ${sanitizeForReport(detail)}`,
+    };
+    collector.add({
+      code: frontmatter.code,
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: frontmatter.code === 'E-FM-NO-OPEN' || frontmatter.code === 'E-FM-FIRST-LINE-TOO-LONG' ? 1 : null,
+      message: messages[frontmatter.code],
+      indexerMessage: skippedSkill(folder, tails[frontmatter.code]),
+    });
+    return null;
+  }
+
+  // The frontmatter block excludes both delimiters, and the opening one is always line 1,
+  // so body line N is file line N + 1.
+  const lineOffset = 1;
+  const mapping = parseMiniYaml(frontmatter.text);
+
+  if (mapping.certainError !== null) {
+    const certain = mapping.certainError;
+    collector.add({
+      code: certain.code,
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: certain.line === null ? null : certain.line + lineOffset,
+      message: `${certain.detail}. The indexer never resolves any field of this skill, so no field-level finding would be truthful.`,
+      indexerMessage: skippedSkill(
+        folder,
+        certain.code === 'E-YAML-PARSE'
+          ? `YAML parse error: ${certain.detail}`
+          : 'frontmatter must be a YAML mapping',
+      ),
+    });
+    return null;
+  }
+
+  if (mapping.duplicate !== null) {
+    const dup = mapping.duplicate;
+    collector.add({
+      code: 'E-YAML-DUPLICATE-KEY',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: dup.line + lineOffset,
+      message: `The top-level key \`${sanitizeForReport(dup.key)}\` appears on line ${dup.firstLine + lineOffset} and again on line ${dup.line + lineOffset}. serde_yaml 0.9.34 rejects duplicate mapping keys (mapping.rs:813-822), so the parse fails and the skill is skipped outright. This covers every top-level key, not just the three the indexer reads.`,
+      indexerMessage: skippedSkill(
+        folder,
+        `YAML parse error: duplicate entry with key "${sanitizeForReport(dup.key)}"`,
+      ),
+    });
+    return null;
+  }
+
+  for (const undecidable of mapping.undecidables) {
+    collector.add({
+      code: 'W-YAML-UNDECIDABLE',
+      absolutePath: entrypoint,
+      skillDirectory: candidate.dir,
+      line: undecidable.line + lineOffset,
+      message: `The mini-parser cannot judge ${undecidable.construct}. The construct is outside its fixed YAML subset, so the checker refuses to approve or reject it.`,
+    });
+  }
+
+  const fields = validateFields(candidate, mapping, collector, lineOffset);
+  return fields;
+}
+
+function runCheck(root) {
+  const collector = createCollector(root);
+  const walked = walk(root, collector);
+
+  const validated = [];
+  for (const candidate of walked.candidates) {
+    const before = collector.findings.length;
+    const fields = validateEntrypoint(candidate, collector);
+    const emitted = collector.findings.slice(before);
+    const hasError = emitted.some((finding) => finding.severity === SEVERITY.error);
+
+    // 6.6.4: a candidate carrying ANY hard error never claims its name. :595-670 is a
+    // single loop whose every failure path is a `continue`, and seen_skill_names is
+    // written only at :671, after every hard check has passed.
+    if (fields !== null && !hasError && fields.resolvedName !== null) {
+      validated.push({
+        dir: candidate.dir,
+        entrypoint: candidate.entrypoint,
+        resolvedName: fields.resolvedName,
+        nameLine: fields.nameLine,
+      });
+    }
+  }
+
+  detectDuplicates(validated, collector);
+
+  // A duplicate finding lands after the fact, so recompute indexability from the findings.
+  const erroredEntrypoints = new Set();
+  for (const finding of collector.findings) {
+    if (finding.severity !== SEVERITY.error) continue;
+    if (finding.code === 'W-ENTRYPOINT-CASE-SHADOWED') continue;
+    const owner = walked.candidates.find((candidate) => candidate.entrypoint === finding.absolutePath);
+    if (owner !== undefined) erroredEntrypoints.add(finding.absolutePath);
+  }
+
+  // A shadowed casing variant is excluded from skillsIndexable: it carries only
+  // W-ENTRYPOINT-CASE-SHADOWED and is never validated, so counting it would report one
+  // directory as two indexable skills.
+  const skillsIndexable = walked.candidates.filter(
+    (candidate) => !erroredEntrypoints.has(candidate.entrypoint),
+  ).length;
+
+  for (const candidate of walked.candidates) {
+    const position = classifyPosition(candidate.entrypoint);
+    if (position.canonical) continue;
+    collector.add({
+      code: 'I-NOT-INDEXABLE',
+      absolutePath: candidate.entrypoint,
+      skillDirectory: candidate.dir,
+      reason: position.reason,
+      message: POSITION_MESSAGE[position.reason],
+    });
+  }
+
+  const findings = collector.findings.slice().sort((a, b) => {
+    if (a.path < b.path) return -1;
+    if (a.path > b.path) return 1;
+    const aLine = a.line === null ? 0 : a.line;
+    const bLine = b.line === null ? 0 : b.line;
+    if (aLine !== bLine) return aLine - bLine;
+    if (a.code < b.code) return -1;
+    if (a.code > b.code) return 1;
+    return a.seq - b.seq;
+  });
+
+  const errors = findings.filter((finding) => finding.severity === SEVERITY.error).length;
+  const warnings = findings.filter((finding) => finding.severity === SEVERITY.warning).length;
+  const infos = findings.filter((finding) => finding.severity === SEVERITY.info).length;
+  const exitCode = errors > 0 ? 1 : 0;
+
+  return {
+    tool: TOOL,
+    version: OUTPUT_VERSION,
+    sourceOfTruth: SOURCE_OF_TRUTH,
+    root,
+    summary: {
+      directoriesScanned: walked.directoriesScanned,
+      entrypointsFound: walked.entrypointsFound,
+      skillsIndexable,
+      errors,
+      warnings,
+      infos,
+    },
+    findings: findings.map((finding) => ({
+      code: finding.code,
+      severity: finding.severity,
+      rule: finding.rule,
+      path: finding.path,
+      absolutePath: finding.absolutePath,
+      skillDirectory: finding.skillDirectory,
+      skillName: finding.skillName,
+      line: finding.line,
+      reason: finding.reason,
+      message: finding.message,
+      indexerMessage: finding.indexerMessage,
+    })),
+    exitCode,
+    erroredEntrypoints: erroredEntrypoints.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 6.9 Human report / 6.10 JSON output
+// ---------------------------------------------------------------------------
+
+// Fixed-width tokens, padded to five characters as the report format requires.
+const SEVERITY_LABEL = { error: 'ERROR', warning: 'WARN ', info: 'NOTE ' };
+const LABEL_GAP = ' ';
+
+function wrapContinuation(text) {
+  const width = 92;
+  const words = text.split(' ');
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    if (current === '') {
+      current = word;
+    } else if (`${current} ${word}`.length <= width) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines;
+}
+
+function renderHuman(report, out) {
+  const scanned = report.summary.directoriesScanned;
+  out(`${TAG} root: ${report.root}`);
+  out(
+    `${TAG} scanned ${scanned} ${scanned === 1 ? 'directory' : 'directories'}, found ${plural(report.summary.entrypointsFound, 'SKILL.md entrypoint')}`,
+  );
+
+  if (report.summary.entrypointsFound === 0 && report.findings.length === 0) {
+    out('');
+    out(`${TAG} OK: no SKILL.md entrypoints found`);
+    return;
+  }
+
+  for (const finding of report.findings) {
+    out('');
+    const anchor = finding.line === null ? finding.path : `${finding.path}:${finding.line}`;
+    const suffix =
+      finding.reason === null ? `${finding.code}  (rule ${finding.rule ?? 'checker-only'})` : `${finding.code}  (reason: ${finding.reason})`;
+    out(`${SEVERITY_LABEL[finding.severity]}${LABEL_GAP} ${anchor}  ${suffix}`);
+    for (const line of wrapContinuation(finding.message)) out(`       ${line}`);
+    if (finding.indexerMessage !== null) {
+      const indexerLines = wrapContinuation(`Indexer: ${finding.indexerMessage}`);
+      for (const line of indexerLines) out(`       ${line}`);
+    }
+  }
+
+  out('');
+  out(
+    `${TAG} ${plural(report.summary.errors, 'error')}, ${plural(report.summary.warnings, 'warning')}, ${plural(report.summary.infos, 'note')} across ${plural(report.summary.entrypointsFound, 'entrypoint')}`,
+  );
+
+  if (report.exitCode === 0) {
+    if (report.summary.entrypointsFound === 0) {
+      out(`${TAG} OK: no SKILL.md entrypoints found`);
+    } else {
+      out(`${TAG} OK: ${report.summary.skillsIndexable} skills would be indexed`);
+    }
+    return;
+  }
+
+  // Five error codes attach to no entrypoint at all, so the entrypoint count alone can
+  // print `FAIL: 0`, which flatly contradicts the exit code.
+  const implicated = report.erroredEntrypoints;
+  if (implicated === 0) {
+    out(`${TAG} FAIL: ${plural(report.summary.errors, 'error finding')}, no entrypoint implicated`);
+  } else {
+    out(
+      `${TAG} FAIL: ${implicated} skills would not be indexed, and ${plural(report.summary.errors, 'error finding')} in total`,
+    );
+  }
+}
+
+function renderJson(report) {
+  const document = {
+    tool: report.tool,
+    version: report.version,
+    sourceOfTruth: report.sourceOfTruth,
+    root: report.root,
+    summary: report.summary,
+    findings: report.findings,
+    exitCode: report.exitCode,
+  };
+  return `${JSON.stringify(document, null, 2)}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// 6.1 CLI
+// ---------------------------------------------------------------------------
+
+const USAGE = [
+  `${TOOL} - validate SKILL.md structure the way AgentsCommander's indexer does (issue #1213).`,
+  '',
+  `Source of truth: ${SOURCE_OF_TRUTH}`,
+  '',
+  'Usage:',
+  '  node scripts/01-skills-checker.mjs [root] [--json]',
+  '  node scripts/01-skills-checker.mjs --help | -h',
+  '  node scripts/01-skills-checker.mjs --self-test',
+  '',
+  'Arguments:',
+  '  root          Directory to walk recursively. Defaults to the current directory.',
+  '  --json        Write one JSON document to stdout and nothing else.',
+  '  --self-test   Run the in-script test suite. May not be combined with any other argument.',
+  '  --            Terminate flag parsing, so a root may begin with a hyphen.',
+  '',
+  'Exit codes:',
+  '  0  no error findings (warnings and notes may still be present)',
+  '  1  at least one error finding: one or more skills would not be indexed',
+  '  2  usage error, or the root does not exist / is not a directory / cannot be read',
+];
+
+function printUsage(out) {
+  for (const line of USAGE) out(line);
+}
+
+function parseArgs(argv) {
+  const result = { help: false, selfTest: false, json: false, root: null, error: null };
+  const flags = [];
+  const positionals = [];
+  let flagsTerminated = false;
+
+  for (const arg of argv) {
+    if (!flagsTerminated && arg === '--') {
+      flagsTerminated = true;
+      continue;
+    }
+    if (!flagsTerminated && arg.startsWith('-')) {
+      flags.push(arg);
+      continue;
+    }
+    positionals.push(arg);
+  }
+
+  // `--help` wins over every other argument, including an invalid one. It is scanned
+  // among flags only, so `-- --help` still names a root, which is what `--` is for.
+  if (flags.includes('--help') || flags.includes('-h')) {
+    result.help = true;
+    return result;
+  }
+
+  for (const flag of flags) {
+    if (flag === '--json') result.json = true;
+    else if (flag === '--self-test') result.selfTest = true;
+  }
+
+  const unknown = flags.find((flag) => flag !== '--json' && flag !== '--self-test');
+  if (unknown !== undefined) {
+    result.error = `usage: unknown option '${unknown}'`;
+    return result;
+  }
+  if (result.selfTest && (result.json || positionals.length > 0 || flags.length > 1)) {
+    result.error = 'usage: --self-test may not be combined with any other argument';
+    return result;
+  }
+  if (positionals.length > 1) {
+    result.error = 'usage: at most one root may be given';
+    return result;
+  }
+
+  result.root = positionals.length === 1 ? positionals[0] : null;
+  return result;
+}
+
+function runCli(argv, out, err) {
+  let options;
+  try {
+    options = parseArgs(argv);
+  } catch (error) {
+    err(`internal error: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error && error.stack) err(error.stack);
+    return 2;
+  }
+
+  if (options.help) {
+    printUsage(out);
+    return 0;
+  }
+
+  const fail = (message) => {
+    if (options.json) {
+      err(JSON.stringify({ tool: TOOL, version: OUTPUT_VERSION, error: message, exitCode: 2 }));
+    } else {
+      err(message);
+    }
+    return 2;
+  };
+
+  if (options.error !== null) return fail(options.error);
+  if (options.selfTest) return selfTest(out);
+
+  const root = path.resolve(options.root === null ? process.cwd() : options.root);
+
+  let stats;
+  try {
+    stats = fs.statSync(root);
+  } catch (error) {
+    return fail(`cannot read root '${root}': ${errnoOf(error)}`);
+  }
+  if (!stats.isDirectory()) return fail(`root '${root}' is not a directory`);
+  try {
+    // Exit 2 is only ever about the invocation and the root itself; a directory that
+    // cannot be read INSIDE the walk is a finding, not an exit-2 failure.
+    fs.readdirSync(root);
+  } catch (error) {
+    return fail(`cannot read root '${root}': ${errnoOf(error)}`);
+  }
+
+  let report;
+  try {
+    report = runCheck(root);
+  } catch (error) {
+    err(`internal error: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error && error.stack) err(error.stack);
+    return 2;
+  }
+
+  if (options.json) {
+    out(renderJson(report).replace(/\n$/, ''));
+  } else {
+    renderHuman(report, out);
+  }
+  return report.exitCode;
+}
+
+// ---------------------------------------------------------------------------
+// Section 9: the self-test
+// ---------------------------------------------------------------------------
+
+function assertSelf(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function writeFixture(root, relative, contents) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, contents);
+  return target;
+}
+
+function makeDir(root, relative) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(target, { recursive: true });
+  return target;
+}
+
+// On win32 a junction needs NO Developer Mode and no elevation, works for directories,
+// and Node reports it through Dirent.isSymbolicLink(). That is what keeps cases 11, 11a,
+// 11b, 12, 12b, 63e and 63f from skipping on ordinary Windows.
+function makeDirLink(target, linkPath) {
+  if (process.platform === 'win32') {
+    fs.symlinkSync(path.resolve(target), linkPath, 'junction');
+  } else {
+    fs.symlinkSync(target, linkPath, 'dir');
+  }
+}
+
+function codesOf(report) {
+  return report.findings.map((finding) => finding.code);
+}
+
+function hasCode(report, code) {
+  return report.findings.some((finding) => finding.code === code);
+}
+
+function countCode(report, code) {
+  return report.findings.filter((finding) => finding.code === code).length;
+}
+
+function validSkillMd(name) {
+  return `---\nname: ${name}\ndescription: A valid skill.\n---\n\nBody.\n`;
+}
+
+function tempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ac-skills-check-'));
+}
+
+function removeRoot(root) {
+  try {
+    fs.rmSync(root, { recursive: true, force: true });
+  } catch {
+    // A fixture that resists removal must not turn a passing case into a failure.
+  }
+}
+
+// Probe: can this filesystem hold `SKILL.md` and `skill.md` side by side? Default Windows
+// and default macOS cannot, and there the second write silently overwrites the first.
+function probeCaseSensitiveFs() {
+  const root = tempRoot();
+  try {
+    fs.writeFileSync(path.join(root, 'SKILL.md'), 'a');
+    fs.writeFileSync(path.join(root, 'skill.md'), 'b');
+    return fs.readdirSync(root).length === 2;
+  } catch {
+    return false;
+  } finally {
+    removeRoot(root);
+  }
+}
+
+// Probe: can a directory be made unlistable to the current user? icacls denials do not
+// bind the owner on Windows and chmod 000 does not bind root on Linux, and this script
+// may only use node:fs, so there is no way to shell out to icacls either.
+function probeUnreadableDir() {
+  const root = tempRoot();
+  try {
+    const target = path.join(root, 'probe');
+    fs.mkdirSync(target);
+    try {
+      fs.chmodSync(target, 0o000);
+    } catch {
+      return false;
+    }
+    try {
+      fs.readdirSync(target);
+      return false;
+    } catch {
+      return true;
+    } finally {
+      try {
+        fs.chmodSync(target, 0o700);
+      } catch {
+        // Best effort; removeRoot uses force.
+      }
+    }
+  } catch {
+    return false;
+  } finally {
+    removeRoot(root);
+  }
+}
+
+function probeFileSymlink() {
+  const root = tempRoot();
+  try {
+    const target = path.join(root, 'target.txt');
+    fs.writeFileSync(target, 'x');
+    fs.symlinkSync(target, path.join(root, 'link.txt'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    removeRoot(root);
+  }
+}
+
+function selfTest(out) {
+  const caseSensitiveFs = probeCaseSensitiveFs();
+  const unreadableDirSupported = probeUnreadableDir();
+  const fileSymlinkSupported = probeFileSymlink();
+
+  const skipped = [];
+  let ran = 0;
+  let total = 0;
+  let failure = null;
+
+  const skip = (id, reason) => {
+    skipped.push(id);
+    out(`${TAG} self-test: SKIP case ${id} (${reason})`);
+  };
+
+  // Returns 0 when every case passes and 1 on the FIRST failure, naming the case; every
+  // later case is short-circuited so the printed failure is the one that matters.
+  const run = (id, body) => {
+    if (failure !== null) return;
+    total += 1;
+    const root = tempRoot();
+    try {
+      const outcome = body(root);
+      if (outcome === 'skip') return;
+      ran += 1;
+    } catch (error) {
+      failure = `case ${id}: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      removeRoot(root);
+    }
+  };
+
+  // ---- CLI (6.1) ----
+  run('1', () => {
+    const lines = [];
+    const code = runCli(['--help'], (line) => lines.push(line), () => {});
+    assertSelf(code === 0, '--help must exit 0');
+    assertSelf(lines.join('\n').includes('Exit codes:'), '--help must print the usage block');
+  });
+
+  run('2', (root) => {
+    const missing = path.join(root, 'nope');
+    const errs = [];
+    const code = runCli([missing], () => {}, (line) => errs.push(line));
+    assertSelf(code === 2, 'a nonexistent root must exit 2');
+    assertSelf(errs.join('\n').includes(missing), 'the message must name the path');
+  });
+
+  run('3', (root) => {
+    const file = writeFixture(root, 'a-file.txt', 'x');
+    const errs = [];
+    const code = runCli([file], () => {}, (line) => errs.push(line));
+    assertSelf(code === 2, 'a root that is a file must exit 2');
+    assertSelf(errs.join('\n').includes('is not a directory'), 'the message must say it is not a directory');
+  });
+
+  run('4', (root) => {
+    const code = runCli([root, root], () => {}, () => {});
+    assertSelf(code === 2, 'two positionals must exit 2');
+  });
+
+  run('5', (root) => {
+    const errs = [];
+    const code = runCli([root, '--bogus'], () => {}, (line) => errs.push(line));
+    assertSelf(code === 2, 'an unknown flag must exit 2');
+    assertSelf(errs.join('\n').includes("unknown option '--bogus'"), 'the message must name the flag');
+  });
+
+  run('6', (root) => {
+    const dashed = path.join(root, '-dashed');
+    fs.mkdirSync(dashed);
+    const code = runCli(['--', dashed], () => {}, () => {});
+    assertSelf(code === 0, 'a root after `--` must be treated as the root, not a flag');
+    const parsed = parseArgs(['--', '-dashed']);
+    assertSelf(parsed.root === '-dashed' && parsed.error === null, '`--` must terminate flag parsing');
+  });
+
+  run('7', (root) => {
+    const report = runCheck(root);
+    assertSelf(report.exitCode === 0, 'an empty root must exit 0');
+    assertSelf(report.summary.entrypointsFound === 0, 'an empty root must find no entrypoints');
+  });
+
+  // ---- Traversal (6.2) ----
+  run('8', (root) => {
+    writeFixture(root, 'node_modules/pkg/skills/x/SKILL.md', validSkillMd('x'));
+    writeFixture(root, '.git/skills/y/SKILL.md', validSkillMd('y'));
+    writeFixture(root, 'target/skills/z/SKILL.md', validSkillMd('z'));
+    const report = runCheck(root);
+    assertSelf(report.summary.entrypointsFound === 0, 'SKIP_DIRS must not be traversed');
+  });
+
+  run('9', (root) => {
+    writeFixture(root, 'Node_Modules/pkg/skills/x/SKILL.md', validSkillMd('x'));
+    const report = runCheck(root);
+    assertSelf(report.summary.entrypointsFound === 0, 'the SKIP_DIRS comparison must be case-insensitive');
+  });
+
+  run('10', (root) => {
+    writeFixture(root, 'a/b/c/d/e/SKILL.md', validSkillMd('deep'));
+    const report = runCheck(root);
+    assertSelf(report.summary.entrypointsFound === 1, 'the walk must have no depth limit');
+  });
+
+  run('11', (root) => {
+    const target = makeDir(root, 'link-target');
+    writeFixture(root, 'link-target/SKILL.md', validSkillMd('linked'));
+    makeDir(root, '_agent_x/skills');
+    makeDirLink(target, path.join(root, '_agent_x/skills/linked'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-SKILL-DIR-LINK'), 'a linked skill directory in canonical position is a hard error');
+    assertSelf(
+      !report.findings.some((f) => f.absolutePath.includes(`skills${path.sep}linked${path.sep}`)),
+      'the walk must not descend into a linked skill directory',
+    );
+  });
+
+  run('11a', (root) => {
+    const target = makeDir(root, 'link-target');
+    makeDir(root, 'docs/skills');
+    makeDirLink(target, path.join(root, 'docs/skills/linked'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'W-SKILL-DIR-LINK'), 'a linked skill directory outside canonical position is a warning');
+    assertSelf(report.exitCode === 0, 'a docs/skills link must not fail the run');
+  });
+
+  run('11b', (root) => {
+    const fileTarget = makeDir(root, 'file-target');
+    const goneTarget = makeDir(root, 'gone-target');
+    makeDir(root, '_agent_x/skills');
+    makeDirLink(fileTarget, path.join(root, '_agent_x/skills/to-file'));
+    makeDirLink(goneTarget, path.join(root, '_agent_x/skills/to-nothing'));
+    // :578 tests only is_symlink() and never inspects the target, so repointing one link
+    // at a file and breaking the other must change nothing.
+    fs.rmSync(fileTarget, { recursive: true, force: true });
+    fs.writeFileSync(fileTarget, 'now a file');
+    fs.rmSync(goneTarget, { recursive: true, force: true });
+    const report = runCheck(root);
+    assertSelf(countCode(report, 'E-SKILL-DIR-LINK') === 2, 'both links must be hard errors regardless of target');
+  });
+
+  run('12', (root) => {
+    const target = makeDir(root, 'link-target');
+    makeDir(root, 'plain');
+    makeDirLink(target, path.join(root, 'plain/linked'));
+    const report = runCheck(root);
+    assertSelf(report.findings.length === 0, 'a link outside any skills/ folder produces no finding');
+  });
+
+  run('12a', (root) => {
+    const broken = '---\nname: ok-name\n';
+    writeFixture(root, '_agent_x/skills/target/SKILL.md', broken);
+    writeFixture(root, '_agent_x/skills/node_modules/SKILL.md', broken);
+    writeFixture(root, '_agent_x/skills/.git/SKILL.md', broken);
+    const report = runCheck(root);
+    assertSelf(
+      countCode(report, 'E-FM-NO-CLOSE') === 3,
+      'SKIP_DIRS must not apply inside a skills/ directory: target, node_modules and .git are legal skill names there',
+    );
+  });
+
+  run('12b', (root) => {
+    const target = makeDir(root, 'real-dir');
+    makeDir(root, '_agent_x');
+    makeDirLink(target, path.join(root, '_agent_x/skills'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-SKILLS-NOT-DIR'), 'a resolving `skills` link is E-SKILLS-NOT-DIR');
+    assertSelf(!hasCode(report, 'E-SKILL-DIR-LINK'), 'the symlink branch of step 3 must not claim it first');
+  });
+
+  // ---- Entrypoint (6.3) ----
+  run('13', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', validSkillMd('x'));
+    const report = runCheck(root);
+    assertSelf(report.summary.errors === 0, 'a valid skill produces no error');
+    assertSelf(report.summary.skillsIndexable === 1, 'a valid skill counts as indexable');
+  });
+
+  run('14', (root) => {
+    writeFixture(root, '_agent_x/skills/x/skill.md', validSkillMd('x'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-ENTRYPOINT-CASE'), 'a wrongly cased entrypoint is a hard error');
+    assertSelf(report.exitCode === 1, 'a wrongly cased entrypoint fails the run');
+  });
+
+  run('15', (root) => {
+    writeFixture(root, '_agent_x/skills/x/Skill.md', '---\nname: Bad_Name\ndescription: x\n---\n');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-ENTRYPOINT-CASE'), 'the casing error is reported');
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'validation continues after a casing error');
+  });
+
+  run('16', (root) => {
+    makeDir(root, '_agent_x/skills/x');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-NO-ENTRYPOINT'), 'a canonical skill directory with no entrypoint is a hard error');
+  });
+
+  run('17', (root) => {
+    makeDir(root, 'docs/skills/x');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'I-NO-ENTRYPOINT'), 'outside canonical position the same absence is a note');
+    assertSelf(report.exitCode === 0, 'a note must not fail the run');
+  });
+
+  run('18', (root) => {
+    makeDir(root, '_agent_x/skills/x/SKILL.md');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-ENTRYPOINT-NOT-FILE'), 'a directory named SKILL.md is a hard error');
+  });
+
+  run('19', (root) => {
+    if (!fileSymlinkSupported) {
+      skip('19', 'file symlinks need Developer Mode or elevation on this platform');
+      return 'skip';
+    }
+    const target = writeFixture(root, 'real.md', validSkillMd('x'));
+    makeDir(root, '_agent_x/skills/x');
+    fs.symlinkSync(target, path.join(root, '_agent_x/skills/x/SKILL.md'), 'file');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-ENTRYPOINT-LINK'), 'a linked SKILL.md is a hard error');
+    return undefined;
+  });
+
+  run('20', (root) => {
+    if (!caseSensitiveFs) {
+      skip('20', 'case-insensitive filesystem: SKILL.md and skill.md cannot coexist');
+      return 'skip';
+    }
+    const dir = makeDir(root, '_agent_x/skills/x');
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), validSkillMd('x'));
+    fs.writeFileSync(path.join(dir, 'skill.md'), validSkillMd('x'));
+    assertSelf(fs.readdirSync(dir).length === 2, 'the probe promised two entries');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'W-ENTRYPOINT-CASE-SHADOWED'), 'the stray variant is a warning');
+    assertSelf(report.exitCode === 0, 'the working SKILL.md keeps the run green');
+    return undefined;
+  });
+
+  // ---- Frontmatter (6.4) ----
+  const fm = (root, contents) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', contents);
+    return runCheck(root);
+  };
+
+  run('21', (root) => {
+    assertSelf(hasCode(fm(root, 'Just a body.\n'), 'E-FM-NO-OPEN'), 'no frontmatter at all is E-FM-NO-OPEN');
+  });
+  run('22', (root) => {
+    assertSelf(hasCode(fm(root, '\n---\nname: x\n---\n'), 'E-FM-NO-OPEN'), 'a blank first line is E-FM-NO-OPEN');
+  });
+  run('23', (root) => {
+    const report = fm(root, '---\r\nname: ok-name\r\ndescription: x\r\n---\r\n');
+    assertSelf(report.summary.errors === 0, 'CRLF delimiters are valid');
+  });
+  run('24', (root) => {
+    const report = fm(root, '﻿---\nname: ok-name\ndescription: x\n---\n');
+    assertSelf(report.summary.errors === 0, 'a BOM on the opening delimiter is valid');
+  });
+  run('25', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x\n﻿---\n');
+    assertSelf(hasCode(report, 'E-FM-NO-CLOSE'), 'a BOM on the closing delimiter is not tolerated');
+  });
+  run('26', (root) => {
+    const report = fm(root, '  ---  \nname: ok-name\ndescription: x\n  ---  \n');
+    assertSelf(report.summary.errors === 0, 'whitespace around the fences is trimmed');
+  });
+  run('27', (root) => {
+    assertSelf(hasCode(fm(root, '----\nname: x\n----\n'), 'E-FM-NO-OPEN'), 'a longer fence is rejected');
+  });
+  run('28', (root) => {
+    assertSelf(hasCode(fm(root, '+++\nname = "x"\n+++\n'), 'E-FM-NO-OPEN'), 'a TOML fence is rejected');
+  });
+  run('29', (root) => {
+    const report = fm(root, '---');
+    assertSelf(hasCode(report, 'E-FM-NO-CLOSE'), 'a bare `---` with no newline is E-FM-NO-CLOSE, not E-FM-NO-OPEN');
+    assertSelf(!hasCode(report, 'E-FM-NO-OPEN'), 'and specifically not E-FM-NO-OPEN');
+  });
+  run('29a', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x\n---');
+    assertSelf(report.summary.errors === 0, 'a closing delimiter as the unterminated final line is valid');
+    assertSelf(report.exitCode === 0, 'and the run stays green');
+  });
+  run('29b', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x');
+    assertSelf(hasCode(report, 'E-FM-NO-CLOSE'), 'an unterminated final BODY line is E-FM-NO-CLOSE');
+  });
+  run('29c', (root) => {
+    // Sized into the 8-byte window between Guard A (> remaining + 8) and Guard B
+    // (> remaining), so Guard B is what decides, pinning that the append at :385 runs
+    // before the `missing closing` return at :389.
+    const body = `${'a'.repeat(16000)}\n`;
+    const remaining = FRONTMATTER_MAX_BYTES - body.length;
+    const report = fm(root, `---\n${body}${'b'.repeat(remaining + 4)}`);
+    assertSelf(hasCode(report, 'E-FM-TOO-LARGE'), 'an overflowing unterminated final line is E-FM-TOO-LARGE');
+    assertSelf(!hasCode(report, 'E-FM-NO-CLOSE'), 'and not E-FM-NO-CLOSE');
+  });
+  run('29d', (root) => {
+    assertSelf(hasCode(fm(root, ''), 'E-FM-NO-OPEN'), 'a zero-byte file is E-FM-NO-OPEN');
+  });
+  run('30', (root) => {
+    assertSelf(hasCode(fm(root, '---\nname: ok-name\n'), 'E-FM-NO-CLOSE'), 'EOF before a closing fence');
+  });
+  run('31', (root) => {
+    const report = fm(root, `---\n${'a'.repeat(16384)}\n---\n`);
+    assertSelf(hasCode(report, 'E-FM-TOO-LARGE'), 'a 16385-byte body overflows');
+  });
+  run('32', (root) => {
+    const report = fm(root, `---\nname: ok-name\ndescription: ${'a'.repeat(16000 - 30)}\n---\n`);
+    assertSelf(!hasCode(report, 'E-FM-TOO-LARGE'), 'a 16000-byte body fits');
+  });
+  run('33', (root) => {
+    const bytes = Buffer.concat([
+      Buffer.from('---\nname: ', 'utf8'),
+      Buffer.from([0xff, 0xfe]),
+      Buffer.from('\n---\n', 'utf8'),
+    ]);
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', bytes);
+    assertSelf(hasCode(runCheck(root), 'E-FM-NOT-UTF8'), 'invalid UTF-8 in the frontmatter is a hard error');
+  });
+  run('34', (root) => {
+    const bytes = Buffer.concat([
+      Buffer.from('---\nname: ok-name\ndescription: x\n---\n', 'utf8'),
+      Buffer.from([0xff, 0xfe, 0xff]),
+    ]);
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', bytes);
+    const report = runCheck(root);
+    assertSelf(report.summary.errors === 0, 'invalid UTF-8 in the BODY is never read');
+  });
+  run('35', (root) => {
+    const report = fm(root, `${'a'.repeat(2000)}\n---\nname: ok-name\n---\n`);
+    assertSelf(hasCode(report, 'E-FM-FIRST-LINE-TOO-LONG'), 'a 2000-byte first line is too long');
+  });
+  run('35a', (root) => {
+    const report = fm(root, `${' '.repeat(1020)}---\nname: ok-name\ndescription: x\n---\n`);
+    assertSelf(report.summary.errors === 0, '1020 spaces + `---\\n` is exactly 1024 bytes and is valid');
+  });
+  run('35b', (root) => {
+    const report = fm(root, `${' '.repeat(1021)}---\nname: ok-name\n---\n`);
+    assertSelf(hasCode(report, 'E-FM-FIRST-LINE-TOO-LONG'), '1025 bytes fails, proving the terminator is counted');
+  });
+  run('35c', (root) => {
+    const body = `${'a'.repeat(16000)}\n`;
+    const remaining = FRONTMATTER_MAX_BYTES - body.length;
+    const report = fm(root, `---\n${body}${' '.repeat(remaining + 20)}---\n`);
+    assertSelf(hasCode(report, 'E-FM-TOO-LARGE'), 'Guard A rejects an over-padded closing delimiter');
+    assertSelf(!hasCode(report, 'E-FM-NO-CLOSE'), 'and it is not treated as a successful close');
+  });
+  run('35d', (root) => {
+    const line = `${'a'.repeat(30)}\r\n`; // 32 bytes counting both terminator bytes
+    const fits = line.repeat(FRONTMATTER_MAX_BYTES / line.length);
+    assertSelf(fits.length === FRONTMATTER_MAX_BYTES, 'the fixture must be exactly at the limit');
+    const okReport = fm(root, `---\r\n${fits}---\r\n`);
+    assertSelf(!hasCode(okReport, 'E-FM-TOO-LARGE'), 'exactly 16384 bytes of CRLF body fits');
+    const over = tempRoot();
+    try {
+      writeFixture(over, '_agent_x/skills/x/SKILL.md', `---\r\n${fits}${line}---\r\n`);
+      assertSelf(hasCode(runCheck(over), 'E-FM-TOO-LARGE'), 'one more CRLF line tips it over');
+    } finally {
+      removeRoot(over);
+    }
+  });
+  run('35e', (root) => {
+    const report = fm(root, '---\rname: ok-name\r---\r');
+    assertSelf(hasCode(report, 'E-FM-NO-OPEN'), 'classic-Mac line endings are not supported');
+  });
+  run('35f', (root) => {
+    const report = fm(root, '\v---\v\nname: ok-name\n---\n');
+    assertSelf(hasCode(report, 'E-FM-NO-OPEN'), '\\x0B is not ASCII whitespace in Rust, so the fence is rejected');
+  });
+
+  // ---- YAML (6.5) ----
+  run('36', (root) => {
+    assertSelf(hasCode(fm(root, '---\n---\n'), 'E-YAML-NOT-MAPPING'), 'empty frontmatter is not a mapping');
+  });
+  run('37', (root) => {
+    assertSelf(hasCode(fm(root, '---\n- a\n- b\n---\n'), 'E-YAML-NOT-MAPPING'), 'a sequence root is not a mapping');
+  });
+  run('38', (root) => {
+    assertSelf(hasCode(fm(root, '---\nname: ok-name\n\tdescription: x\n---\n'), 'E-YAML-PARSE'), 'a tab in indentation');
+  });
+  run('39', (root) => {
+    const report = fm(root, '---\nname: \'ok-name\'\ndescription: "a quoted value"\n---\n');
+    assertSelf(report.summary.errors === 0, 'quoted scalars are strings');
+    assertSelf(!hasCode(report, 'W-DESC-MISSING'), 'a double-quoted description is present');
+  });
+  run('40', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: |\n  line one\n  line two\nwhen_to_use: >\n  folded text\n---\n');
+    assertSelf(report.findings.length === 0, 'block scalars are strings and produce no finding');
+  });
+  run('41', (root) => {
+    for (const value of ['42', 'true', 'null', '']) {
+      const inner = tempRoot();
+      try {
+        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname:${value === '' ? '' : ` ${value}`}\ndescription: x\n---\n`);
+        assertSelf(hasCode(runCheck(inner), 'E-NAME-NOT-STRING'), `name: ${value} must be E-NAME-NOT-STRING`);
+      } finally {
+        removeRoot(inner);
+      }
+    }
+  });
+  run('42', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: yes\n---\n');
+    assertSelf(report.findings.length === 0, '`yes` is a plain STRING under the YAML 1.2 core schema');
+    const other = tempRoot();
+    try {
+      writeFixture(other, '_agent_x/skills/x/SKILL.md', '---\nname: ok-name\ndescription: on\n---\n');
+      assertSelf(runCheck(other).findings.length === 0, '`on` is a plain STRING too');
+    } finally {
+      removeRoot(other);
+    }
+  });
+  run('42a', (root) => {
+    const report = fm(root, '---\nThis skill helps with X.\nIt does Y.\n---\n');
+    assertSelf(hasCode(report, 'E-YAML-NOT-MAPPING'), 'a multi-line plain scalar root is not a mapping');
+    assertSelf(report.exitCode === 1, 'and it fails the run');
+  });
+  run('42b', (root) => {
+    const report = fm(root, '---\n{name: ok-name}\n---\n');
+    assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), 'a flow mapping at the root is undecidable');
+    assertSelf(!hasCode(report, 'E-YAML-NOT-MAPPING'), 'zero recognized entries is not proof the root is a scalar');
+    assertSelf(report.exitCode === 0, 'and it must not fail the run');
+  });
+  run('42c', (root) => {
+    const report = fm(root, '---\nname: "ok-name"  # renamed\ndescription: x\n---\n');
+    assertSelf(report.findings.length === 0, 'a trailing comment after a quoted scalar is not a finding');
+    const other = tempRoot();
+    try {
+      writeFixture(other, '_agent_x/skills/x/SKILL.md', '---\nname:\tok-name\ndescription: x\n---\n');
+      assertSelf(runCheck(other).findings.length === 0, 'a TAB is legal separation whitespace after `key:`');
+    } finally {
+      removeRoot(other);
+    }
+  });
+  run('42d', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: |\n  \ttab-indented example line\n  plain line\n---\n');
+    assertSelf(report.findings.length === 0, 'a tab INSIDE block-scalar content is not E-YAML-PARSE');
+  });
+  run('42e', (root) => {
+    const report = fm(root, '---\ndescription: |\n  name: shadowed\nname: ok-name\n---\n');
+    assertSelf(!hasCode(report, 'E-YAML-DUPLICATE-KEY'), 'the block consumes `name: shadowed` as content');
+    assertSelf(report.summary.errors === 0, 'and the file is valid');
+  });
+  run('42f', (root) => {
+    for (const value of ['!!str ok-name', '&a ok-name']) {
+      const inner = tempRoot();
+      try {
+        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname: ${value}\ndescription: x\n---\n`);
+        const report = runCheck(inner);
+        assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), `${value} must be undecidable`);
+        assertSelf(hasCode(report, 'W-NAME-UNDECIDABLE'), `${value} must warn, never E-NAME-INVALID`);
+        assertSelf(!hasCode(report, 'E-NAME-INVALID'), 'an undecidable value may never produce an error');
+        assertSelf(report.exitCode === 0, 'and the run stays green');
+      } finally {
+        removeRoot(inner);
+      }
+    }
+  });
+  run('43', (root) => {
+    const report = fm(root, '---\nname: ok-name\nnested:\n  a: 1\ndescription: x\n---\n');
+    assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), 'a nested mapping is undecidable');
+  });
+  run('44', (root) => {
+    const report = fm(root, '---\nname: ok-name\nother: {a: 1}\ndescription: x\n---\n');
+    assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), 'a flow mapping value is undecidable');
+  });
+  run('45', (root) => {
+    const report = fm(root, '---\nname: ok-name\na: &anchor x\nb: *anchor\nc: !!str y\ndescription: z\n---\n');
+    assertSelf(countCode(report, 'W-YAML-UNDECIDABLE') === 3, 'an anchor, an alias and a tag are each undecidable');
+  });
+  run('46', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x\nname: other-name\n---\n');
+    assertSelf(hasCode(report, 'E-YAML-DUPLICATE-KEY'), 'a duplicate key is a hard error');
+    assertSelf(report.exitCode === 1, 'and it fails the run');
+    assertSelf(!hasCode(report, 'W-DESC-MISSING'), 'no field-level finding is emitted for that entrypoint');
+    assertSelf(report.findings.length === 1, 'the duplicate is the only finding');
+  });
+  run('46b', (root) => {
+    const report = fm(root, '---\nname: ok-name\nfoo: 1\ndescription: x\nfoo: 2\n---\n');
+    assertSelf(hasCode(report, 'E-YAML-DUPLICATE-KEY'), 'duplicate detection covers keys the indexer never reads');
+  });
+  run('46c', (root) => {
+    const report = fm(root, "---\nname: ok-name\n'name': other\n---\n");
+    assertSelf(hasCode(report, 'E-YAML-DUPLICATE-KEY'), '`name` and `\'name\'` are the same key after unquoting');
+  });
+  run('46d', (root) => {
+    const report = fm(root, '---\nname: ok-name\nName: other\ndescription: x\n---\n');
+    assertSelf(!hasCode(report, 'E-YAML-DUPLICATE-KEY'), 'key matching is case-sensitive');
+    assertSelf(report.summary.errors === 0, 'and the file is otherwise valid');
+  });
+  run('47', (root) => {
+    const report = fm(root, '---\nname: ok-name\nfoo: bar\ndescription: x\n---\n');
+    assertSelf(report.findings.length === 0, 'an unknown key produces no finding');
+  });
+  run('48', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x\nwhen-to-use: never read\n---\n');
+    assertSelf(hasCode(report, 'I-KEY-HYPHEN-VARIANT'), 'the hyphenated spelling is surfaced');
+    assertSelf(report.exitCode === 0, 'as a note only');
+  });
+  run('49', (root) => {
+    const report = fm(root, '---\n# a comment\n\nname: ok-name\n\n  # an indented comment\ndescription: x\n---\n');
+    assertSelf(report.findings.length === 0, 'blank and comment lines are ignored');
+  });
+
+  // ---- Fields (6.6) ----
+  run('50', (root) => {
+    writeFixture(root, '_agent_x/skills/my-skill/SKILL.md', '---\ndescription: x\n---\n');
+    const report = runCheck(root);
+    assertSelf(report.summary.errors === 0, 'the folder fallback resolves a valid name');
+  });
+  run('51', (root) => {
+    writeFixture(root, '_agent_x/skills/My_Skill/SKILL.md', '---\ndescription: x\n---\n');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'the folder fallback is charset-checked too');
+    const finding = report.findings.find((f) => f.code === 'E-NAME-INVALID');
+    assertSelf(finding.message.includes('containing directory name'), 'the message must name the folder fallback');
+  });
+  run('52', (root) => {
+    writeFixture(root, '_agent_x/skills/ok-name/SKILL.md', "---\nname: ''\ndescription: x\n---\n");
+    const report = runCheck(root);
+    assertSelf(report.summary.errors === 0, 'an empty name trims to absent and falls back to the folder');
+  });
+  run('53', (root) => {
+    writeFixture(root, '_agent_x/skills/folder-name/SKILL.md', validSkillMd('other-name'));
+    assertSelf(runCheck(root).findings.length === 0, 'name need not match the directory name');
+  });
+  run('54', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', validSkillMd('a'.repeat(64)));
+    assertSelf(runCheck(root).summary.errors === 0, 'a 64-character name is valid');
+  });
+  run('55', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', validSkillMd('a'.repeat(65)));
+    assertSelf(hasCode(runCheck(root), 'E-NAME-INVALID'), 'a 65-character name is invalid');
+  });
+  run('56', (root) => {
+    const report = fm(root, '---\nname: Café\ndescription: x\n---\n');
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'a non-ASCII name is invalid');
+    const finding = report.findings.find((f) => f.code === 'E-NAME-INVALID');
+    assertSelf(finding.message.includes(' 4'), 'the length must be counted in Unicode scalar values');
+  });
+  run('57', (root) => {
+    writeFixture(root, '_agent_x/skills/aaa/SKILL.md', validSkillMd('shared'));
+    writeFixture(root, '_agent_x/skills/bbb/SKILL.md', validSkillMd('shared'));
+    const report = runCheck(root);
+    assertSelf(countCode(report, 'E-NAME-DUPLICATE') === 1, 'exactly the loser is reported');
+    const finding = report.findings.find((f) => f.code === 'E-NAME-DUPLICATE');
+    assertSelf(finding.path.includes('bbb'), 'the second in sort order loses');
+    assertSelf(finding.message.includes('aaa'), 'and the message names the winner');
+  });
+  run('58', (root) => {
+    writeFixture(root, '_agent_x/skills/aaa/SKILL.md', validSkillMd('shared'));
+    writeFixture(root, '_agent_y/skills/bbb/SKILL.md', validSkillMd('shared'));
+    assertSelf(!hasCode(runCheck(root), 'E-NAME-DUPLICATE'), 'two matrices are separate indexes');
+  });
+  run('59', (root) => {
+    const report = fm(root, '---\nname: ok-name\n---\n');
+    assertSelf(hasCode(report, 'W-DESC-MISSING'), 'a missing description is a warning');
+    assertSelf(report.exitCode === 0, 'and never fails the run');
+    assertSelf(report.summary.skillsIndexable === 1, 'and the skill is still indexable');
+  });
+  run('60', (root) => {
+    assertSelf(hasCode(fm(root, "---\nname: ok-name\ndescription: ''\n---\n"), 'W-DESC-MISSING'), 'an empty description');
+  });
+  run('61', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: 42\n---\n');
+    assertSelf(hasCode(report, 'W-DESC-NOT-STRING'), 'a numeric description is a warning');
+    assertSelf(report.exitCode === 0, 'and never fails the run');
+  });
+  run('62', (root) => {
+    const report = fm(root, '---\nname: ok-name\ndescription: x\nwhen_to_use: 42\n---\n');
+    assertSelf(hasCode(report, 'W-WHEN-NOT-STRING'), 'a numeric when_to_use is a warning');
+    assertSelf(report.exitCode === 0, 'and never fails the run');
+  });
+  run('63', (root) => {
+    assertSelf(fm(root, '---\nname: ok-name\ndescription: x\n---\n').findings.length === 0, 'absent when_to_use');
+  });
+  run('63a', (root) => {
+    const report = fm(root, '---\nname: "﻿ok-name"\ndescription: x\n---\n');
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'Rust str::trim does NOT strip U+FEFF, so this name is invalid');
+  });
+  run('63b', (root) => {
+    const report = fm(root, '---\nname: "ok-name"\ndescription: x\n---\n');
+    assertSelf(report.summary.errors === 0, 'Rust str::trim DOES strip U+0085, so this name is valid');
+  });
+  run('63c', (root) => {
+    if (!unreadableDirSupported) {
+      skip('63c', 'directory permissions do not bind the current user on this platform');
+      return 'skip';
+    }
+    const dir = makeDir(root, '_agent_x/skills/x');
+    fs.chmodSync(dir, 0o000);
+    try {
+      const report = runCheck(root);
+      assertSelf(hasCode(report, 'E-SKILL-DIR-UNREADABLE'), 'an unreadable canonical skill directory is a hard error');
+      assertSelf(!hasCode(report, 'W-DIR-UNREADABLE'), 'and not a warning');
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+    return undefined;
+  });
+  run('63g', (root) => {
+    if (!unreadableDirSupported) {
+      skip('63g', 'directory permissions do not bind the current user on this platform');
+      return 'skip';
+    }
+    const dir = makeDir(root, 'docs/skills/x');
+    fs.chmodSync(dir, 0o000);
+    try {
+      const report = runCheck(root);
+      assertSelf(hasCode(report, 'W-DIR-UNREADABLE'), 'outside canonical position the same failure is a warning');
+      assertSelf(report.exitCode === 0, 'and it must not fail the run');
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+    return undefined;
+  });
+  run('63d', (root) => {
+    writeFixture(root, '_agent_x/skills/aaa/SKILL.md', '---\nname: shared\n');
+    writeFixture(root, '_agent_x/skills/bbb/SKILL.md', validSkillMd('shared'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-FM-NO-CLOSE'), 'the broken candidate is reported');
+    assertSelf(!hasCode(report, 'E-NAME-DUPLICATE'), 'a candidate with any hard error never claims its name');
+    assertSelf(
+      !report.findings.some((f) => f.path.includes('bbb')),
+      'and the innocent skill gets no finding at all',
+    );
+  });
+  run('63e', (root) => {
+    const target = makeDir(root, 'gone');
+    makeDir(root, '_agent_x');
+    makeDirLink(target, path.join(root, '_agent_x/skills'));
+    fs.rmSync(target, { recursive: true, force: true });
+    const report = runCheck(root);
+    assertSelf(report.findings.length === 0, 'a broken `skills` symlink is silent, exactly as the indexer is');
+    assertSelf(report.exitCode === 0, 'and never fails the run');
+  });
+  run('63f', (root) => {
+    const target = makeDir(root, 'real');
+    makeDir(root, '_agent_x');
+    makeDirLink(target, path.join(root, '_agent_x/skills'));
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-SKILLS-NOT-DIR'), 'a resolving `skills` symlink is a hard error');
+    assertSelf(report.exitCode === 1, 'and it fails the run');
+  });
+
+  // ---- Position (6.7) ----
+  run('64', (root) => {
+    writeFixture(root, '_agent_x/skills/y/SKILL.md', validSkillMd('y'));
+    assertSelf(!hasCode(runCheck(root), 'I-NOT-INDEXABLE'), 'canonical position produces no position finding');
+  });
+  run('65', (root) => {
+    writeFixture(root, '__agent_x/skills/y/SKILL.md', validSkillMd('y'));
+    const report = runCheck(root);
+    const finding = report.findings.find((f) => f.code === 'I-NOT-INDEXABLE');
+    assertSelf(finding !== undefined && finding.reason === 'replica-root', 'a replica root is never scanned');
+    assertSelf(report.exitCode === 0, 'and it is a note only');
+  });
+  run('66', (root) => {
+    writeFixture(root, '_agent_x/skills/y/z/SKILL.md', validSkillMd('z'));
+    const finding = runCheck(root).findings.find((f) => f.code === 'I-NOT-INDEXABLE');
+    assertSelf(finding.reason === 'not-under-skills-dir', 'depth is fixed at one');
+  });
+  run('67', (root) => {
+    writeFixture(root, '_agent_x/Skills/y/SKILL.md', validSkillMd('y'));
+    const finding = runCheck(root).findings.find((f) => f.code === 'I-NOT-INDEXABLE');
+    assertSelf(finding.reason === 'skills-dir-case', 'a case-variant skills dir is platform-dependent');
+  });
+  run('68', (root) => {
+    // 6.7 and the 6.9 worked example both give `not-under-skills-dir` for this exact
+    // path; the 9.2 row naming `owner-root-not-recognized` for it contradicts them and
+    // the numbered section wins. The second fixture exercises the reason that row meant.
+    writeFixture(root, 'docs/examples/SKILL.md', validSkillMd('examples'));
+    const finding = runCheck(root).findings.find((f) => f.code === 'I-NOT-INDEXABLE');
+    assertSelf(finding.reason === 'not-under-skills-dir', 'a SKILL.md not under a skills/ folder');
+    const other = tempRoot();
+    try {
+      writeFixture(other, 'not-a-matrix/skills/y/SKILL.md', validSkillMd('y'));
+      const owner = runCheck(other).findings.find((f) => f.code === 'I-NOT-INDEXABLE');
+      assertSelf(owner.reason === 'owner-root-not-recognized', 'an unrecognized owner root is a note');
+    } finally {
+      removeRoot(other);
+    }
+  });
+  run('69', (root) => {
+    writeFixture(root, 'docs/skills/y/SKILL.md', '---\nname: Bad_Name\ndescription: x\n---\n');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'severity rule 1: a present entrypoint is held to the rules everywhere');
+    assertSelf(report.exitCode === 1, 'and it fails the run wherever it sits');
+  });
+
+  // ---- Output (6.9, 6.10) ----
+  run('70', (root) => {
+    writeFixture(root, '_agent_x/skills/Bad_Name/SKILL.md', '---\ndescription: x\n---\n');
+    writeFixture(root, '_agent_x/skills/warn/SKILL.md', '---\nname: warn\n---\n');
+    writeFixture(root, 'docs/examples/SKILL.md', validSkillMd('examples'));
+    const lines = [];
+    const code = runCli([root, '--json'], (line) => lines.push(line), () => {});
+    const document = JSON.parse(lines.join('\n'));
+    assertSelf(document.exitCode === code, '`exitCode` must match the process exit code');
+    assertSelf(
+      document.summary.errors === document.findings.filter((f) => f.severity === 'error').length,
+      'summary.errors must match the array',
+    );
+    assertSelf(
+      document.summary.warnings === document.findings.filter((f) => f.severity === 'warning').length,
+      'summary.warnings must match the array',
+    );
+    assertSelf(
+      document.summary.infos === document.findings.filter((f) => f.severity === 'info').length,
+      'summary.infos must match the array',
+    );
+  });
+  run('71', (root) => {
+    writeFixture(root, '_agent_x/skills/b-skill/SKILL.md', '---\nname: Bad_Name\ndescription: x\n---\n');
+    writeFixture(root, '_agent_x/skills/a-skill/SKILL.md', '---\nname: ok-name\n---\n');
+    const first = renderJson(runCheck(root));
+    const second = renderJson(runCheck(root));
+    assertSelf(first === second, 'two runs must produce byte-identical output');
+    const document = JSON.parse(first);
+    for (let i = 1; i < document.findings.length; i += 1) {
+      const previous = document.findings[i - 1];
+      const current = document.findings[i];
+      const ordered =
+        previous.path < current.path ||
+        (previous.path === current.path && (previous.line ?? 0) <= (current.line ?? 0));
+      assertSelf(ordered, 'findings must be sorted by path then line');
+    }
+  });
+  run('72', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', '---\nname: ok-name\n---\n');
+    const document = runCheck(root);
+    for (const finding of document.findings) {
+      assertSelf(!finding.path.includes('\\'), '`path` must be /-separated on every platform');
+      assertSelf(
+        finding.skillDirectory === null || !finding.skillDirectory.includes('\\'),
+        '`skillDirectory` must be /-separated on every platform',
+      );
+    }
+  });
+  run('73', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', validSkillMd('x'));
+    const lines = [];
+    const code = runCli([root], (line) => lines.push(line), () => {});
+    assertSelf(code === 0, 'a clean tree exits 0');
+    assertSelf(lines[lines.length - 1].includes('OK:'), 'and the human report ends with OK:');
+  });
+  run('74', (root) => {
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', '---\nname: ok-name\n---\n');
+    writeFixture(root, 'docs/examples/SKILL.md', validSkillMd('examples'));
+    const report = runCheck(root);
+    assertSelf(report.summary.warnings > 0 && report.summary.infos > 0, 'the fixture must carry both');
+    assertSelf(report.exitCode === 0, 'warnings and notes never change the exit code');
+  });
+  run('75', (root) => {
+    writeFixture(root, '_agent_x/skills/x/skill.md', validSkillMd('x'));
+    assertSelf(runCheck(root).exitCode === 1, 'one error exits 1');
+  });
+  run('76', (root) => {
+    makeDir(root, '_agent_x');
+    fs.writeFileSync(path.join(root, '_agent_x/skills'), 'not a directory');
+    const lines = [];
+    const code = runCli([root], (line) => lines.push(line), () => {});
+    assertSelf(code === 1, 'a `skills` file is a hard error');
+    const last = lines[lines.length - 1];
+    assertSelf(last.includes('no entrypoint implicated'), 'the FAIL line must say no entrypoint is implicated');
+    assertSelf(!last.includes('FAIL: 0 skills'), 'and must never read `FAIL: 0 skills would not be indexed`');
+  });
+  run('77', (root) => {
+    if (!caseSensitiveFs) {
+      skip('77', 'case-insensitive filesystem: SKILL.md and skill.md cannot coexist');
+      return 'skip';
+    }
+    const dir = makeDir(root, '_agent_x/skills/x');
+    fs.writeFileSync(path.join(dir, 'SKILL.md'), validSkillMd('x'));
+    fs.writeFileSync(path.join(dir, 'skill.md'), validSkillMd('x'));
+    const report = runCheck(root);
+    assertSelf(report.summary.entrypointsFound === 2, 'every discovered match counts, shadowed ones included');
+    assertSelf(report.summary.skillsIndexable === 1, 'but a shadowed variant is not a second indexable skill');
+    return undefined;
+  });
+  run('78', (root) => {
+    // The parser emits at most one W-YAML-UNDECIDABLE per line, so two of them against
+    // the SAME line of the same file is unreachable here and the emission-order tiebreak
+    // is defensive. What is reachable, and what this case pins, is that several findings
+    // sharing a code order identically across runs, so the sort is total in practice.
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', '---\nname: ok-name\ndescription: x\nother: {a: 1}\nmore: {b: 2}\n---\n');
+    writeFixture(root, '_agent_x/skills/y/SKILL.md', '---\nname: ok-two\ndescription: x\nother: {a: 1}\nmore: {b: 2}\n---\n');
+    const first = renderJson(runCheck(root));
+    const second = renderJson(runCheck(root));
+    assertSelf(first === second, 'the emission-order tiebreak must make the sort total');
+    assertSelf(JSON.parse(first).summary.warnings === 4, 'the fixture must carry four same-code findings');
+  });
+  run('79', (root) => {
+    if (!unreadableDirSupported) {
+      skip('79', 'directory permissions do not bind the current user on this platform');
+      return 'skip';
+    }
+    const dir = makeDir(root, '_agent_x/skills');
+    fs.chmodSync(dir, 0o000);
+    try {
+      const report = runCheck(root);
+      assertSelf(hasCode(report, 'E-SKILLS-DIR-UNREADABLE'), 'an unreadable skills root is its own code');
+      const finding = report.findings.find((f) => f.code === 'E-SKILLS-DIR-UNREADABLE');
+      assertSelf(
+        finding.indexerMessage.includes('`skills` directory could not be read'),
+        'and it carries the skills-root message, distinct from case 63c',
+      );
+    } finally {
+      fs.chmodSync(dir, 0o700);
+    }
+    return undefined;
+  });
+  run('80', (root) => {
+    writeFixture(
+      root,
+      '_agent_x/skills/x/SKILL.md',
+      `---\nname: "bad\\nname\\u001b[31m${'z'.repeat(300)}"\ndescription: x\n---\n`,
+    );
+    const lines = [];
+    runCli([root], (line) => lines.push(line), () => {});
+    for (const line of lines) {
+      const controls = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/;
+      assertSelf(!controls.test(line), 'no raw control character may reach the report');
+    }
+    const finding = runCheck(root).findings.find((f) => f.code === 'E-NAME-INVALID');
+    assertSelf(finding.message.length < 400, 'and the value must be truncated');
+  });
+
+  // Acceptance criterion 12: every code in Section 6.8 must be emitted by at least one
+  // case, with ONE named exemption. E-ENTRYPOINT-UNREADABLE needs a file whose open or
+  // read throws and is not reliably constructible as the owning user on Windows or as
+  // root on Linux (9.2.2), so it has no case by design and this comment is what marks
+  // it as an exemption rather than an oversight.
+
+  if (failure !== null) {
+    out(`${TAG} self-test FAILED: ${failure}`);
+    return 1;
+  }
+
+  const skippedNote = skipped.length === 0 ? '0 skipped' : `${skipped.length} skipped (${skipped.join(', ')})`;
+  out(`${TAG} self-test passed: ${total} cases, ${ran} run, ${skippedNote}`);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+function main() {
+  const write = (line) => process.stdout.write(`${line}\n`);
+  const warn = (line) => process.stderr.write(`${line}\n`);
+  try {
+    process.exitCode = runCli(process.argv.slice(2), write, warn);
+  } catch (error) {
+    warn(`internal error: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof Error && error.stack) warn(error.stack);
+    process.exitCode = 2;
+  }
+}
+
+main();

--- a/scripts/01-skills-checker.mjs
+++ b/scripts/01-skills-checker.mjs
@@ -2311,6 +2311,37 @@ function selfTest(out) {
     assertSelf(!hasCode(report, 'W-YAML-UNDECIDABLE'), '`|2` stays inside the subset');
     assertSelf(report.findings.length === 0, 'and resolves to a non-empty string');
   });
+  run('42h', () => {
+    // The negative half of the quoted-key branch. Allowing whitespace between a quoted
+    // key and its `:` widened what that branch accepts, so this pins the boundary from
+    // the other side: a quoted scalar at column 0 that is NOT a mapping key must never
+    // become one. Each body is a single line, so the root really is a scalar and 6.5.3
+    // row 4 fires; `findings.length === 1` also proves the certain error is terminal and
+    // no W-YAML-UNDECIDABLE leaks past it.
+    const notKeys = [
+      "'just a quoted doc'",
+      "'quoted' trailing text",
+      "'quoted'   ",
+      "'quoted' # comment",
+      "'a' 'b': c",
+      '"double quoted doc"',
+    ];
+    for (const body of notKeys) {
+      const inner = tempRoot();
+      try {
+        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\n${body}\n---\n`);
+        const report = runCheck(inner);
+        assertSelf(
+          hasCode(report, 'E-YAML-NOT-MAPPING'),
+          `\`${body}\` must not become a mapping key`,
+        );
+        assertSelf(report.exitCode === 1, `\`${body}\` must fail the run`);
+        assertSelf(report.findings.length === 1, `\`${body}\` must yield exactly one finding`);
+      } finally {
+        removeRoot(inner);
+      }
+    }
+  });
   run('43', (root) => {
     const report = fm(root, '---\nname: ok-name\nnested:\n  a: 1\ndescription: x\n---\n');
     assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), 'a nested mapping is undecidable');
@@ -2349,6 +2380,20 @@ function selfTest(out) {
       } finally {
         removeRoot(inner);
       }
+    }
+    // The line the strip must not cross. A space INSIDE the quotes is part of the key, so
+    // `'name '` is a different key from `name` and the two must not merge. The folder is
+    // deliberately invalid: if `name` had been mis-resolved, the fallback would fire and
+    // this would exit 1 on E-NAME-INVALID instead of staying clean.
+    const distinct = tempRoot();
+    try {
+      writeFixture(distinct, '_agent_x/skills/Bad_Folder/SKILL.md', "---\nname: ok-name\n'name ': other\ndescription: x\n---\n");
+      const report = runCheck(distinct);
+      assertSelf(!hasCode(report, 'E-YAML-DUPLICATE-KEY'), "`'name '` and `name` are two distinct keys");
+      assertSelf(!hasCode(report, 'E-NAME-INVALID'), '`name` still resolves through the key, not the folder');
+      assertSelf(report.findings.length === 0, 'and the file is otherwise clean');
+    } finally {
+      removeRoot(distinct);
     }
   });
   run('46d', (root) => {

--- a/scripts/01-skills-checker.mjs
+++ b/scripts/01-skills-checker.mjs
@@ -2194,10 +2194,28 @@ function selfTest(out) {
 
   // ---- YAML (6.5) ----
   run('36', (root) => {
-    assertSelf(hasCode(fm(root, '---\n---\n'), 'E-YAML-NOT-MAPPING'), 'empty frontmatter is not a mapping');
+    // Three of 6.5.3's rows all emit E-YAML-NOT-MAPPING, so a bare hasCode() here is
+    // satisfied by whichever row happens to fire: disable the empty-body row and the
+    // zero-entries row at the bottom of parseMiniYaml produces the same code. The
+    // message is what distinguishes which rule actually ran.
+    const report = fm(root, '---\n---\n');
+    const finding = report.findings.find((f) => f.code === 'E-YAML-NOT-MAPPING');
+    assertSelf(finding !== undefined, 'empty frontmatter is not a mapping');
+    assertSelf(
+      finding.message.includes('empty or contains only blank'),
+      'and it must be reported as an EMPTY body, not as a scalar root',
+    );
   });
   run('37', (root) => {
-    assertSelf(hasCode(fm(root, '---\n- a\n- b\n---\n'), 'E-YAML-NOT-MAPPING'), 'a sequence root is not a mapping');
+    // Same trap as case 36: disable the sequence-root row and the colon-free lines fall
+    // through to the zero-entries row, which emits the identical code.
+    const report = fm(root, '---\n- a\n- b\n---\n');
+    const finding = report.findings.find((f) => f.code === 'E-YAML-NOT-MAPPING');
+    assertSelf(finding !== undefined, 'a sequence root is not a mapping');
+    assertSelf(
+      finding.message.includes('sequence'),
+      'and it must be reported as a SEQUENCE root, not as a scalar root',
+    );
   });
   run('38', (root) => {
     assertSelf(hasCode(fm(root, '---\nname: ok-name\n\tdescription: x\n---\n'), 'E-YAML-PARSE'), 'a tab in indentation');
@@ -2301,7 +2319,21 @@ function selfTest(out) {
       try {
         writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname: ok-name\ndescription: ${header}\n  text\n---\n`);
         const report = runCheck(inner);
-        assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), `\`${header}\` is outside the subset, not a block scalar`);
+        // A bare hasCode('W-YAML-UNDECIDABLE') pins NOTHING here: the orphaned `  text`
+        // line is undecidable whether or not the header was rejected, so the assertion
+        // is satisfied by the wrong finding. Both assertions below discriminate.
+        // Rejected header: the header AND the orphan are undecidable, and `description`
+        // resolves to `undecidable`, which asserts no W-DESC-*.
+        // Accepted header: `|0` yields an empty block scalar, so `description` trims to
+        // empty and W-DESC-MISSING fires, leaving only ONE undecidable.
+        assertSelf(
+          countCode(report, 'W-YAML-UNDECIDABLE') === 2,
+          `\`${header}\` itself must be undecidable, not only the orphaned content line`,
+        );
+        assertSelf(
+          !hasCode(report, 'W-DESC-MISSING'),
+          `\`${header}\` must not resolve to an empty block scalar`,
+        );
       } finally {
         removeRoot(inner);
       }

--- a/scripts/01-skills-checker.mjs
+++ b/scripts/01-skills-checker.mjs
@@ -542,11 +542,15 @@ function parseKeyValueLine(body) {
   if (body[0] === "'" || body[0] === '"') {
     const quoted = readQuotedScalar(body, 0);
     if (!quoted.ok) return { ok: false, reason: quoted.reason };
-    if (body[quoted.end] !== ':') {
+    // Whitespace may sit between the key and the `:` here for the same reason it may in
+    // the unquoted branch below: YAML treats it as separation, not as part of the key.
+    let after = quoted.end;
+    while (body[after] === ' ' || body[after] === '\t') after += 1;
+    if (body[after] !== ':') {
       return { ok: false, reason: 'a quoted scalar at column 0 that is not a mapping key' };
     }
     key = quoted.value;
-    rest = body.slice(quoted.end + 1);
+    rest = body.slice(after + 1);
   } else {
     let separator = -1;
     for (let i = 0; i < body.length; i += 1) {
@@ -558,7 +562,13 @@ function parseKeyValueLine(body) {
       }
     }
     if (separator === -1) return { ok: false, reason: 'a line that is not a `key:` mapping entry' };
-    key = body.slice(0, separator);
+    // YAML strips trailing white space from a plain scalar, so `name :` and `name<TAB>:`
+    // are both the key `name`. 6.5.4 defines key identity as the unquoted key text, and
+    // the unquoted key text of `name :` is `name`. Keeping the space here made the whole
+    // line look like an ordinary entry for a key nothing reads, so a plain typo produced
+    // a run with no finding at all, not even W-YAML-UNDECIDABLE. Leading whitespace is
+    // already routed to W-YAML-UNDECIDABLE by the `indent > 0` branch of parseMiniYaml.
+    key = body.slice(0, separator).replace(/[ \t]+$/, '');
     rest = body.slice(separator + 1);
   }
 
@@ -566,14 +576,21 @@ function parseKeyValueLine(body) {
   const header = /^([|>])([0-9]*)([-+]?)([0-9]*)[ \t]*(?:#.*)?$/.exec(value);
   if (header) {
     const explicit = header[2] || header[4];
-    return {
-      ok: true,
-      key,
-      value,
-      blockScalar: true,
-      blockStyle: header[1],
-      blockIndent: explicit === '' ? null : Number(explicit),
-    };
+    const blockIndent = explicit === '' ? null : Number(explicit);
+    // serde_yaml rejects a zero indentation indicator outright ("found an indentation
+    // indicator equal to 0"), so `|0` and `>0` are outside the subset rather than block
+    // scalars. Falling through leaves the value starting with `|` or `>`, which
+    // resolveScalar reports as W-YAML-UNDECIDABLE.
+    if (blockIndent !== 0) {
+      return {
+        ok: true,
+        key,
+        value,
+        blockScalar: true,
+        blockStyle: header[1],
+        blockIndent,
+      };
+    }
   }
   return { ok: true, key, value, blockScalar: false };
 }
@@ -1074,6 +1091,10 @@ function validateFields(candidate, mapping, collector, lineOffset) {
       message: 'The `name:` value is not a YAML string. `yaml_field_string` accepts only Value::String (:448-462).',
       indexerMessage: skippedSkill(folder, 'name must be a string'),
     });
+    // 6.6.1 step 2: STOP. :641-650 is `Err(e) => { push; continue }`, so `description`
+    // (:674) and `when_to_use` (:687) are never reached and any finding about them would
+    // carry an indexerMessage the startup log will never print.
+    return { resolvedName: null, nameLine: null };
   } else {
     // :453 trims with Rust str::trim; Y5 maps an empty result to absent (:452-459).
     const trimmed = trimYamlValue(nameEntry.value);
@@ -1111,7 +1132,10 @@ function validateFields(candidate, mapping, collector, lineOffset) {
           `invalid skill name \`${sanitizeForReport(resolvedName)}\`; expected 1-64 lowercase ASCII letters, digits, or hyphens`,
         ),
       });
-      nameResolved = false;
+      // Same stop, for the same reason: :653-660 also `continue`s past the field layer.
+      // The plan states the stop only for the type failure at step 2, so this half is a
+      // tech-lead decision recorded in the Step 9 dispatch rather than plan text.
+      return { resolvedName: null, nameLine };
     }
   }
 
@@ -2191,8 +2215,21 @@ function selfTest(out) {
     for (const value of ['42', 'true', 'null', '']) {
       const inner = tempRoot();
       try {
-        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname:${value === '' ? '' : ` ${value}`}\ndescription: x\n---\n`);
-        assertSelf(hasCode(runCheck(inner), 'E-NAME-NOT-STRING'), `name: ${value} must be E-NAME-NOT-STRING`);
+        // No `description` and a non-string `when_to_use`, so both field-layer findings
+        // WOULD fire if validation did not stop at the name failure.
+        writeFixture(
+          inner,
+          '_agent_x/skills/x/SKILL.md',
+          `---\nname:${value === '' ? '' : ` ${value}`}\nwhen_to_use: 9\n---\n`,
+        );
+        const report = runCheck(inner);
+        assertSelf(hasCode(report, 'E-NAME-NOT-STRING'), `name: ${value} must be E-NAME-NOT-STRING`);
+        // 6.6.1 step 2 says Stop, and :641-650 continues past the field layer, so an
+        // indexerMessage about description or when_to_use would name a startup-log line
+        // that is never printed.
+        assertSelf(!hasCode(report, 'W-DESC-MISSING'), 'field validation must stop at the name failure');
+        assertSelf(!hasCode(report, 'W-WHEN-NOT-STRING'), 'and it must not reach when_to_use either');
+        assertSelf(report.findings.length === 1, 'the name failure is the only finding');
       } finally {
         removeRoot(inner);
       }
@@ -2255,6 +2292,25 @@ function selfTest(out) {
       }
     }
   });
+  run('42g', (root) => {
+    // serde_yaml rejects a zero indentation indicator outright, so `|0` is a hard parse
+    // error there. Treating it as a block scalar made the checker exit 0 on a file the
+    // indexer refuses to parse.
+    for (const header of ['|0', '>0']) {
+      const inner = tempRoot();
+      try {
+        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname: ok-name\ndescription: ${header}\n  text\n---\n`);
+        const report = runCheck(inner);
+        assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), `\`${header}\` is outside the subset, not a block scalar`);
+      } finally {
+        removeRoot(inner);
+      }
+    }
+    // A non-zero indicator is still an ordinary block scalar.
+    const report = fm(root, '---\nname: ok-name\ndescription: |2\n  text\n---\n');
+    assertSelf(!hasCode(report, 'W-YAML-UNDECIDABLE'), '`|2` stays inside the subset');
+    assertSelf(report.findings.length === 0, 'and resolves to a non-empty string');
+  });
   run('43', (root) => {
     const report = fm(root, '---\nname: ok-name\nnested:\n  a: 1\ndescription: x\n---\n');
     assertSelf(hasCode(report, 'W-YAML-UNDECIDABLE'), 'a nested mapping is undecidable');
@@ -2281,6 +2337,19 @@ function selfTest(out) {
   run('46c', (root) => {
     const report = fm(root, "---\nname: ok-name\n'name': other\n---\n");
     assertSelf(hasCode(report, 'E-YAML-DUPLICATE-KEY'), '`name` and `\'name\'` are the same key after unquoting');
+    // Whitespace before the `:` is separation, not part of the key, so these collide too.
+    for (const second of ['name : other', 'name\t: other', "'name' : other"]) {
+      const inner = tempRoot();
+      try {
+        writeFixture(inner, '_agent_x/skills/x/SKILL.md', `---\nname: ok-name\n${second}\n---\n`);
+        assertSelf(
+          hasCode(runCheck(inner), 'E-YAML-DUPLICATE-KEY'),
+          `\`${second}\` must collide with \`name\`: YAML strips the trailing space from the key`,
+        );
+      } finally {
+        removeRoot(inner);
+      }
+    }
   });
   run('46d', (root) => {
     const report = fm(root, '---\nname: ok-name\nName: other\ndescription: x\n---\n');
@@ -2307,12 +2376,51 @@ function selfTest(out) {
     const report = runCheck(root);
     assertSelf(report.summary.errors === 0, 'the folder fallback resolves a valid name');
   });
+  run('50a', (root) => {
+    // A space or tab before the `:` is separation whitespace; the key is still `name`.
+    // Keeping it made the parser record a key nothing reads, so `name` resolved from the
+    // folder instead and the run came back with NO finding at all.
+    writeFixture(root, '_agent_x/skills/ok-folder/SKILL.md', '---\nname : Bad_Name\ndescription: x\n---\n');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), '`name : Bad_Name` must resolve through the key, not the folder');
+    assertSelf(report.exitCode === 1, 'and it must fail the run');
+
+    const tabbed = tempRoot();
+    try {
+      writeFixture(tabbed, '_agent_x/skills/ok-folder/SKILL.md', '---\nname\t: Bad_Name\ndescription: x\n---\n');
+      assertSelf(hasCode(runCheck(tabbed), 'E-NAME-INVALID'), 'a tab before the `:` behaves the same');
+    } finally {
+      removeRoot(tabbed);
+    }
+
+    // The mirror image: the key resolves, so the bad FOLDER name is never consulted and
+    // the skill is clean. Keeping the space here produced a spurious E-NAME-INVALID.
+    const mirrored = tempRoot();
+    try {
+      writeFixture(mirrored, '_agent_x/skills/Bad_Folder/SKILL.md', '---\nname : ok-name\ndescription: x\n---\n');
+      const clean = runCheck(mirrored);
+      assertSelf(clean.findings.length === 0, '`name : ok-name` in a bad folder is indexed cleanly');
+      assertSelf(clean.exitCode === 0, 'and must not fail the run');
+    } finally {
+      removeRoot(mirrored);
+    }
+  });
   run('51', (root) => {
     writeFixture(root, '_agent_x/skills/My_Skill/SKILL.md', '---\ndescription: x\n---\n');
     const report = runCheck(root);
     assertSelf(hasCode(report, 'E-NAME-INVALID'), 'the folder fallback is charset-checked too');
     const finding = report.findings.find((f) => f.code === 'E-NAME-INVALID');
     assertSelf(finding.message.includes('containing directory name'), 'the message must name the folder fallback');
+  });
+  run('51a', (root) => {
+    // :653-660 also continues past the field layer, so the charset failure stops
+    // validation exactly like the type failure in case 41 does.
+    writeFixture(root, '_agent_x/skills/x/SKILL.md', '---\nname: Bad_Name\nwhen_to_use: 9\n---\n');
+    const report = runCheck(root);
+    assertSelf(hasCode(report, 'E-NAME-INVALID'), 'the charset failure is reported');
+    assertSelf(!hasCode(report, 'W-DESC-MISSING'), 'and validation stops before description');
+    assertSelf(!hasCode(report, 'W-WHEN-NOT-STRING'), 'and before when_to_use');
+    assertSelf(report.findings.length === 1, 'the name failure is the only finding');
   });
   run('52', (root) => {
     writeFixture(root, '_agent_x/skills/ok-name/SKILL.md', "---\nname: ''\ndescription: x\n---\n");


### PR DESCRIPTION
Closes #1213

## What this adds

`scripts/01-skills-checker.mjs` — a zero-dependency Node script that walks any directory tree, finds
every skill entrypoint file, and validates it against the rules the Rust skill indexer enforces in
`src-tauri/src/config/session_context.rs:206-909`.

- **Traversal**: root as an argument, defaulting to the working directory; recursive with no depth
  limit; skips `.git`, `node_modules` and `target` — except inside a `skills/` directory, where those
  are legal skill names and must be scanned.
- **Discovery is case-insensitive, validation is byte-exact.** A wrongly cased entrypoint is found and
  reported as a hard error rather than silently missed. The indexer compares `entry.file_name()`
  against `OsStr::new("SKILL.md")` at `session_context.rs:401`, so wrong casing fails on **every**
  platform including Windows, where the file still opens fine and the mistake is invisible.
- **Output**: human-readable report plus `--json`; exit codes 0 clean / 1 validation findings /
  2 usage or IO error, so CI and husky can consume it.
- **Self-test**: `--self-test` with 114 runtime-built fixture cases, wired as `check:skills:self`.
- **`package.json`**: adds `check:skills` and `check:skills:self`. No dependency, so
  `package-lock.json` is untouched.

Verified end to end against the live case that motivated the issue: running the checker over an Agent
Matrix reports `E-NO-ENTRYPOINT` on `skills/tiktok-news-publisher` with an `Indexer:` line
byte-identical to the real startup warning.

## Review

Full delivery path: architect plan → dev-rust fidelity enrichment → dev-rust-grinch adversarial
enrichment → architect consensus (`READY_FOR_IMPLEMENTATION`) → implementation → review.

The plan is committed at `plans/1213-skills-checker.md`, frozen at
`Plan-SHA256: D68087F4AE1DDC82E55A96C8F667685C3A3F047BF31E52F19F085601A7B7A6E0`, and the digest was
verified unchanged at every gate through landing.

What review caught, in order:

- **Planning passes**: 7 fidelity defects, then 17 more (3 false passes, 6 false positives), then 8
  findings that had been recorded in a findings section but never applied to the normative section an
  implementer follows.
- **Code review**: 3 confirmed divergences, ground-truthed against a throwaway crate built on the
  pinned `serde_yaml 0.9.34+deprecated` rather than argued from memory. The worst was silent — a plain
  typo, a space before the colon in `name : value`, produced **zero findings** while the indexer hard-
  rejects the skill.
- **Test quality**: three self-test assertions were hollow — they passed even with the code they
  guarded reverted. Found by mutation sweep, not by static inspection; a scan by assertion form
  missed the very case that was hollow. All three now discriminate, confirmed by independent
  before/after mutation with the suite's short-circuit disabled so every catching case is visible.

Gates on the merged tree: `check:skills:self` exit 0 (114 cases, 109 run, 5 skipped with a printed
reason each), `check:skills` exit 0, `typecheck` 0, `npm test` 147 files / 1476 tests, `test:debt` 0,
`version:check` 0.

Non-visual change: no GUI surface, no Tauri command or IPC, not imported by anything under `src/`,
and not executed at app runtime.

## Known limitations, deferred to #1220

- The plan's scalar-resolution table does not cover `0b` radix, exponent floats, or
  `digits_but_not_number`. Consequence: skill names that are themselves YAML numbers (`0b101`,
  `-0x1f`, `1e5`) pass the checker where the indexer rejects them, and `0123` is flagged where the
  indexer accepts it. Closing it requires a plan change and full recertification; the reachable set is
  names nobody writes.
- `description: |0` and `|10` exit 0 where the indexer exits 1. Plan-constrained: 6.5.3's preamble
  says "Only these three" rows.
- Two `E-YAML-NOT-MAPPING` shapes carry an `indexerMessage` naming the wrong indexer string, because a
  mini-parser cannot distinguish a scalar root from a two-document stream.

#1220 tracks the real mitigation: a CI job running the Rust indexer and this script over one shared
fixture corpus, failing on any per-fixture disagreement. This PR's own review history is the argument
for it — 17 fidelity defects survived two careful review passes over a ~500-line Rust surface, and a
third pass over the same table still missed the scalar-resolution gaps.
