### PR TITLE
fix(teams): consume the coordinator entry in team_members instead of rejecting it (refs #1245)

### DIFF
--- a/src-tauri/src/cli/terminal_snapshot.rs
+++ b/src-tauri/src/cli/terminal_snapshot.rs
@@ -187,6 +187,29 @@ fn execute_inner(args: TerminalSnapshotArgs) -> Result<(), String> {
     }
 }
 
+/// #1245: fixed, path-free diagnostic for a local requester-identity failure.
+/// The stable CLI error stays `requester_unavailable`; this text only reaches
+/// `app.log`, never stdout or stderr. Every reason in this chain is a fixed
+/// literal except the five `config::workspace::ensure_authoritative_workspace_dir`
+/// messages, which format absolute paths, so anything outside the known set is
+/// reported as `unexpected`.
+fn requester_identity_diagnostic(stage: &'static str, reason: &str) -> String {
+    const KNOWN: [&str; 6] = [
+        "sender_identity_invalid",
+        "target_not_member",
+        "invalid_target",
+        "unsafe_path",
+        "invalid_envelope",
+        "capacity_exceeded",
+    ];
+    let safe = if KNOWN.contains(&reason) {
+        reason
+    } else {
+        "unexpected"
+    };
+    format!("[terminal-snapshot] requester identity failed stage={stage} reason={safe}")
+}
+
 fn verify_requester_root(
     root: &Path,
 ) -> Result<(crate::path_identity::VerifiedPathIdentity, String), String> {
@@ -196,10 +219,20 @@ fn verify_requester_root(
             crate::config::root_agent::ROOT_AGENT_SENDER.to_string(),
         ));
     }
-    let identity = crate::config::teams::verify_pty_input_replica_cwd(root)
-        .map_err(|_| "requester_unavailable".to_string())?;
-    let supplied = crate::path_identity::verify_directory(root)
-        .map_err(|_| "requester_unavailable".to_string())?;
+    let identity = crate::config::teams::verify_pty_input_replica_cwd(root).map_err(|reason| {
+        log::warn!(
+            "{}",
+            requester_identity_diagnostic("replica_identity", &reason)
+        );
+        "requester_unavailable".to_string()
+    })?;
+    let supplied = crate::path_identity::verify_directory(root).map_err(|reason| {
+        log::warn!(
+            "{}",
+            requester_identity_diagnostic("root_directory", &reason)
+        );
+        "requester_unavailable".to_string()
+    })?;
     if !identity.is_coordinator
         || !crate::path_identity::same_object(&supplied, &identity.replica_identity)
     {
@@ -683,6 +716,56 @@ fn reason_code(value: &str) -> Option<TerminalSnapshotReasonCode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn requester_identity_diagnostic_filters_unknown_and_path_bearing_reasons() {
+        for reason in [
+            "sender_identity_invalid",
+            "target_not_member",
+            "invalid_target",
+            "unsafe_path",
+            "invalid_envelope",
+            "capacity_exceeded",
+        ] {
+            let text = requester_identity_diagnostic("replica_identity", reason);
+            assert!(
+                text.starts_with("[terminal-snapshot] requester identity failed stage="),
+                "unexpected prefix: {text}"
+            );
+            assert!(text.contains("stage=replica_identity"), "got {text}");
+            assert!(text.ends_with(&format!("reason={reason}")), "got {text}");
+        }
+
+        // The five `config::workspace::ensure_authoritative_workspace_dir`
+        // messages are the only non-literal reasons reachable here, and each
+        // formats at least one absolute path. All five must collapse to
+        // `unexpected`, so no path text can reach `app.log`. One sample proves
+        // the fallback exists; five prove no message shape collides with an
+        // allowlisted literal.
+        const CALLER: &str = r"C:\Users\someone\proj\.ac";
+        const PROJECT: &str = r"C:\Users\someone\proj";
+        const AUTHORITATIVE: &str = r"C:\Users\someone\proj\.agentscommander";
+        for reason in [
+            format!("Project AC Root path '{CALLER}' has no valid directory name"),
+            format!("Project AC Root path '{CALLER}' is not a Project AC Root directory"),
+            format!("Project AC Root path '{CALLER}' has no parent project directory"),
+            format!("project '{PROJECT}' has no Project AC Root directory"),
+            format!(
+                "Project AC Root '{CALLER}' rejected because authoritative Project AC Root '{AUTHORITATIVE}' exists"
+            ),
+            String::new(),
+        ] {
+            let text = requester_identity_diagnostic("root_directory", &reason);
+            assert!(text.ends_with("reason=unexpected"), "got {text}");
+            assert!(text.contains("stage=root_directory"), "got {text}");
+            for forbidden in [r"C:\", "someone", ".ac"] {
+                assert!(
+                    !text.contains(forbidden),
+                    "diagnostic leaked {forbidden}: {text}"
+                );
+            }
+        }
+    }
 
     fn write_private_response(path: &Path, bytes: &[u8]) {
         std::fs::write(path, bytes).unwrap();

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -4439,6 +4439,61 @@ mod tests {
         write_team_config_guarded(workspace_dir, team_name, config, &guard)
     }
 
+    /// #1245: the writer and `config::teams::team_members` enforced mutually
+    /// exclusive invariants over the same `agents` array, so every team config
+    /// the application was able to write was rejected by the privileged
+    /// validator. The two assertions below cannot both hold unless the writer
+    /// and the validator agree on where the coordinator belongs, which is what
+    /// stops them drifting apart again.
+    #[test]
+    fn team_config_written_by_the_app_passes_the_privileged_validator() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let workspace_dir = tmp.path().join("proj-a").join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
+        std::fs::create_dir_all(&team_dir).expect("team directory");
+        for agent in ["tech-lead", "dev-rust"] {
+            // `resolve_agent_ref` requires the matrix directory to exist already.
+            std::fs::create_dir_all(workspace_dir.join(format!("_agent_{agent}")))
+                .expect("matrix directory");
+            let replica = wg_dir.join(format!("__agent_{agent}"));
+            std::fs::create_dir_all(&replica).expect("replica directory");
+            std::fs::write(
+                replica.join("config.json"),
+                format!(r#"{{"identity":"../../_agent_{agent}"}}"#),
+            )
+            .expect("replica config");
+        }
+
+        let config = TeamConfigResult {
+            agents: vec!["_agent_tech-lead".into(), "_agent_dev-rust".into()],
+            coordinator: "_agent_tech-lead".into(),
+            repos: vec![],
+            context_alert_percentages: vec![],
+        };
+        let bytes = normalized_team_config_bytes(&workspace_dir, &config)
+            .expect("the writer requires the coordinator inside `agents`");
+        std::fs::write(team_dir.join("config.json"), &bytes).expect("team config");
+
+        let project_paths = vec![tmp.path().to_string_lossy().to_string()];
+        crate::config::teams::verify_pty_input_route(
+            &wg_dir.join("__agent_tech-lead"),
+            false,
+            "proj-a:wg-1-dev-team/dev-rust",
+            &project_paths,
+        )
+        .expect("the privileged validator must accept the bytes the writer produced");
+
+        let without_coordinator = TeamConfigResult {
+            agents: vec!["_agent_dev-rust".into()],
+            ..config
+        };
+        assert_eq!(
+            normalized_team_config_bytes(&workspace_dir, &without_coordinator).unwrap_err(),
+            "Coordinator must be one of the selected agents"
+        );
+    }
+
     #[test]
     #[cfg(windows)]
     fn git_cli_path_strips_windows_verbatim_prefix() {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -5918,7 +5918,7 @@ mod tests {
         }
         std::fs::write(
             team.join("config.json"),
-            r#"{"agents":["../_agent_dev-one","../_agent_dev-two"],"coordinator":"../_agent_lead"}"#,
+            r#"{"agents":["../_agent_dev-one","../_agent_dev-two","../_agent_lead"],"coordinator":"../_agent_lead"}"#,
         )
         .unwrap();
         for (replica, identity) in [

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -7450,7 +7450,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         }
         std::fs::write(
             team.join("config.json"),
-            r#"{"coordinator":"../_agent_tech-lead","agents":["../_agent_dev-rust"]}"#,
+            r#"{"coordinator":"../_agent_tech-lead","agents":["../_agent_dev-rust","../_agent_tech-lead"]}"#,
         )
         .expect("write team config");
         std::fs::write(

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -2094,7 +2094,7 @@ mod tests {
 
         std::fs::write(
             team_dir.join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead"],"coordinator":"../_agent_tech-lead"}"#,
         )
         .unwrap();
         let tech_lead_identity = if spoofed_coordinator_identity {
@@ -2249,7 +2249,7 @@ mod tests {
 
         std::fs::write(
             workspace.join("_team_dev-team").join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"agents":[],"coordinator":"../_agent_tech-lead"}"#,
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead"],"agents":[],"coordinator":"../_agent_tech-lead"}"#,
         )
         .unwrap();
         assert!(verify_pty_input_route(
@@ -2277,7 +2277,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             workspace.join("_team_dev-team").join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead","benign":"changed"}"#,
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead"],"coordinator":"../_agent_tech-lead","benign":"changed"}"#,
         )
         .unwrap();
         let second =

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -793,21 +793,31 @@ fn team_members(
         .filter(|values| values.len() <= 1_024)
         .ok_or_else(|| "sender_identity_invalid".to_string())?;
     let mut members: Vec<String> = Vec::with_capacity(values.len());
+    let mut seen: Vec<String> = Vec::with_capacity(values.len());
     for value in values {
         let raw = value
             .as_str()
             .ok_or_else(|| "sender_identity_invalid".to_string())?;
         let member =
             agent_bare_name_from_ref(raw).map_err(|_| "sender_identity_invalid".to_string())?;
-        if identity_name_eq(&member, &coordinator)
-            || members
-                .iter()
-                .any(|existing| identity_name_eq(existing, &member))
+        if seen
+            .iter()
+            .any(|existing| identity_name_eq(existing, &member))
         {
             return Err("sender_identity_invalid".to_string());
         }
         crate::path_identity::verify_directory(&workspace.join(format!("_agent_{member}")))?;
-        members.push(member);
+        seen.push(member.clone());
+        // #1245: the application's team-config writer requires the coordinator
+        // to appear in `agents` (commands/entity_creation.rs::
+        // normalize_team_config_for_project, and rule 4 of
+        // docs/agent-matrix-conventions.md). The coordinator is returned
+        // separately and must not also be counted as an ordinary member, so its
+        // entry is consumed here instead of rejecting the whole config. `seen`
+        // still covers it, so a repeated coordinator entry stays rejected.
+        if !identity_name_eq(&member, &coordinator) {
+            members.push(member);
+        }
     }
     crate::path_identity::verify_directory(&workspace.join(format!("_agent_{coordinator}")))?;
     Ok((coordinator, members, config_identity))
@@ -2115,6 +2125,114 @@ mod tests {
 
         let paths = vec![tmp.path().to_string_lossy().to_string()];
         (tmp, paths)
+    }
+
+    /// #1245: the team-config shape the application's writer actually produces,
+    /// with the coordinator listed inside `agents`. A third member exists so the
+    /// surviving member order can be pinned once the coordinator entry is
+    /// consumed; `make_coordinator_fixture` has only one ordinary member.
+    fn make_writer_shaped_team_fixture() -> (FixtureRoot, Vec<String>) {
+        let tmp = FixtureRoot::new("teams-writer-shape-fixture");
+        let workspace_dir = tmp.path().join("proj-a").join(".ac");
+        let team_dir = workspace_dir.join("_team_dev-team");
+        let wg_dir = workspace_dir.join("wg-1-dev-team");
+
+        std::fs::create_dir_all(&team_dir).unwrap();
+        for agent in ["tech-lead", "dev-rust", "dev-ts"] {
+            std::fs::create_dir_all(workspace_dir.join(format!("_agent_{agent}"))).unwrap();
+            let replica = wg_dir.join(format!("__agent_{agent}"));
+            std::fs::create_dir_all(&replica).unwrap();
+            std::fs::write(
+                replica.join("config.json"),
+                format!(r#"{{"identity":"../../_agent_{agent}"}}"#),
+            )
+            .unwrap();
+        }
+        std::fs::write(
+            team_dir.join("config.json"),
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead","../_agent_dev-ts"],"coordinator":"../_agent_tech-lead"}"#,
+        )
+        .unwrap();
+
+        let paths = vec![tmp.path().to_string_lossy().to_string()];
+        (tmp, paths)
+    }
+
+    #[test]
+    fn team_config_with_coordinator_in_agents_verifies_and_excludes_the_coordinator_from_members() {
+        let (fixture, paths) = make_writer_shaped_team_fixture();
+        let workspace = fixture.path().join("proj-a").join(".ac");
+        let wg_dir = workspace.join("wg-1-dev-team");
+        let tech_lead = wg_dir.join("__agent_tech-lead");
+        let dev_rust = wg_dir.join("__agent_dev-rust");
+
+        let route =
+            verify_pty_input_route(&tech_lead, false, "proj-a:wg-1-dev-team/dev-rust", &paths)
+                .unwrap();
+        assert_eq!(route.sender.canonical_fqn, "proj-a:wg-1-dev-team/tech-lead");
+        assert!(route.sender.is_coordinator);
+
+        assert!(
+            verify_pty_input_route(&dev_rust, false, "proj-a:wg-1-dev-team/dev-ts", &paths)
+                .is_err(),
+            "a worker sender must still be rejected"
+        );
+
+        let snapshot = verify_terminal_snapshot_route(
+            &tech_lead,
+            false,
+            "proj-a:wg-1-dev-team/dev-ts",
+            &paths,
+        )
+        .unwrap();
+        assert_eq!(snapshot.kind, TerminalSnapshotAuthorityKind::Coordinator);
+
+        // The coordinator is still not a valid capture target even though it now
+        // appears in `agents`. This guards the authorization matrix. It cannot
+        // observe the member exclusion: `verify_replica` derives
+        // `is_coordinator` from the `coordinator` key and short-circuits the
+        // `target_not_member` gate, so it holds for any `members` content.
+        assert!(verify_terminal_snapshot_route(
+            &tech_lead,
+            false,
+            "proj-a:wg-1-dev-team/tech-lead",
+            &paths,
+        )
+        .is_err());
+
+        // Only a direct call can pin the exclusion. Asserting the whole vector
+        // also pins that consuming the coordinator entry leaves the order and
+        // the count of the remaining members untouched.
+        let (coordinator, members, _) = team_members(&workspace, "dev-team").unwrap();
+        assert_eq!(coordinator, "tech-lead");
+        assert_eq!(members, vec!["dev-rust".to_string(), "dev-ts".to_string()]);
+    }
+
+    #[test]
+    fn team_config_rejects_repeated_agent_and_repeated_coordinator_entries() {
+        let (fixture, paths) = make_writer_shaped_team_fixture();
+        let workspace = fixture.path().join("proj-a").join(".ac");
+        let team_config = workspace.join("_team_dev-team").join("config.json");
+        let tech_lead = workspace.join("wg-1-dev-team").join("__agent_tech-lead");
+
+        for agents in [
+            r#"["../_agent_dev-rust","../_agent_dev-rust","../_agent_tech-lead"]"#,
+            r#"["../_agent_tech-lead","../_agent_tech-lead","../_agent_dev-rust"]"#,
+            // Equivalent spellings collapse in `agent_bare_name_from_ref`, so a
+            // repeated coordinator is caught whichever way it is written.
+            r#"["../_agent_tech-lead","_agent_tech-lead","../_agent_dev-rust"]"#,
+        ] {
+            std::fs::write(
+                &team_config,
+                format!(r#"{{"agents":{agents},"coordinator":"../_agent_tech-lead"}}"#),
+            )
+            .unwrap();
+            assert!(
+                verify_pty_input_route(&tech_lead, false, "proj-a:wg-1-dev-team/dev-rust", &paths)
+                    .is_err(),
+                "duplicate detection must not weaken for agents {agents}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -11834,7 +11834,7 @@ mod tests {
 
         std::fs::write(
             team_dir.join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead"],"coordinator":"../_agent_tech-lead"}"#,
         )
         .unwrap();
         let tech_lead_identity = if spoofed_coordinator_identity {
@@ -11993,7 +11993,7 @@ mod tests {
 
         std::fs::write(
             team_dir.join("config.json"),
-            r#"{"agents":["../_agent_dev-rust"],"coordinator":"../_agent_tech-lead"}"#,
+            r#"{"agents":["../_agent_dev-rust","../_agent_tech-lead"],"coordinator":"../_agent_tech-lead"}"#,
         )
         .unwrap();
         std::fs::write(

--- a/src-tauri/src/pty/terminal_snapshot/acceptance_tests.rs
+++ b/src-tauri/src/pty/terminal_snapshot/acceptance_tests.rs
@@ -265,7 +265,7 @@ impl ReplicaPaths {
         }
         std::fs::write(
             team.join("config.json"),
-            r#"{"agents":["../_agent_worker","../_agent_member-live","../_agent_member-exited","../_agent_member-tampered"],"coordinator":"../_agent_coordinator"}"#,
+            r#"{"agents":["../_agent_worker","../_agent_member-live","../_agent_member-exited","../_agent_member-tampered","../_agent_coordinator"],"coordinator":"../_agent_coordinator"}"#,
         )
         .expect("team config");
         for name in ["coordinator", "worker", "member-live", "member-exited"] {


### PR DESCRIPTION
Closes #1245

## What was broken

Terminal snapshots (#1173 / PR #1238) were inoperative for **every** requester in any real
installation, and PTY-input's coordinator half (#1057) was dead for the same reason.

`config/teams.rs:802-807` (`team_members()`) rejected any team config whose `agents` array contained
the coordinator, while the team config writer `commands/entity_creation.rs:1033-1035` **requires**
the coordinator to be in `agents`. Every team config the application can write was therefore rejected
by the validator. All 11 team configs in the live workspace have that shape.

CI never caught it because the test fixtures used a shape the writer would reject — the code path was
only ever covered against data that cannot occur in production.

A second-order effect: because `verify_pty_input_replica_cwd` always failed, `pty/manager.rs:489-492`
left `verified_replica_anchor = None` on **every** session.

## What changed

1. **`config/teams.rs::team_members`** — the loop now carries a `seen` vector covering all entries
   (including the coordinator's) and pushes to `members` only entries that are not the coordinator,
   instead of rejecting the config. Duplicate detection is preserved, and a repeated coordinator entry
   is still rejected. The 1024 bound, the unconditional `verify_directory` of the coordinator matrix
   directory, and the tuple shape are unchanged.
2. **`cli/terminal_snapshot.rs`** — stopped discarding the real requester identity failure reason. A
   new private `requester_identity_diagnostic` logs it to `app.log` through a fixed allowlist of six
   compile-time literals, mapping anything else to `unexpected`. The stderr contract is byte-for-byte
   unchanged. The allowlist exists because some reachable reasons interpolate absolute paths.
3. **Eight test fixtures corrected** to the shape the application actually writes, plus four new
   tests, including a cross-check that builds a team config with the real writer
   (`normalized_team_config_bytes`) and asserts the privileged validator accepts it, with the inverse
   guard that the writer still rejects a config without the coordinator in `agents`. Those two
   assertions together make it impossible for writer and validator to silently diverge again.

**No authorization route is widened.** The matrices in `docs/security.md` and
`docs/features/terminal-snapshots.md` are unchanged. The change is a strict widening of the accepted
config set, and what it accepts is exactly the shape the writer produces.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test --lib --bins --tests`: **3329 passed, 0 failed, 22 ignored** (3347 before + 4 new
  tests; the same 22 ignored, so no assertion was inverted, deleted or ignored).
- `-p terminal-snapshot-renderer`: 24 tests. `-p session-bridge ... terminal_snapshot`: 13 tests.
- All gates independently re-run by the reviewer, not accepted from the implementer's report.

Empirical, with pre-fix/post-fix pairs from the same `--root` and `--token`, reproduced by two
different agents from two different replicas:

| | Pre-fix | Post-fix |
|---|---|---|
| `list-peers-lean --snapshot-targets` from a non-coordinator replica | exit 1, `sender_identity_invalid` | exit 0, `[]` |
| same, from the coordinator replica | exit 1, `sender_identity_invalid` | exit 0, the 7 non-coordinator members, coordinator absent |
| `terminal-snapshot` from a worker replica | `code=requester_unavailable` | `code=not_authorized` |

The last row shows the denial now comes from policy rather than from a broken validator.

Live end-to-end capture (and the daemon-side pre-admission path) were **not** exercised: the running
instance is still the unfixed build, replacing it kills every agent session in the workspace, and
`terminalSnapshotsEnabled` is `false`. That path is covered by tests — the eight
`acceptance_tests.rs` cases now exercise `pre_admit_requester` against the shape the app really
writes, which they did not before this change.

## Review

Plan certified `READY_FOR_IMPLEMENTATION` and frozen by SHA-256 before implementation, which ran from
a cold start against the frozen plan as sole specification. Adversarial review verdict: **PASS**, with
four non-blocking findings, none requiring a code change.

Follow-up filed: #1246 (snapshot target discovery walk fails all-or-nothing without naming the
offending replica).

## Behaviour change worth flagging

This restores capabilities that were dead, not new ones: coordinator PTY-input over workgroup members,
the container API `pty-input` and `terminal-snapshot` scopes, and the append of
`PTY_INPUT_COORDINATOR_CONTEXT`. On the first run of a fixed build, 11 coordinator replicas gain a
1014-byte context block at once. That is #1057's intended behaviour, which had never executed.
