### PR TITLE
feat(sidebar): display active screenshot shortcut, refs #1274

### DIFF
--- a/docs/testing/semantic-ui-automation-affordance-matrix.md
+++ b/docs/testing/semantic-ui-automation-affordance-matrix.md
@@ -78,6 +78,12 @@ This matrix seeds issue #497 acceptance coverage. It tracks user-visible screen/
 - `hover` drives JS handlers (`onMouseEnter` / `onPointerEnter` and their leave twins). It cannot drive the CSS `:hover` pseudo-class, and it deliberately dispatches no `pointermove` / `mousemove`, so nothing that listens for pointer movement — a drag, a splitter, the screenshot crosshair — can see it.
 - `hover` runs the same visibility and **obscured** gates as `click`: a covered element genuinely receives no pointer, so it is refused with `target_obscured`, and `diagnostics.topmost` names what is on top of it. The one place this bites in practice: the Browse flyout flips to the **left** of its anchor when it would overflow the viewport, so on a narrow window it can land on top of the menu itself, and the next `hover` on another repo entry is refused. Recovery: widen the window, or `hover --leave` (which closes the flyout) and retry.
 
+## Sidebar Titlebar (#1274)
+
+| Behavior | Selector | Action |
+|---|---|---|
+| Inspect the active screenshot-capture shortcut status | `[data-ac-testid="screenshot-hotkey-status"]` | `query` only; passive status with no semantic action |
+
 ## Known Gaps For Follow-Up
 
 | Surface | Missing action/selector family |

--- a/src/sidebar/components/Titlebar.screenshot-hotkey.test.tsx
+++ b/src/sidebar/components/Titlebar.screenshot-hotkey.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { render } from "solid-js/web";
+import type { Component } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScreenshotHotkeyStatus } from "../../shared/types";
+
+const mocks = vi.hoisted(() => ({
+  getHotkeyStatus: vi.fn(),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    minimize: vi.fn(),
+    isMaximized: vi.fn(() => Promise.resolve(false)),
+    maximize: vi.fn(),
+    unmaximize: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+vi.mock("../../shared/ipc", () => ({
+  ScreenshotAPI: {
+    getHotkeyStatus: mocks.getHotkeyStatus,
+  },
+  SettingsAPI: {
+    get: mocks.getSettings,
+    update: mocks.updateSettings,
+  },
+}));
+
+vi.mock("./WebServerMenu", () => ({
+  default: () => <span data-testid="webserver-menu" />,
+}));
+
+vi.mock("./ZoomStepper", () => ({
+  default: () => <span data-testid="zoom-stepper" />,
+}));
+
+interface MountOptions {
+  native?: boolean;
+  status?: ScreenshotHotkeyStatus;
+  rejectStatus?: boolean;
+}
+
+interface MountedTitlebar {
+  root: HTMLDivElement;
+  cleanup: () => void;
+}
+
+const cleanups: Array<() => void> = [];
+const tauriGlobalKeys = ["__TAURI_INTERNALS__", "__TAURI__"] as const;
+
+const screenshotStatus = (
+  overrides: Partial<ScreenshotHotkeyStatus> = {},
+): ScreenshotHotkeyStatus => ({
+  configured: "Ctrl+1",
+  registered: true,
+  error: null,
+  ...overrides,
+});
+
+const setNativeRuntime = (native: boolean) => {
+  for (const key of tauriGlobalKeys) {
+    if (native) {
+      Reflect.set(window, key, {});
+    } else {
+      Reflect.deleteProperty(window, key);
+    }
+  }
+};
+
+const flushAsyncWork = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const mountTitlebar = async ({
+  native = true,
+  status = screenshotStatus(),
+  rejectStatus = false,
+}: MountOptions = {}): Promise<MountedTitlebar> => {
+  setNativeRuntime(native);
+  mocks.getSettings.mockResolvedValue({ mainSidebarSide: "right" });
+  mocks.invoke.mockResolvedValue("");
+  if (rejectStatus) {
+    mocks.getHotkeyStatus.mockRejectedValue(new Error("status unavailable"));
+  } else {
+    mocks.getHotkeyStatus.mockResolvedValue(status);
+  }
+
+  vi.resetModules();
+  const { default: Titlebar } = await import("./Titlebar");
+  const root = document.createElement("div");
+  document.body.append(root);
+  const cleanup = render(() => <Titlebar />, root);
+  cleanups.push(() => {
+    cleanup();
+    root.remove();
+  });
+
+  await flushAsyncWork();
+  return { root, cleanup };
+};
+
+const getChip = (root: Element): HTMLElement | null =>
+  root.querySelector<HTMLElement>("[data-testid='screenshot-hotkey-status']");
+
+describe("Titlebar screenshot hotkey status", () => {
+  beforeEach(() => {
+    mocks.getHotkeyStatus.mockReset();
+    mocks.getSettings.mockReset();
+    mocks.updateSettings.mockReset();
+    mocks.invoke.mockReset();
+  });
+
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+    setNativeRuntime(false);
+    vi.clearAllMocks();
+  });
+
+  it("renders an active native status before WebServerMenu and ZoomStepper", async () => {
+    const { root } = await mountTitlebar();
+    const controls = root.querySelector<HTMLElement>(".titlebar-controls");
+    const chip = getChip(root);
+    const webServerMenu = root.querySelector<HTMLElement>("[data-testid='webserver-menu']");
+    const zoomStepper = root.querySelector<HTMLElement>("[data-testid='zoom-stepper']");
+
+    expect(controls).not.toBeNull();
+    expect(chip).not.toBeNull();
+    expect(webServerMenu).not.toBeNull();
+    expect(zoomStepper).not.toBeNull();
+    expect(chip?.querySelector(".screenshot-hotkey-status-text")?.textContent).toBe("Ctrl + 1");
+
+    const controlOrder = Array.from(controls?.children ?? []);
+    expect(controlOrder.indexOf(chip as Element)).toBeLessThan(controlOrder.indexOf(webServerMenu as Element));
+    expect(controlOrder.indexOf(webServerMenu as Element)).toBeLessThan(controlOrder.indexOf(zoomStepper as Element));
+  });
+
+  it("formats multipart combinations without changing token order or spelling", async () => {
+    const { root } = await mountTitlebar({
+      status: screenshotStatus({ configured: "Ctrl+Shift+F9" }),
+    });
+
+    expect(getChip(root)?.querySelector(".screenshot-hotkey-status-text")?.textContent)
+      .toBe("Ctrl + Shift + F9");
+  });
+
+  it("is accessible but exposes no activation semantics", async () => {
+    const { root } = await mountTitlebar();
+    const chip = getChip(root);
+
+    expect(chip).not.toBeNull();
+    expect(chip?.tagName).toBe("SPAN");
+    expect(chip?.getAttribute("title")).toBe("Screenshot capture shortcut: Ctrl + 1");
+    expect(chip?.getAttribute("aria-label")).toBe("Screenshot capture shortcut: Ctrl + 1");
+    expect(chip?.querySelector(".screenshot-hotkey-status-icon")?.getAttribute("aria-hidden"))
+      .toBe("true");
+    expect(chip?.getAttribute("role")).toBeNull();
+    expect(chip?.getAttribute("tabindex")).toBeNull();
+    expect(chip?.querySelector("button, a")).toBeNull();
+    expect(chip?.onclick).toBeNull();
+    expect(chip?.onkeydown).toBeNull();
+  });
+
+  it.each([
+    ["unregistered", screenshotStatus({ registered: false })],
+    ["error-bearing", screenshotStatus({ error: "already registered" })],
+    ["empty", screenshotStatus({ configured: "" })],
+    ["malformed", screenshotStatus({ configured: "Ctrl++1" })],
+  ])("hides a %s status", async (_label, status) => {
+    const { root } = await mountTitlebar({ status });
+
+    expect(getChip(root)).toBeNull();
+  });
+
+  it("hides a rejected status request without a duplicate warning", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { root } = await mountTitlebar({ rejectStatus: true });
+
+    expect(getChip(root)).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("does not request status in a browser sidebar", async () => {
+    const { root } = await mountTitlebar({ native: false });
+
+    expect(getChip(root)).toBeNull();
+    expect(mocks.getHotkeyStatus).not.toHaveBeenCalled();
+  });
+
+  it("uses the typed status route without invoking screenshot actions", async () => {
+    await mountTitlebar();
+
+    expect(mocks.getHotkeyStatus).toHaveBeenCalledTimes(1);
+    expect(mocks.invoke).not.toHaveBeenCalledWith("screenshot_get_hotkey_status");
+    expect(mocks.invoke).not.toHaveBeenCalledWith("screenshot_capture");
+  });
+});

--- a/src/sidebar/components/Titlebar.screenshot-hotkey.test.tsx
+++ b/src/sidebar/components/Titlebar.screenshot-hotkey.test.tsx
@@ -45,7 +45,7 @@ vi.mock("./ZoomStepper", () => ({
 
 interface MountOptions {
   native?: boolean;
-  status?: ScreenshotHotkeyStatus;
+  status?: unknown;
   rejectStatus?: boolean;
 }
 
@@ -77,7 +77,7 @@ const setNativeRuntime = (native: boolean) => {
 };
 
 const flushAsyncWork = async () => {
-  await Promise.resolve();
+  await vi.dynamicImportSettled();
   await Promise.resolve();
 };
 
@@ -110,7 +110,7 @@ const mountTitlebar = async ({
 };
 
 const getChip = (root: Element): HTMLElement | null =>
-  root.querySelector<HTMLElement>("[data-testid='screenshot-hotkey-status']");
+  root.querySelector<HTMLElement>("[data-ac-testid='screenshot-hotkey-status']");
 
 describe("Titlebar screenshot hotkey status", () => {
   beforeEach(() => {
@@ -139,9 +139,11 @@ describe("Titlebar screenshot hotkey status", () => {
     expect(zoomStepper).not.toBeNull();
     expect(chip?.querySelector(".screenshot-hotkey-status-text")?.textContent).toBe("Ctrl + 1");
 
-    const controlOrder = Array.from(controls?.children ?? []);
-    expect(controlOrder.indexOf(chip as Element)).toBeLessThan(controlOrder.indexOf(webServerMenu as Element));
-    expect(controlOrder.indexOf(webServerMenu as Element)).toBeLessThan(controlOrder.indexOf(zoomStepper as Element));
+    expect(chip?.parentElement).toBe(controls);
+    expect(webServerMenu?.parentElement).toBe(controls);
+    expect(zoomStepper?.parentElement).toBe(controls);
+    expect(webServerMenu?.previousElementSibling).toBe(chip);
+    expect(zoomStepper?.previousElementSibling).toBe(webServerMenu);
   });
 
   it("formats multipart combinations without changing token order or spelling", async () => {
@@ -175,6 +177,7 @@ describe("Titlebar screenshot hotkey status", () => {
     ["error-bearing", screenshotStatus({ error: "already registered" })],
     ["empty", screenshotStatus({ configured: "" })],
     ["malformed", screenshotStatus({ configured: "Ctrl++1" })],
+    ["runtime-malformed registration", { ...screenshotStatus(), registered: "true" }],
   ])("hides a %s status", async (_label, status) => {
     const { root } = await mountTitlebar({ status });
 
@@ -197,11 +200,10 @@ describe("Titlebar screenshot hotkey status", () => {
     expect(mocks.getHotkeyStatus).not.toHaveBeenCalled();
   });
 
-  it("uses the typed status route without invoking screenshot actions", async () => {
+  it("uses the typed status route while preserving the complete native invoke allowlist", async () => {
     await mountTitlebar();
 
     expect(mocks.getHotkeyStatus).toHaveBeenCalledTimes(1);
-    expect(mocks.invoke).not.toHaveBeenCalledWith("screenshot_get_hotkey_status");
-    expect(mocks.invoke).not.toHaveBeenCalledWith("screenshot_capture");
+    expect(mocks.invoke.mock.calls).toEqual([["get_instance_label"]]);
   });
 });

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -1,6 +1,6 @@
 import { Component, Show, For, createSignal, createMemo, onMount, onCleanup } from "solid-js";
 import iconUrl from "../../assets/icon-16.png";
-import { SettingsAPI } from "../../shared/ipc";
+import { ScreenshotAPI, SettingsAPI } from "../../shared/ipc";
 import { isTauri } from "../../shared/platform";
 import { extractWorkgroupName, computeTrailingText } from "../../shared/path-extractors";
 import { terminalStore } from "../../terminal/stores/terminal";
@@ -26,6 +26,60 @@ const SIDEBAR_SIDE_PRESETS: Array<{ label: string; side: MainSidebarSide }> = [
   { label: "Left", side: "left" },
   { label: "Right", side: "right" },
 ];
+
+const formatScreenshotHotkeyForDisplay = (canonicalHotkey: string): string | null => {
+  const displayTokens = canonicalHotkey.split("+").map((token) => token.trim());
+  if (displayTokens.some((token) => token.length === 0)) return null;
+
+  return displayTokens.join(" + ");
+};
+
+const ScreenshotHotkeyStatusChip: Component = () => {
+  const [canonicalHotkey, setCanonicalHotkey] = createSignal<string | null>(null);
+  const displayHotkey = createMemo(() => {
+    const canonical = canonicalHotkey();
+    return canonical === null ? null : formatScreenshotHotkeyForDisplay(canonical);
+  });
+
+  onMount(() => {
+    let disposed = false;
+    onCleanup(() => {
+      disposed = true;
+    });
+
+    void ScreenshotAPI.getHotkeyStatus()
+      .then((status) => {
+        if (
+          disposed ||
+          !status.registered ||
+          status.error !== null ||
+          typeof status.configured !== "string" ||
+          formatScreenshotHotkeyForDisplay(status.configured) === null
+        ) {
+          return;
+        }
+
+        setCanonicalHotkey(status.configured);
+      })
+      .catch(() => {});
+  });
+
+  return (
+    <Show when={displayHotkey()}>
+      {(hotkey) => (
+        <span
+          class="screenshot-hotkey-status"
+          data-testid="screenshot-hotkey-status"
+          title={`Screenshot capture shortcut: ${hotkey()}`}
+          aria-label={`Screenshot capture shortcut: ${hotkey()}`}
+        >
+          <span class="screenshot-hotkey-status-icon" aria-hidden="true">&#x1F4F7;</span>
+          <span class="screenshot-hotkey-status-text">{hotkey()}</span>
+        </span>
+      )}
+    </Show>
+  );
+};
 
 const Titlebar: Component = () => {
   const [layoutOpen, setLayoutOpen] = createSignal(false);
@@ -142,10 +196,13 @@ const Titlebar: Component = () => {
       </div>
       <div class="titlebar-controls">
         <Show when={isTauri}>
-          <WebServerMenu
-            open={webServerOpen()}
-            onOpenChange={setWebServerMenuOpen}
-          />
+          <>
+            <ScreenshotHotkeyStatusChip />
+            <WebServerMenu
+              open={webServerOpen()}
+              onOpenChange={setWebServerMenuOpen}
+            />
+          </>
         </Show>
         <ZoomStepper />
         <div class="layout-dropdown-wrapper">

--- a/src/sidebar/components/Titlebar.tsx
+++ b/src/sidebar/components/Titlebar.tsx
@@ -51,7 +51,7 @@ const ScreenshotHotkeyStatusChip: Component = () => {
       .then((status) => {
         if (
           disposed ||
-          !status.registered ||
+          status.registered !== true ||
           status.error !== null ||
           typeof status.configured !== "string" ||
           formatScreenshotHotkeyForDisplay(status.configured) === null
@@ -69,7 +69,7 @@ const ScreenshotHotkeyStatusChip: Component = () => {
       {(hotkey) => (
         <span
           class="screenshot-hotkey-status"
-          data-testid="screenshot-hotkey-status"
+          data-ac-testid="screenshot-hotkey-status"
           title={`Screenshot capture shortcut: ${hotkey()}`}
           aria-label={`Screenshot capture shortcut: ${hotkey()}`}
         >

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -92,6 +92,27 @@ html, body, #root {
 /* .titlebar-wg-badge canonical definition lives in terminal.css.
    Both stylesheets are bundled together, so the badge is styled in both windows. */
 
+.screenshot-hotkey-status {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.screenshot-hotkey-status-icon {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.screenshot-hotkey-status-text {
+  white-space: nowrap;
+}
+
 .titlebar-controls {
   display: flex;
   gap: 0;


### PR DESCRIPTION
Closes #1274.

## Summary
- Display the active screenshot shortcut as a passive native titlebar status chip before the web-server control.
- Use the typed hotkey-status API, strict active-registration gating, and an inspect-only semantic UI target.
- Preserve the existing titlebar native transport call while testing that no direct screenshot transport is added.

## Verification
- Focused screenshot-hotkey tests: 11 passing.
- Typecheck: passing.
- Full test suite: 1,515 passing.
- Adversarial Standards + Spec review: PASS.

## Visual follow-up
- A native sidebar launch with registered and unavailable hotkeys remains to be performed from the landed workgroup build.