### PR TITLE
fix(sidebar): exclude Alert me from Ungrouped (refs #1277)

### DIFF
--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -25,12 +25,42 @@ const projectPath = "C:\\Project";
 const wg1Path = `${projectPath}\\.ac\\wg-1-dev-team`;
 const wg2Path = `${projectPath}\\.ac\\wg-2-rust-team`;
 const coordRowTestId = "replica.row.quick.wg-1-dev-team.dev-webpage-ui";
+const workgroupRowTestId = "replica.row.workgroups.wg-1-dev-team.dev-webpage-ui";
 
 function groupsConfig(groups = [{ id: "frontend", name: "Frontend", regex: "^wg-1-" }]) {
   return {
     ...defaultGroupsConfig(),
     groups,
   };
+}
+
+function nonStopConfig(
+  regex: string,
+  show: boolean
+): NonNullable<ReturnType<typeof defaultGroupsConfig>["nonStop"]> {
+  return {
+    name: "Alert me!",
+    regex,
+    show,
+    toleranceSeconds: 0,
+    telegram: { enabled: false },
+    sound: { enabled: false, seconds: 0 },
+  };
+}
+
+async function renderProjectPanelForGroupFiltering(
+  config: Parameters<typeof workgroupGroupsStore.applyExternalUpdate>[1],
+  selection: Parameters<typeof workgroupGroupsStore.select>[1]
+) {
+  const transport = new FakeTransport();
+  setupProjectTransport(transport);
+  transport.onInvoke("open_project", () => ({ path: projectPath, ...projectDiscovery() }));
+  transport.onInvoke("discover_project", () => projectDiscovery());
+  workgroupGroupsStore.setActiveProject(projectPath);
+  workgroupGroupsStore.applyExternalUpdate(projectPath, config);
+  workgroupGroupsStore.select(projectPath, selection);
+  renderWithFakeTransport(() => <ProjectPanel />, transport);
+  await projectStore.loadProject(projectPath);
 }
 
 function projectDiscovery() {
@@ -130,6 +160,86 @@ describe("ProjectPanel workgroup groups", () => {
     cleanupDom = null;
     resetUiStoresForTests();
     document.body.replaceChildren();
+  });
+
+  it("alert_me_only_visible_is_excluded_from_ungrouped", async () => {
+    await renderProjectPanelForGroupFiltering(
+      {
+        ...groupsConfig([]),
+        nonStop: nonStopConfig(exactGroupRegexForWorkgroup("wg-1-dev-team"), true),
+      },
+      { kind: "ungrouped" }
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).toBeNull()
+    );
+
+    workgroupGroupsStore.select(projectPath, { kind: "nonstop" });
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).not.toBeNull()
+    );
+  });
+
+  it("regular_group_match_is_excluded_from_ungrouped", async () => {
+    await renderProjectPanelForGroupFiltering(
+      {
+        ...groupsConfig([
+          {
+            id: "frontend",
+            name: "Frontend",
+            regex: exactGroupRegexForWorkgroup("wg-1-dev-team"),
+          },
+        ]),
+        nonStop: nonStopConfig(exactGroupRegexForWorkgroup("wg-2-rust-team"), true),
+      },
+      { kind: "ungrouped" }
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).toBeNull()
+    );
+
+    workgroupGroupsStore.select(projectPath, { kind: "group", id: "frontend" });
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).not.toBeNull()
+    );
+  });
+
+  it("no_explicit_match_remains_ungrouped", async () => {
+    await renderProjectPanelForGroupFiltering(
+      {
+        ...groupsConfig([
+          {
+            id: "frontend",
+            name: "Frontend",
+            regex: exactGroupRegexForWorkgroup("wg-2-rust-team"),
+          },
+        ]),
+        nonStop: nonStopConfig(exactGroupRegexForWorkgroup("wg-2-rust-team"), true),
+      },
+      { kind: "ungrouped" }
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).not.toBeNull()
+    );
+  });
+
+  it("hidden_alert_me_match_stays_excluded_from_ungrouped", async () => {
+    await renderProjectPanelForGroupFiltering(
+      {
+        ...groupsConfig([]),
+        nonStop: nonStopConfig(exactGroupRegexForWorkgroup("wg-1-dev-team"), false),
+      },
+      { kind: "ungrouped" }
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector(`[data-ac-testid="${workgroupRowTestId}"]`)).toBeNull()
+    );
   });
 
   it("ANDs the selected group with the existing visible regex filter", async () => {

--- a/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
+++ b/src/sidebar/components/ProjectPanel.groups-filter.test.tsx
@@ -26,6 +26,7 @@ const wg1Path = `${projectPath}\\.ac\\wg-1-dev-team`;
 const wg2Path = `${projectPath}\\.ac\\wg-2-rust-team`;
 const coordRowTestId = "replica.row.quick.wg-1-dev-team.dev-webpage-ui";
 const workgroupRowTestId = "replica.row.workgroups.wg-1-dev-team.dev-webpage-ui";
+let cleanupGroupFilteringRenderer: (() => void) | null = null;
 
 function groupsConfig(groups = [{ id: "frontend", name: "Frontend", regex: "^wg-1-" }]) {
   return {
@@ -59,7 +60,10 @@ async function renderProjectPanelForGroupFiltering(
   workgroupGroupsStore.setActiveProject(projectPath);
   workgroupGroupsStore.applyExternalUpdate(projectPath, config);
   workgroupGroupsStore.select(projectPath, selection);
-  renderWithFakeTransport(() => <ProjectPanel />, transport);
+  cleanupGroupFilteringRenderer = renderWithFakeTransport(
+    () => <ProjectPanel />,
+    transport
+  ).cleanup;
   await projectStore.loadProject(projectPath);
 }
 
@@ -156,10 +160,15 @@ describe("ProjectPanel workgroup groups", () => {
   });
 
   afterEach(() => {
-    cleanupDom?.();
-    cleanupDom = null;
-    resetUiStoresForTests();
-    document.body.replaceChildren();
+    try {
+      cleanupGroupFilteringRenderer?.();
+    } finally {
+      cleanupGroupFilteringRenderer = null;
+      cleanupDom?.();
+      cleanupDom = null;
+      resetUiStoresForTests();
+      document.body.replaceChildren();
+    }
   });
 
   it("alert_me_only_visible_is_excluded_from_ungrouped", async () => {

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1002,9 +1002,14 @@ const ProjectPanel: Component = () => {
           const compiled = compiledGroups().find((entry) => entry.group.id === groupId);
           return !!compiled?.regex?.test(groupMatchId(wg));
         };
-        const workgroupMatchesAnyGroup = (wg: AcWorkgroup) =>
-          canTestGroupMatchId(wg) &&
-          compiledGroups().some((entry) => entry.regex?.test(groupMatchId(wg)));
+        const workgroupMatchesAnyGroup = (wg: AcWorkgroup) => {
+          const nonStop = groupsConfig().nonStop;
+          return (
+            (canTestGroupMatchId(wg) &&
+              compiledGroups().some((entry) => entry.regex?.test(groupMatchId(wg)))) ||
+            (!!nonStop && nonStopMatchesWorkgroup(nonStop, wg))
+          );
+        };
         const groupPredicate = (wg: AcWorkgroup) => {
           const selected = selectedGroup();
           if (selected.kind === "all") return true;


### PR DESCRIPTION
## Summary
- Exclude workgroups matching the built-in Alert me regex from the Ungrouped partition.
- Preserve Alert me visibility independently from explicit membership.
- Add runtime regression coverage for visible Alert me, hidden Alert me, regular groups, and unassigned workgroups.

## Verification
- `npx vitest run src/sidebar/components/ProjectPanel.groups-filter.test.tsx --reporter=verbose`
- `npm test`
- `npm run typecheck`
- `git diff --check`

## Review
- Adversarial review passed after a focused test-cleanup correction.

## Delivery
- This is a visual behavior change; the workgroup-specific build will run after merge.

Closes #1277