### PR TITLE
fix(profile): match Codex context-first row (#1287)

### DIFF
--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -407,7 +407,7 @@ export function defaultInstructionsFilename(command: string): string {
 }
 
 export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
-export const CODEX_CONTEXT_REGEX = String.raw`^ {2}.*· Context (\d{1,3})% used`;
+export const CODEX_CONTEXT_REGEX = String.raw`^ {2}(?:.*· )?Context (\d{1,3})% used`;
 export const PI_CONTEXT_REGEX = String.raw`^(?:.*? )?(\d{1,3})\.\d%/`;
 
 export function suggestedContextRegex(command: string): string | null {


### PR DESCRIPTION
## Summary

- Allow Codex context-first terminal rows to populate the context badge.
- Keep support for prefixed context rows.

## Verification

- Deterministic runtime regex check captures `0` from `  Context 0% used · weekly 97% left`.
- Focused post-rebase Grinch review: PASS (Standards 0 findings; Spec 0 findings).

Closes #1287