### PR TITLE
chore: cap cargo build jobs to 12

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+jobs = 12


### PR DESCRIPTION
Closes #1293

## Summary
New repo-level `.cargo/config.toml` with `[build] jobs = 12` so cargo caps parallel rustc/link.exe processes at 12 on this 24-core machine. Previously cargo defaulted `-j` to 24, saturating CPU and disk during builds (measured 2026-08-09: 7-8 simultaneous `link.exe`, CPU 98%, disk 242%).

## Change
- One new file: `.cargo/config.toml` (2 lines).
- No linker config, no Cargo.toml/profile/codegen-units changes, no global user config. Per-repository only.

## Verification
- `cargo check --all-targets` from clean target x3: EXIT 0, no TOML parse error.
- Process sampling during full build: peak 12 simultaneous `rustc.exe`, never above 12 (default without config: 24).
- Grinch review: PASS, non-visual change.
- Branch `chore/1293-cargo-build-jobs` contains origin/main.