### PR TITLE
feat: add setting to disable activity.jsonl generation, default off (refs #1299)

### DIFF
--- a/src-tauri/src/config/activity_log.rs
+++ b/src-tauri/src/config/activity_log.rs
@@ -652,11 +652,6 @@ fn rotate_if_needed(path: &Path) -> bool {
 ///
 /// Called exactly once, from `lib.rs::run()`, before the Tauri builder exists.
 /// Every append before this call is a no-op.
-///
-/// #1299 - `enabled == false` (the default) stores no sink: no `app_start`,
-/// no previous-run scan, and every later `append` / `append_batch` stays
-/// inert. This is the single cut point for the disable setting; producers
-/// are unchanged. Pre-existing `activity.jsonl` files are never touched.
 pub fn init_run(dir: &Path, run_id: &str, enabled: bool) {
     if !enabled {
         log::info!(

--- a/src-tauri/src/config/activity_log.rs
+++ b/src-tauri/src/config/activity_log.rs
@@ -652,7 +652,19 @@ fn rotate_if_needed(path: &Path) -> bool {
 ///
 /// Called exactly once, from `lib.rs::run()`, before the Tauri builder exists.
 /// Every append before this call is a no-op.
-pub fn init_run(dir: &Path, run_id: &str) {
+///
+/// #1299 - `enabled == false` (the default) stores no sink: no `app_start`,
+/// no previous-run scan, and every later `append` / `append_batch` stays
+/// inert. This is the single cut point for the disable setting; producers
+/// are unchanged. Pre-existing `activity.jsonl` files are never touched.
+pub fn init_run(dir: &Path, run_id: &str, enabled: bool) {
+    if !enabled {
+        log::info!(
+            "[activity] recording disabled by settings (activityLogEnabled=false); \
+             activity.jsonl will not be written this run"
+        );
+        return;
+    }
     // First-wins: a second call would be a programming error, and silently
     // keeping the first sink is the fail-soft direction.
     let _ = SINK.set(Sink {
@@ -1327,6 +1339,22 @@ mod tests {
         assert!(
             !dir.path().join(FILE_NAME).exists(),
             "an unconfigured sink must write nothing"
+        );
+    }
+
+    #[test]
+    fn init_run_disabled_stores_no_sink_and_writes_nothing() {
+        let dir = TempDir::new().expect("temp dir");
+        init_run(dir.path(), "run-disabled", false);
+        init_run(dir.path(), "run-disabled", false);
+        assert!(sink_path().is_none());
+        assert!(run_id().is_empty());
+        assert!(!dir.path().join(FILE_NAME).exists());
+        append(build_app_alive(vec![]));
+        append_batch(&[build_app_stop(true, 0)]);
+        assert!(
+            !dir.path().join(FILE_NAME).exists(),
+            "a disabled run must never create the activity file"
         );
     }
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -449,10 +449,6 @@ pub struct AppSettings {
     /// Phase 2 (UI dropdown) and Phase 3 (live reload) are deferred per the issue.
     #[serde(default)]
     pub log_level: Option<String>,
-    /// #1299 - when false (default), the per-run activity recorder
-    /// (`activity.jsonl`) is not initialized: no `app_start`, no previous-run
-    /// scan, and every heartbeat/busy/idle/shutdown append is inert. Read once
-    /// at startup; takes effect on the next launch.
     #[serde(default)]
     pub activity_log_enabled: bool,
     /// When true, on Coordinator session spawn AC injects a prompt asking the
@@ -2077,9 +2073,6 @@ fn read_activity_log_enabled_from_path(path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
-/// See `read_activity_log_enabled_from_path`. Resolves the canonical settings
-/// path and delegates. Missing file, missing key, malformed JSON, unreadable
-/// filesystem: all resolve to `false` (fail-closed: the recorder stays off).
 pub fn read_activity_log_enabled_only() -> bool {
     match settings_path() {
         Some(path) => read_activity_log_enabled_from_path(&path),
@@ -5340,7 +5333,6 @@ mod tests {
     fn read_activity_log_enabled_only_defaults_false_when_settings_missing() {
         let path =
             std::env::temp_dir().join(format!("rale-no-such-file-{}.json", std::process::id()));
-        // Intentionally do not create the file.
         assert!(!super::read_activity_log_enabled_from_path(&path));
     }
 
@@ -6254,7 +6246,6 @@ mod tests {
 
     #[test]
     fn activity_log_enabled_defaults_false_when_missing_from_json() {
-        // Old settings.json without the new field must deserialize to false.
         let json = r#"{
             "defaultShell": "bash",
             "defaultShellArgs": [],

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -449,6 +449,12 @@ pub struct AppSettings {
     /// Phase 2 (UI dropdown) and Phase 3 (live reload) are deferred per the issue.
     #[serde(default)]
     pub log_level: Option<String>,
+    /// #1299 - when false (default), the per-run activity recorder
+    /// (`activity.jsonl`) is not initialized: no `app_start`, no previous-run
+    /// scan, and every heartbeat/busy/idle/shutdown append is inert. Read once
+    /// at startup; takes effect on the next launch.
+    #[serde(default)]
+    pub activity_log_enabled: bool,
     /// When true, on Coordinator session spawn AC injects a prompt asking the
     /// agent to add a YAML frontmatter `title:` line to its workgroup
     /// `TASK.md` (only if the brief is non-empty and has no `title:` yet).
@@ -851,6 +857,7 @@ impl Default for AppSettings {
             coord_sort_by_activity: false,
             always_show_selected_workgroup: true,
             log_level: None,
+            activity_log_enabled: false,
             auto_generate_task_title: true,
             agent_templates_path: None,
             theme_light: false,
@@ -2056,6 +2063,28 @@ fn read_log_level_from_path(path: &std::path::Path) -> Option<String> {
 /// See `read_log_level_from_path`. Resolves the canonical settings path and delegates.
 pub fn read_log_level_only() -> Option<String> {
     read_log_level_from_path(&settings_path()?)
+}
+
+fn read_activity_log_enabled_from_path(path: &std::path::Path) -> bool {
+    let Some(contents) = std::fs::read_to_string(path).ok() else {
+        return false;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    v.get("activityLogEnabled")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// See `read_activity_log_enabled_from_path`. Resolves the canonical settings
+/// path and delegates. Missing file, missing key, malformed JSON, unreadable
+/// filesystem: all resolve to `false` (fail-closed: the recorder stays off).
+pub fn read_activity_log_enabled_only() -> bool {
+    match settings_path() {
+        Some(path) => read_activity_log_enabled_from_path(&path),
+        None => false,
+    }
 }
 
 /// #774: counter feeding the per-call unique temp filename for settings saves.
@@ -5140,6 +5169,17 @@ mod tests {
     }
 
     #[test]
+    fn activity_log_enabled_round_trips_through_serde() {
+        let mut s = AppSettings::default();
+        assert!(!s.activity_log_enabled);
+        s.activity_log_enabled = true;
+        let json = serde_json::to_string(&s).expect("serialize");
+        assert!(json.contains("\"activityLogEnabled\":true"));
+        let back: AppSettings = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.activity_log_enabled);
+    }
+
+    #[test]
     fn log_level_round_trips_through_serde() {
         let mut s = AppSettings::default();
         assert!(s.log_level.is_none());
@@ -5254,6 +5294,54 @@ mod tests {
         std::fs::write(&path, r#"{"logLevel":"","other":"value"}"#).unwrap();
         assert_eq!(super::read_log_level_from_path(&path), Some(String::new()));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_activity_log_enabled_from_path_returns_true_when_true() {
+        let dir = std::env::temp_dir().join(format!("rale-present-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, r#"{"activityLogEnabled":true,"other":"x"}"#).unwrap();
+        assert!(super::read_activity_log_enabled_from_path(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_activity_log_enabled_from_path_defaults_false_when_key_missing() {
+        let dir = std::env::temp_dir().join(format!("rale-missing-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, r#"{"other":"value"}"#).unwrap();
+        assert!(!super::read_activity_log_enabled_from_path(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_activity_log_enabled_from_path_defaults_false_when_null() {
+        let dir = std::env::temp_dir().join(format!("rale-null-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, r#"{"activityLogEnabled":null}"#).unwrap();
+        assert!(!super::read_activity_log_enabled_from_path(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_activity_log_enabled_from_path_defaults_false_when_json_malformed() {
+        let dir = std::env::temp_dir().join(format!("rale-malformed-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, "{ invalid json no closing brace").unwrap();
+        assert!(!super::read_activity_log_enabled_from_path(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_activity_log_enabled_only_defaults_false_when_settings_missing() {
+        let path =
+            std::env::temp_dir().join(format!("rale-no-such-file-{}.json", std::process::id()));
+        // Intentionally do not create the file.
+        assert!(!super::read_activity_log_enabled_from_path(&path));
     }
 
     // ── #778: disk-authoritative project_paths (Design S) ────────────────────
@@ -6162,6 +6250,40 @@ mod tests {
         }"#;
         let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
         assert!(!s.coord_sort_by_activity);
+    }
+
+    #[test]
+    fn activity_log_enabled_defaults_false_when_missing_from_json() {
+        // Old settings.json without the new field must deserialize to false.
+        let json = r#"{
+            "defaultShell": "bash",
+            "defaultShellArgs": [],
+            "agents": [],
+            "telegramBots": [],
+            "startOnlyCoordinators": true,
+            "sidebarAlwaysOnTop": false,
+            "raiseTerminalOnClick": true,
+            "voiceToTextEnabled": false,
+            "geminiApiKey": "",
+            "geminiModel": "gemini-2.5-flash",
+            "voiceAutoExecute": true,
+            "voiceAutoExecuteDelay": 15,
+            "sidebarZoom": 1.0,
+            "terminalZoom": 1.0,
+            "guideZoom": 1.0,
+            "darkfactoryZoom": 1.0,
+            "sidebarGeometry": null,
+            "terminalGeometry": null,
+            "webServerEnabled": false,
+            "webServerPort": 7777,
+            "webServerBind": "127.0.0.1",
+            "projectPath": null,
+            "projectPaths": [],
+            "sidebarStyle": "noir-minimal",
+            "onboardingDismissed": false
+        }"#;
+        let s: AppSettings = serde_json::from_str(json).expect("deserialize old json");
+        assert!(!s.activity_log_enabled);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1024,7 +1024,11 @@ pub fn run(
     // which the next startup reports as unclean. This is also the last point at
     // which `daemon.pid` still holds the PREVIOUS writer's PID, which is what
     // lets the scan tell a dead predecessor from a live sibling.
-    crate::config::activity_log::init_run(&config_dir, &instance_id);
+    // #1299 - gate the activity recorder on the persisted setting. Read-only
+    // disk read (mirror of `read_log_level_only`): the full settings load runs
+    // later. Missing key / malformed file => false => recorder off.
+    let activity_log_enabled = config::settings::read_activity_log_enabled_only();
+    crate::config::activity_log::init_run(&config_dir, &instance_id, activity_log_enabled);
     let app_outbox_path = instances_dir.join(&instance_id).join("outbox");
     std::fs::create_dir_all(&app_outbox_path).expect("Failed to create app outbox directory");
     let app_outbox = AppOutbox::new(app_outbox_path.to_string_lossy().to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1024,9 +1024,6 @@ pub fn run(
     // which the next startup reports as unclean. This is also the last point at
     // which `daemon.pid` still holds the PREVIOUS writer's PID, which is what
     // lets the scan tell a dead predecessor from a live sibling.
-    // #1299 - gate the activity recorder on the persisted setting. Read-only
-    // disk read (mirror of `read_log_level_only`): the full settings load runs
-    // later. Missing key / malformed file => false => recorder off.
     let activity_log_enabled = config::settings::read_activity_log_enabled_only();
     crate::config::activity_log::init_run(&config_dir, &instance_id, activity_log_enabled);
     let app_outbox_path = instances_dir.join(&instance_id).join("outbox");

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -175,6 +175,7 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     codingAgentProfiles: overrides.codingAgentProfiles ?? defaultCodingAgentProfiles(),
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -627,6 +627,8 @@ export interface AppSettings {
   autoSelfClearByAgent: Record<string, boolean>;
   containerCredentialsFromHost: boolean;
   logLevel: LogLevel | null;
+  /** #1299 - when false (default), `activity.jsonl` is not written. Applies on the next launch. */
+  activityLogEnabled: boolean;
   screenshotCaptureHotkey?: string;
   /**
    * #1171 - root-level watcher patterns, keyed by watcher id. Optional because the Rust

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -627,7 +627,6 @@ export interface AppSettings {
   autoSelfClearByAgent: Record<string, boolean>;
   containerCredentialsFromHost: boolean;
   logLevel: LogLevel | null;
-  /** #1299 - when false (default), `activity.jsonl` is not written. Applies on the next launch. */
   activityLogEnabled: boolean;
   screenshotCaptureHotkey?: string;
   /**

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -179,6 +179,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };

--- a/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
@@ -118,6 +118,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -119,6 +119,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -155,6 +155,7 @@ function settings(overrides: Partial<AppSettings> = {}): SettingsSnapshot {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
     // #1077: get_settings returns a SettingsSnapshot; SettingsModal ignores the
@@ -337,6 +338,31 @@ describe("SettingsModal automation hooks", () => {
 
     const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
     expect(saved?.apiServerEnabled).toBe(true);
+
+    dispose();
+  });
+
+  it("renders the activity log checkbox and persists the toggle", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {} }),
+      root,
+    );
+    await settle();
+
+    const toggle = byTestId<HTMLInputElement>("settings.general.activityLogEnabled");
+    expect(toggle.checked).toBe(false);
+
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.activityLogEnabled).toBe(true);
 
     dispose();
   });

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -80,6 +80,7 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -2397,10 +2397,36 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             <option value="trace">Trace</option>
           </select>
         </label>
+        <label class="settings-checkbox-field">
+          <input
+            type="checkbox"
+            class="settings-checkbox"
+            checked={settings.data!.activityLogEnabled}
+            disabled={saving()}
+            onChange={(e) =>
+              updateField("activityLogEnabled", e.currentTarget.checked)
+            }
+            data-ac-testid="settings.general.activityLogEnabled"
+            data-ac-role="checkbox"
+            data-ac-state={
+              settings.data!.activityLogEnabled ? "checked" : "unchecked"
+            }
+          />
+          <span>Record activity log (activity.jsonl)</span>
+        </label>
         <div class="settings-hint">
           Controls AgentsCommander log verbosity (applies immediately, no
           restart). Higher levels are noisier. The RUST_LOG env var, if set,
           overrides this until restart.
+        </div>
+        <div
+          class="settings-hint"
+          data-ac-testid="settings.general.activityLogEnabled.hint"
+        >
+          Writes a diagnostic timeline (app start/stop, heartbeat, session busy/idle
+          edges) that no other feature reads. Applies on the next launch; the current
+          session is unaffected. Existing activity.jsonl files are left untouched.
+          Disabled by default.
         </div>
       </div>
 

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -94,6 +94,7 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoSelfClearByAgent: {},
     containerCredentialsFromHost: true,
     logLevel: null,
+    activityLogEnabled: false,
     ...overrides,
     archivedProjectPaths: overrides.archivedProjectPaths ?? [],
   };


### PR DESCRIPTION
Adds `activityLogEnabled` setting (default **off**) that gates `activity.jsonl` generation.

- **UI**: new checkbox "Activity log" in Settings → Logging, below the Log level dropdown (`settings.general.activityLogEnabled`), disabled while saving; hint documents next-launch semantics and that existing files are untouched.
- **Backend**: single cut point in `activity_log::init_run(dir, run_id, enabled)` — when disabled, no sink is stored, so app_start, heartbeats, busy/idle transitions, and shutdown batches all no-op. Producers untouched; zero new module arcs (`module-arcs.txt` byte-identical, cyclic SCCs unchanged).
- **Fail-closed boot helpers**: `read_activity_log_enabled_only()` mirrors `read_log_level_only` (absent/null/malformed/missing-file → false).
- **Tests**: 7 new settings tests (serde + boot-gate tempdir), 1 activity_log gate test, 1 SettingsModal automation test; 7 TS fixtures updated. `cargo test` (3359), clippy -D warnings, fmt, vitest (1520), tsc all green.

Dev: dev-rust (implemented). Review: dev-rust-grinch PASS (structure gate re-run: 185 modules, 979 arcs, 1 SCC byte-identical base vs head). Plan: `plans/1299-activity-log-disable-setting-full.md`, certified digest D94DE8B8...

Closes #1299
