### PR TITLE
ci: make the clippy gate cover the whole workspace (refs #1301)

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -62,7 +62,7 @@ jobs:
       - name: cargo clippy
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: cargo test (compile only)
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: cargo clippy
         working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: cargo test
         working-directory: src-tauri


### PR DESCRIPTION
Implements #1301 per the frozen lite plan (plan SHA-256 97F0206A5A0AD388BE7098C0DBF87ADEF325C7A68FE01F36AE4B4BF7CE9B95E4).

Changes: add `--workspace` to the cargo clippy run line in `.github/workflows/pr-regression-gates.yml` and `.github/workflows/cache-warm.yml` (one token each). No source changes, no new #[allow].

Local verification: `cargo clippy --workspace --all-targets -- -D warnings` exits 0 with zero warnings (rustc 1.97.1 stable).