### PR TITLE
fix(git): stop blocking the async runtime and deduplicate git status polling (refs #1298)

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -192,6 +192,15 @@ Each registered project is stored in two forms: a canonical absolute path (the e
 
 **Downgrade.** An older AgentsCommander build ignores the companion fields and reads only the absolute fields, so a downgraded install still opens your projects. The caveat: if a dual-path conflict exists, the old build does not see it (it reads only the absolute side) and therefore loses the newer build's fail-closed protection for that registration. Resolve conflicts before downgrading.
 
+### Git status sweeper
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `gitSweepConcurrency` | number | `1` | How many repositories the global git sweeper inspects at once. Clamped to `1..=4` when read. `1` is strictly sequential, which is what bounds concurrent `git.exe`; raise it to `2` only if one slow repository is delaying the others. |
+| `gitSweepMinIntervalSecs` | number | `10` | Lower bound, in seconds, on one sweeper round. Clamped to `1..=3600` when read; `0` is raised to `1`. The effective period is `max(this, round duration)`, so on a large workgroup set the round duration dominates and this never fires. |
+
+Both are manual-only (no UI) and are read from the in-memory settings, so an edit takes effect on the next **restart**.
+
 ### Window & UI
 
 | Field | Type | Default | Description |

--- a/src-tauri/module-arcs.txt
+++ b/src-tauri/module-arcs.txt
@@ -742,6 +742,8 @@ agentscommander_lib::pty::context_scrape -> agentscommander_lib::shutdown
 agentscommander_lib::pty::context_scrape::rows -> agentscommander_lib::pty::context_scrape::pattern
 agentscommander_lib::pty::docker_runtime -> agentscommander_lib::errors
 agentscommander_lib::pty::docker_runtime -> agentscommander_lib::pty::container_runtime
+agentscommander_lib::pty::git_watcher -> agentscommander_lib::config::sessions_persistence
+agentscommander_lib::pty::git_watcher -> agentscommander_lib::config::settings
 agentscommander_lib::pty::git_watcher -> agentscommander_lib::pty::credentials
 agentscommander_lib::pty::git_watcher -> agentscommander_lib::session::manager
 agentscommander_lib::pty::git_watcher -> agentscommander_lib::session::session

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -301,30 +301,56 @@ fn projected_path_string(p: &Path) -> String {
     crate::path_utils::path_to_string_without_windows_verbatim_prefix(p)
 }
 
-/// Detect git branch synchronously for a given directory path.
-fn detect_git_branch_sync(dir: &str) -> Option<String> {
+/// #1298 - bound for the one-shot branch detection below. Deliberately its own
+/// constant and not the sweeper's `DETECT_TIMEOUT`: this is a discovery-time
+/// one-shot on the async command body, not the poll loop's per-round bound, and
+/// the two must be able to move independently.
+const BRANCH_DETECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Detect the git branch of a directory without blocking a runtime worker.
+///
+/// #1298 - the previous synchronous version spawned a `std::process::Command`
+/// straight on the async body of `discover_ac_agents` / `discover_project` and
+/// held its Tokio worker for as long as `git` took, with no bound. Now
+/// `tokio::process` under `BRANCH_DETECT_TIMEOUT`, with `kill_on_drop(true)` so
+/// the timeout's drop is what terminates `git.exe` (same mechanism as
+/// `git_watcher.rs`'s detection).
+///
+/// Named `detect_repo_branch`, not `detect_git_branch`, because
+/// `config/session_context.rs` already owns a private `detect_git_branch` that
+/// runs a DIFFERENT command (`git -C <dir> branch --show-current`); two
+/// same-named private detectors would break argv-based triage of `git.exe` peaks.
+///
+/// No `--no-optional-locks` here, unlike `detect_git_status` three functions
+/// away where it IS load-bearing: `rev-parse` neither takes `.git/index.lock`
+/// nor rewrites `.git/index`, so the flag would be cargo-culted noise.
+async fn detect_repo_branch(dir: &str) -> Option<String> {
     #[cfg(windows)]
     const CREATE_NO_WINDOW: u32 = 0x08000000;
 
-    let mut cmd = std::process::Command::new("git");
-    crate::pty::credentials::scrub_credentials_from_std_command(&mut cmd);
+    let mut cmd = tokio::process::Command::new("git");
+    crate::pty::credentials::scrub_credentials_from_tokio_command(&mut cmd);
     cmd.args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .current_dir(dir);
+        .current_dir(dir)
+        .kill_on_drop(true);
 
     #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
+    cmd.creation_flags(CREATE_NO_WINDOW);
 
-    match cmd.output() {
-        Ok(out) if out.status.success() => {
+    match tokio::time::timeout(BRANCH_DETECT_TIMEOUT, cmd.output()).await {
+        Ok(Ok(out)) if out.status.success() => {
             let branch = String::from_utf8_lossy(&out.stdout).trim().to_string();
             if branch.is_empty() || branch == "HEAD" {
                 None
             } else {
                 Some(branch)
             }
+        }
+        Err(_) => {
+            log::debug!(
+                "[discovery] branch detection timed out after {BRANCH_DETECT_TIMEOUT:?}: {dir}"
+            );
+            None
         }
         _ => None,
     }
@@ -1265,7 +1291,7 @@ pub async fn discover_ac_agents(
 
                                 // Detect git branch for single-repo replicas
                                 let repo_branch = if repo_paths.len() == 1 {
-                                    detect_git_branch_sync(&repo_paths[0])
+                                    detect_repo_branch(&repo_paths[0]).await
                                 } else {
                                     None
                                 };
@@ -1997,7 +2023,7 @@ pub(crate) async fn discover_project_inner(
                             .collect();
 
                         let repo_branch = if repo_paths.len() == 1 {
-                            detect_git_branch_sync(&repo_paths[0])
+                            detect_repo_branch(&repo_paths[0]).await
                         } else {
                             None
                         };

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -1,4 +1,3 @@
-use futures::future::join_all;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -359,26 +358,6 @@ async fn detect_repo_branch(dir: &str) -> Option<String> {
 // --- Discovery Branch Watcher ---
 
 const BRANCH_POLL_INTERVAL: Duration = Duration::from_secs(15);
-const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// #280 §3.3 - per-path counter for `detect_git_status` timeouts (#1028 renamed
-/// the detection; the counter and its policy are unchanged). Mirrors the
-/// `git_watcher.rs` helper but lives in a separate module-local map so the
-/// two watchers track their own paths independently (different scan sets).
-///
-/// #1028 note: this counter stays per-watcher on purpose, unlike
-/// `git_watcher::remember_dirty`'s SHARED map. Sharing would make "1st + every 50th"
-/// fire at the wrong times for both watchers; that reasoning is about a throttle
-/// counter and does not transfer to a fact about a worktree.
-fn note_discovery_timeout(path: &str) -> u64 {
-    use std::sync::OnceLock;
-    static TIMEOUT_COUNTS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
-    let map = TIMEOUT_COUNTS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut g = map.lock().unwrap_or_else(|e| e.into_inner());
-    let count = g.entry(path.to_string()).or_insert(0);
-    *count += 1;
-    *count
-}
 
 #[derive(Clone)]
 struct ReplicaBranchEntry {
@@ -510,6 +489,36 @@ impl DiscoveryBranchWatcher {
         })
     }
 
+    /// #1298 - the ONLY way to mutate `replicas`. Owns the lock scope and republishes
+    /// the flattened watched repo-path list to the global git sweeper on the way out,
+    /// so the map cannot be changed without the sweeper learning about it. The
+    /// sweeper is push-fed rather than holding a handle to this watcher so that
+    /// `pty::git_watcher` never imports a `commands::` type.
+    ///
+    /// Structural, not conventional, because the failure mode is silent: a future
+    /// mutator that forgot to republish would leave the sweeper unaware of its paths,
+    /// so `read_git_status` returns `None` for them forever and the surface is a
+    /// permanently violet chip with no failing test and no log line. The guard is
+    /// dropped before the push, inside this helper, where nobody has to remember it.
+    fn with_replicas_mut<R>(
+        &self,
+        f: impl FnOnce(&mut HashMap<String, Vec<ReplicaBranchEntry>>) -> R,
+    ) -> R {
+        let result = {
+            let mut map = self.replicas.lock().unwrap();
+            f(&mut map)
+        };
+        let paths: Vec<String> = {
+            let map = self.replicas.lock().unwrap();
+            map.values()
+                .flatten()
+                .flat_map(|e| e.repos.iter().map(|(_, path)| path.clone()))
+                .collect()
+        };
+        crate::pty::git_watcher::set_discovery_repo_paths(paths);
+        result
+    }
+
     /// Update this project's replicas in the watcher. `project_dir` is the directory
     /// that directly contains the Project AC Root, not a grand-parent from `settings.project_paths`.
     /// See the invariant comment on the `replicas` field.
@@ -577,16 +586,14 @@ impl DiscoveryBranchWatcher {
         );
 
         // Swap in this project's entries; leave other projects alone.
-        let mut map = self.replicas.lock().unwrap();
-        map.insert(canonical_key, entries);
-
-        // Prune cache entries that no longer belong to ANY project.
-        let valid: std::collections::HashSet<String> = map
-            .values()
-            .flatten()
-            .map(|e| e.replica_path.clone())
-            .collect();
-        drop(map);
+        let valid: std::collections::HashSet<String> = self.with_replicas_mut(|map| {
+            map.insert(canonical_key, entries);
+            // Prune cache entries that no longer belong to ANY project.
+            map.values()
+                .flatten()
+                .map(|e| e.replica_path.clone())
+                .collect()
+        });
         self.discovery_cache
             .lock()
             .unwrap()
@@ -602,12 +609,11 @@ impl DiscoveryBranchWatcher {
     /// tick does not iterate stale `source_path`s between a session-level refresh and the
     /// follow-up `discover_project` call that re-registers the replicas with NEW paths.
     pub fn invalidate_replicas(&self, replica_paths: &[String]) {
-        {
-            let mut map = self.replicas.lock().unwrap();
+        self.with_replicas_mut(|map| {
             for entries in map.values_mut() {
                 entries.retain(|e| !replica_paths.iter().any(|p| p == &e.replica_path));
             }
-        }
+        });
         {
             let mut dc = self.discovery_cache.lock().unwrap();
             let mut rc = self.repos_cache.lock().unwrap();
@@ -677,15 +683,15 @@ impl DiscoveryBranchWatcher {
                     }
                 };
 
-                // Parallelize per-repo detection (Grinch #16). Each call individually bounded by
-                // detect_status_with_timeout (2s). Without join_all this was M*N*2s worst case.
-                let statuses: Vec<Option<crate::pty::git_watcher::GitStatus>> = join_all(
-                    entry
-                        .repos
-                        .iter()
-                        .map(|(_, path)| Self::detect_status_with_timeout(path)),
-                )
-                .await;
+                // #1298 - pure map reads. This loop no longer spawns `git`: the global
+                // `GitSweeper` is the only polling producer, and this poll consumes its
+                // published snapshot. An unpublished path reads `None`, which is the
+                // same "unknown" a failed detection produced before.
+                let statuses: Vec<Option<crate::pty::git_watcher::GitStatus>> = entry
+                    .repos
+                    .iter()
+                    .map(|(_, path)| crate::pty::git_watcher::read_git_status(path))
+                    .collect();
 
                 let refreshed: Vec<SessionRepo> = entry
                     .repos
@@ -962,46 +968,6 @@ impl DiscoveryBranchWatcher {
                     wg_root.display(),
                     e
                 );
-            }
-        }
-    }
-
-    /// #1028 - detection is the shared `git_watcher::detect_git_status`, which replaced
-    /// this watcher's own near-identical `detect_branch` copy. The two copies had already
-    /// diverged (one set a ceiling env, this one did not), and both badge writers must
-    /// compute `dirty` identically.
-    ///
-    /// The timeout wrapper stays here rather than merging with GitWatcher's: this one
-    /// owns `note_discovery_timeout` and the `[DiscoveryBranchWatcher]` tag, which is
-    /// what keeps the two watchers distinguishable in app.log.
-    ///
-    /// Because `timeout` DROPS the future on expiry, `detect_git_status` never returns
-    /// here and cannot remember anything itself: `poll` applies the dirty hold.
-    async fn detect_status_with_timeout(
-        working_dir: &str,
-    ) -> Option<crate::pty::git_watcher::GitStatus> {
-        match tokio::time::timeout(
-            DETECT_TIMEOUT,
-            crate::pty::git_watcher::detect_git_status(working_dir),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(_) => {
-                let n = note_discovery_timeout(working_dir);
-                // #280 §3.3 — same dampening policy as git_watcher.rs: log
-                // first sighting + every 50th. Module tag remains
-                // `[DiscoveryBranchWatcher]` so the two watchers stay
-                // distinguishable in app.log.
-                if n == 1 || n.is_multiple_of(50) {
-                    log::warn!(
-                        "[DiscoveryBranchWatcher] detect_git_status timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
-                        working_dir,
-                        DETECT_TIMEOUT.as_secs(),
-                        n
-                    );
-                }
-                None
             }
         }
     }
@@ -5013,19 +4979,6 @@ mod tests {
             extract_task_first_line(content),
             Some("Body line".to_string())
         );
-    }
-
-    /// #280 §3.3 — `note_discovery_timeout` is a monotonic per-path
-    /// counter, mirroring `git_watcher::note_timeout` but isolated to the
-    /// discovery watcher's path set. Two paths get independent counters.
-    #[test]
-    fn note_discovery_timeout_counts_per_path() {
-        let p1 = "/test-280-3-3/ac-discovery/path-a";
-        let p2 = "/test-280-3-3/ac-discovery/path-b";
-        assert_eq!(note_discovery_timeout(p1), 1);
-        assert_eq!(note_discovery_timeout(p1), 2);
-        assert_eq!(note_discovery_timeout(p2), 1);
-        assert_eq!(note_discovery_timeout(p1), 3);
     }
 
     #[test]

--- a/src-tauri/src/commands/repos.rs
+++ b/src-tauri/src/commands/repos.rs
@@ -141,7 +141,7 @@ pub async fn search_repos(
 }
 
 /// #943 - upper bound for the `git remote get-url` call, mirroring
-/// `GitWatcher::detect_status_with_timeout` (src-tauri/src/pty/git_watcher.rs).
+/// the git sweeper's `detect_status_with_timeout` (src-tauri/src/pty/git_watcher.rs).
 /// The context menu must never wait on a stalled git.
 const GIT_REMOTE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -485,6 +485,21 @@ pub struct AppSettings {
     /// board is an opt-in feature enabled manually from settings.json.
     #[serde(default)]
     pub spec_board_enabled: bool,
+    /// #1298 - how many repositories the global git sweeper detects at once.
+    /// Default 1, i.e. strictly sequential, which is the property the sweeper
+    /// exists for. Read once per round and clamped to 1..=4 at the read site, so a
+    /// hand edit takes effect without a restart. Raising it to 2 halves worst-case
+    /// head-of-line blocking (see INV-1) at the cost of reintroducing bounded
+    /// concurrency. No UI: same manual-opt-in shape as `spec_board_enabled`.
+    #[serde(default = "default_git_sweep_concurrency")]
+    pub git_sweep_concurrency: u8,
+    /// #1298 - lower bound, in seconds, on one sweeper round. GUARD, not an
+    /// optimization: with an empty work list a round takes ~0ms and an unfloored
+    /// loop spins a core. Clamped to 1..=3600 at the read site; 0 is rejected by the
+    /// clamp for that reason. The effective period is max(this, round duration), so
+    /// on a large workgroup set the round duration dominates and this never fires.
+    #[serde(default = "default_git_sweep_min_interval_secs")]
+    pub git_sweep_min_interval_secs: u64,
     #[serde(default = "default_resource_monitor_enabled")]
     pub resource_monitor_enabled: bool,
     #[serde(default = "default_max_concurrent_agent_processes")]
@@ -751,6 +766,14 @@ fn default_main_sidebar_width() -> f64 {
     240.0
 }
 
+fn default_git_sweep_concurrency() -> u8 {
+    1
+}
+
+fn default_git_sweep_min_interval_secs() -> u64 {
+    10
+}
+
 fn default_resource_monitor_enabled() -> bool {
     true
 }
@@ -857,6 +880,8 @@ impl Default for AppSettings {
             rail_collapsed_projects: Vec::new(),
             rail_favorites_collapsed: false,
             spec_board_enabled: false,
+            git_sweep_concurrency: default_git_sweep_concurrency(),
+            git_sweep_min_interval_secs: default_git_sweep_min_interval_secs(),
             resource_monitor_enabled: default_resource_monitor_enabled(),
             max_concurrent_agent_processes: default_max_concurrent_agent_processes(),
             resource_watchdog_action: default_resource_watchdog_action(),

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -487,10 +487,13 @@ pub struct AppSettings {
     pub spec_board_enabled: bool,
     /// #1298 - how many repositories the global git sweeper detects at once.
     /// Default 1, i.e. strictly sequential, which is the property the sweeper
-    /// exists for. Read once per round and clamped to 1..=4 at the read site, so a
-    /// hand edit takes effect without a restart. Raising it to 2 halves worst-case
+    /// exists for. Read once per round and clamped to 1..=4 at the read site, which
+    /// keeps the app from rewriting the user's hand-edited settings.json; changing
+    /// it needs a RESTART, since the sweeper reads the in-memory settings state and
+    /// nothing reloads that from disk. Raising it to 2 halves worst-case
     /// head-of-line blocking (see INV-1) at the cost of reintroducing bounded
-    /// concurrency. No UI: same manual-opt-in shape as `spec_board_enabled`.
+    /// concurrency. No UI: same manual-opt-in shape as `spec_board_enabled`;
+    /// documented in docs/reference/settings.md.
     #[serde(default = "default_git_sweep_concurrency")]
     pub git_sweep_concurrency: u8,
     /// #1298 - lower bound, in seconds, on one sweeper round. GUARD, not an

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1126,6 +1126,7 @@ pub fn run(
         },
     );
     let session_mgr_for_git = Arc::clone(&session_mgr);
+    let session_mgr_for_git_sweeper = Arc::clone(&session_mgr);
     let session_mgr_for_discovery = Arc::clone(&session_mgr);
     let session_mgr_for_web = Arc::clone(&session_mgr);
     let session_mgr_for_api = Arc::clone(&session_mgr);
@@ -1298,6 +1299,23 @@ pub fn run(
                 session_mgr_for_discovery,
             );
             app.manage(Arc::clone(&discovery_branch_watcher));
+
+            // #1298 - the single global POLLING producer of per-repo git state. Both
+            // watchers read its published snapshot instead of spawning `git` themselves.
+            //
+            // Started HERE and not inside `restore_observer_barrier` for exactly one
+            // reason: that barrier gates observers which mutate session metadata or
+            // persistence, and this one mutates neither, it only publishes into
+            // process-local maps. The construction point buys no head start by itself,
+            // because at this point there is nothing to sweep (sessions are restored
+            // below, discovery is frontend-driven). Cold start is governed by the
+            // empty-round floor instead (plan D3). Do not move this under the barrier, and
+            // do not "restore" a head-start rationale that was never true.
+            let git_sweeper = crate::pty::git_watcher::GitSweeper::new(
+                session_mgr_for_git_sweeper,
+                app.state::<SettingsState>().inner().clone(),
+            );
+            git_sweeper.start(shutdown_for_setup.clone());
 
             // PtyManager needs GitWatcher for cleanup on session kill
             let pty_mgr = Arc::new(Mutex::new(PtyManager::new(

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -82,7 +82,7 @@ pub(crate) struct GitStatus {
 /// handed. "Never remembers an ancestor's dirt" is enforced by the caller,
 /// `detect_git_status`, through its three gates (`.git` metadata check, ceiling,
 /// `status.success()`). Only ever feed this from `detect_git_status`. A caller shaped
-/// like `detect_git_branch_sync` (`commands/ac_discovery.rs`), which has no `.git` guard
+/// like `detect_repo_branch` (`commands/ac_discovery.rs`), which has no `.git` guard
 /// and no ceiling, would silently violate it. Nothing does today.
 pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool> {
     use std::sync::OnceLock;

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -572,9 +572,11 @@ async fn detect_status_with_timeout(working_dir: &str) -> Option<GitStatus> {
 }
 
 /// #1298 - read-site clamp for the two sweeper dials. See plan D1: clamping here
-/// rather than in `validate_and_repair_settings` is what lets a hand edit of
-/// `settings.json` take effect without a restart, and what stops the app from
-/// rewriting the user's file.
+/// rather than in `validate_and_repair_settings` is what stops the app from
+/// rewriting the user's hand-edited `settings.json`. It is NOT a hot-reload
+/// mechanism: the sweeper reads the in-memory settings state, which is loaded once
+/// at startup and never refreshed from disk, so changing either dial takes a
+/// RESTART.
 fn sweep_dials(cfg: &AppSettings) -> (usize, Duration) {
     let concurrency = cfg
         .git_sweep_concurrency
@@ -610,6 +612,19 @@ fn sweep_dials(cfg: &AppSettings) -> (usize, Duration) {
 /// workgroups whose project is not in `settings.projectPaths`; sessions alone
 /// lose dormant replicas, which is `DiscoveryBranchWatcher`'s reason to exist.
 ///
+/// NOT pure and NOT cheap: with a non-empty `archived_roots` this performs one
+/// `std::fs::canonicalize` per distinct candidate, through
+/// `is_under_normalized_archived_roots`. It must therefore be called on the
+/// blocking pool whenever `archived_roots` is non-empty (INV-1). With an empty
+/// `archived_roots` the predicate short-circuits with zero syscalls and the call
+/// is a `HashSet` plus a `sort`.
+///
+/// Dedupe FIRST, filter SECOND. The result is identical either way, because the
+/// predicate is deterministic per path string, so this pays one canonicalize per
+/// DISTINCT path instead of one per occurrence: about 24 instead of about 200 on
+/// this layout, which is the same factor applied to the uncancellable blocking
+/// tail at shutdown. Do not fold it back into one chained `filter`.
+///
 /// Sorting is not cosmetic: at concurrency 1 the order decides who waits behind a
 /// hung repo, so a deterministic order makes that reproducible. Consequence worth
 /// knowing before reading a log: the alphabetically first path sits permanently at
@@ -622,14 +637,14 @@ fn build_work_list(
     let mut paths: Vec<String> = discovery
         .into_iter()
         .chain(sessions)
+        .collect::<HashSet<String>>()
+        .into_iter()
         .filter(|p| {
             !crate::config::sessions_persistence::is_under_normalized_archived_roots(
                 p,
                 archived_roots,
             )
         })
-        .collect::<HashSet<String>>()
-        .into_iter()
         .collect();
     paths.sort();
     paths
@@ -730,26 +745,34 @@ impl GitSweeper {
 
         let discovery = discovery_repo_paths();
 
-        let archived_roots: Vec<String> = if archived.is_empty() {
-            Vec::new()
+        // The WHOLE build, normalization included, runs on the blocking pool
+        // whenever the archived list is non-empty: `build_work_list` canonicalizes
+        // once per distinct candidate, which on this single-worker runtime would
+        // otherwise be unbounded blocking I/O with no await point for the shutdown
+        // `select!` to preempt (INV-1). The empty case short-circuits with zero
+        // syscalls, so it belongs on the async body and saves a task hop.
+        let paths = if archived.is_empty() {
+            build_work_list(discovery, sessions, &[])
         } else {
+            // The closure is `move` and consumes both halves, so the join-failure
+            // arm needs its own copies.
+            let (discovery_fb, sessions_fb) = (discovery.clone(), sessions.clone());
             match tokio::task::spawn_blocking(move || {
-                crate::config::sessions_persistence::normalize_project_roots(&archived)
+                let roots = crate::config::sessions_persistence::normalize_project_roots(&archived);
+                build_work_list(discovery, sessions, &roots)
             })
             .await
             {
-                Ok(roots) => roots,
+                Ok(paths) => paths,
                 Err(e) => {
                     // A superset sweep is a freshness cost, never a correctness one.
                     log::warn!(
-                        "[GitSweeper] archived-root normalization failed ({e}); sweeping without the archive filter this round"
+                        "[GitSweeper] work-list build failed ({e}); sweeping unfiltered this round"
                     );
-                    Vec::new()
+                    build_work_list(discovery_fb, sessions_fb, &[])
                 }
             }
         };
-
-        let paths = build_work_list(discovery, sessions, &archived_roots);
 
         // `detect_status_with_timeout(p).await` is evaluated as an ARGUMENT, before
         // `publish_git_status` takes its std guard. Writing it the other way round
@@ -769,18 +792,36 @@ impl GitSweeper {
             retain_swept_paths(&paths.iter().cloned().collect());
         }
 
-        log::info!(
-            "[GitSweeper] round: {} path(s), concurrency={}, {}ms",
-            paths.len(),
-            concurrency,
-            round_started.elapsed().as_millis()
-        );
-
-        if paths.is_empty() {
+        let applied = if paths.is_empty() {
             Duration::from_secs(SWEEP_MIN_INTERVAL_SECS)
         } else {
             floor
+        };
+
+        // The applied floor is in the line because it is the only way both clamps
+        // are observable at the DEFAULT log level: `sweep_dials`'s clamp lines are
+        // `debug!`. The level split matters too: an empty round floors at 1s, so an
+        // unconditional `info!` would emit 86,400 lines/day in exactly the state
+        // INV-2 exists to protect.
+        if paths.is_empty() {
+            log::debug!(
+                "[GitSweeper] round: {} path(s), concurrency={}, floor={}ms, {}ms",
+                paths.len(),
+                concurrency,
+                applied.as_millis(),
+                round_started.elapsed().as_millis()
+            );
+        } else {
+            log::info!(
+                "[GitSweeper] round: {} path(s), concurrency={}, floor={}ms, {}ms",
+                paths.len(),
+                concurrency,
+                applied.as_millis(),
+                round_started.elapsed().as_millis()
+            );
         }
+
+        applied
     }
 }
 

--- a/src-tauri/src/pty/git_watcher.rs
+++ b/src-tauri/src/pty/git_watcher.rs
@@ -1,17 +1,26 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
-use futures::future::join_all;
+use futures::stream::StreamExt;
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
+use crate::config::settings::AppSettings;
 use crate::session::manager::SessionManager;
 use crate::session::session::SessionRepo;
 
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// #1298 - read-site clamp bounds for the two sweeper dials. See plan D1.
+/// `SWEEP_MIN_INTERVAL_SECS` is also the floor an EMPTY round applies, which is
+/// what makes the cold start pick up work about a second after it appears.
+const SWEEP_MIN_CONCURRENCY: u8 = 1;
+const SWEEP_MAX_CONCURRENCY: u8 = 4;
+const SWEEP_MIN_INTERVAL_SECS: u64 = 1;
+const SWEEP_MAX_INTERVAL_SECS: u64 = 3600;
 
 /// #280 §3.3 - per-path counter for `detect_git_status` timeouts (#1028 renamed
 /// the detection; the counter and its policy are unchanged). Used to dampen
@@ -19,8 +28,11 @@ const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
 /// 50th thereafter. Process-local: counts reset on restart. Bounded by the
 /// number of distinct repo paths (~150 in production observations), so no
 /// GC is needed.
+///
+/// #1298 - now the sweeper's SINGLE counter rather than one of two: the
+/// per-watcher twin in `commands/ac_discovery.rs` went with its subject when
+/// detection was merged into one producer.
 fn note_timeout(path: &str) -> u64 {
-    use std::sync::OnceLock;
     static TIMEOUT_COUNTS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
     let map = TIMEOUT_COUNTS.get_or_init(|| Mutex::new(HashMap::new()));
     let mut g = map.lock().unwrap_or_else(|e| e.into_inner());
@@ -37,7 +49,7 @@ fn note_timeout(path: &str) -> u64 {
 /// locally cached `origin/*` upstream. This detector never performs a remote operation.
 /// It remains deliberately separate from the blocking deletion-safety checks in
 /// `commands/entity_creation.rs`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GitStatus {
     /// `None` for a detached HEAD or a mid-rebase, matching what
     /// `rev-parse --abbrev-ref` reported before this replaced it.
@@ -85,10 +97,7 @@ pub(crate) struct GitStatus {
 /// like `detect_repo_branch` (`commands/ac_discovery.rs`), which has no `.git` guard
 /// and no ceiling, would silently violate it. Nothing does today.
 pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool> {
-    use std::sync::OnceLock;
-    static LAST_DIRTY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
-    let map = LAST_DIRTY.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut g = map.lock().unwrap_or_else(|e| e.into_inner());
+    let mut g = last_dirty_map().lock().unwrap_or_else(|e| e.into_inner());
     match detected {
         Some(d) => {
             g.insert(path.to_string(), d);
@@ -96,6 +105,95 @@ pub(crate) fn remember_dirty(path: &str, detected: Option<bool>) -> Option<bool>
         }
         None => g.get(path).copied(),
     }
+}
+
+/// #1298 - `LAST_DIRTY` is hoisted out of `remember_dirty`'s body so
+/// `retain_swept_paths` can evict from it too. See INV-8: this map and the
+/// published snapshot must gain and lose the same paths, or a dropped path reads
+/// `None` from the snapshot and its last successful `bool` from here, which is a
+/// confident colour sourced from a detection that will never be repeated.
+static LAST_DIRTY: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
+
+fn last_dirty_map() -> &'static Mutex<HashMap<String, bool>> {
+    LAST_DIRTY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// #1298 - the snapshot the single global sweeper publishes and both poll loops
+/// read instead of spawning `git` themselves. Keyed by the EXACT repo-path string
+/// its two sources handed the sweeper (INV-3): any normalization here silently
+/// turns a consumer read into a miss, which renders as a permanent violet badge
+/// with no error anywhere.
+///
+/// Storing `Option<GitStatus>` rather than removing the key on failure is
+/// deliberate: "never detected" and "last detection failed" stay indistinguishable
+/// to the reader, which is exactly the semantics both consumers already implement
+/// (a `None` status becomes `branch: None` plus `remember_dirty(path, None)`).
+///
+/// Same lock discipline as `remember_dirty`, including
+/// `.unwrap_or_else(|e| e.into_inner())`, which is required for the reason
+/// documented there. GC is `retain_swept_paths`, not absence of one.
+static GIT_STATUS_SNAPSHOT: OnceLock<Mutex<HashMap<String, Option<GitStatus>>>> = OnceLock::new();
+
+fn git_status_snapshot() -> &'static Mutex<HashMap<String, Option<GitStatus>>> {
+    GIT_STATUS_SNAPSHOT.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn publish_git_status(path: &str, status: Option<GitStatus>) {
+    let mut g = git_status_snapshot()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    g.insert(path.to_string(), status);
+}
+
+/// `pub(crate)` is FORCED, exactly as it is for `remember_dirty`: one of the two
+/// readers lives in `commands/ac_discovery.rs`.
+pub(crate) fn read_git_status(path: &str) -> Option<GitStatus> {
+    let g = git_status_snapshot()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    g.get(path).cloned().flatten()
+}
+
+/// #1298 - the discovery half of the sweeper's work list, PUSHED here by
+/// `DiscoveryBranchWatcher` whenever it mutates its `replicas` map. Push, not
+/// pull: pulling would make `pty::git_watcher` import a `commands::` type, which
+/// is a layering inversion. Duplicates are expected (several replicas name the
+/// same repo) and `build_work_list` dedupes them.
+static DISCOVERY_REPO_PATHS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn discovery_repo_paths_cell() -> &'static Mutex<Vec<String>> {
+    DISCOVERY_REPO_PATHS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub(crate) fn set_discovery_repo_paths(paths: Vec<String>) {
+    *discovery_repo_paths_cell()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = paths;
+}
+
+fn discovery_repo_paths() -> Vec<String> {
+    discovery_repo_paths_cell()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+/// #1298 - drop every path this sweep no longer covers, from BOTH process-global
+/// maps. See INV-8: evicting only the snapshot leaves `LAST_DIRTY` serving the
+/// last successful bool forever, which is a confident lie rather than an
+/// "unknown".
+///
+/// Takes the two guards SEQUENTIALLY, never nested: nesting them would introduce
+/// the tree's only two-lock order between these maps for no benefit.
+fn retain_swept_paths(live: &HashSet<String>) {
+    {
+        let mut snapshot = git_status_snapshot()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        snapshot.retain(|path, _| live.contains(path));
+    }
+    let mut dirty = last_dirty_map().lock().unwrap_or_else(|e| e.into_inner());
+    dirty.retain(|path, _| live.contains(path));
 }
 
 /// Return whether a successful porcelain header confirms that `HEAD` is reachable
@@ -194,10 +292,15 @@ pub(crate) fn parse_status_porcelain_branch(stdout: &str) -> Option<GitStatus> {
 /// ceiling env, the other did not. Both writers must compute `dirty` identically or the
 /// badge flickers, and duplicating the parse is how that guarantee gets lost.
 ///
-/// Each caller keeps its OWN timeout wrapper. That is required, not stylistic: each owns
-/// its per-path counter and log tag (`note_timeout` / `note_discovery_timeout`,
-/// `[GitWatcher]` / `[DiscoveryBranchWatcher]`), and merging them would collapse the two
-/// tags that keep the watchers distinguishable in app.log.
+/// #1298 - one caller now: the global `GitSweeper`, through the single
+/// `detect_status_with_timeout` free function below, logging under `[GitSweeper]`.
+/// INV-1: that wrapper's `DETECT_TIMEOUT` is the ONLY bound on a sweeper round,
+/// whose worst case is `N * DETECT_TIMEOUT` at concurrency 1. Removing it because
+/// "the loop is sequential now" would let one hung repo (dead share, stale
+/// `index.lock`) freeze freshness for every other repo forever, with no recovery
+/// short of restarting the app. `kill_on_drop(true)` below is part of that
+/// invariant: the timeout is what drops this future, and the drop is what kills
+/// `git.exe`.
 ///
 /// `--no-optional-locks` is LOAD-BEARING, not hygiene. Do not drop it in a cleanup. A
 /// plain `status` takes `.git/index.lock` (a ~13ms window) and rewrites `.git/index`;
@@ -373,15 +476,14 @@ impl GitWatcher {
                 continue;
             }
 
-            // Parallelize per-repo detection (Grinch #16). Each call bounded by 2s
-            // (detect_status_with_timeout). Without join_all, worst-case per poll is
-            // M*N*2s under simultaneous stalls.
-            let statuses: Vec<Option<GitStatus>> = join_all(
-                repos
-                    .iter()
-                    .map(|r| Self::detect_status_with_timeout(&r.source_path)),
-            )
-            .await;
+            // #1298 - pure map reads. This loop no longer spawns `git`: the global
+            // `GitSweeper` is the only polling producer, and this poll consumes its
+            // published snapshot. An unpublished path reads `None`, which is the
+            // same "unknown" a failed detection produced before.
+            let statuses: Vec<Option<GitStatus>> = repos
+                .iter()
+                .map(|r| read_git_status(&r.source_path))
+                .collect();
 
             let refreshed: Vec<SessionRepo> = repos
                 .iter()
@@ -434,38 +536,250 @@ impl GitWatcher {
             }
         }
     }
+}
 
-    /// Detect branch + worktree-dirty via the shared `detect_git_status`, bounded by a
-    /// 2s timeout. On timeout the pending future is dropped; `.kill_on_drop(true)`
-    /// ensures the child `git.exe` is terminated so repeated polls can't leak processes.
-    ///
-    /// #1028 - this wrapper stays private to GitWatcher rather than merging with
-    /// DiscoveryBranchWatcher's: each owns its per-path counter and log tag, and merging
-    /// them would collapse `note_timeout`/`note_discovery_timeout` and the two tags that
-    /// keep the watchers distinguishable in app.log.
-    ///
-    /// Because `timeout` DROPS the future here, `detect_git_status` never returns on this
-    /// path and cannot remember anything itself: the caller applies the dirty hold.
-    async fn detect_status_with_timeout(working_dir: &str) -> Option<GitStatus> {
-        match tokio::time::timeout(DETECT_TIMEOUT, detect_git_status(working_dir)).await {
-            Ok(result) => result,
-            Err(_) => {
-                let n = note_timeout(working_dir);
-                // #280 §3.3 — throttle the per-path WARN. Observed rate is
-                // ~120 timeouts/day/path; logging every one floods app.log.
-                // Log the first sighting (heartbeat) and every 50th
-                // thereafter (still ~2-3 WARN/day/path) — enough signal to
-                // notice persistent slowness without spamming.
-                if n == 1 || n.is_multiple_of(50) {
-                    log::warn!(
-                        "[GitWatcher] detect_git_status timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
-                        working_dir,
-                        DETECT_TIMEOUT.as_secs(),
-                        n
-                    );
-                }
-                None
+/// Detect branch + worktree-dirty via the shared `detect_git_status`, bounded by a
+/// 2s timeout. On timeout the pending future is dropped; `.kill_on_drop(true)`
+/// ensures the child `git.exe` is terminated so repeated polls can't leak processes.
+///
+/// #1298 - was one of two per-watcher methods. It is now the sweeper's single
+/// wrapper, and its `DETECT_TIMEOUT` is INV-1: see `detect_git_status` above for
+/// why it must survive any later cleanup.
+///
+/// Because `timeout` DROPS the future here, `detect_git_status` never returns on this
+/// path and cannot remember anything itself: the caller applies the dirty hold.
+async fn detect_status_with_timeout(working_dir: &str) -> Option<GitStatus> {
+    match tokio::time::timeout(DETECT_TIMEOUT, detect_git_status(working_dir)).await {
+        Ok(result) => result,
+        Err(_) => {
+            let n = note_timeout(working_dir);
+            // #280 §3.3 — throttle the per-path WARN. Observed rate is
+            // ~120 timeouts/day/path; logging every one floods app.log.
+            // Log the first sighting (heartbeat) and every 50th
+            // thereafter (still ~2-3 WARN/day/path) — enough signal to
+            // notice persistent slowness without spamming.
+            if n == 1 || n.is_multiple_of(50) {
+                log::warn!(
+                    "[GitSweeper] detect_git_status timed out for {} (>{}s); occurrence={} (logging 1st + every 50th)",
+                    working_dir,
+                    DETECT_TIMEOUT.as_secs(),
+                    n
+                );
             }
+            None
+        }
+    }
+}
+
+/// #1298 - read-site clamp for the two sweeper dials. See plan D1: clamping here
+/// rather than in `validate_and_repair_settings` is what lets a hand edit of
+/// `settings.json` take effect without a restart, and what stops the app from
+/// rewriting the user's file.
+fn sweep_dials(cfg: &AppSettings) -> (usize, Duration) {
+    let concurrency = cfg
+        .git_sweep_concurrency
+        .clamp(SWEEP_MIN_CONCURRENCY, SWEEP_MAX_CONCURRENCY);
+    let interval_secs = cfg
+        .git_sweep_min_interval_secs
+        .clamp(SWEEP_MIN_INTERVAL_SECS, SWEEP_MAX_INTERVAL_SECS);
+
+    if concurrency != cfg.git_sweep_concurrency {
+        log::debug!(
+            "[GitSweeper] gitSweepConcurrency {} clamped to {}",
+            cfg.git_sweep_concurrency,
+            concurrency
+        );
+    }
+    if interval_secs != cfg.git_sweep_min_interval_secs {
+        log::debug!(
+            "[GitSweeper] gitSweepMinIntervalSecs {} clamped to {}",
+            cfg.git_sweep_min_interval_secs,
+            interval_secs
+        );
+    }
+
+    (concurrency as usize, Duration::from_secs(interval_secs))
+}
+
+/// #1298 - the sweeper's work list: the UNION of the discovery replicas and the
+/// live sessions, deduplicated by EXACT path string (INV-3, no normalization),
+/// with archived projects dropped (D2), sorted for a deterministic round order.
+/// `archived_roots` are already normalized.
+///
+/// INV-7: neither half may be dropped. Discovery alone misses sessions in
+/// workgroups whose project is not in `settings.projectPaths`; sessions alone
+/// lose dormant replicas, which is `DiscoveryBranchWatcher`'s reason to exist.
+///
+/// Sorting is not cosmetic: at concurrency 1 the order decides who waits behind a
+/// hung repo, so a deterministic order makes that reproducible. Consequence worth
+/// knowing before reading a log: the alphabetically first path sits permanently at
+/// the head of every round. That pattern is expected, not a bug.
+fn build_work_list(
+    discovery: Vec<String>,
+    sessions: Vec<String>,
+    archived_roots: &[String],
+) -> Vec<String> {
+    let mut paths: Vec<String> = discovery
+        .into_iter()
+        .chain(sessions)
+        .filter(|p| {
+            !crate::config::sessions_persistence::is_under_normalized_archived_roots(
+                p,
+                archived_roots,
+            )
+        })
+        .collect::<HashSet<String>>()
+        .into_iter()
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// #1298 - the single global POLLING producer of per-repo git state. Both watchers
+/// read the snapshot it publishes instead of spawning `git` themselves.
+///
+/// Takes `SettingsState` rather than an `AppHandle` on purpose: the sweeper emits
+/// nothing, so it must not acquire a Tauri transport dependency it does not need.
+/// It unifies DETECTION, not EMISSION (INV-4): the two watchers keep their own
+/// events, keys, cadences and emission gates.
+pub struct GitSweeper {
+    session_manager: Arc<tokio::sync::RwLock<SessionManager>>,
+    settings: crate::config::settings::SettingsState,
+}
+
+impl GitSweeper {
+    pub fn new(
+        session_manager: Arc<tokio::sync::RwLock<SessionManager>>,
+        settings: crate::config::settings::SettingsState,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            session_manager,
+            settings,
+        })
+    }
+
+    /// A dedicated thread owning its own runtime, like `GitWatcher::start`, so the
+    /// sweep never competes with the Tauri runtime that serves the UI. NOT the same
+    /// runtime FLAVOUR: `Runtime::new()` builds one worker per core (24 on the
+    /// machine in #1298) and production already runs four such runtimes, so a fifth
+    /// to drive a loop whose design point is doing one thing at a time is
+    /// indefensible. One worker is sufficient by construction: `buffer_unordered`
+    /// needs concurrency, not parallelism; the work is process spawning and I/O, and
+    /// `enable_all()` installs the I/O and time drivers a current-thread runtime
+    /// needs; and `spawn_blocking` runs on the separate blocking pool regardless.
+    ///
+    /// The round itself sits inside the shutdown `select!`. Without it, worst-case
+    /// shutdown latency would be `N * DETECT_TIMEOUT`. Cancelling mid-round drops
+    /// the in-flight detection, and `kill_on_drop` terminates its `git.exe`.
+    pub fn start(self: &Arc<Self>, shutdown: crate::shutdown::ShutdownSignal) {
+        let sweeper = Arc::clone(self);
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create tokio runtime for GitSweeper");
+            rt.block_on(async move {
+                loop {
+                    // `started` is taken BEFORE the round, which is what makes the
+                    // period max(floor, round duration) and what keeps the first
+                    // round from being delayed (plan D3).
+                    let started = std::time::Instant::now();
+                    let floor = tokio::select! {
+                        biased;
+                        _ = shutdown.token().cancelled() => break,
+                        floor = sweeper.round() => floor,
+                    };
+                    let remaining = floor.saturating_sub(started.elapsed());
+                    tokio::select! {
+                        biased;
+                        _ = shutdown.token().cancelled() => break,
+                        _ = tokio::time::sleep(remaining) => {}
+                    }
+                }
+                log::info!("[GitSweeper] Shutdown signal received, stopping");
+            });
+        });
+    }
+
+    /// One sweep over the whole work list, returning the floor to apply afterwards
+    /// so both dials are read exactly once per round.
+    ///
+    /// An EMPTY round floors at the clamped minimum instead of the configured floor
+    /// (INV-2): a round with no work takes about 0ms, so an unfloored loop would
+    /// spin a core, and a full-length floor would leave the cold start blind for a
+    /// whole interval. Neither floor may be 0.
+    async fn round(&self) -> Duration {
+        let round_started = std::time::Instant::now();
+
+        // The settings read guard must NOT outlive this block: it is a
+        // `tokio::sync::RwLock`, so holding it across an await compiles fine and
+        // would block every `save_settings` write for the whole round.
+        let (concurrency, floor, archived) = {
+            let cfg = self.settings.read().await;
+            let (concurrency, floor) = sweep_dials(&cfg);
+            (concurrency, floor, cfg.archived_project_paths.clone())
+        };
+
+        let sessions: Vec<String> = {
+            let mgr = self.session_manager.read().await;
+            mgr.get_sessions_repos().await
+        }
+        .into_iter()
+        .flat_map(|(_, repos, _)| repos.into_iter().map(|r| r.source_path))
+        .collect();
+
+        let discovery = discovery_repo_paths();
+
+        let archived_roots: Vec<String> = if archived.is_empty() {
+            Vec::new()
+        } else {
+            match tokio::task::spawn_blocking(move || {
+                crate::config::sessions_persistence::normalize_project_roots(&archived)
+            })
+            .await
+            {
+                Ok(roots) => roots,
+                Err(e) => {
+                    // A superset sweep is a freshness cost, never a correctness one.
+                    log::warn!(
+                        "[GitSweeper] archived-root normalization failed ({e}); sweeping without the archive filter this round"
+                    );
+                    Vec::new()
+                }
+            }
+        };
+
+        let paths = build_work_list(discovery, sessions, &archived_roots);
+
+        // `detect_status_with_timeout(p).await` is evaluated as an ARGUMENT, before
+        // `publish_git_status` takes its std guard. Writing it the other way round
+        // would hold a `std::sync::Mutex` guard across an await.
+        futures::stream::iter(paths.iter().map(|p| async move {
+            publish_git_status(p, detect_status_with_timeout(p).await);
+        }))
+        .buffer_unordered(concurrency)
+        .for_each(|_| async {})
+        .await;
+
+        // Defence in depth, and the distinction matters: the tempting justification
+        // (round 1 sweeps an empty list and would wipe everything) is FALSE, since on
+        // round 1 the maps are empty too. Keep the guard anyway, it is free and it
+        // protects a future consumer, but do not defend it with that false mechanism.
+        if !paths.is_empty() {
+            retain_swept_paths(&paths.iter().cloned().collect());
+        }
+
+        log::info!(
+            "[GitSweeper] round: {} path(s), concurrency={}, {}ms",
+            paths.len(),
+            concurrency,
+            round_started.elapsed().as_millis()
+        );
+
+        if paths.is_empty() {
+            Duration::from_secs(SWEEP_MIN_INTERVAL_SECS)
+        } else {
+            floor
         }
     }
 }
@@ -562,6 +876,115 @@ mod tests {
         // Independent counter for a different path.
         assert_eq!(note_timeout(p2), 1);
         assert_eq!(note_timeout(p1), 4);
+    }
+
+    /// #1298 T1 - the read-site clamp, and the executable form of INV-2: no floor
+    /// may be 0, so a configured 0 becomes the 1s minimum rather than a spin.
+    #[test]
+    fn sweep_dials_clamps_both_dials() {
+        let mut cfg = AppSettings::default();
+        assert_eq!(sweep_dials(&cfg), (1, Duration::from_secs(10)));
+
+        cfg.git_sweep_concurrency = 0;
+        cfg.git_sweep_min_interval_secs = 0;
+        assert_eq!(sweep_dials(&cfg), (1, Duration::from_secs(1)));
+
+        cfg.git_sweep_concurrency = 9;
+        cfg.git_sweep_min_interval_secs = 100_000;
+        assert_eq!(sweep_dials(&cfg), (4, Duration::from_secs(3600)));
+    }
+
+    /// #1298 T2 - INV-7 (both halves survive), INV-3 (dedupe by exact string) and
+    /// D2 (archived dropped from BOTH halves, not just the discovery one).
+    #[test]
+    fn build_work_list_unions_dedupes_and_drops_archived() {
+        let archived = crate::config::sessions_persistence::normalize_project_roots(&[
+            "D:/test-1298/archived-project".to_string(),
+        ]);
+        let discovery = vec![
+            "D:/test-1298/live/repo-shared".to_string(),
+            "D:/test-1298/live/repo-dormant".to_string(),
+            "D:/test-1298/archived-project/repo-gone".to_string(),
+        ];
+        let sessions = vec![
+            "D:/test-1298/live/repo-shared".to_string(),
+            "D:/test-1298/unloaded/repo-session-only".to_string(),
+            "D:/test-1298/archived-project/repo-gone".to_string(),
+        ];
+
+        assert_eq!(
+            build_work_list(discovery, sessions, &archived),
+            vec![
+                "D:/test-1298/live/repo-dormant".to_string(),
+                "D:/test-1298/live/repo-shared".to_string(),
+                "D:/test-1298/unloaded/repo-session-only".to_string(),
+            ]
+        );
+    }
+
+    /// #1298 T3 - the snapshot contract, including INV-6: a published `None`
+    /// overwrites a previous `Some`, so `branch` does not hold across a failure.
+    #[test]
+    fn published_git_status_round_trips_and_unknown_paths_read_none() {
+        // Process-global state: unique-per-test path strings, as the
+        // `remember_dirty` and `note_timeout` tests do for the same reason.
+        let path = "/test-1298/snapshot/path-a";
+        assert!(read_git_status("/test-1298/snapshot/never-published").is_none());
+
+        let status = GitStatus {
+            branch: Some("main".to_string()),
+            dirty: true,
+        };
+        publish_git_status(path, Some(status.clone()));
+        assert_eq!(read_git_status(path), Some(status));
+
+        publish_git_status(path, None);
+        assert!(read_git_status(path).is_none());
+    }
+
+    /// #1298 T4 - the executable form of INV-8. The second half of the assertion is
+    /// the whole point: without the `LAST_DIRTY` eviction a dropped path reads
+    /// `None` from the snapshot and its last successful bool from `remember_dirty`,
+    /// i.e. a confident colour sourced from a detection that will never repeat.
+    ///
+    /// `live` spares every key already in the two process-global maps, because the
+    /// `remember_dirty_*` tests share them and run concurrently with this one; the
+    /// retain under test is the one that drops `path-dropped`.
+    #[test]
+    fn retain_swept_paths_evicts_dropped_paths_from_both_maps() {
+        let kept = "/test-1298/retain/path-kept";
+        let dropped = "/test-1298/retain/path-dropped";
+        let status = GitStatus {
+            branch: Some("main".to_string()),
+            dirty: true,
+        };
+
+        publish_git_status(kept, Some(status.clone()));
+        publish_git_status(dropped, Some(status));
+        assert_eq!(remember_dirty(kept, Some(true)), Some(true));
+        assert_eq!(remember_dirty(dropped, Some(true)), Some(true));
+
+        let mut live: HashSet<String> = git_status_snapshot()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .keys()
+            .cloned()
+            .collect();
+        live.extend(
+            last_dirty_map()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .keys()
+                .cloned(),
+        );
+        live.remove(dropped);
+
+        retain_swept_paths(&live);
+
+        assert!(read_git_status(kept).is_some());
+        assert_eq!(remember_dirty(kept, None), Some(true));
+        assert!(read_git_status(dropped).is_none());
+        assert_eq!(remember_dirty(dropped, None), None);
     }
 
     // --- #1078: cached-origin parser semantics ---

--- a/src/shared/testing/ui-harness.tsx
+++ b/src/shared/testing/ui-harness.tsx
@@ -156,6 +156,8 @@ export function baseSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     agentTemplatesPath: null,
     themeLight: false,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -608,6 +608,8 @@ export interface AppSettings {
   railCollapsedProjects?: string[];
   railFavoritesCollapsed?: boolean;
   specBoardEnabled: boolean;
+  gitSweepConcurrency: number;
+  gitSweepMinIntervalSecs: number;
   resourceMonitorEnabled: boolean;
   maxConcurrentAgentProcesses: number;
   resourceWatchdogAction: ResourceWatchdogAction;

--- a/src/sidebar/components/AgentPickerModal.test.tsx
+++ b/src/sidebar/components/AgentPickerModal.test.tsx
@@ -160,6 +160,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
+++ b/src/sidebar/components/CodingAgentQuickConfiguration.test.ts
@@ -99,6 +99,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/sidebar/components/OnboardingModal.test.ts
+++ b/src/sidebar/components/OnboardingModal.test.ts
@@ -100,6 +100,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -136,6 +136,8 @@ function settings(overrides: Partial<AppSettings> = {}): SettingsSnapshot {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/sidebar/components/SettingsModal.test.ts
+++ b/src/sidebar/components/SettingsModal.test.ts
@@ -61,6 +61,8 @@ function settings(overrides: Partial<AppSettings>): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",

--- a/src/sidebar/components/settings-save.test.ts
+++ b/src/sidebar/components/settings-save.test.ts
@@ -75,6 +75,8 @@ function settings(overrides: Partial<AppSettings> = {}): AppSettings {
     autoGenerateTaskTitle: true,
     agentTemplatesPath: null,
     specBoardEnabled: false,
+    gitSweepConcurrency: 1,
+    gitSweepMinIntervalSecs: 10,
     resourceMonitorEnabled: true,
     maxConcurrentAgentProcesses: 3,
     resourceWatchdogAction: "warn",


### PR DESCRIPTION
Closes #1298

Two independent defects that produced the same visible symptom — a frozen window that Windows never flags as unresponsive — fixed through different mechanisms.

## Fix 1 — non-blocking branch detection (`fe18e10`)

`detect_git_branch_sync` spawned `git rev-parse` through `std::process::Command`: blocking, no timeout, on the async body of two Tauri commands. Async runtimes are cooperative, so a task only yields at an `await` and blocking code contains none — the worker was held for the entire process spawn, and a hung `git` held it indefinitely.

Now `detect_repo_branch`, async via `tokio::process`, with its own `BRANCH_DETECT_TIMEOUT`, `kill_on_drop(true)` and `CREATE_NO_WINDOW`. Arguments, parsing and return semantics unchanged.

## Fix 2 — one global sequential sweeper (`09beb49`, `e88c5a3`, `6390c3e`)

`GitWatcher` and `DiscoveryBranchWatcher` each walked their own list and detected per replica and per session. Every replica of a workgroup declares the same repo paths and nothing deduplicated by path, so discovery issued ~177 spawns per round across 21 distinct directories — an ~8x amplification that matched the reported 6.5 spawns/s.

A single `GitSweeper` now owns the question "what is the git state of this repo path":

- Work list = union of discovery replicas and session repos, deduplicated by canonical path, archived projects filtered.
- One repo at a time on a dedicated `new_current_thread` runtime, `buffer_unordered(concurrency)`.
- `gitSweepConcurrency` (default 1, clamped 1..=4) and `gitSweepMinIntervalSecs` (default 10, clamped 1..=3600) in `settings.json`, no UI, mirrored in the TypeScript `AppSettings`. Both require a restart.
- The floor applies per round, not per repo, and can never be 0: an empty round would otherwise spin a core.
- Both existing watchers stop spawning `git` and read the published snapshot. They keep emitting `session_git_repos` and `ac_discovery_branch_updated` with their own keys and cadences, so no frontend behavior changes.

The two watchers deliberately remain separate emitters: their payloads are keyed by `sessionId` and `replicaPath`, and the path-to-{sessions, replicas} mapping is one-to-many.

## Invariants

Eight named invariants, each with its failure mode. Two worth calling out:

- **`DETECT_TIMEOUT` is preserved.** With concurrency 1 it is the only bound on a round (`N * DETECT_TIMEOUT`). Removing it because "the loop is now sequential" would let one hung repo freeze freshness for every other repo permanently.
- **Snapshot and `remember_dirty` are evicted together.** Filtering the work list without evicting both would leave a dropped path serving its last known-good `dirty` forever — a confidently wrong answer, which is the failure mode this module is written to prevent. Covered by a test that asserts both halves.

## Review history

The originally reported root cause was refuted with code evidence: both poll loops are strictly sequential and reschedule on completion, so no unbounded queue can form, and the 2 s timeout does kill the child (`kill_on_drop`, with 8/8 orphaned `index.lock` already measured in-tree). Two further hypotheses were tested and rejected — `--untracked-files` walking `target/`, and the timeout abandoning the future.

Grinch review returned FAIL on the first pass: the work list was built with a blocking `fs::canonicalize` per path on the async body, which broke the `DETECT_TIMEOUT` bound and was uncancellable at shutdown. That defect originated in the plan, which specified the split and asserted the function was pure. READY was invalidated, the plan was amended and recertified with a new digest, and `6390c3e` moves the whole build onto the blocking pool and inverts filter/dedupe. Second pass: PASS.

## Verification

- `cargo test`: 3590 passed, 0 failed. `cargo clippy --all-targets -- -D warnings`: exit 0. `cargo fmt --check`: exit 0.
- `npm run typecheck` green; `npm test` 1519 tests green.
- Dependency-cycle gate, re-run independently by the reviewer with the arc record regenerated from the tree and byte-identical to the committed one: `cyclicSccs` 1 → 1, same 86-member cyclic SCC with identical member sets, exactly 2 arcs added and 0 removed, both internal to the pre-existing SCC, 0 arcs crossing a previously-clean boundary. The sweeper lives in `git_watcher.rs` rather than a new module because a new module would have grown that SCC to 87.
- Built from this branch and deployed for real-app testing; the user confirmed the freeze is gone. The formal §12.6 acceptance checklist was not executed item by item — the confirmation is the user's hands-on run, not the scripted list.

## Known follow-ups, not in this branch

- A third blocking `git` producer exists at `config/session_context.rs:1674` (`git branch --show-current`, no timeout, no `kill_on_drop`, once per repo at session creation). N sessions starting in parallel give N concurrent spawns, which is the best remaining candidate for the reported peak of 18 concurrent `git.exe` — a peak that exceeds what either poll loop can structurally produce and remains unattributed. The three commands are distinguishable by argv, so attribution costs nothing to settle.
- Two plan-text inconsistencies found in review: §12.7.a states "no third call site" while the normative sketch three lines above writes one (the property it protects holds — that site passes an empty root list and short-circuits without syscalls), and §12.6.a became unobservable at the default log level after the empty-round line moved to `debug!`.
