### PR TITLE
chore: remove 6 dead clippy allow attributes (refs #1304)

### DIFF
--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1104,7 +1104,6 @@ pub(crate) async fn preview_coding_agent_profile_selection_inner(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn apply_coding_agent_profile_selection(
     app: AppHandle,

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -2810,7 +2810,6 @@ pub async fn create_team(
 /// Create a workgroup from an existing team.
 /// Clones repos async — partial failures are reported but don't rollback the WG.
 // Tauri command: State<> injections push us over clippy's 7-arg threshold.
-#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn create_workgroup(
     app: AppHandle,

--- a/src-tauri/src/config/seed_manifest.rs
+++ b/src-tauri/src/config/seed_manifest.rs
@@ -3541,7 +3541,6 @@ fn log_record_failure(scope: &str, error: &SeedManifestError) {
 
 #[cfg(test)]
 // The shared test module deliberately precedes the cfg-gated Windows implementation it exercises.
-#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1370,7 +1370,6 @@ pub(crate) const FRESH_IDLE_GUARD: std::time::Duration = std::time::Duration::fr
 /// - `activity_age >= settle` (`idle_threshold + FRESH_IDLE_GUARD`): long-idle -
 ///   InjectNow (no added latency for a genuinely-ready wake).
 /// - otherwise (the `[idle_threshold, settle)` fresh-idle window): Wait.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn live_settle_action(
     activity_age: Option<std::time::Duration>,
     last_resize_age: Option<std::time::Duration>,
@@ -17426,7 +17425,6 @@ mod tests {
         (session.id, session.token)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn build_self_switch_message(
         cwd: &Path,
         msg_id: &str,

--- a/src-tauri/src/pty/docker_runtime.rs
+++ b/src-tauri/src/pty/docker_runtime.rs
@@ -979,7 +979,6 @@ impl DockerRuntime {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn run_command_output_with_context(
         &self,
         spec: DockerCommandSpec,


### PR DESCRIPTION
Removes the 6 dead `#[allow(clippy::...)]` attributes (lint never fires at those sites, verified with clippy 1.97 `--force-warn`): 5x `too_many_arguments` + 1x `items_after_test_module` across 5 files.

Closes #1304

Review: grinch PASS (pending/final on CI). Non-visual change, no shipper build.