### PR TITLE
fix: move activity log checkbox below Log level hint (refs #1306)

### DIFF
--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -2397,6 +2397,11 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
             <option value="trace">Trace</option>
           </select>
         </label>
+        <div class="settings-hint">
+          Controls AgentsCommander log verbosity (applies immediately, no
+          restart). Higher levels are noisier. The RUST_LOG env var, if set,
+          overrides this until restart.
+        </div>
         <label class="settings-checkbox-field">
           <input
             type="checkbox"
@@ -2414,11 +2419,6 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
           />
           <span>Record activity log (activity.jsonl)</span>
         </label>
-        <div class="settings-hint">
-          Controls AgentsCommander log verbosity (applies immediately, no
-          restart). Higher levels are noisier. The RUST_LOG env var, if set,
-          overrides this until restart.
-        </div>
         <div
           class="settings-hint"
           data-ac-testid="settings.general.activityLogEnabled.hint"


### PR DESCRIPTION
Moves the "Record activity log" checkbox below the Log level hint in Settings → Logging (it was rendered between the select and its hint).

- One file, mechanical block move (5+/5-): `src/sidebar/components/SettingsModal.tsx`
- Final order: Log level select → Log level hint → activity log checkbox → activity log hint
- No logic/testid/copy changes; branch updated with `origin/main` (`d08c0ee`, merge ort, no conflicts)
- Verified: tsc, vitest (1520), grinch focused review PASS

Closes #1306
