### PR TITLE
docs: add in-code comment convention (refs #1307)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,3 +118,8 @@ Filter expressions follow standard `env_logger` syntax (e.g. `info,agentscommand
 ⚠️ **Caveat — malformed filters silently suppress agentscommander logs.** If the value does not parse as a valid env_logger filter (e.g., typo, unrecognized level keyword, single `:` instead of `::`), no matching directives are produced for `agentscommander*` targets and all `agentscommander*` logs are suppressed at runtime. Verify your filter once with `RUST_LOG=<filter> agentscommander_mb.exe` from a terminal before persisting it in `settings.json`. This is the same behavior the binary had pre-#93 for malformed `RUST_LOG` values — Phase 1 of #93 does not change this.
 
 Phase 2 of #93 (if shipped) will surface this in the sidebar UI; Phase 3 (if shipped) will move to live reload via `tracing-subscriber`.
+
+## In-code comments
+
+When you add or update source comments, follow the
+[in-code comment convention](docs/in-code-comments.md).

--- a/docs/in-code-comments.md
+++ b/docs/in-code-comments.md
@@ -1,0 +1,20 @@
+# In-code comment convention
+
+Use this page when you add or update comments in hand-authored source, test, or fixture code.
+
+## Scope
+
+Apply rules 1-3 in every language and rules 4-7 only in Rust. Change generated or vendored comments at their source instead of editing generated output. Treat comment-like text inside documentation examples as documentation.
+
+## Rules for every language
+
+1. **Comment only non-inferable information.** Record rationale, a contract, a constraint, or a correctness fact that is expensive to infer from nearby code. Do not narrate syntax or visible control flow, and do not comment self-explanatory code.
+2. **Put local correctness information next to the relevant code.** Use the language's native comment syntax for design rationale, a safety proof such as Rust `// SAFETY:`, a concurrency invariant, a wire or input-format fact, or a sequencing constraint. Explain why a tempting alternative is wrong when that distinction matters.
+3. **Keep history and comments current.** Delete commented-out code because version control retains it. When a behavior change invalidates a comment, update or remove that comment in the same change. Prefer removal over a claim you cannot keep accurate.
+
+## Rust rules
+
+4. **Attach documentation to its subject.** Use `///` on an item instead of a floating `//` when the text documents that item. Use `//!` only for crate-level or module-level documentation.
+5. **Bound the summary and avoid redundant restatement.** Start a doc comment with at most one concise summary sentence or noun phrase, then spend words on relevant Why, How-to-use, and Property information. Do not repeat facts already clear from the signature or body. Name a parameter when you document non-inferable units, valid ranges, sentinel values, ownership, escaping, platform behavior, or another externally relevant semantic contract.
+6. **Make standard sections earn their cost.** Add `# Errors`, `# Panics`, and `# Safety` only when they state externally relevant, non-inferable conditions or obligations; do not add boilerplate or empty headings. For a public, deterministic, setup-light API with a non-obvious protocol, add a minimal runnable `# Examples` doctest. For a private, `pub(crate)`, runtime-bound, or OS-bound API that cannot use a self-contained doctest, document the protocol precisely in prose and cover the behavior with the nearest unit or integration test. Do not omit a necessary protocol because a runnable doctest is impractical, and do not copy a large test setup into the doc comment.
+7. **Keep module docs contractual when present.** State the module's responsibility in a module-level `//!` comment. Add only invariants and call-graph or call-order relationships that exist, matter, and are non-obvious. Do not inventory every item or invent a relationship to fill a template.


### PR DESCRIPTION
Adds the repository's first in-code comment convention as a documentation page, plus a pointer from the contribution guide.

## What changed

- `docs/in-code-comments.md` (new) — the sole authoritative body of the convention. Three rules that apply to hand-authored comments in every language, and four Rust-only rules.
- `CONTRIBUTING.md` — appends a five-line `## In-code comments` pointer. Base content is byte-for-byte unchanged.

25 insertions, 0 deletions, 2 files.

## Why

The repository had no in-code comment convention anywhere. `docs/style-guide.md` governs documentation prose; `CONTRIBUTING.md` covered branch naming and enforcement. Meanwhile 8.8% of Rust lines and 15.5% of Rust tokens are comments, produced with no shared rule.

The rules follow the empirical evidence on what comments are worth their token cost: doc comments are internalized far more reliably than inline comments by code models; comments improve automated bug-fixing accuracy substantially; and restating a signature is the least informative thing a comment can do, since tags are markedly more predictable from the code than free-form prose. So the page spends its words on the non-inferable intents — Why, How-to-use, and Property — and caps the What at one line.

## Placement

An earlier revision placed the convention in a root `AGENTS.md` with `CLAUDE.md` / `GEMINI.md` import adapters, to reach coding agents automatically. A six-cell clean-session load probe measured that assumption and disproved it: with the repository root as launch cwd both Codex and Claude load the file correctly, but in the normal workgroup topology — session cwd in the agent directory, repository a sibling — neither sees it. The automatic-delivery objective was withdrawn as a result, and the convention was placed in `docs/` where it belongs. The contribution-guide pointer is the human discovery path.

## Review

- **architect** — authored and certified the plan across four rounds, including two acceptance-harness corrections and a full audit of the guard's comparator and enumeration semantics.
- **dev-rust** — enriched the plan with five objections on rule workability, then implemented. It refused the first implementation attempt on a genuine plan contradiction and escalated rather than improvising.
- **dev-rust-grinch** — Standards PASS and Spec PASS on the shipped diff, with byte-exact verification of both files against the plan. Filed and then cleared blocking findings against the acceptance harness itself.
- **ac-cli-tester** — ran the load probe that reversed the placement decision.

Non-visual change; no shipper build applies.

Closes #1307
