### PR TITLE
feat(1313): warn when Default Shell is not a complete executable path, refs #1313

### DIFF
--- a/src/sidebar/components/SettingsModal.default-shell.test.tsx
+++ b/src/sidebar/components/SettingsModal.default-shell.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import SettingsModal, { isPlausibleCompleteExecutablePath } from "./SettingsModal";
+import { FakeTransport } from "../../shared/testing/fake-transport";
+import {
+  baseSettings,
+  installBrowserDomStubs,
+  renderWithFakeTransport,
+  resetUiStoresForTests,
+  waitFor,
+} from "../../shared/testing/ui-harness";
+
+// #1313 — the Default Shell field warns (informational red banner) while its
+// value is not a plausible complete executable path, i.e. it contains no
+// directory separator. The check is a pure shape heuristic: no filesystem
+// access, no platform sniffing, and it never blocks saving.
+
+describe("isPlausibleCompleteExecutablePath (#1313)", () => {
+  it.each([
+    // Bare names: no directory separator -> not a complete path.
+    ["powershell.exe", false],
+    ["pwsh", false],
+    ["Powershell.Exe", false],
+    ["C:foo.exe", false],
+    // Empty / whitespace-only: claims no executable -> no warning.
+    ["", true],
+    ["   ", true],
+    // Anything containing a separator is plausible and exempt.
+    ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", true],
+    ["\\\\server\\share\\pwsh.exe", true],
+    ["%SystemRoot%\\System32\\cmd.exe", true],
+    ["/bin/bash", true],
+    ["~/bin/zsh", true],
+  ])("returns %j for %j", (value, expected) => {
+    expect(isPlausibleCompleteExecutablePath(value)).toBe(expected);
+  });
+});
+
+describe("SettingsModal Default Shell warning (#1313)", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installBrowserDomStubs();
+    resetUiStoresForTests();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+    resetUiStoresForTests();
+    document.body.replaceChildren();
+  });
+
+  function byTestId<T extends Element = Element>(root: HTMLElement, testId: string): T | null {
+    return root.querySelector<T>(`[data-ac-testid="${testId}"]`);
+  }
+
+  function renderShell() {
+    const fake = new FakeTransport();
+    fake.resolve("get_settings", baseSettings({ defaultShell: "powershell.exe" }));
+    fake.resolve("get_web_server_status", false);
+    fake.resolve("get_coding_agent_catalog", []);
+    fake.resolve("list_reseedable_agent_commands", []);
+    return renderWithFakeTransport(() => <SettingsModal section="general" onClose={() => {}} />, fake);
+  }
+
+  it("warns for a bare name while typing, never blocks save, and clears for a complete path", async () => {
+    const r = renderShell();
+    try {
+      await waitFor(() => expect(byTestId(r.root, "settings.general.defaultShell")).toBeTruthy());
+
+      const input = byTestId<HTMLInputElement>(r.root, "settings.general.defaultShell")!;
+      expect(input.closest("label.settings-field")?.querySelector(".settings-label")?.textContent).toBe(
+        "Default Shell (Complete path)"
+      );
+
+      // Bare "powershell.exe" (factory default on Windows): banner visible.
+      expect(byTestId(r.root, "settings.general.defaultShell.warning")).toBeTruthy();
+
+      // Informational only: save stays enabled.
+      const save = byTestId<HTMLButtonElement>(r.root, "settings.save")!;
+      expect(save.disabled).toBe(false);
+
+      // Typing a complete path clears the banner live, without saving.
+      input.value = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      await waitFor(() => expect(byTestId(r.root, "settings.general.defaultShell.warning")).toBeNull());
+
+      // Typing back to the bare name brings the banner back, live.
+      const input2 = byTestId<HTMLInputElement>(r.root, "settings.general.defaultShell")!;
+      input2.value = "powershell.exe";
+      input2.dispatchEvent(new Event("input", { bubbles: true }));
+      await waitFor(() => expect(byTestId(r.root, "settings.general.defaultShell.warning")).toBeTruthy());
+    } finally {
+      r.cleanup();
+    }
+  });
+});

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -117,6 +117,16 @@ const API_CLIENT_EXPIRY_MS: Record<Exclude<ApiClientExpiryOption, "default">, nu
 const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err);
 
+/** #1313 - shape-only check: a plausible complete executable path must contain
+ *  a directory separator (`\` or `/`). Bare names like `powershell.exe` or
+ *  `pwsh` warn; anything with a separator is the user's responsibility from
+ *  there on. Empty/whitespace-only values do not warn (an empty field claims
+ *  no executable). Never consult the filesystem. */
+export function isPlausibleCompleteExecutablePath(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed === "" || trimmed.includes("/") || trimmed.includes("\\");
+}
+
 const TERMINAL_SNAPSHOT_SETTING_CONFLICT = "terminal_snapshot_setting_conflict";
 const TERMINAL_SNAPSHOT_CONFLICT_MESSAGE =
   "Terminal snapshots changed in another settings window. The current value was reloaded.";
@@ -1750,13 +1760,23 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       <div class="settings-section">
         <div class="settings-section-title">Shell</div>
         <label class="settings-field">
-          <span class="settings-label">Default Shell</span>
+          <span class="settings-label">Default Shell (Complete path)</span>
           <input
             class="settings-input"
             value={settings.data!.defaultShell}
             onInput={(e) => updateField("defaultShell", e.currentTarget.value)}
+            data-ac-testid="settings.general.defaultShell"
           />
         </label>
+        <Show when={!isPlausibleCompleteExecutablePath(settings.data?.defaultShell ?? "")}>
+          <div
+            class="settings-hint settings-hint-error"
+            data-ac-testid="settings.general.defaultShell.warning"
+          >
+            Not a complete executable path. Enter the complete path to the shell executable,
+            for example C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe.
+          </div>
+        </Show>
         <label class="settings-field">
           <span class="settings-label">Shell Arguments</span>
           <input

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -3216,6 +3216,18 @@ html.light-theme .settings-hint-warning {
   color: #b45309;
 }
 
+/* Red variant of the settings hint (#1313): clearly stronger than the amber
+   .settings-hint-warning. Reuses the base .settings-hint layout; colors match
+   the existing .settings-api-client-error precedent (#f87171 dark, #b91c1c
+   light), with the same per-theme override convention as the warning variant. */
+.settings-hint-error {
+  color: #f87171;
+}
+
+html.light-theme .settings-hint-error {
+  color: #b91c1c;
+}
+
 /* Empty state */
 .empty-state {
   display: flex;


### PR DESCRIPTION
Closes #1313

## Change
- Settings > General > Shell: label renamed `Default Shell` -> `Default Shell (Complete path)`.
- Live red banner under the field when the value is not a plausible complete executable path (e.g. bare `powershell.exe`). Shape-only heuristic (must contain a directory separator); banner informs, never blocks saving.
- New `.settings-hint-error` CSS (dark #f87171 / light #b91c1c, matching the `.settings-api-client-error` precedent).
- New component test: 11-row heuristic table + wiring test (label, banner live transitions, Save enabled).

## Review
- Lite path: architect plan `plans/1313-default-shell-complete-path-warning.md` certified READY (Plan-SHA256 66B702D1...).
- dev-rust implemented (commit 5e640f4); Grinch review PASS, no defects.
- Tests: new test 12/12, full modal suite 664/664, typecheck clean.
- Shipper final build: N/A yet - pending post-merge deploy (Step 11).