### PR TITLE
chore(1323): updateCommands as ordered sequence of full commands

### DIFF
--- a/src-tauri/resources/coding-agents/agents.default.json
+++ b/src-tauri/resources/coding-agents/agents.default.json
@@ -12,7 +12,7 @@
       "isolatedHome": false,
       "configSeed": { "enabled": true, "dest": ".claude" },
       "removable": true,
-      "updateCommands": ["claude", "--update"]
+      "updateCommands": ["claude --update"]
     },
     {
       "key": "codex",

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -101,11 +101,15 @@ pub struct CodingAgentDefinition {
     /// deletable.
     #[serde(default = "default_true")]
     pub removable: bool,
-    /// #1318 - per-agent update-command sequence seeded by AC and executed to
-    /// install a new agent version, e.g. `["claude", "--update"]`. If a vendor
-    /// changes its update command, updates stop working until a new release or
-    /// the user edits the seeded file. Empty = no update command (agent cannot
-    /// auto-update). Consumed by the follow-up update-check feature only.
+    /// #1318/#1323 - per-agent update-command sequence seeded by AC: an ORDERED
+    /// array of COMPLETE command strings, each executed sequentially
+    /// (updateCommands[0], then [1], ...) to install a new agent version, e.g.
+    /// `["claude --update"]` or `["claude --update", "npm i -g @scope/cli"]`.
+    /// NOT argv tokens: each element is one full shell command passed as-is,
+    /// in array order. If a vendor changes its update command, updates stop
+    /// working until a new release or the user edits the seeded file. Empty =
+    /// no update command (agent cannot auto-update). Consumed by the
+    /// follow-up update-check feature only.
     #[serde(default)]
     pub update_commands: Vec<String>,
     /// #1318 - stable catalog default for auto-update. Newly registered agents
@@ -1753,12 +1757,12 @@ mod tests {
         assert!(!loaded[0].auto_update);
 
         let mut def = loaded[0].clone();
-        def.update_commands = vec!["claude".to_string(), "--update".to_string()];
+        def.update_commands = vec!["claude --update".to_string()];
         def.auto_update = true;
         let round = serde_json::to_value(&def).expect("serialize def");
         assert_eq!(
             round["updateCommands"],
-            serde_json::json!(["claude", "--update"])
+            serde_json::json!(["claude --update"])
         );
         assert_eq!(round["autoUpdate"], serde_json::json!(true));
     }
@@ -1776,10 +1780,7 @@ mod tests {
                 def.key
             );
             if def.key == "claude" {
-                assert_eq!(
-                    def.update_commands,
-                    vec!["claude".to_string(), "--update".to_string()]
-                );
+                assert_eq!(def.update_commands, vec!["claude --update".to_string()]);
             } else {
                 assert!(
                     def.update_commands.is_empty(),

--- a/src-tauri/tests/cli_project_registration.rs
+++ b/src-tauri/tests/cli_project_registration.rs
@@ -655,7 +655,7 @@ fn new_project_seeds_catalog_into_ac() {
         .expect("claude entry");
     assert_eq!(
         claude["updateCommands"],
-        serde_json::json!(["claude", "--update"]),
+        serde_json::json!(["claude --update"]),
         "claude carries its update command in the seeded file"
     );
     // Masters seeded per built-in dest.

--- a/src/shared/agent-presets.test.ts
+++ b/src/shared/agent-presets.test.ts
@@ -59,7 +59,7 @@ describe("FALLBACK_CODING_AGENTS drift guard (#769)", () => {
     for (const def of FALLBACK_CODING_AGENTS) {
       expect(def.autoUpdate).toBe(false);
       if (def.key === "claude") {
-        expect(def.updateCommands).toEqual(["claude", "--update"]);
+        expect(def.updateCommands).toEqual(["claude --update"]);
       } else {
         expect(def.updateCommands).toEqual([]);
       }

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -13,7 +13,7 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
     removable: true,
     // #1318 - mirror of the embedded default: only claude ships the update
     // command; every entry defaults autoUpdate to false.
-    updateCommands: ["claude", "--update"],
+    updateCommands: ["claude --update"],
     autoUpdate: false,
   },
   {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -490,7 +490,11 @@ export interface CodingAgentDefinition {
   isolatedHome: boolean;
   configSeed?: ConfigSeedConfig;
   removable: boolean;
-  /** #1318 - per-agent update-command sequence seeded by AC (e.g. ["claude", "--update"]). Empty = no update command. Inert until the follow-up update-check feature reads it. */
+  /** #1318/#1323 - per-agent update-command sequence seeded by AC: an ORDERED
+   * array of COMPLETE command strings, each executed sequentially (e.g.
+   * ["claude --update"] or ["claude --update", "npm i -g @scope/cli"]).
+   * NOT argv tokens. Empty = no update command. Inert until the follow-up
+   * update-check feature reads it. */
   updateCommands: string[];
   /** #1318 - stable catalog default for auto-update; the per-user choice lives in AppSettings.agentAutoUpdate / agentUpdateDontAskAgain. Inert until the follow-up feature reads it. */
   autoUpdate: boolean;


### PR DESCRIPTION
## Summary

`updateCommands` is an ordered sequence of **complete command strings**, each executed sequentially (`updateCommands[0]` → `[1]` → ...), not argv tokens. Fixes the semantics shipped in #1318 before any consumer relies on it.

- Embedded default: claude `updateCommands` → `["claude --update"]`
- Mirrored in `src/shared/agent-presets.ts` + drift-guard test
- Field docs rewritten (Rust `coding_agents_catalog.rs` + `src/shared/types.ts`): ordered / complete commands / sequential / NOT argv, with multi-step example
- Integration test expectation updated (`cli_project_registration.rs`)

Closes #1323

## Verification

- Lite pipeline: architect plan certified (Plan-SHA256 `B073363DE060D44839A31360885C08659CA6B32AFBF96A0294E10B3258FE2D02`), dev-rust implementation (2 commits), grinch review PASS after integration-test fix loop.
- `cargo test --test cli_project_registration` 14/14; `cargo test --lib config::coding_agents_catalog` 33/33; clippy clean; `npm run typecheck` exit 0; vitest 6/6.
- Zero stale `["claude", "--update"]` in `src-tauri/src`, `src/shared`, `src-tauri/tests`.
- Shipper build: N/A — non-visual (data + docs only).
