### PR TITLE
chore(1325): seed pi and codex updateCommands

### DIFF
--- a/src-tauri/resources/coding-agents/agents.default.json
+++ b/src-tauri/resources/coding-agents/agents.default.json
@@ -24,7 +24,8 @@
       "envs": [],
       "isolatedHome": false,
       "configSeed": { "enabled": true, "dest": ".codex" },
-      "removable": true
+      "removable": true,
+      "updateCommands": ["codex update"]
     },
     {
       "key": "hermes",
@@ -57,7 +58,8 @@
       "instructionsFilename": "AGENTS.md",
       "envs": [],
       "isolatedHome": false,
-      "removable": true
+      "removable": true,
+      "updateCommands": ["pi update"]
     },
     {
       "key": "opencode",

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -1768,9 +1768,10 @@ mod tests {
     }
 
     #[test]
-    fn embedded_default_ships_claude_update_command_only() {
-        // #1318 drift guard: only claude ships the update command; the other
-        // five ship none; every entry defaults autoUpdate to false.
+    fn embedded_default_ships_claude_pi_and_codex_update_commands() {
+        // #1318/#1325 drift guard: claude, pi, and codex ship the update
+        // command; the other three ship none; every entry defaults autoUpdate
+        // to false.
         let catalog = embedded_default_catalog();
         assert_eq!(catalog.agents.len(), 6);
         for def in &catalog.agents {
@@ -1781,6 +1782,10 @@ mod tests {
             );
             if def.key == "claude" {
                 assert_eq!(def.update_commands, vec!["claude --update".to_string()]);
+            } else if def.key == "pi" {
+                assert_eq!(def.update_commands, vec!["pi update".to_string()]);
+            } else if def.key == "codex" {
+                assert_eq!(def.update_commands, vec!["codex update".to_string()]);
             } else {
                 assert!(
                     def.update_commands.is_empty(),

--- a/src/shared/agent-presets.test.ts
+++ b/src/shared/agent-presets.test.ts
@@ -55,11 +55,15 @@ describe("FALLBACK_CODING_AGENTS drift guard (#769)", () => {
     }
   });
 
-  it("#1318: only claude ships an update command; every entry defaults autoUpdate off", () => {
+  it("#1318/#1325: claude, pi, and codex ship update commands; every entry defaults autoUpdate off", () => {
     for (const def of FALLBACK_CODING_AGENTS) {
       expect(def.autoUpdate).toBe(false);
       if (def.key === "claude") {
         expect(def.updateCommands).toEqual(["claude --update"]);
+      } else if (def.key === "pi") {
+        expect(def.updateCommands).toEqual(["pi update"]);
+      } else if (def.key === "codex") {
+        expect(def.updateCommands).toEqual(["codex update"]);
       } else {
         expect(def.updateCommands).toEqual([]);
       }

--- a/src/shared/agent-presets.ts
+++ b/src/shared/agent-presets.ts
@@ -11,8 +11,8 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
     envs: [],
     isolatedHome: false,
     removable: true,
-    // #1318 - mirror of the embedded default: only claude ships the update
-    // command; every entry defaults autoUpdate to false.
+    // #1318/#1325 - mirror of the embedded default: claude, pi, and codex
+    // ship the update command; every entry defaults autoUpdate to false.
     updateCommands: ["claude --update"],
     autoUpdate: false,
   },
@@ -26,7 +26,7 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
     envs: [],
     isolatedHome: false,
     removable: true,
-    updateCommands: [],
+    updateCommands: ["codex update"],
     autoUpdate: false,
   },
   {
@@ -65,7 +65,7 @@ export const FALLBACK_CODING_AGENTS: CodingAgentDefinition[] = [
     envs: [],
     isolatedHome: false,
     removable: true,
-    updateCommands: [],
+    updateCommands: ["pi update"],
     autoUpdate: false,
   },
   {


### PR DESCRIPTION
## Summary

Seed `updateCommands` for the pi and codex coding agents (claude already shipped in #1318; semantics from #1323).

- **pi** (`@earendil-works/pi-coding-agent`, bin `pi`): `["pi update"]` — documented self-update subcommand (verified in earendil-works/pi README).
- **codex** (`@openai/codex`): `["codex update"]` — official `Update` subcommand "Update Codex to the latest version" (verified in openai/codex `codex-rs/cli/src/main.rs:162`); resolves install method (npm/brew/standalone) and runs the matching update.
- Mirrored in TS presets + drift guards (FE + Rust). Claude untouched; hermes/cursor/opencode stay without update commands. Integration test untouched (pins only claude).

Closes #1325

## Verification

- Lite pipeline: architect plan certified (Plan-SHA256 `28FE51AE4AEFFAB9AF41E4AF9D6AC2CA4B277E6280B16CC673F41445CCCEAAB8`), dev-rust implementation (`fde0cad9`), grinch review PASS (AC1-AC9 first-hand).
- vitest 6/6; `cargo test --lib config::coding_agents_catalog` 33/33; typecheck exit 0; stale-pin grep exactly 8 lines; `git diff --check` clean.
- Shipper build: N/A — non-visual (data values only).
