### PR TITLE
chore(rust): refresh module arc record (#1334)

### DIFF
--- a/src-tauri/module-arcs.txt
+++ b/src-tauri/module-arcs.txt
@@ -302,6 +302,9 @@ agentscommander_lib::cli::terminal_snapshot -> agentscommander_lib::config::root
 agentscommander_lib::cli::terminal_snapshot -> agentscommander_lib::config::teams
 agentscommander_lib::cli::terminal_snapshot -> agentscommander_lib::path_identity
 agentscommander_lib::cli::terminal_snapshot -> agentscommander_lib::phone::terminal_snapshot
+agentscommander_lib::cli::window_list -> agentscommander_lib
+agentscommander_lib::cli::window_screenshot -> agentscommander_lib::api
+agentscommander_lib::cli::window_screenshot -> agentscommander_lib::screenshot
 agentscommander_lib::cli::workgroup -> agentscommander_lib
 agentscommander_lib::cli::workgroup -> agentscommander_lib::cli::create_agent_matrix
 agentscommander_lib::cli::workgroup -> agentscommander_lib::cli::session_safety


### PR DESCRIPTION
## Summary
- refresh the canonical Rust module arc record for the CLI window modules
- add exactly the three source-derived arcs required by the current graph
- unblock the structural acceptance gate for #1330

## Verification
- canonical generator self-test: 42 passed
- levelizer self-test: 52 passed, 0 failed
- independent graph reduction: 1,007 arcs, zero mismatches
- parent/main vs tip: zero SCC, rank, level, provenance, or sccSize drift
- implementation review: PASS, 0 findings
- Step 9.5 merge review: PASS, 0 findings
- visual gate: N/A - non-visual change

Plan: `plans/1334-refresh-module-arcs.md`
Plan SHA-256: `D3EAE2CFBF67AD6A7F1D492FD820F51DEEC1E0D09F609EEC4B1A756AAABEB6B7`

Closes #1334