### PR TITLE
feat(1342): per-agent auto-update dropdown in the Coding Agent profile

### DIFF
--- a/src/sidebar/components/SettingsModal.automation.test.ts
+++ b/src/sidebar/components/SettingsModal.automation.test.ts
@@ -2239,4 +2239,143 @@ describe("SettingsModal automation hooks", () => {
 
     dispose();
   });
+
+  it("renders the Auto-update dropdown under Command with default No and the shared-command note", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const select = byTestId<HTMLSelectElement>("settings.agentRow.0.autoUpdate");
+    // absent map entry -> default No, and nothing is written until the user changes it
+    expect(select.value).toBe("no");
+    expect(select.querySelector('option[value="yes"]')).toBeTruthy();
+    expect(select.querySelector('option[value="no"]')).toBeTruthy();
+    expect(byTestId("settings.agentRow.0.autoUpdate.note").textContent).toContain(
+      "Applies to every Coding Agent using this command.",
+    );
+
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+    // untouched absent key stays absent: first-time prompt behavior unchanged
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agentAutoUpdateByCommand).toEqual({});
+
+    dispose();
+  });
+
+  it("round-trips the Auto-update dropdown through save: Yes writes true, No writes false (key retained)", async () => {
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const select = byTestId<HTMLSelectElement>("settings.agentRow.0.autoUpdate");
+    select.value = "yes";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    let saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agentAutoUpdateByCommand).toEqual({ codex: true });
+
+    select.value = "no";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[1]?.[0];
+    // false is the stable "off": the key is written, never deleted (deleting it
+    // would resurrect the first-time prompt, absent = never asked, #1327).
+    expect(saved?.agentAutoUpdateByCommand).toEqual({ codex: false });
+
+    dispose();
+  });
+
+  it("shows No for a previously answered No and lets the user flip it to Yes", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agentAutoUpdateByCommand: { codex: false }, // #1327 prompt answered No
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    const select = byTestId<HTMLSelectElement>("settings.agentRow.0.autoUpdate");
+    expect(select.value).toBe("no");
+    select.value = "yes";
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agentAutoUpdateByCommand).toEqual({ codex: true });
+
+    dispose();
+  });
+
+  it("disables Auto-update until a command is set and shares the value across agents using the same command", async () => {
+    vi.mocked(SettingsAPI.get).mockResolvedValueOnce(settings({
+      agents: [
+        { id: "blank", label: "Blank", command: "", color: "#10b981", envs: [], isolatedHome: false },
+        { id: "codex-a", label: "Codex A", command: "codex", color: "#10b981", envs: [], isolatedHome: false },
+        { id: "codex-b", label: "Codex B", command: "codex", color: "#d97706", envs: [], isolatedHome: false },
+      ],
+    }));
+    const root = document.createElement("div");
+    document.body.append(root);
+    const dispose = render(
+      () => SettingsModal({ onClose: () => {}, section: "agents" }),
+      root,
+    );
+    await settle();
+    expandAgentRow(0);
+    await settle();
+
+    // no command yet: writing an empty-string key would be junk, so it is disabled
+    expect(byTestId<HTMLSelectElement>("settings.agentRow.0.autoUpdate").disabled).toBe(true);
+
+    // two agents share "codex": both selects read the SAME map entry. Row
+    // expansion is single-exclusive (one activeAgentId, SettingsModal.tsx:990,
+    // :2611), so the shared entry is verified sequentially: expand row 1, read
+    // its select ("no") and flip it to Yes, then expand row 2 (row 1 collapses)
+    // and read the same shared entry through row 2's select ("yes").
+    expandAgentRow(1);
+    await settle();
+    const a = byTestId<HTMLSelectElement>("settings.agentRow.1.autoUpdate");
+    expect(a.value).toBe("no");
+    a.value = "yes";
+    a.dispatchEvent(new Event("change", { bubbles: true }));
+    await settle();
+
+    expandAgentRow(2);
+    await settle();
+    const b = byTestId<HTMLSelectElement>("settings.agentRow.2.autoUpdate");
+    expect(b.value).toBe("yes");
+    byTestId<HTMLButtonElement>("settings.save").click();
+    await settle();
+
+    const saved = vi.mocked(SettingsAPI.saveDraft).mock.calls[0]?.[0];
+    expect(saved?.agentAutoUpdateByCommand).toEqual({ codex: true });
+
+    dispose();
+  });
 });

--- a/src/sidebar/components/SettingsModal.tsx
+++ b/src/sidebar/components/SettingsModal.tsx
@@ -1202,6 +1202,17 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
     });
   };
 
+  const setAgentAutoUpdate = (index: number, enabled: boolean) => {
+    if (!settings.data) return;
+    const command = settings.data.agents[index]?.command;
+    if (!command) return; // never write an empty-string key
+    setDraftDirty(true);
+    setSettings("data", "agentAutoUpdateByCommand", (map) => ({
+      ...(map ?? {}),
+      [command]: enabled,
+    }));
+  };
+
   const updateAgentEnv = (
     agentIndex: number,
     rowIndex: number,
@@ -2612,6 +2623,8 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
       }
     };
     const agentBackendKind = () => agent.backend?.kind ?? "localProcess";
+    const autoUpdateEnabled = () =>
+      settings.data?.agentAutoUpdateByCommand[agent.command] ?? false;
     const containerImageMissing = () => !agent.backend?.image?.trim();
     const containerBindWarning = () => isContainerLoopbackBind(settings.data?.apiServerBind);
     return (
@@ -2719,6 +2732,29 @@ const SettingsModal: Component<{ onClose: () => void; section?: string }> = (pro
                 data-ac-role="textbox"
               />
             </label>
+            <label class="settings-field">
+              <span class="settings-label">Auto-update</span>
+              <select
+                class="settings-input"
+                value={autoUpdateEnabled() ? "yes" : "no"}
+                onChange={(e) => setAgentAutoUpdate(i(), e.currentTarget.value === "yes")}
+                disabled={!agent.command.trim()}
+                title={agent.command.trim() ? undefined : "Set the Coding Agent command first"}
+                data-ac-testid={`settings.agentRow.${i()}.autoUpdate`}
+                data-ac-role="combobox"
+                data-ac-state={autoUpdateEnabled() ? "yes" : "no"}
+              >
+                <option value="yes">Yes</option>
+                <option value="no">No</option>
+              </select>
+            </label>
+            <div
+              class="settings-label-hint"
+              data-ac-testid={`settings.agentRow.${i()}.autoUpdate.note`}
+              data-ac-role="status"
+            >
+              Applies to every Coding Agent using this command.
+            </div>
             <label class="settings-field">
               <span class="settings-label">Runtime</span>
               <select


### PR DESCRIPTION
## Summary

Per-agent "Auto-update" dropdown (Yes/No, default No) in the Coding Agent profile editor (Settings → Coding Agents), just below the Command field, as originally requested.

- Select writes `AppSettings.agentAutoUpdateByCommand[command]`: Yes → true, No → false; **never deletes keys** (deleting would resurrect the first-time prompt — #1327 semantics preserved).
- Inline note: "Applies to every Coding Agent using this command." (map is command-keyed; shared commands share the entry).
- Disabled when the command is blank; absent map entry renders "No" but writes nothing until the user changes the select (first-time prompt still fires).
- No backend change (map + semantics shipped in #1327); 4 new tests (T1-T4) incl. the amended sequential shared-entry test (single-exclusive row expansion in `renderAgentRow`).

Closes #1342

## Verification

- Lite pipeline: architect plan certified twice (final Plan-SHA256 `A2D6F66A881789F360A8CACD71D8EB679E6BABF35B5F054344AE92692297CFBB` after T4 amendment), dev-rust implementation `76884517` (2 files, +175), grinch review PASS (paths traced: draft → save → settings.rs key space, no prompt regression).
- `npm run typecheck` exit 0; vitest SettingsModal.automation 51/51; `npm run check:frontend-dependencies` PASS; fixture sweep = 7 factories unchanged; cargo check clean.
