### PR TITLE
feat(sidebar): give Coordinator Quick-Access its own collapsible section (refs #1351)

### DIFF
--- a/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
+++ b/src/sidebar/components/ProjectPanel.collapse-state.test.tsx
@@ -296,4 +296,30 @@ describe("ProjectPanel collapse state", () => {
       rendered.cleanup();
     }
   });
+
+  // #1351 - the coordinator strip is now a real section: header, count, collapse.
+  it("renders the Coordinators header with a count and collapses its rows", async () => {
+    const fake = new FakeTransport();
+    fake.resolve("new_project", { path: projectPath, registered: true, created: false });
+    fake.resolve("discover_project", projectDiscovery("Stable task title"));
+
+    const rendered = renderWithFakeTransport(() => <ProjectPanel />, fake);
+    try {
+      await projectStore.createAndLoad(projectPath);
+      const quickRow = '[data-ac-testid="replica.row.quick.wg-2-dev-team.dev-webpage-ui"]';
+      await waitFor(() => expect(rendered.root.querySelector(quickRow)).not.toBeNull());
+
+      const header = headerByName(rendered.root, "Coordinators");
+      expect(header.querySelector(".ac-team-count")?.textContent?.trim()).toBe("1");
+      expect(headerCollapsed(header)).toBe(false);
+
+      click(header);
+      await waitFor(() => {
+        expect(headerCollapsed(headerByName(rendered.root, "Coordinators"))).toBe(true);
+        expect(rendered.root.querySelector(quickRow)).toBeNull();
+      });
+    } finally {
+      rendered.cleanup();
+    }
+  });
 });

--- a/src/sidebar/components/ProjectPanel.tsx
+++ b/src/sidebar/components/ProjectPanel.tsx
@@ -1748,6 +1748,7 @@ const ProjectPanel: Component = () => {
 
         const hasTeams = () => proj.teams.length > 0;
         const projectAutomationId = () => automationIdPart(proj.path);
+        const coordinatorsCollapsedKey = projectPanelCollapseKey(proj.path, "coordinators");
         const selectedWorkgroupCollapsedKey = projectPanelCollapseKey(proj.path, "selected-workgroup");
         const workgroupsCollapsedKey = projectPanelCollapseKey(proj.path, "workgroups");
         const loopsCollapsedKey = projectPanelCollapseKey(proj.path, "loops");
@@ -2531,19 +2532,35 @@ const ProjectPanel: Component = () => {
 
             <Show when={!isProjectPanelCollapsed(proj.path)}>
               <div class="project-content">
-                {/* Coordinator Quick-Access — shown by styles that enable it via CSS */}
+                {/* Coordinators — own collapsible section; shown by styles that enable it via CSS */}
                 {(() => {
                   return (
                     <Show when={filteredCoordinatorItems().length > 0}>
-                      <div class="coord-quick-access">
-                        <For each={filteredCoordinatorItems()}>
-                          {(item) => {
-                            const runningPeers = createMemo(() =>
-                              runningCoordinatorPeers(item.wg, item.replica)
-                            );
-                            return renderReplicaItem(item.replica, item.wg, item.wg.name, runningPeers, item.wg.taskTitle, "quick");
-                          }}
-                        </For>
+                      <div class="coord-quick-access-group">
+                        <div
+                          class="ac-wg-header ac-wg-header--collapsible"
+                          onClick={() => togglePanelCollapsed(coordinatorsCollapsedKey)}
+                        >
+                          <span class="ac-discovery-chevron" classList={{ collapsed: isPanelCollapsed(coordinatorsCollapsedKey) }}>
+                            &#x25BE;
+                          </span>
+                          <div class="ac-wg-header-text">
+                            <span class="ac-wg-name">Coordinators</span>
+                          </div>
+                          <span class="ac-team-count">{filteredCoordinatorItems().length}</span>
+                        </div>
+                        <Show when={!isPanelCollapsed(coordinatorsCollapsedKey)}>
+                          <div class="coord-quick-access">
+                            <For each={filteredCoordinatorItems()}>
+                              {(item) => {
+                                const runningPeers = createMemo(() =>
+                                  runningCoordinatorPeers(item.wg, item.replica)
+                                );
+                                return renderReplicaItem(item.replica, item.wg, item.wg.name, runningPeers, item.wg.taskTitle, "quick");
+                              }}
+                            </For>
+                          </div>
+                        </Show>
                       </div>
                     </Show>
                   );

--- a/src/sidebar/stores/project-collapse.ts
+++ b/src/sidebar/stores/project-collapse.ts
@@ -5,6 +5,7 @@ export const PROJECT_PANEL_COLLAPSE_KEY_SEP = "\u0000";
 
 export type ProjectPanelCollapseSection =
   | "project"
+  | "coordinators"
   | "selected-workgroup"
   | "workgroups"
   | "workgroup"

--- a/src/sidebar/styles/coord-quick-access-css.test.ts
+++ b/src/sidebar/styles/coord-quick-access-css.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// #1351 - the coordinator section now carries a REAL header inside
+// .coord-quick-access-group. jsdom never applies this stylesheet, so the bytes on
+// disk are the only place the visibility gate can be pinned. If the gate slides
+// back onto the inner .coord-quick-access strip, the header stays visible in every
+// style that hides the strip and each of them grows an orphan header.
+const CSS = readFileSync(new URL("./sidebar.css", import.meta.url), "utf8");
+
+describe("coordinator quick-access section CSS", () => {
+  it("gates the whole section, header included, on the group wrapper", () => {
+    expect(CSS).toMatch(/\.coord-quick-access-group\s*\{\s*display:\s*none;\s*\}/);
+    // No rule may target the inner strip as a whole element again.
+    expect(CSS).not.toMatch(/\.coord-quick-access\s*\{/);
+  });
+
+  it("paints no CSS pseudo-title now that the section has a real header", () => {
+    expect(CSS).not.toMatch(/\.coord-quick-access(-group)?::before\s*\{/);
+  });
+});

--- a/src/sidebar/styles/coord-quick-access-css.test.ts
+++ b/src/sidebar/styles/coord-quick-access-css.test.ts
@@ -8,6 +8,58 @@ import { describe, expect, it } from "vitest";
 // style that hides the strip and each of them grows an orphan header.
 const CSS = readFileSync(new URL("./sidebar.css", import.meta.url), "utf8");
 
+// #1351 amend — the header's computed style is identical outside .ac-wg-group, but its
+// POSITION comes from the container's box. Revision 1 only checked the former, so the
+// section shipped 6px to the left of its siblings in the user's own sidebar style. The
+// left inset is pinned here, computed from the bytes on disk, for every enabling style.
+const ENABLING_STYLES = ["noir-minimal", "arctic-ops", "deep-space", "obsidian-mesh", "neon-circuit"];
+
+function ruleBody(style: string, className: string): string {
+  const re = new RegExp(`^\\[data-sidebar-style="${style}"\\] \\.${className} \\{([^}]*)\\}`, "m");
+  const match = CSS.match(re);
+  if (!match) throw new Error(`missing rule: [data-sidebar-style="${style}"] .${className}`);
+  return match[1];
+}
+
+function declarations(body: string): Array<[string, string]> {
+  return body
+    .split(";")
+    .map((d) => d.trim())
+    .filter((d) => d.includes(":"))
+    .map((d) => [
+      d.slice(0, d.indexOf(":")).trim(),
+      d.slice(d.indexOf(":") + 1).trim().replace(/\s+/g, " "),
+    ]);
+}
+
+// Left side of a 1-to-4 value margin/padding shorthand.
+const leftOf = (parts: string[]): string =>
+  parts.length >= 4 ? parts[3] : parts.length >= 2 ? parts[1] : parts[0];
+
+// margin-left + border-left-width + padding-left, in px. Later declarations win,
+// mirroring the cascade inside a single rule body.
+function leftInset(body: string): number {
+  let margin = 0;
+  let border = 0;
+  let padding = 0;
+  for (const [prop, value] of declarations(body)) {
+    const parts = value.split(" ");
+    if (prop === "margin") margin = Number.parseFloat(leftOf(parts));
+    else if (prop === "margin-left") margin = Number.parseFloat(parts[0]);
+    else if (prop === "padding") padding = Number.parseFloat(leftOf(parts));
+    else if (prop === "padding-left") padding = Number.parseFloat(parts[0]);
+    else if (prop === "border" || prop === "border-left") border = Number.parseFloat(parts[0]);
+    else if (prop === "border-left-width") border = Number.parseFloat(parts[0]);
+  }
+  return margin + border + padding;
+}
+
+function declValue(body: string, prop: string): string | undefined {
+  let found: string | undefined;
+  for (const [p, v] of declarations(body)) if (p === prop) found = v;
+  return found;
+}
+
 describe("coordinator quick-access section CSS", () => {
   it("gates the whole section, header included, on the group wrapper", () => {
     expect(CSS).toMatch(/\.coord-quick-access-group\s*\{\s*display:\s*none;\s*\}/);
@@ -17,5 +69,16 @@ describe("coordinator quick-access section CSS", () => {
 
   it("paints no CSS pseudo-title now that the section has a real header", () => {
     expect(CSS).not.toMatch(/\.coord-quick-access(-group)?::before\s*\{/);
+  });
+
+  it("starts on the same column as its sibling sections in every enabling style", () => {
+    for (const style of ENABLING_STYLES) {
+      const sister = ruleBody(style, "ac-wg-group");
+      const group = ruleBody(style, "coord-quick-access-group");
+      expect(leftInset(group), `${style}: left inset`).toBe(leftInset(sister));
+      expect(declValue(group, "border-top"), `${style}: separator`).toBe(
+        declValue(sister, "border-top")
+      );
+    }
   });
 });

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -6171,7 +6171,7 @@ html.light-theme .ac-discovery-badge.running-peer {
   padding-left: calc(var(--spacing-md) + 20px);
 }
 
-[data-sidebar-style="noir-minimal"] .coord-quick-access {
+[data-sidebar-style="noir-minimal"] .coord-quick-access-group {
   display: block;
   margin: 4px 6px 2px;
   padding: 4px 0;
@@ -6771,7 +6771,7 @@ html.light-theme[data-sidebar-style="arctic-ops"] .replica-item.active {
   box-shadow: 0 0 6px rgba(100, 180, 255, 0.5);
 }
 
-[data-sidebar-style="arctic-ops"] .coord-quick-access {
+[data-sidebar-style="arctic-ops"] .coord-quick-access-group {
   display: block;
   margin: 4px 6px 2px;
   padding: 4px 0;
@@ -6780,7 +6780,7 @@ html.light-theme[data-sidebar-style="arctic-ops"] .replica-item.active {
   border-radius: 6px;
 }
 
-html.light-theme[data-sidebar-style="arctic-ops"] .coord-quick-access {
+html.light-theme[data-sidebar-style="arctic-ops"] .coord-quick-access-group {
   background: rgba(100, 160, 220, 0.08);
   border-color: rgba(100, 160, 220, 0.2);
 }
@@ -7269,11 +7269,15 @@ html.light-theme[data-sidebar-style="neon-circuit"] .replica-item.active {
 
 /* =============================================================================
    COORDINATOR QUICK-ACCESS SECTION
-   Hidden by default. Styles that want coordinator-first layout enable it
-   via display override. Shows coordinators pulled out of workgroup nesting.
+   #1351 — the section is a real collapsible section: .coord-quick-access-group
+   wraps the ac-wg-header and the .coord-quick-access row list. The visibility
+   gate lives on the GROUP, never on the inner strip: if it slid back onto the
+   strip, the header would stay visible in every style that hides the strip and
+   each of them would grow an orphan header. Hidden by default; the five styles
+   that want coordinator-first layout override display on the group.
    ============================================================================= */
 
-.coord-quick-access {
+.coord-quick-access-group {
   display: none;
 }
 
@@ -7337,7 +7341,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access .replic
 
 /* ---- Deep Space: coordinator quick-access enabled ---- */
 
-[data-sidebar-style="deep-space"] .coord-quick-access {
+[data-sidebar-style="deep-space"] .coord-quick-access-group {
   display: block;
   margin: 4px 6px 2px;
   padding: 4px 0;
@@ -7351,17 +7355,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access .replic
   overflow: hidden;
 }
 
-[data-sidebar-style="deep-space"] .coord-quick-access::before {
-  content: "COORDINATORS";
-  display: block;
-  padding: 3px 12px 5px;
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.15em;
-  color: rgba(255, 180, 40, 0.5);
-}
-
-html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access {
+html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access-group {
   background: linear-gradient(
     135deg,
     rgba(255, 180, 40, 0.06) 0%,
@@ -7370,13 +7364,9 @@ html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access {
   border-color: rgba(200, 140, 20, 0.15);
 }
 
-html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access::before {
-  color: rgba(160, 100, 10, 0.5);
-}
-
 /* ---- Obsidian Mesh: coordinator quick-access enabled ---- */
 
-[data-sidebar-style="obsidian-mesh"] .coord-quick-access {
+[data-sidebar-style="obsidian-mesh"] .coord-quick-access-group {
   display: block;
   margin: 2px 0;
   padding: 2px 0;
@@ -7384,24 +7374,14 @@ html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access::before {
   background: rgba(255, 80, 40, 0.03);
 }
 
-[data-sidebar-style="obsidian-mesh"] .coord-quick-access::before {
-  content: "COORD";
-  display: block;
-  padding: 2px 10px 3px;
-  font-size: 8px;
-  font-weight: 800;
-  letter-spacing: 0.2em;
-  color: rgba(255, 100, 40, 0.45);
-}
-
-html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access {
+html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access-group {
   border-left-color: rgba(200, 80, 20, 0.25);
   background: rgba(200, 100, 20, 0.04);
 }
 
 /* ---- Neon Circuit: coordinator quick-access enabled ---- */
 
-[data-sidebar-style="neon-circuit"] .coord-quick-access {
+[data-sidebar-style="neon-circuit"] .coord-quick-access-group {
   display: block;
   margin: 4px 6px 2px;
   padding: 4px 0;
@@ -7411,18 +7391,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access {
   overflow: hidden;
 }
 
-[data-sidebar-style="neon-circuit"] .coord-quick-access::before {
-  content: "COORD";
-  display: block;
-  padding: 2px 10px 4px;
-  font-size: 8px;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  color: rgba(255, 0, 180, 0.45);
-  font-family: var(--font-mono);
-}
-
-[data-sidebar-style="neon-circuit"] .coord-quick-access::after {
+[data-sidebar-style="neon-circuit"] .coord-quick-access-group::after {
   content: "";
   position: absolute;
   top: 0;
@@ -7437,7 +7406,7 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access {
   );
 }
 
-html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access {
+html.light-theme[data-sidebar-style="neon-circuit"] .coord-quick-access-group {
   border-color: rgba(200, 0, 140, 0.12);
 }
 

--- a/src/sidebar/styles/sidebar.css
+++ b/src/sidebar/styles/sidebar.css
@@ -6171,9 +6171,14 @@ html.light-theme .ac-discovery-badge.running-peer {
   padding-left: calc(var(--spacing-md) + 20px);
 }
 
+/* #1351 — box geometry mirrors [data-sidebar-style="noir-minimal"] .ac-wg-group:
+   the same 12px left inset and the same 1px separator, so the Coordinators header
+   lines up with its sibling section headers instead of sitting 6px to their left.
+   margin-right drops to 0 so the separator spans the same width as theirs. */
 [data-sidebar-style="noir-minimal"] .coord-quick-access-group {
   display: block;
-  margin: 4px 6px 2px;
+  margin: 4px 0 2px 12px;
+  border-top: 1px solid var(--sidebar-border);
   padding: 4px 0;
 }
 
@@ -7369,7 +7374,7 @@ html.light-theme[data-sidebar-style="deep-space"] .coord-quick-access-group {
 [data-sidebar-style="obsidian-mesh"] .coord-quick-access-group {
   display: block;
   margin: 2px 0;
-  padding: 2px 0;
+  padding: 2px 0 2px 6px;
   border-left: 3px solid rgba(255, 100, 40, 0.3);
   background: rgba(255, 80, 40, 0.03);
 }
@@ -7381,10 +7386,13 @@ html.light-theme[data-sidebar-style="obsidian-mesh"] .coord-quick-access-group {
 
 /* ---- Neon Circuit: coordinator quick-access enabled ---- */
 
+/* #1351 — 6px margin + 1px border + 7px padding = the 14px left inset of
+   [data-sidebar-style="neon-circuit"] .ac-wg-group (4 + 2 + 8), so the header
+   lines up with its siblings. The frame keeps its own 6px right margin. */
 [data-sidebar-style="neon-circuit"] .coord-quick-access-group {
   display: block;
   margin: 4px 6px 2px;
-  padding: 4px 0;
+  padding: 4px 0 4px 7px;
   border: 1px solid rgba(255, 0, 180, 0.1);
   border-radius: 4px;
   position: relative;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,8 +5,9 @@ declare module "*.png" {
   export default src;
 }
 
-/* #1167 - node:fs for static source guards ONLY (today: the one in
-   src/sidebar/styles/agent-badge-css.test.ts, which has to read real stylesheet
+/* #1167 - node:fs for static source guards ONLY (today: the ones in
+   src/sidebar/styles/agent-badge-css.test.ts and
+   src/sidebar/styles/coord-quick-access-css.test.ts, which have to read real stylesheet
    bytes because Vitest replaces every CSS module with `export default ""` unless
    test.css is enabled). @types/node is deliberately not a dependency of this
    frontend, so the single function that guard needs is declared here, next to the


### PR DESCRIPTION
Closes #1351

## What changed

The Coordinator Quick-Access strip at the top of the project panel was a bare `<div>` with no section header, no collapse chevron and no count, while every sibling block (`Selected Workgroup`, `Workgroups`, `Loops`, `Agents`, `Teams`) had all three. It now gets a real collapsible section header labelled `Coordinators`, with a chevron and a count of the coordinators currently listed.

- New wrapper `.coord-quick-access-group` holds the header plus the existing `.coord-quick-access` row list. The per-sidebar-style `display` gate moved from the strip to the wrapper, so the header is hidden in exactly the styles that hide the strip — no orphan headers.
- New collapse key `projectPanelCollapseKey(proj.path, "coordinators")`; the section starts expanded.
- The CSS `::before` pseudo-titles (`COORDINATORS` / `COORD`) in `deep-space`, `obsidian-mesh` and `neon-circuit` are gone, now that there is a real header. The `neon-circuit` `::after` scan line is preserved.
- The wrapper's left inset and separator now match `.ac-wg-group` in every enabling style, so the `Coordinators` header lines up with its siblings.

Visibility gating is unchanged: the strip stays hidden by default and is still enabled only by `noir-minimal`, `arctic-ops`, `deep-space`, `obsidian-mesh` and `neon-circuit`. Coordinator inclusion, ordering, `coordSortByActivity`, the anti-jump order stabilization and the group/text filters are untouched, as is `rowContext "quick"` and every `replica.row.quick.*` test id.

## Review

Planned and certified by the architect, implemented by dev-webpage-ui, reviewed adversarially by dev-rust-grinch.

The first review round returned FAIL: the new header sat 6px left of its siblings in `noir-minimal` (also the fallback style) and lacked their `border-top` separator, with the same misalignment in `obsidian-mesh` and `neon-circuit`. The plan was amended and recertified, and the fix aligns the wrapper's box geometry with `.ac-wg-group` in those three styles. The second round returned PASS, with the reviewer measuring `margin-left + border-left-width + padding-left` per style: 12/7/7/9/14, each identical to its sibling.

That class of defect had slipped through because the acceptance criteria covering it were manual visual checks that nobody could execute. They were replaced with a GUI-free byte-level test that pins the invariant; run against the pre-fix commit it fails on all three broken styles, confirmed independently by the reviewer.

## Verification

- `npm run typecheck` — exit 0
- `npm test` — 157 files / 1598 tests passed, exit 0
- `coord-quick-access-css.test.ts` — 3 tests passed, none skipped
- Branch merged with `origin/main` (`a91b629`), no conflicts; reviewer confirmed blob-level that both #1351 and #1347 came through intact and ruled out an evil merge

No files under `src-tauri/` are touched, so the dependency-cycle criteria are unchanged by construction.

## Known follow-up (non-blocking)

The reviewer logged two latent blind spots in the new CSS test's parser: it reads a single rule per style (geometry added later in a `html.light-theme` or `:last-child` variant would pass unnoticed) and it ignores units (`6px` and `6rem` compare equal). Neither is a defect today — every rule involved uses px with no `!important`, and no other rule in the cascade contributes left geometry.