### PR TITLE
fix(pty): require rendered content, not just idle, in the cold-spawn wake settle (refs #1388)

### DIFF
--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -1323,8 +1323,11 @@ pub(crate) fn is_viable_root_recipient(status: &SessionStatus, has_pty: bool) ->
 /// `idle_since` (the instant the session was first seen continuously idle, or
 /// `None` if it is currently busy / has not yet been observed idle) and returns
 /// the next `idle_since` plus whether idle has now held for `settle`:
-/// - busy (`waiting_for_input == false`) resets the clock to `None`: a late
-///   startup render restarts the settle window.
+/// - not ready (`waiting_for_input == false`) resets the clock to `None`: a late
+///   startup render restarts the settle window. #1388: the cold-spawn caller now
+///   passes the composed `wake_settle_ready`, so `false` also means "idle with a
+///   blank screen", and the reset makes the settle window measure idle-AND-rendered
+///   held continuously.
 /// - idle starts (or keeps) the clock; once `now - idle_since >= settle` the
 ///   caller may inject.
 pub(crate) fn next_sustained_idle_state(
@@ -1458,21 +1461,38 @@ pub(crate) enum LiveWakeRoute {
     Established,
 }
 
+/// #1388 - the readiness input for the cold-spawn wake settle.
+///
+/// Idle ALONE is satisfied by a child that has painted nothing: `IdleDetector`
+/// seeds activity at spawn (`idle_detector.rs:128-145`) and the watcher flips a
+/// silent session idle after `idle_threshold`, so a stalled start satisfies an
+/// idle-only gate FASTER than a healthy one. Requiring a rendered cell as well
+/// closes that. Both conditions are re-evaluated every tick and fed to
+/// `next_sustained_idle_state`, which resets the clock when this returns false,
+/// so the settle window measures idle-AND-rendered held continuously - not two
+/// conditions that were each true at some point.
+pub(crate) fn wake_settle_ready(
+    waiting_for_input: bool,
+    has_rendered_visible_content: bool,
+) -> bool {
+    waiting_for_input && has_rendered_visible_content
+}
+
 /// (#1001 PR2 / B) Pure per-tick decision for the COLD-SPAWN settle loop, so the
 /// sustained-idle + inject-anyway-cap policy is unit-testable without timers. The
-/// cold-spawn path gates on `SessionManager.waiting_for_input` (a freshly spawned
+/// cold-spawn path gates on the composed `wake_settle_ready` (#1388: idle AND
+/// rendered, not `SessionManager.waiting_for_input` alone - a freshly spawned
 /// session has no meaningful `activity_age` during startup churn); the live path
 /// uses `live_settle_action` on real-time `activity_age` instead (grinch P1).
 pub(crate) fn settle_tick(
-    waiting_for_input: bool,
+    ready: bool,
     idle_since: Option<std::time::Instant>,
     now: std::time::Instant,
     settle: std::time::Duration,
     elapsed: std::time::Duration,
     max_wait: std::time::Duration,
 ) -> (Option<std::time::Instant>, SettleAction) {
-    let (next_idle_since, settled) =
-        next_sustained_idle_state(waiting_for_input, idle_since, now, settle);
+    let (next_idle_since, settled) = next_sustained_idle_state(ready, idle_since, now, settle);
     if settled {
         return (next_idle_since, SettleAction::InjectNow);
     }
@@ -7603,7 +7623,10 @@ impl MailboxPoller {
     /// (bias-to-deliver). `initial_idle_since` seeds the settle: the live path
     /// credits real idle age so a ready session is not delayed; cold-spawn passes
     /// None. Never drops a delivery: on `max_wait` it injects anyway. Errs only if
-    /// the session was destroyed mid-settle. It reads and decides BEFORE sleeping,
+    /// the session was destroyed mid-settle, or (#1388/E8) has already exited. It
+    /// gates on `wake_settle_ready` (idle AND rendered), not on idle alone, so a
+    /// child that paints nothing no longer settles faster than a healthy one.
+    /// It reads and decides BEFORE sleeping,
     /// so a seeded already-ready session injects with zero added latency; the
     /// cold-spawn sustained-idle requirement is unchanged.
     async fn settle_until_ready<R: tauri::Runtime>(
@@ -7620,12 +7643,36 @@ impl MailboxPoller {
         let mut idle_since = initial_idle_since;
 
         loop {
+            // #1388: first condition, read in its own scope so the std Mutex guard is
+            // dropped before the await below - the guard is not Send, so this is enforced
+            // by the compiler rather than by convention. `try_state` (not `state`) mirrors
+            // the IdleDetector read in `settle_live_before_inject` (:7719): a missing
+            // manager is "no claim", not "not rendered", and must not gate.
+            let rendered = match app.try_state::<Arc<Mutex<PtyManager>>>() {
+                Some(pty_mgr) => match pty_mgr.lock() {
+                    Ok(pty) => pty.has_rendered_visible_content(session_id),
+                    Err(_) => true,
+                },
+                None => true,
+            };
+
             // Read the flag under a short-lived lock; never hold it across the
             // pure decision or the sleep below.
             let waiting = {
                 let mgr = session_mgr.read().await;
                 let sessions = mgr.list_sessions().await;
                 match sessions.iter().find(|s| s.id == session_id.to_string()) {
+                    // #1388/E8: a child that already exited can never satisfy the render
+                    // condition, so without this it would hold the single global delivery
+                    // lane for the full 90s and delay shutdown with it. Treated like the
+                    // vanished case below: stop settling and let the caller's existing
+                    // error path run.
+                    Some(s) if matches!(s.status, SessionStatus::Exited(_)) => {
+                        return Err(format!(
+                            "Session {} exited before message injection",
+                            session_id
+                        ));
+                    }
                     Some(s) => s.waiting_for_input,
                     None => {
                         return Err(format!(
@@ -7635,10 +7682,11 @@ impl MailboxPoller {
                     }
                 }
             };
+            let ready = wake_settle_ready(waiting, rendered);
 
             let was_settling = idle_since.is_some();
             let (next_idle_since, action) = settle_tick(
-                waiting,
+                ready,
                 idle_since,
                 std::time::Instant::now(),
                 settle,
@@ -7651,17 +7699,21 @@ impl MailboxPoller {
                 SettleAction::InjectNow => {
                     if start.elapsed() >= max_wait {
                         log::warn!(
-                            "[mailbox] wake: timeout waiting for session {} to reach sustained idle; injecting anyway",
-                            session_id
+                            "[mailbox] wake: timeout waiting for session {} to reach sustained idle; injecting anyway (waiting_for_input={}, rendered={})",
+                            session_id,
+                            waiting,
+                            rendered
                         );
                     }
                     return Ok(());
                 }
                 SettleAction::Wait => {
-                    if was_settling && !waiting {
+                    if was_settling && !ready {
                         log::info!(
-                            "[mailbox] wake: session {} went busy during settle; re-waiting",
-                            session_id
+                            "[mailbox] wake: session {} left the settle window during settle (waiting_for_input={}, rendered={}); re-waiting",
+                            session_id,
+                            waiting,
+                            rendered
                         );
                     }
                     tokio::time::sleep(poll).await;
@@ -15357,6 +15409,43 @@ mod tests {
             action,
             SettleAction::InjectNow,
             "cap must never drop a delivery"
+        );
+    }
+
+    /// #1388, T1 - the composed readiness input requires BOTH conditions.
+    ///
+    /// The suite's only genuinely new assertion. It does not verify the wiring: the
+    /// composition happens here, in the test, and `settle_tick` is a free function that
+    /// cannot observe what `settle_until_ready` passes it. Criteria C1 and C2 carry that.
+    #[test]
+    fn wake_settle_ready_requires_both() {
+        assert!(wake_settle_ready(true, true));
+        assert!(!wake_settle_ready(true, false), "idle but nothing painted");
+        assert!(!wake_settle_ready(false, true), "painted but still busy");
+        assert!(!wake_settle_ready(false, false));
+    }
+
+    /// #1388, T3 - a `settle_tick` regression test for one uncovered input combination
+    /// (`ready == false` with `elapsed >= max_wait`), NOT evidence this change works.
+    ///
+    /// The existing pair covers `true`/over-cap and `false`/zero-elapsed. Decision 4.1 is
+    /// a decision NOT to change `settle_tick`, already pinned by
+    /// `settle_tick_caps_and_injects_anyway`, which must stay green unmodified.
+    #[test]
+    fn settle_tick_caps_when_not_ready() {
+        let now = std::time::Instant::now();
+        let (_, action) = settle_tick(
+            false,
+            Some(now),
+            now,
+            Duration::from_millis(2000),
+            Duration::from_secs(91),
+            Duration::from_secs(90),
+        );
+        assert_eq!(
+            action,
+            SettleAction::InjectNow,
+            "cap must never drop a delivery, not even for a never-rendered session"
         );
     }
 

--- a/src-tauri/src/pty/backend.rs
+++ b/src-tauri/src/pty/backend.rs
@@ -215,6 +215,17 @@ pub(crate) trait PtyBackend: Any + Send + Sync {
 
     fn get_screen_snapshot(&self, id: Uuid) -> Option<PtyScreenSnapshot>;
 
+    /// #1388 - does this session's screen currently show a cell a human would see?
+    ///
+    /// **Defaulted**, following `screen_rows_since` below: `true` reads as "no claim,
+    /// do not gate", so the ~20 in-tree `PtyBackend` fakes and any out-of-tree
+    /// implementor keep compiling AND keep today's wake timing. Only a backend that
+    /// owns a `SessionIoFanout` can answer; both production backends do, and both
+    /// override this.
+    fn has_rendered_visible_content(&self, _id: Uuid) -> bool {
+        true
+    }
+
     /// Read-only fixed-cell viewport copy. Backends unrelated to the two live
     /// production fanouts remain source-compatible and report unavailable.
     #[allow(private_interfaces)]

--- a/src-tauri/src/pty/container_backend.rs
+++ b/src-tauri/src/pty/container_backend.rs
@@ -3270,6 +3270,10 @@ impl PtyBackend for ContainerTransportBackend {
         self.fanout.get_screen_snapshot(id)
     }
 
+    fn has_rendered_visible_content(&self, id: Uuid) -> bool {
+        self.fanout.has_rendered_visible_content(id)
+    }
+
     fn activate_terminal_output(
         &self,
         id: Uuid,

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -2187,6 +2187,10 @@ impl PtyBackend for LocalProcessBackend {
         self.fanout.get_screen_snapshot(id)
     }
 
+    fn has_rendered_visible_content(&self, id: Uuid) -> bool {
+        self.fanout.has_rendered_visible_content(id)
+    }
+
     fn activate_terminal_output(
         &self,
         id: Uuid,

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -655,6 +655,24 @@ impl PtyManager {
         self.backend_for_kind(kind).get_screen_snapshot(id)
     }
 
+    /// #1388 - forwards to the routed backend. An unrouted id yields `true` ("no
+    /// claim"), matching the trait default.
+    ///
+    /// **This deliberately inverts its two nearest siblings**, which answer
+    /// conservatively for an unrouted id: `has_session` returns `false` (`:589-594`)
+    /// and `context_session_liveness` returns `SessionOver` (`:596-601`). Here
+    /// "cannot tell" must not gate, which is the rule `backend.rs:231-235` already
+    /// states for `Unavailable`. A permissive answer on a vanished route leads to an
+    /// injection that fails loudly with `AppError::SessionNotFound`; `false` would
+    /// silently hold a live session to the 90s cap on a routing transient. Fail loud
+    /// beats stall silent.
+    pub fn has_rendered_visible_content(&self, id: Uuid) -> bool {
+        let Ok(kind) = self.kind_for_session(id) else {
+            return true;
+        };
+        self.backend_for_kind(kind).has_rendered_visible_content(id)
+    }
+
     pub fn get_pty_size(&self, id: Uuid) -> Option<(u16, u16)> {
         let kind = self.kind_for_session(id).ok()?;
         self.backend_for_kind(kind).get_pty_size(id)
@@ -1496,6 +1514,19 @@ mod tests {
             manager.screen_rows_since(Uuid::new_v4(), None),
             crate::pty::watchers::ScreenRowsSince::Gone
         ));
+    }
+
+    /// #1388, T4 - the trait default reads as "no claim, do not gate".
+    ///
+    /// Exercised on an existing fake that does not override it, which is the one path
+    /// production never takes: both production backends override. Its only content is the
+    /// literal `true` in `backend.rs`, so this is a guard against a future flip to `false`,
+    /// which would strand every non-answering implementor at the wake settle's cap.
+    #[test]
+    fn pty_backend_default_reports_rendered() {
+        let backend = RecordingBackend::default();
+
+        assert!(backend.has_rendered_visible_content(Uuid::new_v4()));
     }
 
     /// #1171, 9.1.8 - a backend that never heard of the seam keeps working through the trait

--- a/src-tauri/tests/wake_consumption_measure.rs
+++ b/src-tauri/tests/wake_consumption_measure.rs
@@ -433,14 +433,17 @@ async fn settle_like_b(ctx: &HarnessCtx, id: Uuid, max_wait: Duration) {
         .is_some_and(|a| a < STARTUP_THRESHOLD)
     {
         // Starting: route to the sustained-idle settle, mirroring prod's #611 path
-        // (cold-spawn params: 90s cap, 2s hold). FIDELITY CAVEAT (grinch F2): this
-        // wait_for_settle proxy is STRICTER than prod's idle-only settle_until_ready
-        // (it also requires rendered content), so it injects LATER and is LESS likely
-        // to drop. It can therefore HIDE a drop the earlier-injecting shipped gate
-        // would take; it does NOT prove the shipped Starting gate drop-free. The
-        // Starting gate's real validation is #611's production track record - it is
-        // the same idle-only sustained settle already shipped for cold-spawn - not
-        // this harness arm.
+        // (cold-spawn params: 90s cap, 2s hold). FIDELITY CAVEAT (grinch F2, revised
+        // for #1388): the proxy now matches prod's DEFINITION - settle_until_ready
+        // gates on idle AND rendered, which is what this arm already did. The residual
+        // gap is narrower and different: this proxy's rendered check is
+        // `nonblank_lines(strip_ansi(snapshot)) > 0` (see wait_for_settle / screen_text),
+        // whereas prod uses `screen_shows_visible_content` over the live vt100 screen,
+        // which also counts an inverse or coloured-background cell whose glyph is a
+        // space. The two therefore differ on a screen whose only visible content is
+        // coloured or inverse whitespace: prod calls that rendered, this proxy does
+        // not. The proxy still injects NO EARLIER than prod, so it still cannot prove
+        // the shipped Starting gate drop-free.
         let deadline = Instant::now() + Duration::from_secs(90);
         wait_for_settle(ctx, id, Duration::from_millis(2000), deadline).await;
         return;


### PR DESCRIPTION
Closes #1388

## The bug

`send --mode wake` to a cold peer returned `Delivered` with exit 0 while the peer never started. Re-sending the same file always worked. Measured 11/11 across 4 distinct peers in one session by a coordinator in another workgroup, with a live case preserved ~12 hours for evidence capture. It reproduced again inside this very delivery cycle.

## Cause

The cold-spawn wake gate `settle_until_ready` read exactly one thing: `waiting_for_input`. It gated on **silence alone**.

But `IdleDetector::register_session` seeds activity at spawn and the watcher transitions to idle after 2500 ms of *pure silence* (pinned by `seeded_silent_session_crosses_idle_threshold`). Startup silence and "idle waiting for input" were therefore indistinguishable, so **a stalled start satisfied the gate faster than a healthy one**: inject landed at ~5.0-5.5 s post-spawn while the measured first paint fell between 5.1 and 7.3 s. The body was written before the TUI had an input box, and the two `\r` hit an empty prompt.

The wake harness already documented the gap it left: its own settle proxy is stricter than production *because it also requires rendered content*, and its caveat warned it could hide a drop the shipped gate would take.

## The change

The settle now requires **idle AND rendered visible content sustained for 2 s**, reusing `SessionIoFanout::has_rendered_visible_content` — the stateful vt100 predicate shipped in #973 for the resize gate. A child that has only emitted ConPTY handshake bytes has no visible cells, so the gate stays shut instead of opening at ~5 s.

Wired through the `PtyBackend` seam with a `true` default (the trait's existing convention for optional capabilities; ~21 in-tree fakes would otherwise break), implemented on **both** production backends.

Also included, and the reason this is not a two-line change:

- **E8 mitigation.** `MailboxPoller` is serial — one delivery in flight process-wide. This change inverts which sessions hold that lane: previously a blank or dead child released it fastest, now it would hold it for the full 90 s cap. A cold spawn whose child died silently would have stalled delivery for **every agent in every workgroup**, and delayed shutdown behind a live PTY. An `Exited` match arm, reading status the settle already had in hand, removes that population.
- Doc corrections where the change made existing comments false, and a rewrite of the harness fidelity caveat which this change makes factually wrong.

## What this does not do

- **`Delivered` is still a write-receipt**, not a claim about consumption. That residual is #1001 PR3/A.
- **The window is narrowed, not closed.** Sustained paste-ready was measured at up to 13.7 s for a cold Claude on Windows/ConPTY; this moves injection to >= first paint.
- **Established live sessions are byte-for-byte unchanged.** Only the cold-spawn route and the Starting live route (which already delegates to the same gate) are affected.
- E4 (sticky `ParserAvailability::Unavailable`) and E6 keep their full 90 s and are documented residuals.

## Scope corrections made during planning

Two things the issue originally stated were disproved by review and are recorded in [a comment on #1388](https://github.com/mblua/AgentsCommander/issues/1388#issuecomment-5308507485): the container backend was excluded on a **false premise** and is now implemented, and the E8 blocking above was not in the original analysis at all.

## Review

Full delivery path: architect plan -> dev-rust enrichment -> dev-rust-grinch adversarial review -> architect consensus, certified `READY_FOR_IMPLEMENTATION` at round 1 with a SHA-256 digest freezing the plan bytes. Implementation ran from a cold start against that digest, reviewed by dev-rust-grinch from a second cold start.

Both reviewers found real defects in the draft plan, and both were closed before implementation:

- The plan's stated "criterion that cannot pass cosmetically" **did not exist** — it duplicated a test and the composition happened inside the test, so an unwired implementation passed the whole suite. Replaced by structural diff criteria pinning both the *position* and the *argument* of the new read.
- The `PtyManager` forwarder and both production overrides had **no test coverage at all**; a forwarder returning a bare constant would have passed everything while shipping the gate disabled. Covered by a body-shape criterion.

Section 9 of the plan states plainly that the unit tests do not verify the behaviour — the structural criteria do.

## Verification

| Command | Result |
|---|---|
| `cargo check --all-targets` | OK, no warnings |
| `cargo clippy --all-targets -- -D warnings` | clean, zero issues |
| `cargo test --lib` | **3483 passed, 0 failed**, 23 ignored |

All eight acceptance criteria plus the Step-N dependency criterion verified independently by the reviewer from the diff. Zero new module arcs, zero new `use` lines, `output.rs` untouched.

The successful compile is itself evidence: `MailboxPoller::start` spawns under a `Send` bound and `std::sync::MutexGuard` is not `Send`, so the build passing proves the `PtyManager` guard does not survive into the `.await`.

Nothing was measured against a live session; no harness run. The plan says so explicitly rather than implying otherwise.

Non-visual change: no shipper build.
