### PR TITLE
docs: document the in-app screenshot capture flow (#1405)

### DIFF
--- a/docs/features/screenshot-capture.md
+++ b/docs/features/screenshot-capture.md
@@ -1,0 +1,121 @@
+# Screenshot capture
+
+In-app screenshot capture lets you press a global hotkey, drag a rectangle over the frozen screen, and save a PNG inside the workgroup replica that owns the session you are working with, with the saved path already on your clipboard.
+
+Use this feature when you want to hand a coding agent a picture of what you are looking at. It is not a terminal snapshot (that reads a backend terminal viewport without touching OS pixels) and not [window capture](window-capture.md) (that captures exactly one native window from the CLI or the API). Screenshot capture is Windows-only: other targets compile a stub that reports the feature as unsupported and never registers the hotkey.
+
+## Before you start
+
+You need:
+
+- AgentsCommander running on Windows;
+- a session selected in the app and displayable, because the screenshot belongs to that session; and
+- that session's working directory inside a workgroup replica (an `__agent_*` directory), because the replica root is the destination.
+
+A screenshot records whatever is on your monitors, including passwords, tokens, source code, and personal data. AgentsCommander saves the exact cropped pixels with no redaction, and it copies the file path to your clipboard.
+
+## Capture a screenshot
+
+1. Select the session the screenshot belongs to.
+2. Press the capture hotkey (`Ctrl+Q` by default).
+   AgentsCommander captures every monitor and opens one overlay window per monitor. Each overlay shows a frozen image of that monitor, not a live view, so the screen you are photographing cannot change under you.
+3. Drag a rectangle over the area you want. A magnifier follows the pointer while you hover and while you drag, so you can place the edges precisely.
+4. Release the pointer.
+   AgentsCommander crops the frozen image, writes the PNG, copies its path to the clipboard, and closes every overlay.
+
+To abandon the capture, press `Escape` or close the overlay. Nothing is written.
+
+Two behaviors are deliberate and are not failures:
+
+- Releasing on a selection that is a few pixels wide or tall discards that selection and leaves the overlay open, so you can drag again.
+- Pressing the hotkey while a capture is already in flight does nothing. The second press is ignored so you cannot photograph your own overlays or start two captures at once.
+
+## Where the file goes
+
+AgentsCommander walks up from the active session's working directory to its `__agent_*` replica root and writes the file directly in that root:
+
+```text
+<workgroup-replica-root>\agentscommander-screenshot-<YYYYMMDD>-<HHMMSS>-<session-id-prefix>.png
+```
+
+The timestamp is local time. The last segment is the first 8 hexadecimal characters of the session id, so two sessions capturing in the same second still get distinct names.
+
+The saved path is copied to the clipboard as text. Copying is best effort: if the clipboard is unavailable, AgentsCommander logs a warning and the capture still succeeds.
+
+The app log records one line per successful capture:
+
+```text
+[screenshot] saved <path> for session '<session-name>'
+```
+
+If a write fails after the file is created, AgentsCommander deletes the partial file, closes the overlays, and reports the failure.
+
+## Configure the hotkey
+
+The hotkey lives in `settings.json`:
+
+```json
+{
+  "screenshotCaptureHotkey": "Ctrl+Q"
+}
+```
+
+The value must be one modifier plus one key, joined by `+`:
+
+| Part | Accepted | Notes |
+|---|---|---|
+| Modifier | `Ctrl` or `Control` | Case-insensitive. No other modifier is supported. |
+| Key | One ASCII letter or digit | Normalized to upper case. |
+
+AgentsCommander validates the value when it reads settings and when you save them, and refuses an invalid value with an exact message:
+
+| Message | Cause |
+|---|---|
+| `hotkey must not be empty` | The value is empty or only whitespace. |
+| `hotkey '<value>' must be one modifier plus one key, e.g. Ctrl+Q` | The value is not exactly two parts separated by `+`. |
+| `unsupported modifier '<other>'; only Ctrl is supported` | The modifier is anything other than `Ctrl` or `Control`. |
+| `hotkey key '<key>' must be a single letter or digit` | The key is empty, longer than one character, or not alphanumeric. |
+
+See the [settings reference](../reference/settings.md#window--ui) for the field entry. If the shortcut does not become active after you save, restart AgentsCommander.
+
+## Check that the shortcut is active
+
+When the hotkey is registered, the titlebar shows a chip with a camera glyph and the shortcut, for example `Ctrl + Q`. Its tooltip and accessible name are `Screenshot capture shortcut: <hotkey>`.
+
+**An absent chip means the shortcut is not active.** The most common cause is another application already owning that combination at the OS level. Pick a different key in `screenshotCaptureHotkey` and restart.
+
+Registration is also written to the app log:
+
+```text
+[screenshot] global hotkey registered 'Ctrl+Q'
+[screenshot] global hotkey registration failed: <error>
+```
+
+## Availability right after startup
+
+The shortcut becomes live when the app's event loop starts pumping, which is shortly after the window appears, not at process start. This is by design: the OS registers a global hotkey on the main thread, and forcing that work to complete earlier would block the main thread, which is exactly what starves the WebView and prevents dialogs such as the update prompt from rendering.
+
+Presses inside that window are queued by the OS, not lost. They are serviced in a burst as soon as the event loop drains, so a press made while AgentsCommander is still restoring sessions still runs.
+
+A press serviced before any session is selectable does not hang or crash. It fails visibly with `No active session is selected in AgentsCommander`, and you retry once the session list is up.
+
+## Failures and recovery
+
+Every failure before the overlays open raises and focuses the AgentsCommander window and requests your attention, so the message cannot be missed behind other applications.
+
+| Message | Cause | Recovery |
+|---|---|---|
+| `No active session is selected in AgentsCommander` | No session is selected, or the selected session is not displayable. | Select a live session and press the hotkey again. |
+| `The active session could not be found` | The selected session disappeared from the session list between the press and the capture. | Select an existing session and retry. |
+| `Cannot resolve the active session directory: <error>` | The session's working directory cannot be canonicalized (it was deleted, renamed, or is unreachable). | Restore the directory, or point the session at a valid working directory. |
+| `The active session is not inside a workgroup replica directory, so there is no place to save the screenshot` | The session's working directory has no `__agent_*` replica root above it, for example an ad-hoc shell outside a workgroup. | Run the capture from a session that lives inside a workgroup replica. |
+| `No monitors were found to capture` | The monitor enumeration returned nothing. | Confirm a display is attached and active, then retry. |
+| `saved file escaped the replica root` | The destination resolved outside the replica root between validation and write. | Do not link or redirect the replica root. Retry from a plain directory. |
+
+AgentsCommander also refuses a replica root that is a link or reparse point, and validates the replica's identity before writing. A replica that fails those checks reports a failure instead of writing outside its owner.
+
+## See also
+
+- [Window capture](window-capture.md)
+- [Terminal snapshots](terminal-snapshots.md)
+- [Settings reference](../reference/settings.md#window--ui)

--- a/docs/features/screenshot-capture.md
+++ b/docs/features/screenshot-capture.md
@@ -21,13 +21,13 @@ A screenshot records whatever is on your monitors, including passwords, tokens, 
    AgentsCommander captures every monitor and opens one overlay window per monitor. Each overlay shows a frozen image of that monitor, not a live view, so the screen you are photographing cannot change under you.
 3. Drag a rectangle over the area you want. A magnifier follows the pointer while you hover and while you drag, so you can place the edges precisely.
 4. Release the pointer.
-   AgentsCommander crops the frozen image, writes the PNG, copies its path to the clipboard, and closes every overlay.
+   AgentsCommander crops the frozen image, writes the PNG, copies its path to the clipboard, and closes every overlay. A success toast reads `Screenshot saved. Path copied: <path>` and clears itself after 30 seconds.
 
 To abandon the capture, press `Escape` or close the overlay. Nothing is written.
 
 Two behaviors are deliberate and are not failures:
 
-- Releasing on a selection that is a few pixels wide or tall discards that selection and leaves the overlay open, so you can drag again.
+- Releasing on a selection thinner than 2 pixels in either direction discards that selection and leaves the overlay open, so you can drag again. Both the width and the height must reach 2 pixels, so a 1 by 500 pixel drag is rejected.
 - Pressing the hotkey while a capture is already in flight does nothing. The second press is ignored so you cannot photograph your own overlays or start two captures at once.
 
 ## Where the file goes
@@ -52,7 +52,14 @@ If a write fails after the file is created, AgentsCommander deletes the partial 
 
 ## Configure the hotkey
 
-The hotkey lives in `settings.json`:
+Change the shortcut from the Settings dialog. The dialog validates the field before it saves anything:
+
+| Message | Cause |
+|---|---|
+| `Screenshot hotkey is required` | The field is empty. |
+| `Screenshot hotkey must look like Ctrl+Q` | The value does not match the expected shape. |
+
+The same value lives in `settings.json`:
 
 ```json
 {
@@ -67,7 +74,7 @@ The value must be one modifier plus one key, joined by `+`:
 | Modifier | `Ctrl` or `Control` | Case-insensitive. No other modifier is supported. |
 | Key | One ASCII letter or digit | Normalized to upper case. |
 
-AgentsCommander validates the value when it reads settings and when you save them, and refuses an invalid value with an exact message:
+AgentsCommander validates the value again when it reads settings and when you save them, and refuses an invalid value with an exact message:
 
 | Message | Cause |
 |---|---|
@@ -76,13 +83,22 @@ AgentsCommander validates the value when it reads settings and when you save the
 | `unsupported modifier '<other>'; only Ctrl is supported` | The modifier is anything other than `Ctrl` or `Control`. |
 | `hotkey key '<key>' must be a single letter or digit` | The key is empty, longer than one character, or not alphanumeric. |
 
-See the [settings reference](../reference/settings.md#window--ui) for the field entry. If the shortcut does not become active after you save, restart AgentsCommander.
+See the [settings reference](../reference/settings.md#window--ui) for the field entry.
+
+### What happens when you save
+
+AgentsCommander registers the new shortcut immediately after the save. You do not restart the app. Saving the same value twice succeeds and changes nothing, and when you save a different value AgentsCommander registers the new shortcut first and releases the old one afterwards, so you are never left with no shortcut at all.
+
+The two ways a save can go wrong behave differently:
+
+- **The syntax is invalid.** The save is rejected before anything is written to disk, and your previous hotkey stays registered and keeps working. You rarely reach this path, because the Settings dialog refuses the value first.
+- **The syntax is valid but Windows refuses the combination**, usually because another application already owns it. The save succeeds and the new value is persisted; only the registration fails. AgentsCommander raises an error toast reading `Screenshot hotkey was saved but could not be registered: <error>`, and keeps the previously registered shortcut alive as a fallback. So the configured value is the new combination, the key that actually fires is still the old one, and the status for the configured value reports it as not registered. Pick another combination and save again.
 
 ## Check that the shortcut is active
 
 When the hotkey is registered, the titlebar shows a chip with a camera glyph and the shortcut, for example `Ctrl + Q`. Its tooltip and accessible name are `Screenshot capture shortcut: <hotkey>`.
 
-**An absent chip means the shortcut is not active.** The most common cause is another application already owning that combination at the OS level. Pick a different key in `screenshotCaptureHotkey` and restart.
+**An absent chip means the shortcut is not active.** The most common cause is another application already owning that combination at the OS level. At startup AgentsCommander checks the registration and raises an error toast reading `Screenshot hotkey <configured> is not active: <error>` when the configured shortcut failed to register, so a conflict detected at launch reaches you even if you never look at the titlebar. Pick a different combination in Settings and save; the new shortcut registers at once.
 
 Registration is also written to the app log:
 
@@ -93,7 +109,7 @@ Registration is also written to the app log:
 
 ## Availability right after startup
 
-The shortcut becomes live when the app's event loop starts pumping, which is shortly after the window appears, not at process start. This is by design: the OS registers a global hotkey on the main thread, and forcing that work to complete earlier would block the main thread, which is exactly what starves the WebView and prevents dialogs such as the update prompt from rendering.
+The shortcut is active as soon as the app finishes starting, without waiting for session restore. It is not active at process start: Windows registers a global hotkey on the main thread, so the registration completes only once the app's event loop is running. This is by design. Forcing that work to complete earlier would block the main thread, which is exactly what starves the WebView and prevents dialogs such as the update prompt from rendering.
 
 Presses inside that window are queued by the OS, not lost. They are serviced in a burst as soon as the event loop drains, so a press made while AgentsCommander is still restoring sessions still runs.
 
@@ -101,7 +117,7 @@ A press serviced before any session is selectable does not hang or crash. It fai
 
 ## Failures and recovery
 
-Every failure before the overlays open raises and focuses the AgentsCommander window and requests your attention, so the message cannot be missed behind other applications.
+AgentsCommander reports every failure as an error toast carrying the backend message verbatim. The toast has no timeout: it stays until you dismiss it, so a failure cannot scroll past unnoticed. A failure before the overlays open also raises and focuses the AgentsCommander window and requests your attention, so the message cannot be missed behind other applications.
 
 | Message | Cause | Recovery |
 |---|---|---|

--- a/docs/features/window-capture.md
+++ b/docs/features/window-capture.md
@@ -2,7 +2,7 @@
 
 Window capture lets you capture exactly one live native window as a PNG file on Windows, either from the CLI (local, in-process, no authorization boundary) or through the authenticated control-plane API. It is Windows-only: the CLI verbs and the HTTP route are compiled only on Windows and are deliberately absent on other targets.
 
-Use this feature when you need the current pixels of a live native desktop window. It is not a terminal snapshot (that reads the backend terminal viewport without touching OS pixels), not a monitor-wide screenshot, and not the in-app overlay/hotkey flow.
+Use this feature when you need the current pixels of a live native desktop window. It is not a terminal snapshot (that reads the backend terminal viewport without touching OS pixels), not a monitor-wide screenshot, and not the in-app overlay/hotkey flow (see [Screenshot capture](screenshot-capture.md)).
 
 ## Before you start
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -252,7 +252,7 @@ Both are manual-only (no UI) and are read from the in-memory settings, so an edi
 | `soundsEnabled` | bool | `true` | Master switch for all app-emitted sounds. |
 | `teamIdleBeepEnabled` | bool | `true` | Beep when a team transitions from busy → all-idle. Gated by `soundsEnabled`. |
 | `coordSortByActivity` | bool | `false` | Sort the coordinator quick-access list by most-recent activity. |
-| `screenshotCaptureHotkey` | string | `"Ctrl+Q"` | Native global hotkey for screenshot capture. |
+| `screenshotCaptureHotkey` | string | `"Ctrl+Q"` | Native global hotkey for screenshot capture. One modifier plus one key; only `Ctrl` (or `Control`) and a single letter or digit are accepted. Windows-only. See [Screenshot capture](../features/screenshot-capture.md). |
 | `mainResourceMonitorAttached` | bool | `false` | Whether the Resource Monitor occupies the main central pane instead of the terminal. Restored on startup. |
 | `alwaysShowSelectedWorkgroup` | bool | `true` | Keep the selected workgroup visible in the sidebar. |
 | `railCollapsedProjects` | string[] | `[]` | Rail project sections the user collapsed by clicking their header. Entries are frontend-normalized project paths (lowercase, forward slashes, no trailing slash). Written only by the dedicated rail collapse action; whole-settings writers restore it from live memory. |


### PR DESCRIPTION
Closes #1405

Documents the in-app screenshot capture flow, which had no documentation: `docs/features/window-capture.md` covers the CLI and API paths and explicitly excludes "the in-app overlay/hotkey flow", and `docs/reference/settings.md` carried a single `screenshotCaptureHotkey` row. Nothing described how a user takes a screenshot from inside the app, what the titlebar chip means, or what happens when the hotkey is pressed during startup.

## Contents

New `docs/features/screenshot-capture.md`, plus cross-links from the exclusion line in `window-capture.md` and from the `screenshotCaptureHotkey` row in `settings.md`.

- **The startup availability window, documented as by design.** The shortcut is active as soon as the app finishes starting, without waiting for session restore, but not at process start: Windows registers a global hotkey on the main thread, so registration completes only once the event loop is running. Registering earlier would mean blocking the main thread, which is what #1341 removed. Presses inside that window are queued, not lost. No millisecond figures are quoted, since the window scales with startup work and machine speed.
- **Live re-registration on save.** The hotkey registers immediately when saved; no restart. Invalid syntax is rejected before anything is persisted, leaving the old shortcut working. Valid syntax the OS refuses persists the save but keeps the previous shortcut alive as a fallback, so the configured value and the key that actually fires differ, and a sticky toast says so.
- **Settings dialog as the normal path**, with its two client-side validation messages.
- **Toasts**, previously undocumented: a success toast with the copied path clearing after 30 seconds, and sticky error toasts that stay until dismissed, including the launch-time hotkey-conflict toast that explains an absent titlebar chip.
- Hotkey grammar and backend messages, per-monitor frozen overlay and magnifier, the 2-pixel per-axis minimum selection, replica-root destination and filename format, clipboard copy, and log lines.

## Verification

Every user-facing claim was read from the source rather than inferred; the four facts that could not initially be confirmed were resolved in a second pass and applied, including removing an incorrect "restart AgentsCommander" instruction. `docs/style-guide.md` followed. Documentation only: no code or test changes.

Depends on #1398 (merged as 17c8c361), which this documentation describes the behaviour of.
