### PR TITLE
docs: document the AgentsCommander RTK hook for Claude Code (#1414)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 crates/terminal-snapshot-renderer/assets/LICENSE-DejaVu.txt binary
 crates/terminal-snapshot-renderer/tests/fixtures/*.png binary
 src-tauri/module-arcs.txt text eol=lf
+docs/integrations/rtk_claude/hooks/*.js text eol=lf

--- a/docs/integrations/rtk.md
+++ b/docs/integrations/rtk.md
@@ -88,6 +88,8 @@ The wrapped command's own exit code does not change any of this. A command that 
 
 ### The hook covers the filtered set, and nothing else
 
+This section is about RTK's own hook, the one `rtk init` installs. AgentsCommander seeds a **different** `PreToolUse` hook into every workgroup replica, and that one also writes a log of the commands it declined to rewrite. If you run agents in replicas, read [The AgentsCommander RTK hook for Claude Code](rtk_claude/README.md) before you conclude which hook produced what.
+
 `rtk init` installs both halves of the adoption problem: it writes RTK's instructions into the coding agent's context file, and it patches the agent's configuration with a `PreToolUse` hook that rewrites commands before they run. `--no-patch` skips the patching and prints manual instructions instead. This is the excerpt a patched Claude Code `settings.json` holds under `hooks.PreToolUse`, once per shell tool, not a complete settings file:
 
 ```json
@@ -314,6 +316,7 @@ For those roots use `%AC_WORKSPACE_ROOT%\rtk-history.db` instead, which gives on
 ## See also
 
 - [Agent Matrix conventions §5](../agent-matrix-conventions.md#5-profile-path-placeholders) - the three path placeholders, where each one resolves, and the fail-closed rules
+- [The AgentsCommander RTK hook for Claude Code](rtk_claude/README.md) - the hook AC seeds into every replica, and the two files it produces
 - [Coding agents](coding-agents.md) - the coding-agent catalog and the ENVIRONMENT rows this page uses
 - [Settings reference - coding agents](../reference/settings.md#coding-agents) - the `agents[].envs` shape behind the ENVIRONMENT panel
 - [RTK upstream repository](https://github.com/rtk-ai/rtk)

--- a/docs/integrations/rtk_claude/README.md
+++ b/docs/integrations/rtk_claude/README.md
@@ -98,7 +98,9 @@ rtk rewrite "grep '(foo)' f.txt"
 rtk grep '(foo)' f.txt
 ```
 
-When `rtk rewrite` comes back empty, the character test decides, and **that test is textual, not syntactic**. Any of `\n ; | & < > ( ) { }` or a backtick counts wherever it appears, including inside quotes, where the shell treats it as an ordinary character and does nothing with it. So an everyday invocation that redirects nothing, spawns no subshell and substitutes nothing still lands in the ignored log:
+When `rtk rewrite` comes back empty, the character test decides, and **that test is textual, not syntactic**. Any of `\n ; | & < > ( ) { }` or a backtick counts wherever it appears, quoted or not. Quoting changes what the shell will do with the character, never whether the hook counts it, and the two are worth keeping apart: inside double quotes most of these are inert, but a backtick and `$(` still run a command. So a logged line means the hook handed the command back untouched, not that the shell did nothing interesting with it.
+
+An everyday invocation that redirects nothing, spawns no subshell and substitutes nothing still lands in the ignored log:
 
 ```bash
 rtk rewrite "python -c \"print(1)\""
@@ -131,6 +133,7 @@ The second column is the first stage, and it is what decides the third. Where it
 | `ls; cat x` | `rtk ls; rtk read x` | rewritten |
 | `git status && ls` | `rtk git status && rtk ls` | rewritten |
 | `FOO=bar ls` | `FOO=bar rtk ls` | rewritten |
+| `grep foo f.txt 2>/dev/null` | `rtk grep foo f.txt 2>/dev/null` | rewritten, and the `>` is never reached |
 | `node --version` | nothing | prefixed to `rtk node --version`, nothing in the character class |
 | `nosuchbinary-xyz` | nothing | prefixed to `rtk nosuchbinary-xyz` |
 | `echo hola` | nothing | **ignored log**, `echo` is a builtin |

--- a/docs/integrations/rtk_claude/README.md
+++ b/docs/integrations/rtk_claude/README.md
@@ -1,0 +1,197 @@
+# The AgentsCommander RTK hook for Claude Code
+
+For operators who want to know what a Claude Code agent actually ran, not what it reported. AgentsCommander seeds a `PreToolUse` hook into every workgroup replica; after this page you can read the two files it produces and say which shell command landed in which one, and why.
+
+The hook and its registration are copied into this directory so you can review them without opening a replica:
+
+- [`hooks/ac_rtk_claude.js`](hooks/ac_rtk_claude.js), 132 lines
+- [`settings.local.json`](settings.local.json)
+
+Both are faithful copies of `<workspace>/.ac/default.claude/`, the seed AC installs from. Do not edit them here: this directory is a mirror, not the source.
+
+## What the hook is and where it lands
+
+AC seeds `.ac/default.claude/` into each workgroup replica when it creates the replica. A replica ends up with:
+
+```text
+<workspace>/.ac/<wg-N-name>/__agent_<name>/.claude/hooks/ac_rtk_claude.js
+<workspace>/.ac/<wg-N-name>/__agent_<name>/.claude/settings.local.json
+```
+
+`settings.local.json` registers the hook, and the whole registration is this:
+
+```json
+"hooks": {
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "node .claude/hooks/ac_rtk_claude.js" }]
+    }
+  ]
+}
+```
+
+Before every `Bash` tool call, Claude Code runs the hook with the tool input as JSON on stdin. The hook decides whether to rewrite the command so it runs through RTK, and answers with `permissionDecision: "allow"`.
+
+Two files come out of that decision, both in the agent's **origin Agent Matrix**, not in the replica:
+
+| File | Holds |
+|---|---|
+| `<workspace>/.ac/_agent_<name>/rtk-matrix-history.db` | The RTK history database, tables `commands` and `parse_failures`, written by `rtk` itself. See [RTK usage and per-agent statistics](../rtk.md). |
+| `<workspace>/.ac/_agent_<name>/rtk_ignored_tools.md` | One line per command the hook handed back untouched, written by the hook. |
+
+The pair exists so you can tell "RTK covered this command" from "RTK never saw it". Neither file alone answers that.
+
+## This is not the hook `rtk init` installs
+
+RTK ships its own Claude Code hook, and [RTK usage and per-agent statistics](../rtk.md#the-hook-covers-the-filtered-set-and-nothing-else) documents it. The two are separate pieces of software that happen to do related work:
+
+| | AC hook | RTK hook |
+|---|---|---|
+| Command | `node .claude/hooks/ac_rtk_claude.js` | `rtk hook claude` |
+| Installed by | AgentsCommander, when it seeds a replica | You, by running `rtk init` |
+| Registered in | the replica's `.claude/settings.local.json` | the Claude Code settings you point `rtk init` at |
+| Writes `rtk_ignored_tools.md` | yes | no |
+
+Both are `PreToolUse` hooks and both route commands to RTK, so a machine can have both active at once. Only the AC hook produces `rtk_ignored_tools.md`, so that file is the one that tells you the AC hook ran.
+
+## What it covers: the `Bash` tool, and nothing else
+
+The registration has a single matcher, `Bash`. Every other tool the model calls goes straight to its implementation and reaches neither file:
+
+`Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `Task`, every MCP tool, and any other shell tool the harness exposes, including `PowerShell`.
+
+Take that seriously before you read either file as a record of the agent's work. An agent that splits its shell work between the `Bash` tool and the `PowerShell` tool leaves half of it out of both files, with nothing marking the gap.
+
+Inside the `Bash` tool the coverage is complete: every non-empty command reaches one of the two files. The exceptions are the hook's two early exits, an unparseable JSON payload and a command that is empty after leading whitespace is stripped. Both leave no trace anywhere.
+
+## The routing rule
+
+A command is handed back untouched and written to `rtk_ignored_tools.md` when **both** of these hold:
+
+1. `rtk rewrite "<command>"` prints nothing on stdout, and
+2. the command is not safe to prefix, meaning any one of: it contains shell syntax (`\n ; | & < > ( ) { }` or a backtick), its first word contains `=` (the `FOO=bar cmd` form), or the shell resolves its first word to a `builtin`, `keyword`, `function` or `alias`.
+
+If `rtk rewrite` prints nothing but the command **is** safe to prefix, the hook prefixes `rtk ` anyway and writes no log line. That fallback is what puts an unknown binary into the statistics.
+
+Two details worth knowing:
+
+- The hook keys on **stdout**, not on the exit code, because `rtk rewrite` returns a good rewrite with exit 3 for compound commands.
+- There is no builtin list in the hook. It asks the shell with `type -t`, so the two never drift apart.
+
+### The rule the informal description gets wrong
+
+Being a compound command sends nothing to the ignored log. `rtk rewrite` splits on `;` and `&&` and handles `|` without help, and the hook rewrites all three. What pushes a command into the ignored log is a **redirection**, a subshell, a heredoc, command substitution, or a first word the shell owns.
+
+Measured against the installed RTK, driving the hook the way Claude Code does:
+
+| Command | Result |
+|---|---|
+| `ls -la` | rewritten to `rtk ls -la` |
+| `cat file.txt` | rewritten to `rtk read file.txt` |
+| `ls \| sort` | rewritten to `rtk ls \| sort` |
+| `ls; cat x` | rewritten to `rtk ls; rtk read x` |
+| `git status && ls` | rewritten to `rtk git status && rtk ls` |
+| `FOO=bar ls` | rewritten to `FOO=bar rtk ls` |
+| `node --version` | prefixed to `rtk node --version` by the fallback |
+| `nosuchbinary-xyz` | prefixed to `rtk nosuchbinary-xyz` by the fallback |
+| `echo hola` | **ignored log**, `echo` is a builtin |
+| `cd /tmp && export X=1` | **ignored log**, builtins |
+| `ls > /tmp/x` | **ignored log**, redirection |
+| `ls \| sort > /tmp/now.txt` | **ignored log**, redirection, not the pipe |
+| `(ls)` | **ignored log**, subshell |
+| `echo "total=$(wc -l < f)"` | **ignored log**, command substitution |
+
+Reproduce any row from inside a replica:
+
+```bash
+echo '{"tool_input":{"command":"ls -la"}}' | node .claude/hooks/ac_rtk_claude.js
+```
+
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"ac_rtk_claude","updatedInput":{"command":"exec 2> >(grep --line-buffered -v 'No hook installed' >&2)\nrtk ls -la"}}}
+```
+
+A passed-through command prints nothing and exits 0. Run one from a real replica and it appends a line to that agent's real `rtk_ignored_tools.md`.
+
+The `exec 2> >(grep ...)` line prepended to every rewrite silences a known RTK false positive on stderr. It is a separate statement rather than a wrapper, so heredocs keep working and the command's exit code and remaining stderr survive.
+
+**The list above is not a contract.** The hook delegates the decision to `rtk rewrite` and treats it as the source of truth. Which shapes `rtk rewrite` declines is a property of your installed RTK, so a new RTK version can move commands between the two files with no change to the hook. Re-measure after an RTK upgrade rather than trusting this table.
+
+## `rtk_ignored_tools.md`
+
+### Only workgroup replicas write it
+
+The hook derives the target from its own location: two levels up from `.claude/hooks/` is the replica root, and the Matrix folder is the replica's name with one leading underscore dropped, so `__agent_foo` writes to `_agent_foo`.
+
+It requires the replica root to start with `__`. An agent running directly in its Matrix, or anywhere else, writes no line at all, and nothing reports that. An empty or missing `rtk_ignored_tools.md` therefore means either "nothing was ignored" or "this agent never writes here", and the file cannot tell you which.
+
+### Format
+
+One line per entry, no header:
+
+```text
+20260818_110844: ls | sort > /tmp/now.txt
+```
+
+- The timestamp is **local time** in `YYYYMMDD_HHMMSS`, with no zone and no offset.
+- The command is the **original**, not the rewrite.
+- All whitespace collapses to single spaces, newlines included, so a heredoc stays one entry. A multi-line script therefore survives as one unindented line and is no longer runnable as written.
+- The hook appends and does nothing else: no truncation, no escaping, no rotation, no deduplication, and no locking. Two live replicas of the same agent append to the same file.
+
+### The timestamps do not line up with the database
+
+`rtk_ignored_tools.md` stamps local time with no zone. The `timestamp` column of `commands` is RFC 3339 with an offset, as documented in [RTK usage and per-agent statistics](../rtk.md#the-commands-table). The two artifacts do not share a time format, so **you cannot correlate them by string comparison**. Convert one side before you line up a session across both files.
+
+### An entry does not prove the command ran
+
+The hook is a `PreToolUse` hook: it writes the line before the shell starts, and it never sees the command's exit code. If you deny the permission prompt afterwards, or the command dies, the line is already written and nothing corrects it. Read the file as "the model asked to run this and the hook declined to rewrite it".
+
+## What reaches the database
+
+The hook never touches the database. It reads no `RTK_DB_PATH`, knows nothing about SQLite, and only rewrites the command and returns `allow`. The rows are written by `rtk` when the rewritten command runs, into the `RTK_DB_PATH` of that session. [RTK usage and per-agent statistics](../rtk.md) covers how to point that variable at the agent's Matrix and how to read the results.
+
+Which table a rewritten command lands in, measured against a scratch database:
+
+| Invocation | `commands` | `parse_failures` |
+|---|---|---|
+| `rtk ls -la .` | yes | no |
+| `rtk ls /noexiste`, exit 2 | yes | no |
+| `rtk node --version`, via the fallback | yes, as `rtk fallback: node --version` | yes, `fallback_succeeded=1` |
+| `rtk nosuchbinary-xyz`, exit 127 | no | yes, `fallback_succeeded=0` |
+| `rtk read /noexiste`, exit 1 | no | no |
+
+A failing command is recorded like a passing one: the first four rows above cover exits 0, 2, 0 and 127. The pattern is that the hook's `rtk ` fallback produces a `parse_failures` row, because RTK cannot parse its own argv and falls back to direct execution, and that execution adds a `commands` row only when the binary exists.
+
+The last row is the exception, and it is RTK's behaviour rather than the hook's: a failing `rtk ls` is recorded and a failing `rtk read` is not. So do not read either table as a complete ledger of everything routed through RTK.
+
+## Failure modes
+
+### RTK missing from PATH breaks simple commands
+
+This is the one to watch. The hook calls `rtk rewrite` through `spawnSync`, which does not throw when the binary is absent, it returns empty stdout. Empty stdout is the fallback path, so a plain command still comes back rewritten:
+
+```bash
+echo '{"tool_input":{"command":"ls -la"}}' | node .claude/hooks/ac_rtk_claude.js
+```
+
+With `rtk` off the PATH the hook still answers `rtk ls -la`, and that dies with exit 127 when it runs. Commands carrying shell syntax keep working, because they take the passthrough path. So losing RTK does not degrade tracking quietly, it breaks the agent's simple shell commands while the complicated ones keep running.
+
+### An invalid `RTK_DB_PATH` loses the record silently
+
+The hook ignores the variable entirely. The rewritten command runs, prints its normal output and exits 0, and the row is never written. Nothing on this side reports it. [RTK usage and per-agent statistics](../rtk.md#failure-modes) covers how that surfaces when you read the statistics.
+
+### A failed write to the ignored log is silent
+
+Writing the log line is wrapped in an empty `catch`. A missing Matrix directory, a locked file or a full disk costs you the line and nothing else. That is deliberate: the hook must not cost you the command you asked for.
+
+### The hook never blocks a tool
+
+Every path out of the hook is either a silent `exit(0)` or `permissionDecision: "allow"`. There is no `deny` and no blocking exit code, so a broken hook cannot stop an agent from working.
+
+## See also
+
+- [RTK usage and per-agent statistics](../rtk.md) - configuring `RTK_DB_PATH` per agent type and reading the database this hook feeds
+- [Agent Matrix conventions](../../agent-matrix-conventions.md) - replica and Matrix layout, which is what the hook derives the log path from
+- [Coding agents](../coding-agents.md) - the coding-agent catalog and its ENVIRONMENT rows
+- [RTK upstream repository](https://github.com/rtk-ai/rtk)

--- a/docs/integrations/rtk_claude/README.md
+++ b/docs/integrations/rtk_claude/README.md
@@ -40,7 +40,7 @@ Two files come out of that decision, both in the agent's **origin Agent Matrix**
 | `<workspace>/.ac/_agent_<name>/rtk-matrix-history.db` | The RTK history database, tables `commands` and `parse_failures`, written by `rtk` itself. See [RTK usage and per-agent statistics](../rtk.md). |
 | `<workspace>/.ac/_agent_<name>/rtk_ignored_tools.md` | One line per command the hook handed back untouched, written by the hook. |
 
-The pair exists so you can tell "RTK covered this command" from "RTK never saw it". Neither file alone answers that.
+The pair exists so you can tell "RTK covered this command" from "RTK never saw it". Neither file alone answers that, and a command missing from both is not proof it never ran: see [what it covers](#what-it-covers-the-bash-tool-and-nothing-else).
 
 ## This is not the hook `rtk init` installs
 
@@ -63,7 +63,12 @@ The registration has a single matcher, `Bash`. Every other tool the model calls 
 
 Take that seriously before you read either file as a record of the agent's work. An agent that splits its shell work between the `Bash` tool and the `PowerShell` tool leaves half of it out of both files, with nothing marking the gap.
 
-Inside the `Bash` tool the coverage is complete: every non-empty command reaches one of the two files. The exceptions are the hook's two early exits, an unparseable JSON payload and a command that is empty after leading whitespace is stripped. Both leave no trace anywhere.
+Inside the `Bash` tool the coverage is close to complete but not total. Three kinds of command reach neither file:
+
+- an unparseable JSON payload, and a command that is empty after leading whitespace is stripped, the hook's two early exits;
+- a command the hook rewrites whose RTK invocation then records nothing. `cat /noexiste` becomes `rtk read /noexiste`, which leaves no line in the ignored log because it was rewritten, and no row in either table. It does not even create the database file.
+
+The third kind is the one to remember, because it is indistinguishable from a command that was never issued.
 
 ## The routing rule
 
@@ -81,26 +86,59 @@ Two details worth knowing:
 
 ### The rule the informal description gets wrong
 
-Being a compound command sends nothing to the ignored log. `rtk rewrite` splits on `;` and `&&` and handles `|` without help, and the hook rewrites all three. What pushes a command into the ignored log is a **redirection**, a subshell, a heredoc, command substitution, or a first word the shell owns.
+Being a compound command is not what decides. Neither is any particular piece of shell syntax. **The first question is whether `rtk rewrite` produced any output**, and only when it produced none does anything else get looked at.
+
+When `rtk rewrite` recognises something, the command is rewritten whatever its shape. Pipes, `;`, `&&` and redirections do not send it to the ignored log:
+
+```bash
+rtk rewrite "grep '(foo)' f.txt"
+```
+
+```text
+rtk grep '(foo)' f.txt
+```
+
+When `rtk rewrite` comes back empty, the character test decides, and **that test is textual, not syntactic**. Any of `\n ; | & < > ( ) { }` or a backtick counts wherever it appears, including inside quotes, where the shell treats it as an ordinary character and does nothing with it. So an everyday invocation that redirects nothing, spawns no subshell and substitutes nothing still lands in the ignored log:
+
+```bash
+rtk rewrite "python -c \"print(1)\""
+```
+
+prints nothing, and the parenthesis inside the quoted argument then sends the command to the log. `node -e "console.log(1)"` goes the same way, and so does `nosuchbinary-xyz "a;b"` on its quoted semicolon.
+
+The two halves of the rule are easiest to see as pairs that differ by one thing:
+
+| Pair | `rtk rewrite` | Result |
+|---|---|---|
+| `grep '(foo)' f.txt` | `rtk grep '(foo)' f.txt` | rewritten, the quoted `(` never gets looked at |
+| `python -c "print(1)"` | empty | **ignored log**, on the same quoted `(` |
+| `nosuchbinary-xyz` | empty | prefixed to `rtk nosuchbinary-xyz` |
+| `nosuchbinary-xyz \| sort` | empty | **ignored log**, and the pipe is the only difference |
+
+The second pair is a compound command that does reach the ignored log, which is the case the informal rule denies outright. The first pair carries a parenthesis to both outcomes, which is why no list of shell constructs can describe this correctly.
+
+So when you find a command in `rtk_ignored_tools.md`, do not go looking for a redirection. Look for any of those characters anywhere in the line, quoted or not, or an `=` in the first word, or a first word the shell owns.
 
 Measured against the installed RTK, driving the hook the way Claude Code does:
 
-| Command | Result |
-|---|---|
-| `ls -la` | rewritten to `rtk ls -la` |
-| `cat file.txt` | rewritten to `rtk read file.txt` |
-| `ls \| sort` | rewritten to `rtk ls \| sort` |
-| `ls; cat x` | rewritten to `rtk ls; rtk read x` |
-| `git status && ls` | rewritten to `rtk git status && rtk ls` |
-| `FOO=bar ls` | rewritten to `FOO=bar rtk ls` |
-| `node --version` | prefixed to `rtk node --version` by the fallback |
-| `nosuchbinary-xyz` | prefixed to `rtk nosuchbinary-xyz` by the fallback |
-| `echo hola` | **ignored log**, `echo` is a builtin |
-| `cd /tmp && export X=1` | **ignored log**, builtins |
-| `ls > /tmp/x` | **ignored log**, redirection |
-| `ls \| sort > /tmp/now.txt` | **ignored log**, redirection, not the pipe |
-| `(ls)` | **ignored log**, subshell |
-| `echo "total=$(wc -l < f)"` | **ignored log**, command substitution |
+The second column is the first stage, and it is what decides the third. Where it is empty, the deciding characters are named.
+
+| Command | `rtk rewrite` prints | Result |
+|---|---|---|
+| `ls -la` | `rtk ls -la` | rewritten |
+| `cat file.txt` | `rtk read file.txt` | rewritten |
+| `ls \| sort` | `rtk ls \| sort` | rewritten, the pipe is never consulted |
+| `ls; cat x` | `rtk ls; rtk read x` | rewritten |
+| `git status && ls` | `rtk git status && rtk ls` | rewritten |
+| `FOO=bar ls` | `FOO=bar rtk ls` | rewritten |
+| `node --version` | nothing | prefixed to `rtk node --version`, nothing in the character class |
+| `nosuchbinary-xyz` | nothing | prefixed to `rtk nosuchbinary-xyz` |
+| `echo hola` | nothing | **ignored log**, `echo` is a builtin |
+| `cd /tmp && export X=1` | nothing | **ignored log**, on `&` and on a builtin head |
+| `ls > /tmp/x` | nothing | **ignored log**, on `>` |
+| `ls \| sort > /tmp/now.txt` | nothing | **ignored log**, on `\|` and `>` |
+| `(ls)` | nothing | **ignored log**, on `(` and `)` |
+| `echo "total=$(wc -l < f)"` | nothing | **ignored log**, on several, and a builtin head |
 
 Reproduce any row from inside a replica:
 
@@ -187,7 +225,7 @@ Writing the log line is wrapped in an empty `catch`. A missing Matrix directory,
 
 ### The hook never blocks a tool
 
-Every path out of the hook is either a silent `exit(0)` or `permissionDecision: "allow"`. There is no `deny` and no blocking exit code, so a broken hook cannot stop an agent from working.
+Every path out of the hook is either a silent `exit(0)` or `permissionDecision: "allow"`. There is no `deny` and no blocking exit code, so a hook that runs cannot stop an agent from working, however badly it misjudges a command. What Claude Code does when the hook does not run at all, with `node` missing or the file removed, is not something these two files answer.
 
 ## See also
 

--- a/docs/integrations/rtk_claude/hooks/ac_rtk_claude.js
+++ b/docs/integrations/rtk_claude/hooks/ac_rtk_claude.js
@@ -1,0 +1,132 @@
+// PreToolUse/Bash hook: routes the command through rtk so its output is compacted.
+//
+// The rewrite decision is delegated to `rtk rewrite`, which rtk documents as the
+// single source of truth for hooks. It splits on `&&` / `;`, rewrites each segment
+// that has an rtk equivalent and leaves the rest alone -- notably shell builtins
+// like `cd` and `export`, which a blind "rtk " prefix would break (rtk tries to
+// resolve them via PATH and exits 127).
+//
+// We key on non-empty stdout rather than the exit code: `rtk rewrite "cd /tmp && ls"`
+// returns a perfectly good rewrite with exit 3, so rtk's own documented idiom
+// (`REWRITTEN=$(rtk rewrite "$CMD") || exit 0`) would discard compound commands.
+//
+// Empty stdout from `rtk rewrite` means two different things: the command has no rtk
+// equivalent (`hola`, `node --version`) *and* the command is pure shell builtins
+// (`cd /tmp && export X=1`, `echo hola`). We still want stats on the first group, so we
+// fall back to prefixing `rtk `, but only when the command is a single plain invocation
+// whose head the shell does not resolve to a builtin or keyword. Prefixing those is the
+// old bug (`rtk cd x && ls` -> exit 127, "Binary 'cd' not found on PATH").
+//
+// When a rewrite happens we also silence the "No hook installed" notice rtk writes
+// to stderr on every filtered invocation. It is a known false positive (rtk only
+// looks for its hook in the global settings) with no config to turn it off. The
+// filter is prepended as its own `exec` statement instead of wrapping the command,
+// so heredocs keep working; exit codes and the rest of stderr are preserved.
+//
+// Commands we hand back untouched leave no trace anywhere, which makes it impossible to
+// tell "rtk covered it" from "rtk never saw it". So every skip is appended to
+// `rtk_ignored_tools.md` in the origin Agent Matrix before we bow out.
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const NAG = "No hook installed";
+const FILTER = `exec 2> >(grep --line-buffered -v '${NAG}' >&2)\n`;
+
+// The log lives with the canonical agent state, not with the throwaway replica, so it
+// survives across workgroups. Everything is derived, nothing hardcoded: this file sits
+// at <replica root>/.claude/hooks/, so two levels up is the replica root and two more
+// is `.ac`. From there the origin Matrix folder is the replica's own name with one
+// leading underscore dropped (`__agent_foo` -> `_agent_foo`).
+function ignoredLogPath() {
+  const replicaRoot = path.resolve(__dirname, "..", "..");
+  const replicaName = path.basename(replicaRoot);
+  if (!replicaName.startsWith("__")) return null; // not a WG replica: no Matrix above us
+  return path.join(path.resolve(replicaRoot, "..", ".."), replicaName.slice(1), "rtk_ignored_tools.md");
+}
+
+// One `YYYYMMDD_HHMMSS: <command>` line per skip, local time. Newlines are folded to
+// spaces so a heredoc stays a single entry. Never touches stdout -- the hook protocol
+// reads it -- and never throws: a missing Matrix or a locked file must not cost the
+// user the command they asked for.
+function logIgnored(cmd) {
+  try {
+    const target = ignoredLogPath();
+    if (!target) return;
+    const d = new Date();
+    const p = (n) => String(n).padStart(2, "0");
+    const ts = `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}_${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`;
+    fs.appendFileSync(target, `${ts}: ${cmd.replace(/\s+/g, " ").trim()}\n`, "utf8");
+  } catch {
+    // best effort
+  }
+}
+
+// Only a bare `cmd arg arg` line is safe to prefix. Anything with shell syntax --
+// operators, redirects, subshells, heredocs, command substitution, newlines -- would
+// either attach the prefix to the wrong segment or change what the shell does with it.
+// Whether the head is something rtk can exec is asked of the shell (`type -t`) rather
+// than kept as a builtin list here, so there is no second copy to drift: builtin /
+// keyword / function / alias stay untouched, `file` and not-found get wrapped.
+function prefixable(cmd) {
+  if (/[\n;|&<>(){}`]/.test(cmd)) return false; // `(` and backtick already cover $( )
+  const head = cmd.split(/\s+/)[0];
+  if (!head || head.includes("=")) return false; // FOO=bar cmd
+  const t = spawnSync("bash", ["-c", 'type -t -- "$1"', "bash", head], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    shell: false,
+  });
+  return !["builtin", "keyword", "function", "alias"].includes((t.stdout || "").trim());
+}
+
+const chunks = [];
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", () => {
+  let data;
+  try {
+    data = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  } catch {
+    process.exit(0); // unreadable input: leave the command untouched
+  }
+
+  const ti = { ...(data.tool_input || {}) };
+  const orig = typeof ti.command === "string" ? ti.command : "";
+  const body = orig.replace(/^\s+/, "");
+  if (!body) process.exit(0);
+
+  // Already routed through rtk (e.g. a command we wrote by hand): only silence the notice.
+  let rewritten;
+  if (/^rtk\s/.test(body)) {
+    rewritten = body;
+  } else {
+    // Passed as a single argv entry, so no shell re-parsing happens here.
+    const r = spawnSync("rtk", ["rewrite", body], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      shell: false,
+    });
+    rewritten = (r.stdout || "").trim();
+    if (!rewritten) {
+      if (!prefixable(body)) {
+        logIgnored(body); // builtins / shell syntax: leave it alone, but on the record
+        process.exit(0);
+      }
+      rewritten = "rtk " + body; // unknown binary: wrap it so rtk still reports stats
+    }
+  }
+
+  ti.command = FILTER + rewritten;
+
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason: "ac_rtk_claude",
+        updatedInput: ti,
+      },
+    })
+  );
+});

--- a/docs/integrations/rtk_claude/settings.local.json
+++ b/docs/integrations/rtk_claude/settings.local.json
@@ -1,0 +1,22 @@
+{
+  "includeCoAuthoredBy": false,
+  "enableAllProjectMcpServers": false,
+  "enabledMcpjsonServers": [],
+  "mcpServers": {},
+  "claudeMdExcludes": [
+    "C:/Users/maria/.claude/CLAUDE.md"
+  ],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/ac_rtk_claude.js"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds `docs/integrations/rtk_claude/`, documenting the RTK hook AgentsCommander seeds into every agent replica and the two artifacts it produces.

## What lands

- A faithful copy of `.ac/default.claude` — `hooks/ac_rtk_claude.js` and `settings.local.json` — so the seeded configuration is visible and byte-comparable from the repository. A `.gitattributes` rule keeps the copied hook at LF, without which a Windows checkout materializes it as CRLF and the comparison against the seed fails.
- `README.md`, covering: what the hook is and where it lands; the real routing predicate; the format of `rtk_ignored_tools.md`; what reaches `commands`, `parse_failures`, both, or neither; and the failure modes.
- Two additions to `docs/integrations/rtk.md` disambiguating this hook from the one `rtk init` installs. Both are `PreToolUse` hooks that mention RTK, and only this one produces `rtk_ignored_tools.md`.

## Corrections the work produced

The informal description this started from was wrong, and so were two of our own attempts to correct it. What the code actually does:

- Routing is two-stage. The first and only question is whether `rtk rewrite` produced output. When it did, the command is rewritten whatever its shape — `grep foo f.txt 2>/dev/null` survives with its redirection intact. Only when it did not is a character test applied, and that test is textual, not syntactic: any of `\n ; | & < > ( ) { }` or a backtick counts wherever it appears, quotes included.
- Consequently `python -c "print(1)"` lands in the ignored log while `grep '(foo)' f.txt` does not, though both contain a quoted parenthesis. No list of shell constructs describes this correctly.
- Coverage is close to complete but not total. `cat /noexiste` is rewritten to `rtk read /noexiste`, which leaves no log line and no database row — it does not even create the database file — so it is indistinguishable from a command that was never issued.
- The hook declares a single matcher, `Bash`. Everything the harness runs through `Read`, `Write`, `Edit`, `Glob`, `Grep`, `WebFetch`, `Task`, MCP tools, and the `PowerShell` tool never reaches it and leaves no trace in either artifact. Closing that gap is #1416.
- `rtk_ignored_tools.md` timestamps are local time without offset, while the `commands` table stores RFC 3339 with a UTC offset. The two artifacts cannot be correlated by string.

## Review

Documentation-only; `git diff --stat origin/main -- src src-tauri scripts .github` is empty.

Source read and routing predicate established by `dev-rust` from `ac_rtk_claude.js`, then reproduced independently by `technical-writer` before writing. Adversarially reviewed by `dev-rust-grinch` over three rounds, every claim reproduced by execution against an isolated replica: three defects in the first round, one in the second, zero in the third. Final verdict PASS.

Three of the four defects were in prose summarizing a rule that was already stated correctly elsewhere on the same page. The formal rule never failed.

Closes #1414
