### PR TITLE
docs: document the shipped features that had no user-facing pages (refs #1407)

### DIFF
--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -549,3 +549,44 @@ Messaging is file-based. Write your message to `<workgroup-root>/messaging/YYYYM
 ```
 
 The peer name comes from `list-peers` output. Use `--mode wake` for fire-and-forget.
+
+---
+
+## 11. Agent memory rotation at spawn
+
+Every agent starts a fresh session with an empty `memory/`. AC does that for you: when it spawns a session for an agent, it rotates that agent's `memory/` directory in the **origin Agent Matrix** to `memory_YYYYMMDD_hhmmss/` and recreates an empty `memory/` next to it. The timestamp is local time.
+
+Rotation always happens in the origin Agent Matrix, never in a workgroup replica. If you launch the session from a replica (`wg-*/__agent_<name>/`), AC reads the replica's own configuration to find the matrix it came from and rotates there. If that lookup lands on anything that is not a canonical Agent Matrix directory, AC rotates nothing and the session still launches.
+
+### What happens in each case
+
+| State of `memory/` | What AC does |
+|---|---|
+| Present and non-empty | Renames it to `memory_YYYYMMDD_hhmmss/`, then recreates an empty `memory/` |
+| Present and empty | Nothing. An empty directory has no history to archive |
+| Absent | Recreates it empty. Nothing is rotated, because there was nothing to move |
+| A junction, a symlink, or any other reparse point | Refuses, with `memory is not a real directory`. Renaming the link would move the link entry itself and hand you a real directory in place of your link |
+| Not a directory at all (a file named `memory`) | Refuses, with the same `memory is not a real directory` |
+| A `memory_<timestamp>/` of the same name already exists | Refuses, with `memory rotation target already exists`. AC never overwrites an archive |
+
+A refusal is not fatal. The session launches either way, and AC records the reason:
+
+```text
+[memory] #1172: memory rotation failed for <matrix root> (non-fatal; the session still launches): <error>
+```
+
+A successful rotation records:
+
+```text
+[memory] #1172: rotated <matrix>/memory -> <matrix>/memory_YYYYMMDD_hhmmss at fresh session spawn
+```
+
+The no-op cases (empty and absent) log nothing at this level, so silence in the log means "there was nothing to rotate", not "rotation broke".
+
+### What this means for you as an agent
+
+The `memory_YYYYMMDD_hhmmss/` directories are **read-only history**. Read them whenever you need what a previous session knew. Never edit one, never delete one, and never move files back out of one into `memory/`: your current `memory/` is the only directory you write to, and the archives are the record of how you got here.
+
+If you find your `memory/` still holding the previous session's files, rotation refused. Check the log for the `[memory] #1172` line, and check whether `memory/` is a junction rather than a real directory.
+
+See [Directory layout](reference/directory-layout.md) for where the Agent Matrix and its archives sit on disk.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-For developers reading the docs for the first time. Nine terms. Once these click, the rest of the docs make sense.
+For developers reading the docs for the first time. Thirteen terms. Once these click, the rest of the docs make sense.
 
 ## Agent
 
@@ -50,6 +50,22 @@ The **coordinator** is the only member that can:
 A workgroup is a Team **in action** on a specific task. When the coordinator decides "we are working on task X," AC creates `.ac/wg-<N>-<team>/` and replicates the team's agent directories into it as **replicas** (`__agent_<name>/`). The replicas are isolated working copies — every replica has its own scratch space, inbox, and outbox.
 
 You can run multiple workgroups for the same team in parallel.
+
+## Non-stop mode
+
+A per-project group of workgroups AC watches for you. While the group has at least one member and at least one alert measure turned on, AC compares how many of its workgroups are working against how many there are; a shortfall that lasts longer than the group's tolerance raises one alert. The default name of that group is `Alert me!`. See [Non-stop mode](features/non-stop-mode.md).
+
+## Project Loop
+
+A scheduled prompt. A Loop belongs to one project, targets one workgroup, and carries a cron expression and the text to send. When it comes due, AC delivers that text to the workgroup's coordinator, waking or respawning the session if it is not running. See [Project Loops](features/project-loops.md).
+
+## Watcher
+
+A pattern AC matches against the terminal output of your agent sessions. Watchers live at the root of `settings.json`, keyed by watcher id, so one pattern can reach every configured agent, which the per-agent context pattern cannot. Matches land in the Watcher Activity window. See [Watchers](features/watchers.md).
+
+## Spec Board
+
+A separate window holding one Mermaid file: the source on one side, the rendered diagram on the other. It saves to a real file in your repository, snapshots your edits as you make them, and can hand the file to a running agent. See [Spec Board](features/spec-board.md).
 
 ## Brief
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -19,12 +19,14 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | [Non-stop mode](non-stop-mode.md) | Watch a group of workgroups and get a Telegram message or a sound when one stops working. |
 | [Project Loops](project-loops.md) | Send a scheduled prompt to a workgroup coordinator on a cron expression, waking or respawning the session. |
 | [Spec Board](spec-board.md) | Edit a Mermaid file in its own window with a live preview, snapshots, and an agent handoff. |
+| [Watchers](watchers.md) | Match a pattern against every agent terminal at once and read the hits in the activity window. |
 
 ## Monitoring
 
 | Page | What it covers |
 |---|---|
 | [Resource monitor](resource-monitor.md) | Watch what each agent group is using and set the thresholds at which AC warns you or kills it. |
+| [Context tracking](context-tracking.md) | Read how much of an agent context window is used and alert a coordinator when a member crosses a threshold. |
 | [Terminal snapshots](terminal-snapshots.md) | Read one live backend terminal viewport as versioned JSON or a PNG without changing the session. |
 | [Window capture](window-capture.md) | Capture one live native window as a PNG from the CLI or the control-plane API. Windows only. |
 | [Screenshot capture](screenshot-capture.md) | Press a global hotkey, drag a rectangle, and save a PNG inside the replica that owns your session. Windows only. |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,39 @@
+# Features
+
+For developers looking for the page that covers one AgentsCommander feature. Every feature page lives in this directory; this index is the map.
+
+## Agents and sessions
+
+| Page | What it covers |
+|---|---|
+| [Coding Agent Profiles](coding-agent-profiles.md) | Define several launch variants of one coding agent and switch a single session between them. |
+| [Container coding agents](container-coding-agents.md) | Run a coding agent under AC's Container runtime, what it does with your host credentials, and what does not work yet. |
+| [Session auto-close](session-auto-close.md) | Close idle teams on a timeout, read the idle badge, and change or turn the timeout off. |
+| [Voice-to-text](voice-to-text.md) | Dictate prompts to a coding agent instead of typing them. |
+
+## Automation
+
+| Page | What it covers |
+|---|---|
+
+## Monitoring
+
+| Page | What it covers |
+|---|---|
+| [Terminal snapshots](terminal-snapshots.md) | Read one live backend terminal viewport as versioned JSON or a PNG without changing the session. |
+| [Window capture](window-capture.md) | Capture one live native window as a PNG from the CLI or the control-plane API. Windows only. |
+| [Screenshot capture](screenshot-capture.md) | Press a global hotkey, drag a rectangle, and save a PNG inside the replica that owns your session. Windows only. |
+
+## Remote access
+
+| Page | What it covers |
+|---|---|
+| [Telegram bridge](telegram-bridge.md) | Attach a Telegram bot to one session so PTY output reaches your phone and your replies reach the agent. |
+
+## Configuration and packaging
+
+| Page | What it covers |
+|---|---|
+| [Config seed](config-seed.md) | Copy a template config folder into every replica at spawn, with AC path tokens already substituted. |
+| [Seed manifest](seed-manifest.md) | Read the Git-diffable inventory of the project-scoped files AC published into your project's `.ac` folder. |
+| [Portable instances](portable-instances.md) | Run isolated AgentsCommander instances side by side from separate copies of the binary. |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,12 +17,14 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | Page | What it covers |
 |---|---|
 | [Non-stop mode](non-stop-mode.md) | Watch a group of workgroups and get a Telegram message or a sound when one stops working. |
+| [Project Loops](project-loops.md) | Send a scheduled prompt to a workgroup coordinator on a cron expression, waking or respawning the session. |
 | [Spec Board](spec-board.md) | Edit a Mermaid file in its own window with a live preview, snapshots, and an agent handoff. |
 
 ## Monitoring
 
 | Page | What it covers |
 |---|---|
+| [Resource monitor](resource-monitor.md) | Watch what each agent group is using and set the thresholds at which AC warns you or kills it. |
 | [Terminal snapshots](terminal-snapshots.md) | Read one live backend terminal viewport as versioned JSON or a PNG without changing the session. |
 | [Window capture](window-capture.md) | Capture one live native window as a PNG from the CLI or the control-plane API. Windows only. |
 | [Screenshot capture](screenshot-capture.md) | Press a global hotkey, drag a rectangle, and save a PNG inside the replica that owns your session. Windows only. |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -11,6 +11,8 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | [Session auto-close](session-auto-close.md) | Close idle teams on a timeout, read the idle badge, and change or turn the timeout off. |
 | [Coding agent auto-update](agent-auto-update.md) | Answer the startup update prompt once per coding-agent command and have AC remember it. |
 | [Sidebar guide](sidebar-guide.md) | Read every rail entry, row, badge and indicator in the sidebar, and find the page behind each one. |
+| [App windows](app-windows.md) | Name every window AC opens, what each is for, and how it appears. |
+| [Notifications and dialogs](notifications-and-dialogs.md) | Match any toast, banner or modal on screen to what raised it and what each button does. |
 | [Voice-to-text](voice-to-text.md) | Dictate prompts to a coding agent instead of typing them. |
 
 ## Automation

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -10,6 +10,7 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | [Container coding agents](container-coding-agents.md) | Run a coding agent under AC's Container runtime, what it does with your host credentials, and what does not work yet. |
 | [Session auto-close](session-auto-close.md) | Close idle teams on a timeout, read the idle badge, and change or turn the timeout off. |
 | [Coding agent auto-update](agent-auto-update.md) | Answer the startup update prompt once per coding-agent command and have AC remember it. |
+| [Sidebar guide](sidebar-guide.md) | Read every rail entry, row, badge and indicator in the sidebar, and find the page behind each one. |
 | [Voice-to-text](voice-to-text.md) | Dictate prompts to a coding agent instead of typing them. |
 
 ## Automation
@@ -47,3 +48,4 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | [Config seed](config-seed.md) | Copy a template config folder into every replica at spawn, with AC path tokens already substituted. |
 | [Seed manifest](seed-manifest.md) | Read the Git-diffable inventory of the project-scoped files AC published into your project's `.ac` folder. |
 | [Portable instances](portable-instances.md) | Run isolated AgentsCommander instances side by side from separate copies of the binary. |
+| [Project archiving](project-archiving.md) | Hide a project from the sidebar without touching its files, and get it back. |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -27,6 +27,7 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 |---|---|
 | [Resource monitor](resource-monitor.md) | Watch what each agent group is using and set the thresholds at which AC warns you or kills it. |
 | [Context tracking](context-tracking.md) | Read how much of an agent context window is used and alert a coordinator when a member crosses a threshold. |
+| [Activity log](activity-log.md) | Read the append-only JSONL record of when each session was working and when it went idle. |
 | [Terminal snapshots](terminal-snapshots.md) | Read one live backend terminal viewport as versioned JSON or a PNG without changing the session. |
 | [Window capture](window-capture.md) | Capture one live native window as a PNG from the CLI or the control-plane API. Windows only. |
 | [Screenshot capture](screenshot-capture.md) | Press a global hotkey, drag a rectangle, and save a PNG inside the replica that owns your session. Windows only. |
@@ -35,6 +36,8 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 
 | Page | What it covers |
 |---|---|
+| [Remote web UI](remote-web-ui.md) | Serve the AgentsCommander interface to a browser, on this machine or a trusted LAN. |
+| [Control-plane API](control-plane-api.md) | Let a machine client speak the inter-agent control plane over HTTP with a scoped token. |
 | [Telegram bridge](telegram-bridge.md) | Attach a Telegram bot to one session so PTY output reaches your phone and your replies reach the agent. |
 
 ## Configuration and packaging

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -9,12 +9,15 @@ For developers looking for the page that covers one AgentsCommander feature. Eve
 | [Coding Agent Profiles](coding-agent-profiles.md) | Define several launch variants of one coding agent and switch a single session between them. |
 | [Container coding agents](container-coding-agents.md) | Run a coding agent under AC's Container runtime, what it does with your host credentials, and what does not work yet. |
 | [Session auto-close](session-auto-close.md) | Close idle teams on a timeout, read the idle badge, and change or turn the timeout off. |
+| [Coding agent auto-update](agent-auto-update.md) | Answer the startup update prompt once per coding-agent command and have AC remember it. |
 | [Voice-to-text](voice-to-text.md) | Dictate prompts to a coding agent instead of typing them. |
 
 ## Automation
 
 | Page | What it covers |
 |---|---|
+| [Non-stop mode](non-stop-mode.md) | Watch a group of workgroups and get a Telegram message or a sound when one stops working. |
+| [Spec Board](spec-board.md) | Edit a Mermaid file in its own window with a live preview, snapshots, and an agent handoff. |
 
 ## Monitoring
 

--- a/docs/features/activity-log.md
+++ b/docs/features/activity-log.md
@@ -1,0 +1,99 @@
+# Activity log
+
+For developers who want a machine-readable record of when their sessions were working and when they were idle. After this page you can turn the log on, find the file, and read a line without guessing what its fields mean.
+
+The activity log is an append-only JSONL file. AC writes one line per event: a session started working, a session went idle, the app started, the app is alive, the app stopped. It is **off by default** and it records no terminal content.
+
+## What it records
+
+Every line is one event, and there are five kinds:
+
+| Event | When AC writes it |
+|---|---|
+| `busy` | A session's working state goes from false to true. |
+| `idle` | A session's working state goes from true to false. |
+| `app_start` | AC starts. The line carries the process id, the app version, what it found of the previous run, and the metrics declaration. |
+| `app_alive` | A heartbeat carrying the detector's current view of which sessions are working. It is also the backstop for closing edges no other site emits. |
+| `app_stop` | AC stops, with whether the open sessions could be enumerated and how many there were. |
+
+A `metrics` line also appears as the first record of a freshly rotated file. It re-declares the metrics contract so the file stays self-describing after the original `app_start` has been rotated away. It is deliberately not a second `app_start`.
+
+What the log does **not** contain: terminal output, prompts, command text, or anything a session printed. It records edges and identities, not content.
+
+## Turning it on
+
+Set `activityLogEnabled` to `true` in `settings.json`. It is `false` by default, and a missing, null or malformed value is read as `false`.
+
+Writing is best-effort by design. If an append fails, AC logs a warning and keeps running rather than failing the operation that produced the event:
+
+```text
+[activity] append to <path> failed (continuing): <error>
+```
+
+## Where the file lives
+
+The file is `activity.jsonl`, in the same per-instance configuration directory as `settings.json` and `sessions.json`. That directory is chosen per binary instance, which is what makes two copies of AC keep separate logs.
+
+See [Directory layout](../reference/directory-layout.md) for the rule that picks that directory; this page does not restate it.
+
+The file rotates when it grows past its size limit. On rotation, AC starts the new file with the `metrics` line described above, for the same run as the record that triggered it.
+
+## Record format
+
+One event per line, each a complete JSON object. Here is a heartbeat line:
+
+```json
+{"v":1,"at":"2026-08-18T14:32:07.412Z","runId":"9d0d0f6a-6f5c-4d7f-9f5e-2f3b1c8a44e1","event":"app_alive","workingSessionIds":["2f9a1c7e-77d1-4a0a-9c53-0f6f9f2f1a20"]}
+```
+
+Every line carries the same three envelope fields, then the event tag, then the fields belonging to that event:
+
+| Field | Present on | Meaning |
+|---|---|---|
+| `v` | every line | Schema version. Currently `1`. |
+| `at` | every line | The timestamp, RFC 3339 in UTC with milliseconds, for example `2026-08-18T14:32:07.412Z`. |
+| `runId` | every line | Identifies one run of the app. Every line written between a start and a stop shares it. |
+| `event` | every line | Which of the five kinds this is, plus `metrics`. |
+| `sessionId` | `busy`, `idle` | The session the edge belongs to. |
+| `name` | `busy`, `idle` | The session's name at the time of the edge. |
+| `cwd` | `busy`, `idle` | The session's working directory. |
+| `agentKind` | `busy`, `idle` | Which coding agent the session runs. Absent when AC has none recorded. |
+| `reason` | `busy`, `idle` | Why the edge was recorded. |
+| `continuesBlock` | `busy` | Whether this `busy` continues the previous working block rather than starting a new one. |
+| `gapMs` | `busy` | The gap since the previous block, in milliseconds. Present exactly when `continuesBlock` is true, and absent otherwise. There is no third case. |
+| `idleThresholdMs` | `idle` | Present only when the close waited out the idle threshold. Its absence is what tells a consumer not to subtract anything. |
+| `workingSessionIds` | `app_alive` | The sessions the detector currently considers working. |
+| `pid` | `app_start` | The process id of the run. |
+| `appVersion` | `app_start` | The AC version that wrote the line. |
+| `previousRunScan` | `app_start` | What AC found when it looked for the previous run's state. |
+| `previousRun` | `app_start` | The previous run's details, or `null` when the scan found nothing readable. |
+| `concurrentInstancePid` | `app_start` | Present only when another live process holds the previous `daemon.pid`. Its presence forbids recovery-based closing. |
+| `metrics` | `app_start`, `metrics` | The self-describing metrics declaration. |
+| `openSessionsEnumerated` | `app_stop` | Whether the open sessions could be counted at shutdown. |
+| `openSessionCount` | `app_stop` | How many there were. |
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `activityLogEnabled` | Whether AC writes `activity.jsonl`. `false` by default. |
+
+See [Settings reference](../reference/settings.md#logging) for the logging group this key belongs to.
+
+## Troubleshooting
+
+**"There is no `activity.jsonl`."** `activityLogEnabled` is `false`, which is the default. Note that AC also reads it as `false` when the key is missing, `null`, or the settings file is malformed, so a JSON syntax error elsewhere in the file turns the log off without complaining about the log.
+
+**"The file exists but stopped growing."** Look for `[activity] append to <path> failed (continuing): <error>` in the application log. Appends are best-effort: a failure is warned about and skipped, never retried into a blocking error.
+
+**"I am looking at the wrong file."** Each binary instance has its own configuration directory, so a second copy of AC writes a second `activity.jsonl`. Confirm which instance you are reading before concluding anything from an empty file.
+
+**"An old `app_start` disappeared."** The file rotated. The rotated file opens with a `metrics` line instead, which is why a consumer can still read it without the original `app_start`.
+
+**"I need the application log, not this."** The activity log is not the debug log. `logLevel` and the filter syntax are covered in [Log filtering](../reference/log-filtering.md).
+
+## See also
+
+- [Directory layout](../reference/directory-layout.md) - where `activity.jsonl` sits and why
+- [Log filtering](../reference/log-filtering.md) - the separate application log and its levels
+- [Settings reference](../reference/settings.md#logging) - `activityLogEnabled` and `logLevel`

--- a/docs/features/agent-auto-update.md
+++ b/docs/features/agent-auto-update.md
@@ -1,0 +1,61 @@
+# Coding agent auto-update
+
+For developers who want their coding agents updated at startup without being asked every time. After this page you know what the startup prompt asks, what each answer commits you to, and how to change an answer you already gave.
+
+When AC starts, it can update the coding agents you use before you launch a session with them. The first time it meets a coding agent it has not asked about, it shows one prompt per agent. Your answer is remembered per coding-agent command, and AC never asks about that command again.
+
+## What it does
+
+At startup AC runs an update pass over your coding agents. While that pass is running, an overlay covers the sidebar and reads `Actualizando coding agents...`.
+
+The pass is keyed by **command**, not by agent id. Several coding agent profiles can share one binary (a "max effort" `claude` and a "cheap" `claude`, for example), and the binary is what gets updated, so AC asks once for `claude` rather than once per profile.
+
+An agent AC has never asked about is not updated silently. It gets the prompt below, and the default answer is No.
+
+## The startup prompt
+
+The prompt appears inside the same overlay, one at a time, and names the coding agent by its label:
+
+> ¿Querés que al arranque se intente actualizar automáticamente el coding agent `<label>`?
+
+Two buttons answer it: `Sí` and `No`. `No` holds the focus when the prompt opens.
+
+Pressing **Enter or Escape answers No**. Both keys take the safe answer rather than the focused-button answer, so dismissing the prompt out of reflex never signs you up for automatic updates. While an answer is in flight the buttons are disabled and the keys are ignored, so you cannot answer twice.
+
+## How your answer is remembered
+
+Your answer is written into `agentAutoUpdateByCommand` in `settings.json`, a map from coding-agent command to your answer:
+
+- `true` means AC updates that command at every startup and does not ask again.
+- `false` means AC never updates that command and does not ask again.
+- **An absent key means AC has never asked**, so it asks on the next startup.
+
+AC persists your answer **before** it tries to act on it. The point is that a failure while starting the update cannot cost you the answer: whatever happens next, that command is not asked about again.
+
+To change your mind later, edit the entry in `settings.json`. Setting a command back to an absent key (removing it from the map) makes AC ask you again on the next startup.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `agentAutoUpdateByCommand` | Your remembered answer per coding-agent command. `{}` by default, which means AC has asked about nothing yet. |
+
+See [Settings reference](../reference/settings.md#coding-agents) for the field's type and defaults.
+
+## Troubleshooting
+
+**"I answered and got `Se actualizará en el próximo arranque.`"** Your answer arrived after the prompt had already closed on the backend, so nothing was updated this time. The answer is saved: the update runs at the next startup, and you are not asked again.
+
+**"I answered No and got `No se volverá a preguntar.`"** Same race, harmless outcome. The prompt had already closed, and since a No means "never update", nothing was pending anyway. The answer is stored.
+
+**"The prompt shows an error toast and stays open."** The answer did not reach the backend at all. The overlay keeps the prompt open on purpose so you can press the button again; the toast stays until you dismiss it because a silent failure here would leave you thinking you had answered.
+
+**"AC updated an agent I never approved."** Check `agentAutoUpdateByCommand` for the agent's **command**, not its label or id. Two profiles sharing one command share one answer, so approving the update for one profile approves it for the binary they both use.
+
+**"I want to be asked again."** Remove that command's key from `agentAutoUpdateByCommand`. An absent key is what makes AC ask.
+
+## See also
+
+- [Settings reference](../reference/settings.md#coding-agents) - `agentAutoUpdateByCommand` and the rest of the coding agent configuration
+- [Coding agents](../integrations/coding-agents.md) - configuring the agents this prompt asks about
+- [Coding Agent Profiles](coding-agent-profiles.md) - why several profiles can share one command

--- a/docs/features/app-windows.md
+++ b/docs/features/app-windows.md
@@ -11,8 +11,8 @@ AC is one application that opens several windows. One page routes them all: the 
 | Sidebar | Projects, workgroups, replicas and sessions, plus the workgroup rail | Part of the main window; also runs on its own in the browser build |
 | Main | The default window: the sidebar beside a central pane | Starting AC |
 | Terminal | The central pane's terminal, or a detached window locked to one session | Part of the main window; detaching moves one session into its own window |
-| Guide | Hints and a tutorial | A separate window, routed as `?window=guide` |
-| Watchers | Watcher match activity | A separate window, routed as `?window=watchers`. See [Watchers](watchers.md) |
+| Guide | Hints and a tutorial | A button in the sidebar action bar |
+| Watchers | Watcher match activity | A button in the terminal status bar, which opens it scoped to that session. See [Watchers](watchers.md) |
 | Resource Monitor | Per-agent memory, CPU and process counts | Its own window, or attached to the main window's central pane. See [Resource monitor](resource-monitor.md) |
 | Spec Board | One Mermaid file with a live preview | The Spec Board button in the sidebar toolbar, once `specBoardEnabled` is on. See [Spec Board](spec-board.md) |
 | Screenshot overlay | The frozen-screen selection surface for a capture | The global screenshot hotkey. See [Screenshot capture](screenshot-capture.md) |

--- a/docs/features/app-windows.md
+++ b/docs/features/app-windows.md
@@ -1,0 +1,88 @@
+# App windows
+
+For developers wondering which AgentsCommander window they are looking at and where the others come from. After this page you can name every window AC opens, know what each is for, and find the page that owns it.
+
+AC is one application that opens several windows. One page routes them all: the window you get is decided by a `?window=` parameter, and the main window is what you get without one.
+
+## The window map
+
+| Window | What it is for | How to open it |
+|---|---|---|
+| Sidebar | Projects, workgroups, replicas and sessions, plus the workgroup rail | Part of the main window; also runs on its own in the browser build |
+| Main | The default window: the sidebar beside a central pane | Starting AC |
+| Terminal | The central pane's terminal, or a detached window locked to one session | Part of the main window; detaching moves one session into its own window |
+| Guide | Hints and a tutorial | A separate window, routed as `?window=guide` |
+| Watchers | Watcher match activity | A separate window, routed as `?window=watchers`. See [Watchers](watchers.md) |
+| Resource Monitor | Per-agent memory, CPU and process counts | Its own window, or attached to the main window's central pane. See [Resource monitor](resource-monitor.md) |
+| Spec Board | One Mermaid file with a live preview | The Spec Board button in the sidebar toolbar, once `specBoardEnabled` is on. See [Spec Board](spec-board.md) |
+| Screenshot overlay | The frozen-screen selection surface for a capture | The global screenshot hotkey. See [Screenshot capture](screenshot-capture.md) |
+
+## Sidebar
+
+The sidebar is the navigation surface: the workgroup rail down one edge, and the project panel listing projects, workgroups, replicas and sessions.
+
+In the desktop app it lives inside the main window. In the browser build it is rendered beside the terminal in the served page, with a draggable divider between them and a toggle to move it to the other side.
+
+Everything the sidebar shows is documented in [Sidebar guide](sidebar-guide.md).
+
+## Main window and Home
+
+The main window is the sidebar plus a central pane. The pane usually holds the terminal, and it can hold the Resource Monitor instead when you attach it.
+
+Before a session is selected the pane shows **Home**, a markdown document rendered inside the app. The markdown is parsed and then sanitized before it is displayed, so a document cannot inject scripts into the app.
+
+Home has three states and a control:
+
+- A refresh button, tooltipped `Refresh`, disabled while a fetch is in flight.
+- While loading with nothing to show yet: `Loading Home…`.
+- When the fetch fails with nothing to show yet: `Could not load Home: <error>`, with a `Try again` button.
+
+Both states are conditioned on there being no content yet, so refreshing an already-loaded Home leaves the current document on screen instead of blanking it.
+
+## Terminal
+
+The terminal is where a session's output goes, and it exists in two shapes: the central pane of the main window, and a detached window locked to one session. A detached window is marked as such in its titlebar.
+
+Around the terminal itself:
+
+- **The titlebar** carries the session name and its shell, and the detached marker when the window is detached.
+- **The status bar** carries the session's launch command and its controls, including the microphone button. See [Voice-to-text](voice-to-text.md) for what the mic does and how to cancel a recording.
+- **The last prompt** display shows the most recent command for the session.
+
+**The workgroup task** strip shows the title from the workgroup's `TASK.md`, parsed from the file's frontmatter. You can edit the title in place: `Enter` saves it, `Escape` cancels. The control refuses an empty title with `Title cannot be empty.`, and it stops if the session changed underneath the edit, with `Session changed; cancel and retry.` Both the edit and the clean control are disabled when there is no session or the session is not inside a workgroup.
+
+**Cleaning the task** asks first. The confirmation is titled `Clean TASK?` and states what it will do: it resets the workgroup `TASK.md`, replacing all frontmatter fields and body content with `title: 'Clean'` and the body `Ready to start a new topic`. If a `TASK.md` exists, a timestamped backup is saved alongside it before the reset. The buttons are `Cancel`, which has focus when the dialog opens, and `Clean`. `Escape` cancels, and `Enter` cleans only when `Clean` already has focus.
+
+## Guide
+
+The Guide is a small separate window with its own titlebar, holding two tabs: **Hints**, which opens first, and **Tutorial**.
+
+The tutorial covers the same ground as [Quickstart](../quickstart.md). Read whichever you prefer; they are not different procedures.
+
+## Other windows
+
+**Watchers.** One window listing watcher matches across your agent sessions, with a scope selector and filters. See [Watchers](watchers.md).
+
+**Resource Monitor.** Per-agent memory, CPU and process counts, plus the watchdog state. It runs either as its own window or attached to the main window's central pane, and it remembers which. See [Resource monitor](resource-monitor.md).
+
+**Spec Board.** One Mermaid file with source on one side and a live diagram on the other. Off by default. See [Spec Board](spec-board.md).
+
+**Screenshot overlay.** The full-screen surface you drag a rectangle on after pressing the capture hotkey. See [Screenshot capture](screenshot-capture.md).
+
+## Troubleshooting
+
+**"Home is stuck on `Loading Home…`."** The fetch has not returned. The message only appears while there is no content at all, so this is a first load, not a refresh. Press `Refresh` once it enables.
+
+**"Home says `Could not load Home:` and an error."** The document could not be fetched. `Try again` re-runs the same fetch; the error text names the cause.
+
+**"The task controls are greyed out."** Either no session is selected, or the selected session is not inside a workgroup. `TASK.md` belongs to a workgroup, so a plain shell has nothing to edit.
+
+**"I cleaned the task and lost its content."** The reset is what `Clean` does, and the confirmation says so before you press it. A timestamped backup is written next to `TASK.md` when one existed; look there.
+
+**"The Spec Board button is not in the toolbar."** `specBoardEnabled` is `false`, which is the default. See [Spec Board](spec-board.md).
+
+## See also
+
+- [Sidebar guide](sidebar-guide.md) - everything the sidebar window shows
+- [Keyboard shortcuts](../reference/keyboard-shortcuts.md) - the two window shortcuts and the one global hotkey
+- [Notifications and dialogs](notifications-and-dialogs.md) - the modals these windows raise

--- a/docs/features/context-tracking.md
+++ b/docs/features/context-tracking.md
@@ -1,0 +1,112 @@
+# Context tracking
+
+For developers who want to see how much of a coding agent's context window is gone before it runs out. After this page you can turn the reading on for an agent, read the badge on a session row, set per-team alert thresholds, and know exactly when AC notifies a coordinator and when it does not.
+
+AC scrapes the context percentage out of an agent's own terminal output using a pattern you configure, shows it as a badge on the session row, and can notify a workgroup's coordinator when a member crosses a threshold you set. It never acts on the reading itself.
+
+## What it tracks
+
+The reading comes from the agent, not from AC. Each coding agent in your catalog can carry a `contextRegex`: a regex pattern AC matches against that agent's terminal to pull out a percentage.
+
+Two consequences follow from that:
+
+- **No pattern, no reading.** An absent or blank `contextRegex` disables the reading for that agent. The value is used byte-for-byte and is never trimmed, so a pattern with a stray space is a different pattern.
+- **The reading is best-effort.** It is whatever the agent printed and the pattern matched. Treat it as an indicator, not as an accounting of the context window.
+
+The reading is per session, because the pattern belongs to the coding agent that session is running.
+
+## The context badge
+
+Each session row carries a badge with the current reading:
+
+| Badge | Meaning |
+|---|---|
+| `CTX 42%` | The last successful reading for that session. |
+| `CTX N/A` | The badge is configured, but there is no reading yet. |
+
+The badge is exposed as a meter running from 0 to 100, labelled `Context window used`, with the value read out as `Context <n>% used` for assistive technology.
+
+The badge appears only when the session's coding agent has a non-blank `contextRegex`. A session whose agent has no pattern shows no badge at all, which is different from `CTX N/A`: the first means "not configured", the second means "configured, nothing read yet".
+
+## Context alerts
+
+A team can carry up to **three** context alert thresholds. When a member session crosses one, AC sends that workgroup's coordinator an informational message. **No automatic action is taken**: no session is cleared, closed, restarted, handed off, or reassigned.
+
+The thresholds are validated when you save them:
+
+- Each is a whole percentage from **1 through 100**.
+- They must be **distinct**; two equal thresholds are rejected.
+- At most **three** per team.
+- They are stored **sorted ascending**, whatever order you typed them in.
+
+**Alerts are off by default.** A newly built team has no thresholds at all, so nothing fires until you add one.
+
+**The firing rule: once per crossing.** Each threshold has its own latch. When a reading reaches or passes a threshold whose latch is armed, AC queues the alert and latches that threshold. While the session stays above it, later readings are skipped, so a session parked at 92 percent does not alert every time it is sampled. Thresholds crossed in the same reading are queued together and delivered as one message.
+
+**A session that drops below and climbs back alerts again.** That is the behavior most likely to surprise you, and it is the point of the latch: it suppresses repetition, not recurrence.
+
+Four things re-arm a latch:
+
+1. the reading drops back below that threshold, the normal case and the only one you control directly;
+2. the session ends;
+3. the session is reported unavailable and confirmed no longer live, or its member policy resolves to disabled or permanently ineligible;
+4. the session's identity fingerprint changes.
+
+The last three drop the session's whole alert state, latches included.
+
+## Setting thresholds for a team
+
+Thresholds are edited in the team modals, in a section headed `Context usage alerts (optional)`. They apply to **every workgroup of that team**.
+
+The editor works one threshold at a time:
+
+- `Add threshold` appends a row, and a counter beside it reads `<n> of 3 thresholds`. The button disables at three.
+- Each row is labelled `Threshold <n> percentage` and takes a number, with a `%` suffix shown beside the input.
+- `Remove` deletes that row.
+- With none configured, the section reads `No context alerts configured.`
+
+**These thresholds are not a `settings.json` key.** They are stored in the team's own configuration, alongside the rest of what the team defines. There is no global context-alert setting, and nothing you can add to `settings.json` will turn alerts on for every team at once.
+
+## The injected alert message
+
+The message AC injects is a template with the id `context-alert`, and it ships pinned to this text:
+
+```text
+[AC context alert] `%MEMBER%` in `%WORKGROUP%` reached threshold(s): %THRESHOLDS%. No action taken; you decide any follow-up.
+```
+
+Three tokens are substituted: `%MEMBER%` for the member that crossed, `%WORKGROUP%` for the workgroup it belongs to, and `%THRESHOLDS%` for the threshold or thresholds crossed in that reading.
+
+The template is operator-editable. If you have changed it and want the shipped default back:
+
+```bash
+agentscommander injected-messages reseed --id context-alert
+```
+
+That rewrites only the `context-alert` entry, after writing a timestamped `.bak-` copy, and leaves your comments, entry order and every other message untouched. See [`injected-messages`](../reference/cli.md#injected-messages) for the full command.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `contextRegex` | The per-agent regex that produces the reading. `null` by default; absent or blank disables the reading for that agent. |
+
+See [Settings reference](../reference/settings.md#coding-agents) for the field in context; it lives on each entry of the coding agent catalog.
+
+## Troubleshooting
+
+**"The session row shows no badge."** The coding agent that session runs has no `contextRegex`, or it is blank. Set the pattern on the agent, not on the session.
+
+**"The badge is stuck on `CTX N/A`."** The pattern is configured but has matched nothing yet. Check that the agent actually prints a context percentage, and that the pattern matches its exact output; the value is used byte-for-byte, so a trailing space in the pattern is a real difference.
+
+**"A member is clearly over the threshold and no alert arrived."** Most often the alert already fired for that crossing and the threshold is latched. It re-arms when the reading drops back below. If the reading has never been under it, check the log: **a reading above 100 percent is rejected outright, with an error line and no alert**, so an agent printing a nonsense percentage produces silence rather than a warning.
+
+**"The team modal rejected my thresholds."** The validation is strict and says which rule you hit: at most three values, each a whole percentage from 1 through 100, and all distinct.
+
+**"I edited the alert text and want the original back."** Run `agentscommander injected-messages reseed --id context-alert`. The previous version is preserved in a timestamped `.bak-` file next to the config.
+
+## See also
+
+- [Watchers](watchers.md) - root-level patterns that reach every agent, where `contextRegex` reaches one
+- [`injected-messages` CLI reference](../reference/cli.md#injected-messages) - resetting the `context-alert` template
+- [Settings reference](../reference/settings.md#coding-agents) - `contextRegex` and the coding agent catalog

--- a/docs/features/control-plane-api.md
+++ b/docs/features/control-plane-api.md
@@ -1,0 +1,110 @@
+# Control-plane API
+
+For developers running a containerized coding agent, or any machine client that has to speak the inter-agent control plane over HTTP instead of the filesystem. After this page you can turn the API on, mint a scoped client token, and know which endpoint does what and what each one refuses.
+
+The control-plane API is a local HTTP server hosted inside the AC daemon. It lets a machine client send messages, list its peers, attach a session transport, and, with the right live binding, actuate PTY input or read a terminal snapshot. It is **off by default**: no listening socket appears unless you opt in.
+
+## What it is
+
+The API is a sibling of the web server, not the same thing. The web server serves the AgentsCommander interface to a human in a browser; the control-plane API serves a program. They have separate ports, separate bind addresses and separate credentials, and neither configures the other.
+
+The filesystem messaging path stays fully live alongside it. An API send is stored in the same durable queue and dispatched through the same actuation as a filesystem send, so a container and a host agent reach a peer the same way.
+
+Its first consumer is a Dockerized coding agent: the daemon starts the container with the API URL, a minted token and a session id in its environment, and never mounts the host config directory, the host `messaging/` directory or the Docker socket into it.
+
+## Turning it on
+
+Set `apiServerEnabled` to `true`. The port comes from `apiServerPort`, whose default is profile-aware per binary suffix and deliberately distinct from the web port so development and production builds do not collide.
+
+`apiServerBind` defaults to `127.0.0.1`. Widen it **only** when you are serving a container, and know what you are doing when you do: **any non-loopback bind logs a loud startup warning**, and the token, not the interface, is the trust boundary.
+
+Docker Desktop containers cannot reach a daemon bound only to `127.0.0.1`. For local container sessions the documented approach is to bind a Docker-reachable interface and limit access with host firewall rules scoped to the local Docker or WSL subnet.
+
+A bind or port change takes effect by saving settings and stopping and starting the API server. A full daemon restart is not required.
+
+## Authentication
+
+Every request except `healthz` needs a bearer token:
+
+```text
+Authorization: Bearer <client-token>
+```
+
+Tokens are minted host-side with the [`api-client`](../reference/cli.md#api-client) CLI verb, which requires the master or root token. A container has no master token by construction and cannot mint its own.
+
+```bash
+agentscommander api-client mint \
+  --token "$MASTER_TOKEN" \
+  --root "D:\path\to\wg-8-dev-v5-team\__agent_dev-rust" \
+  --scopes send,list-peers-lean \
+  --label "CI bot"
+```
+
+Four properties matter more than the syntax:
+
+- **A token is bound to exactly one replica.** The caller's identity is derived at request time from that bound root, never from the request body. The Root Agent is rejected, both at mint time and at request time.
+- **The secret is printed once.** The registry stores only a SHA-256 hash, in a host-only file that is never mounted into a container. `list` never shows secrets or hashes.
+- **Scopes are `send`, `list-peers-lean`, `session-transport`, `pty-input` and `terminal-snapshot`**, and they do not imply one another.
+- **The two privileged scopes never work on their own.** A manually minted `pty-input` or `terminal-snapshot` scope gains no live authority: both additionally require a matching automatically bound container credential, checked fresh on every request. Workers never receive them automatically.
+
+Revocation takes effect on the next request. Authentication is unconditional in every build profile, and a per-source-IP failed-auth lockout throttles unauthenticated probing.
+
+## Endpoints
+
+All routes live under `/api/v1`.
+
+| Route | Handler | What it does |
+|---|---|---|
+| `POST /api/v1/send` | `send` | Durable inline send to a peer FQN. `opId` is the idempotency key, enforced per sender, so a replay returns the same queued message id and never creates a second row. Inline payloads are capped at 256 KiB. Answers `202` with `{ "status": "queued", "messageId": "..." }`. |
+| `GET /api/v1/peers` | `list_peers` | `list-peers-lean` for the caller's bound replica. Reachability is computed from the bound identity, not from anything in the request. |
+| `GET /api/v1/session-transport` | `session_transport` | A WebSocket upgrade carrying one container session's terminal transport. Authorization happens before the upgrade, and the socket is bound to that session, its backend and its bound root, with a fixed maximum frame size. |
+| `POST /api/v1/pty-input` | `pty_input` | Privileged exact PTY actuation into one live, automatically bound container coordinator's same-workgroup member. Requires the `pty-input` scope. `text` is 1 through 65,536 decoded UTF-8 bytes. `opId` is permanently idempotent for that sender incarnation. |
+| `GET /api/v1/pty-input/{opId}` | `pty_input` | Metadata-only status for the authenticated sender's own operation. Statuses are `queued`, `actuating`, `injected`, `rejected` and `indeterminate`. Returns `200` or `404`. |
+| `POST /api/v1/terminal-snapshot` | `terminal_snapshot` | Reads one live backend terminal viewport as JSON or PNG. Requires the `terminal-snapshot` scope **and** the default-off `terminalSnapshotsEnabled` gate. See [Terminal snapshots](terminal-snapshots.md). |
+| `GET /api/v1/windows/{window_id}/screenshot` | `window_screenshot` | Returns the PNG bytes of exactly one live native window. **Windows only**: the route is absent from other builds rather than emulated. It enforces the `pty-input` scope and the same fresh bound-credential guard. See [Window capture](window-capture.md). |
+| `GET /api/v1/healthz` | `health` | Unauthenticated liveness. The body is exactly `{"ok":true}`. |
+
+Two notes on reading that table. `injected` proves the backend accepted the exact text and the required first Enter; it does not prove the model consumed or completed anything. `indeterminate` means actuation began and complete submission cannot be proven, and it is never replayed automatically: keep the same operation id and look the status up rather than retrying under a new one.
+
+## Authorization and audit
+
+Scope is necessary and never sufficient. Authority is based on live physical identity, and the [security model](../security.md) is the binding description; the short version:
+
+- A live container coordinator may target one verified non-coordinator member in the same exact project and workgroup.
+- Manual API clients, workers, stale sessions, cross-workgroup and cross-project routes, aliases and wildcards have no privileged authority, whatever their scope list says.
+- Target names must be exact canonical FQNs.
+
+**Audit is metadata-only.** Every mint, revoke and authenticated request appends a record to a host-only audit log with a size cap and one rotation. Terminal snapshots emit their own metadata-only event instead of the generic one. Secrets and hashes are never logged, and neither is terminal text, JSON, PNG data, a raw nonce, an output path, or arbitrary parser errors.
+
+Two limits stated plainly, because they are easy to over-read. The audit is **fail-soft operational metadata, not compliance-grade fail-closed audit**. And the message bus database on the host holds queued message bodies and replayable nonterminal PTY-input text in plaintext until the operation commits or rejects; clearing those bytes is redaction of live application state, not forensic secure erasure.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `apiServerEnabled` | Whether the control-plane API server runs. `false` by default. |
+| `apiServerPort` | The listening port. Profile-aware default per binary suffix, distinct from the web port. |
+| `apiServerBind` | The bind address. `"127.0.0.1"` by default. Any non-loopback bind logs a loud startup warning at startup. |
+
+See [Settings reference](../reference/settings.md#control-plane-api-server-opt-in) for the field types.
+
+## Troubleshooting
+
+**"Every request comes back 401."** The token is absent, revoked or expired. Revocation takes effect on the next request, so a token that worked a moment ago can stop between calls. `api-client list` shows which clients are registered.
+
+**"The token authenticates but a privileged call returns 403."** The scope is missing, or the call is privileged and the client is manually minted. `pty-input` and `terminal-snapshot` require a live automatically bound container credential in addition to the scope; a hand-minted token holding those scopes never gains authority.
+
+**"A container cannot reach the API at all."** Check `apiServerBind`. A daemon bound only to `127.0.0.1` is unreachable from a Docker Desktop container; that is the documented cause, and the fix is a Docker-reachable bind plus firewall rules limiting access to the local Docker or WSL subnet.
+
+**"A PTY-input retry returned 409."** The same `opId` was reused with a changed target, text, profile, source semantics or sender identity. That combination can never create a second injection under that id. Use a new `opId` for new work, and the original one only for an exact retry.
+
+**"The status says `indeterminate`."** Actuation began and completion cannot be proven. Do not replay it under a new id. Look the same operation id up; a new id would risk a second injection of the same text.
+
+**"Is the server even up?"** `GET /api/v1/healthz` needs no token and answers exactly `{"ok":true}`.
+
+## See also
+
+- [Terminal snapshots](terminal-snapshots.md) - the full contract behind the snapshot endpoint
+- [Window capture](window-capture.md) - the window screenshot route, its limits and its audit
+- [Security model](../security.md) - the authority matrix these endpoints enforce
+- [`api-client` CLI reference](../reference/cli.md#api-client) - minting, revoking and listing clients

--- a/docs/features/non-stop-mode.md
+++ b/docs/features/non-stop-mode.md
@@ -53,7 +53,7 @@ The group's display name is derived, not stored blindly:
 - The legacy name `Non-stop` also falls back to `Alert me!`, so instances configured before the rename show the current name.
 - A longer name is capped at the group-name limit.
 
-The rail entry and the project-panel tooltip both show that derived name, which is why they always agree.
+The rail entry shows that derived name. The project panel does not: its non-stop slot and the slot's tooltip always render the built-in `Alert me!`, so after you rename the group the two surfaces disagree until you rename it back.
 
 ## Where the configuration lives
 

--- a/docs/features/non-stop-mode.md
+++ b/docs/features/non-stop-mode.md
@@ -1,0 +1,80 @@
+# Non-stop mode
+
+For developers running several workgroups at once who cannot watch all of them. After this page you can put a workgroup under non-stop watch, set how long a stall may last before AC tells you, and diagnose a group that looks configured but never alerts.
+
+Non-stop mode watches a group of workgroups and tells you when one of them stops working. You choose the workgroups, how long a stall is allowed to last, and how AC reaches you: a Telegram message, a sound, or both. AC checks once a second and alerts once per stall, so a workgroup that stalls for an hour does not produce an hour of alerts.
+
+## What it does
+
+Each project has one built-in non-stop group. Its default name is `Alert me!`, and it sits pinned above the groups you create yourself.
+
+While that group has at least one member workgroup and at least one alert measure turned on, the sidebar reports the group's state to the backend: how many members are working, how many there are in total, and the names of the members that are not working. AC calls "not every member is working" a **disparity**.
+
+A disparity on its own is not an alert. Workgroups pause between turns all the time, and a pause of a few seconds is normal. What AC acts on is a disparity that **lasts**, which is what the group's tolerance sets.
+
+If neither Telegram nor sound is enabled for the group, the sidebar does not report it at all. That is deliberate: a group with no way to reach you has nothing to fire, so AC stays quiet rather than tracking a state nobody will see.
+
+## Turning it on
+
+Two controls do the same thing, and either one is enough.
+
+- **The workgroup rail.** The rail shows one entry per group, and the non-stop entry carries the group's display name (`Alert me!` unless you renamed it). Selecting it shows the workgroups currently in the group.
+- **The project panel.** Each workgroup row in the project tree has a non-stop checkbox in the built-in slot pinned above your own groups. Its tooltip reads `Watch this workgroup in the Alert me! group`. Tick it and that workgroup joins the group; untick it and it leaves.
+
+Turning the group on is not the whole setup. Enable Telegram, sound, or both for the group, otherwise nothing is watched. See [Troubleshooting](#troubleshooting).
+
+## What the watchdog does
+
+The watchdog is a backend loop that ticks **once a second** for as long as AC runs. Nothing you configure stops it: turning non-stop off for a workgroup changes what a tick finds, not whether ticks happen.
+
+On each tick, for each project's non-stop group:
+
+- If there is no disparity, there is nothing to arm.
+- When a disparity begins, AC records when it started.
+- When that disparity has lasted the tolerance configured for the group, the episode **fires once**. It does not fire again while the same disparity continues.
+- If the disparity ends, the episode re-arms and can fire again on the next one.
+
+The watchdog also protects itself against a frontend that has gone away. An armed episode whose last report is older than **180 seconds** is disarmed instead of fired, and AC logs:
+
+```text
+[non-stop] '<project path>' disarmed: no frontend report for >180s (frontend gone)
+```
+
+That is why closing the window that reports stops alerts rather than triggering them.
+
+## Scope: per workgroup
+
+Non-stop is **per workgroup within one project**, never a global switch. Each project keeps its own non-stop group, and a workgroup is watched only if it is a member of its own project's group.
+
+The group's display name is derived, not stored blindly:
+
+- The name you set is trimmed of surrounding whitespace.
+- An empty name falls back to `Alert me!`.
+- The legacy name `Non-stop` also falls back to `Alert me!`, so instances configured before the rename show the current name.
+- A longer name is capped at the group-name limit.
+
+The rail entry and the project-panel tooltip both show that derived name, which is why they always agree.
+
+## Where the configuration lives
+
+**There is no non-stop key in `settings.json`.** Non-stop is not a global preference, so it is not in the global settings file and there is no key to add there.
+
+The configuration is per project, in the project's `.ac/project-settings.json`, alongside the rest of the project's group configuration. AC writes that file for you when you use the rail or the project panel; you do not need to edit it by hand.
+
+What that file holds for the group: its name, its member workgroups, its tolerance in seconds, and the two measures (Telegram, with its bot, and sound, with its duration).
+
+## Troubleshooting
+
+**"The group has workgroups in it and nothing ever alerts."** Check that Telegram or sound is enabled for the group. With neither enabled, the sidebar stops reporting the group and the watchdog never sees it. This is the most common cause, and it is silent by design: there is no error and no toast.
+
+**"The group is on, a workgroup is clearly stalled, and nothing happened."** Two checks. First, the group must have at least one member: an empty group produces no report, because no disparity is possible. Second, the stall must outlast the group's tolerance; a stall shorter than that never arms an episode long enough to fire.
+
+**"Alerts stopped after I closed a window."** Look for `[non-stop] '<project path>' disarmed: no frontend report for >180s (frontend gone)` in the log. The backend disarms an episode when the sidebar stops reporting for more than three minutes, so a closed or unloaded frontend silences the group instead of firing it.
+
+**"I renamed the group and the rail still says `Alert me!`."** The name `Non-stop` is treated as the legacy name and falls back to `Alert me!`. Pick any other name.
+
+## See also
+
+- [Concepts](../concepts.md) - workgroup, session, and what "working" means for a session
+- [Project Loops](project-loops.md) - the other way AC acts on a workgroup without you
+- [Telegram bridge](telegram-bridge.md) - the bridge that delivers a Telegram alert

--- a/docs/features/non-stop-mode.md
+++ b/docs/features/non-stop-mode.md
@@ -53,7 +53,7 @@ The group's display name is derived, not stored blindly:
 - The legacy name `Non-stop` also falls back to `Alert me!`, so instances configured before the rename show the current name.
 - A longer name is capped at the group-name limit.
 
-The rail entry shows that derived name. The project panel does not: its non-stop slot and the slot's tooltip always render the built-in `Alert me!`, so after you rename the group the two surfaces disagree until you rename it back.
+The rail entry shows that derived name. The project panel does not: its non-stop slot and the slot's tooltip always render the built-in `Alert me!`. Rename the group to anything that does not fall back to that name and the two surfaces disagree until you rename it back.
 
 ## Where the configuration lives
 

--- a/docs/features/notifications-and-dialogs.md
+++ b/docs/features/notifications-and-dialogs.md
@@ -82,6 +82,8 @@ Two settings govern every sound AC makes.
 
 `soundsEnabled` is the master switch for all app-emitted sounds, and it is `true` by default. Turn it off and AC makes no sound at all.
 
+You do not have to edit `settings.json` for that one: the sidebar action bar carries a mute button whose tooltip and accessible label follow the current value, reading `Mute all app sounds` while sounds are on and `Unmute app sounds` once they are off. It writes the same setting.
+
 `teamIdleBeepEnabled`, also `true` by default, beeps when a team transitions from busy to all-idle. It is gated by `soundsEnabled`: with the master switch off, this one changes nothing.
 
 ## Settings

--- a/docs/features/notifications-and-dialogs.md
+++ b/docs/features/notifications-and-dialogs.md
@@ -48,7 +48,7 @@ The confirmation is hosted by more than one window, including the Guide, so you 
 
 ## Onboarding
 
-The first-run wizard opens when AC has no configuration to work from, and walks you through adding a coding agent so the app is usable when it closes. `Get started` is the control that carries you through it.
+The first-run wizard is titled `Welcome`. It opens when AC has no configuration to work from, and walks you through adding a coding agent so the app is usable when it closes.
 
 `onboardingDismissed` in `settings.json` records whether the first-run wizard was dismissed, and it defaults to `false`.
 

--- a/docs/features/notifications-and-dialogs.md
+++ b/docs/features/notifications-and-dialogs.md
@@ -1,0 +1,114 @@
+# Notifications and dialogs
+
+For developers who just saw a message from AgentsCommander and want to know what it means before answering it. After this page you can match any toast, banner or modal on screen to what raised it and what each button does.
+
+AC interrupts you in three ways: a toast in the corner, a banner inside the sidebar, and a modal that blocks until you answer. This page covers all of them, in the order you are likely to meet them.
+
+## Toasts
+
+A toast is a short message in the corner. Every toast has a kind, and the kind decides how long it stays:
+
+| Kind | Lifetime |
+|---|---|
+| `error` | **Sticky.** It stays until you dismiss it. |
+| `success` | Auto-dismisses after 4 seconds. |
+| `info` | Auto-dismisses after 4 seconds. This is the default kind. |
+
+Any toast can be dismissed by hand with the `×` button, labelled `Dismiss notification` for assistive technology. A caller can also override a toast's lifetime, including making a non-error toast sticky.
+
+At most **four** toasts are visible at once. Past that, AC evicts the oldest one that is **not** an error, and falls back to the oldest overall only when every visible toast is an error. That rule exists so a transient info toast can never quietly bury an error you have not read.
+
+Clicking a toast's body does not raise or focus the terminal behind it, so dismissing one never steals your place.
+
+## The error modal
+
+The error modal is titled `Application Error`. It appears when AC has an application-level failure to report that is too important for a toast.
+
+It shows the error's detail in a region labelled `Error detail`, and when more than one error is queued it also shows a counter, reading for example `1 of 3`, so you know how many are waiting behind the one on screen.
+
+`Dismiss` closes the current error and moves to the next queued one, if any.
+
+## Quitting the app
+
+Closing AC while detached terminal windows are open asks first. The dialog is titled `Quit AgentsCommander?` and tells you what is open:
+
+> You have `<n>` detached session`(s)` open. Quit the app and close all detached sessions?
+
+Two buttons: `Cancel` and `Quit`. `Cancel` has focus when the dialog opens, so a reflexive `Enter` cancels rather than quits. `Escape` cancels. `Enter` quits **only** when `Quit` already has focus.
+
+## Opening an external link
+
+A link that leads outside the app is confirmed before it opens. The dialog says:
+
+> This link opens outside Agents Commander.
+
+`Open anyway` proceeds and hands the URL to your browser. Declining leaves you where you were and opens nothing.
+
+The confirmation is hosted by more than one window, including the Guide, so you get the same prompt wherever the link was.
+
+## Onboarding
+
+The first-run wizard opens when AC has no configuration to work from, and walks you through adding a coding agent so the app is usable when it closes. `Get started` is the control that carries you through it.
+
+`onboardingDismissed` in `settings.json` records whether the first-run wizard was dismissed, and it defaults to `false`.
+
+**One caveat before you build automation on that flag.** Exactly what sets it, and whether it means "onboarding completed" or only "the user cancelled onboarding", is an open product question tracked as issue #505 in the repository's own QA notes. This page does not state which reading is correct, because source did not settle it.
+
+## Restart prompt
+
+Some changes to a session's configuration only apply to a fresh process. When you make one, AC asks:
+
+> Restart the session now to apply it?
+
+Accepting restarts that session. Declining leaves it running with the previous configuration until you restart it yourself.
+
+## Root Agent banner
+
+The banner sits at the top of the sidebar and belongs to the **Root Agent** session: the single host-level agent described in the [glossary](../glossary.md#root-agent).
+
+With no Root Agent session running, the banner's action creates one. With one running, the banner is that session's compact control strip: its status dot, its context badge when the agent has a context pattern configured, and controls to open its folder in the file explorer (`Open folder in explorer`), close it (`Close session`), restart it (`Restart Session`), pick its coding agent (`Coding Agent`), and cancel a voice recording in progress (`Cancel recording`).
+
+## Context-template updates
+
+When AC ships a newer default for a project context template you have edited, it asks rather than overwriting. The modal is titled `Context template update` and offers the choice in as many words: keep your version, or overwrite it with the new default.
+
+Two buttons: `Keep my version` leaves your file untouched, and `Overwrite with default` replaces it with the version this build ships.
+
+See [Agent Matrix conventions](../agent-matrix-conventions.md) for what project context templates are and where they live.
+
+## Sounds
+
+Two settings govern every sound AC makes.
+
+`soundsEnabled` is the master switch for all app-emitted sounds, and it is `true` by default. Turn it off and AC makes no sound at all.
+
+`teamIdleBeepEnabled`, also `true` by default, beeps when a team transitions from busy to all-idle. It is gated by `soundsEnabled`: with the master switch off, this one changes nothing.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `soundsEnabled` | Master switch for all app-emitted sounds. `true` by default. |
+| `teamIdleBeepEnabled` | Beep when a team transitions from busy to all-idle. `true` by default, gated by `soundsEnabled`. |
+
+See [Settings reference](../reference/settings.md#window--ui) for both keys in context.
+
+## Troubleshooting
+
+**"An error toast will not go away on its own."** That is deliberate: error toasts are sticky and wait for you. Dismiss it with the `×`.
+
+**"A toast disappeared before I read it."** Four toasts are visible at once and a fifth evicts the oldest non-error. Errors are protected from that eviction, so what vanished was an info or success message.
+
+**"The idle beep does not fire for the workgroup I am watching."** Expected. AC suppresses the beep for the workgroup whose session currently has your focus, and briefly after you move focus away from one. A workgroup you are not looking at still beeps.
+
+**"No sound at all, and `teamIdleBeepEnabled` is `true`."** Check `soundsEnabled`. It is the master switch, and the beep is gated by it.
+
+**"`Enter` quit the app when I meant to cancel."** It should not have: `Cancel` holds focus when the quit dialog opens, and `Enter` quits only when `Quit` has focus. If it did quit, the focus had moved to `Quit` first.
+
+**"Onboarding came back after I completed it."** See the caveat in [Onboarding](#onboarding) above: what persists the dismissal is an open question tracked as issue #505, and this page does not assert either behavior.
+
+## See also
+
+- [App windows](app-windows.md) - the windows these dialogs appear in
+- [Settings reference](../reference/settings.md#window--ui) - `soundsEnabled` and `teamIdleBeepEnabled`
+- [Agent Matrix conventions](../agent-matrix-conventions.md) - the context templates the update modal offers to replace

--- a/docs/features/project-archiving.md
+++ b/docs/features/project-archiving.md
@@ -18,7 +18,9 @@ What changes for you:
 
 ## Archiving a project
 
-Archiving is started from the project's own row in the sidebar and applies to that one project.
+Right-click the project's row in the sidebar and choose `Archive Project`. It applies to that one project.
+
+A refusal comes back as an **error toast**, which is sticky: it stays until you dismiss it, so the message naming the sessions that blocked the archive cannot scroll away before you read it.
 
 AC checks for open sessions before it writes anything. If the project has any, the archive is refused and nothing changes; see the next section for what counts as open. If the check passes, AC writes the archive, then **checks a second time**. If a session became live between the two checks, AC unarchives the project again, tells the sidebar, restores the project catalog, and reports the same refusal message as if it had never started.
 

--- a/docs/features/project-archiving.md
+++ b/docs/features/project-archiving.md
@@ -1,0 +1,102 @@
+# Project archiving
+
+For developers whose sidebar has collected projects they are done with. After this page you can archive a project, understand exactly what that does and does not touch, get it back, and read the message that tells you why an archive was refused.
+
+Archiving hides a project from the sidebar. It is a change to AC's registration list, not to your files: the project's folder, its `.ac` directory, its workgroups and its history stay exactly where they are.
+
+## What archiving does
+
+Archiving moves one path from AC's active project list to its archived list. That is the whole operation. `projectPaths` loses the entry and `archivedProjectPaths` gains it, each alongside its portable companion path, preserving array order.
+
+**Nothing on disk is moved, renamed or deleted.** Archiving is not a delete, it does not free space, and it does not touch the project's contents. An archived project is described in the settings reference as "registered but hidden", which is exactly right: AC still knows about it, and stops showing it.
+
+What changes for you:
+
+- The project disappears from the sidebar and from the workgroup rail.
+- It stops taking part in startup restoration and team discovery.
+- No session can start inside it while it is archived. That is enforced, not a convention, and it is why the auto-unarchive flow below exists.
+
+## Archiving a project
+
+Archiving is started from the project's own row in the sidebar and applies to that one project.
+
+AC checks for open sessions before it writes anything. If the project has any, the archive is refused and nothing changes; see the next section for what counts as open. If the check passes, AC writes the archive, then **checks a second time**. If a session became live between the two checks, AC unarchives the project again, tells the sidebar, restores the project catalog, and reports the same refusal message as if it had never started.
+
+A project whose folder has vanished can still be archived. That is deliberate: a registration pointing at a folder you deleted is exactly the kind of entry you want out of the sidebar.
+
+## What blocks an archive
+
+One thing blocks an archive: **open sessions inside the project**. AC builds a single list of blocker names from two places and deduplicates it, so the same name never appears twice:
+
+- pending spawns whose working directory is inside the project, and
+- live sessions whose working directory is inside the project.
+
+Both feed the same "open session(s)" count in the same message.
+
+Two exclusions matter, because without them the count will not match what you see in the sidebar:
+
+- **Root Agent sessions never block an archive.** Not by their Root Agent flag, and not by their directory name.
+- **A running session with no terminal does not block.** Liveness here means a live PTY, so a session record that is listed but has no terminal attached is not a blocker. An exited session under the project does not block either.
+
+The practical consequence: close the sessions the message names, then archive again. There is no force flag, and this page will not invent one.
+
+## Unarchiving
+
+Archived projects live in the **Archived projects** modal. Each row shows the project's folder name and its full path, and carries an `Unarchive` button, which reads `Unarchiving...` while it runs. Unarchiving puts the path back in the active list and the project back in the sidebar.
+
+Two things a row can tell you before you restore it:
+
+- `Folder missing` means the folder the registration points at is gone.
+- `Workspace missing` means the folder is there but its workspace is not.
+
+A row in either state gains a second button, `Remove from list`, which drops the registration entirely. **That button removes the project from AC, not from disk**, and it is offered only for rows AC could not validate.
+
+When the list is empty the modal reads `No archived projects`. `Close` and the Escape key both close it.
+
+## Auto-unarchive
+
+An archived project cannot hold a running session. When a session starts inside one anyway, AC does not refuse it and does not leave the project archived: it restores the project and then tells you.
+
+The dialog is titled `Project un-archived`, or `Projects un-archived` when more than one was restored, and it names each project and the session that caused it. For a single project it reads:
+
+> `<folder name>` was restored to your project list. A session started inside it, and an archived project cannot hold a running session.
+
+For several:
+
+> These projects were restored to your project list because sessions started inside them, and archived projects cannot hold running sessions.
+
+The only control is `Got it`, and Escape does not close the dialog. **Confirming it acknowledges the notice; it does not perform or undo anything.** The restore already happened before you were told. If you did not want the project back, archive it again after closing the session that pulled it in.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `archivedProjectPaths` | Absolute paths of archived projects: registered but hidden. `[]` by default. |
+| `archivedProjectPathsRelativeToInstance` | The portable companion of each archived path, same length and order. |
+| `projectPaths` | The active project list an archive removes an entry from. |
+
+See [Settings reference](../reference/settings.md#projects) for the companion-path rules and how archiving moves the whole pair together.
+
+## Troubleshooting
+
+**"Cannot archive: 2 open session(s) in this project (dev-rust, tech-lead). Close them first."** Exactly what it says: those sessions are open under the project. Close them and archive again. The message names at most three:
+
+```text
+Cannot archive: 5 open session(s) in this project (dev-rust, tech-lead, architect, and 2 more). Close them first.
+```
+
+The count in front is the total, and `and <m> more` covers the ones past the first three.
+
+**"The count is higher than the sessions I can see."** A pending spawn counts as an open session, even before its terminal exists. Wait for it to finish starting, or close it, and the count drops.
+
+**"The count is lower than the sessions I can see."** Root Agent sessions are excluded, and so is any session without a live terminal. Both are deliberate.
+
+**"The project got archived and I got `The project could not be restored automatically (<error>). Open Archived Projects to restore it.`"** This is the rare case: a session became live between AC's two checks, AC tried to roll the archive back, and the rollback itself failed. The project is archived and you did not want it archived. Open the **Archived projects** modal and press `Unarchive` on it. The blocker message that precedes that sentence tells you which sessions appeared.
+
+**"I archived a project and its files are gone."** Archiving does not touch files. It edits two lists in `settings.json`. If files are missing, something else removed them; check the row in the modal for `Folder missing`, which means the registration now points at nothing.
+
+## See also
+
+- [Settings reference](../reference/settings.md#projects) - the project and archived-project path arrays
+- [Sidebar guide](sidebar-guide.md) - the project panel the archived project disappears from
+- [Portable instances](portable-instances.md#portable-project-paths) - the companion path format archiving preserves

--- a/docs/features/project-loops.md
+++ b/docs/features/project-loops.md
@@ -81,7 +81,7 @@ Each outcome produces a toast in the sidebar:
 | Came due while AC was closed | `Loop "<name>" was missed while AgentsCommander was closed` |
 | Delivery failed | `Loop "<name>" failed` |
 
-The first four and the last carry the backend's own message when it has one, so the text you see can be more specific than the table above.
+Every one of them carries the backend's own message when it has one, so the text you see can be more specific than the table above.
 
 ## Busy sessions and respawn
 

--- a/docs/features/project-loops.md
+++ b/docs/features/project-loops.md
@@ -85,7 +85,7 @@ The first four and the last carry the backend's own message when it has one, so 
 
 ## Busy sessions and respawn
 
-**Busy.** A coordinator is busy when it is working rather than waiting for input. The busy policy decides what a Loop does about it:
+**Busy.** AC checks whether the target coordinator is busy at the moment the Loop comes due, and the busy policy decides what to do about it:
 
 - **Wait until idle** holds the delivery and marks the Loop pending. AC retries it on later scans and delivers when the coordinator goes idle. This is the default.
 - **Force inject** delivers anyway, interrupting whatever the coordinator is doing. This is the `Force inject even if coordinator is busy` checkbox.

--- a/docs/features/project-loops.md
+++ b/docs/features/project-loops.md
@@ -1,0 +1,129 @@
+# Project Loops
+
+For developers who want a coordinator prompted on a schedule instead of remembering to do it. After this page you can create a Loop that wakes a workgroup's coordinator on a cron expression, choose what happens when that coordinator is busy, and read the toast that tells you what the Loop did.
+
+A Project Loop is a scheduled prompt. You give it a cron expression, a target workgroup, and the text to send; AC delivers that text to the workgroup's coordinator when the schedule comes due, waking or respawning the session if it is not running.
+
+## What a Loop is
+
+A Loop belongs to one registered project and targets one workgroup inside it. It carries four things: an id, a cron expression, the target workgroup whose **coordinator** receives the prompt, and the prompt text.
+
+Two more properties control its behavior: whether it is enabled, and its busy policy, which decides what happens when the coordinator is mid-task at delivery time.
+
+A Loop is not a background agent and does not run anything itself. All it does is put your prompt into a coordinator's terminal at the right moment. What happens next is whatever that coordinator does with it.
+
+## Creating a Loop
+
+**From the sidebar.** The project's Loops section carries the actions: create a Loop, run one now, edit it, enable or disable it, and delete it. Deleting asks for confirmation first.
+
+The `New Loop` modal has four fields and two checkboxes:
+
+| Control | What it takes |
+|---|---|
+| `Name` | A human-readable name, for example `Weekday standup`. |
+| `Cron` | A five-field cron expression, for example `0 9 * * 1-5`. |
+| `Workgroup Coordinator` | The target workgroup, chosen from a list. Starts on `Select a coordinator...`. |
+| `Prompt` | The text to inject into the coordinator. |
+| `Enabled` | On by default. Off creates the Loop without scheduling it. |
+| `Force inject even if coordinator is busy` | Off by default. See [Busy sessions and respawn](#busy-sessions-and-respawn). |
+
+The modal checks the cron expression while you type. It shows `Checking schedule...` while it asks the backend, then `Next run: <time>` when the expression parses. A wrong field count is rejected up front with `Cron expression must have exactly five fields`, and an expression the backend rejects shows `Invalid cron expression`. **`Create` stays disabled until the preview is ready**, so a Loop with an unparseable schedule cannot be created.
+
+If the project has no workgroup with a verified coordinator, the picker is empty and the modal says `A workgroup with a verified coordinator is required.` Create the coordinator first.
+
+`Ctrl+Enter` creates the Loop, `Escape` closes the modal.
+
+**From the CLI.** Every operation is also a `loop` subcommand, which is what you want for scripting or for a machine with no GUI:
+
+```bash
+agentscommander loop create \
+  --project MyProject \
+  --name "Daily sync" \
+  --cron "0 9 * * 1-5" \
+  --workgroup wg-1-dev-team \
+  --prompt "Check status and ask for blockers."
+```
+
+`list`, `update`, `enable`, `disable` and `remove` complete the set, and `list` also prints the scheduler state. See [`loop`](../reference/cli.md#loop) for every flag and its exact meaning; this page does not repeat them.
+
+The CLI accepts one busy policy the modal does not expose: `--busy-coordinator skip`. The modal's checkbox chooses between waiting and force-injecting only.
+
+## Scheduling
+
+The cron expression has five fields: minute, hour, day-of-month, month, day-of-week.
+
+AC scans each Loop on a schedule and compares the expression against the window since it last checked:
+
+- A **disabled** Loop is skipped entirely.
+- The **first** scan of a new Loop only writes a baseline. A Loop you create today does not fire for occurrences that fell before you created it.
+- When several occurrences fall inside one window, AC takes **the latest one** and delivers once. A machine that was asleep through five daily runs gets one prompt, not five.
+- A Loop that came due while **AgentsCommander was closed** is recorded as missed, not delivered late. You get the missed toast at startup and no surprise prompt.
+- A delivery already **pending** on a busy coordinator is retried before any new occurrence is considered, and a second occurrence arriving while it is still pending is coalesced into it rather than queued.
+
+## Delivery: what happens when a Loop fires
+
+Delivery targets the coordinator of the Loop's workgroup, in this order:
+
+1. AC resolves the target workgroup and its coordinator replica.
+2. If a workgroup purge is destroying that agent right now, delivery is skipped with `purge-wg in progress for '<agent>'; loop delivery skipped`. A Loop tick never resurrects an agent a purge is removing.
+3. If a live coordinator session exists, it is used. If not, AC clears any stale session records and **spawns the coordinator session**.
+4. AC checks whether the coordinator is busy and applies the Loop's busy policy.
+5. The prompt is injected into the session, exactly as if you had typed it, and becomes that session's last prompt.
+
+Each outcome produces a toast in the sidebar:
+
+| Outcome | Toast |
+|---|---|
+| Delivered | `Loop "<name>" delivered` |
+| Coordinator busy, policy waits | `Loop "<name>" is pending until the coordinator is idle` |
+| Coordinator busy, policy skips | `Loop "<name>" skipped because the coordinator is busy` |
+| A second occurrence while one is pending | `Loop "<name>" coalesced into the pending delivery` |
+| Came due while AC was closed | `Loop "<name>" was missed while AgentsCommander was closed` |
+| Delivery failed | `Loop "<name>" failed` |
+
+The first four and the last carry the backend's own message when it has one, so the text you see can be more specific than the table above.
+
+## Busy sessions and respawn
+
+**Busy.** A coordinator is busy when it is working rather than waiting for input. The busy policy decides what a Loop does about it:
+
+- **Wait until idle** holds the delivery and marks the Loop pending. AC retries it on later scans and delivers when the coordinator goes idle. This is the default.
+- **Force inject** delivers anyway, interrupting whatever the coordinator is doing. This is the `Force inject even if coordinator is busy` checkbox.
+- **Skip** drops this occurrence and waits for the next scheduled one. CLI only.
+
+**Respawn.** A Loop does not need its coordinator to be running. AC treats a session as live only when its status is active, running or idle **and** it still has a terminal attached. Anything else is respawned before delivery:
+
+- A session that has **exited** is respawned.
+- A session that is listed but has **no terminal** (dormant, never mounted, or left over from a previous run) is also respawned, and its stale record is cleared first.
+
+The practical consequence: a Loop wakes a workgroup you closed yesterday. If you do not want that, disable the Loop rather than closing the session.
+
+## Where the configuration lives
+
+**There is no Loop key in `settings.json`.** Loops are per project, not a global preference.
+
+Each Loop is a directory inside the project's AC root: `_loop_<id>/config.toml` holds the definition, and its scheduler state (last check, pending delivery) sits beside it. AC writes both, through the sidebar modals or the CLI; you do not need to edit them by hand.
+
+Because the storage is on-disk project files, `loop` CLI commands need **no token**: any process that can already write to the project can write them.
+
+See [`loop`](../reference/cli.md#loop) for the command surface.
+
+## Troubleshooting
+
+**"The Loop never fired."** Check three things in order: it is enabled; its cron expression is the five-field form you meant (`loop list` prints the scheduler state, including the next due time); and the target coordinator exists. A Loop created after today's occurrence does not fire retroactively, by design.
+
+**"I got `Loop "<name>" was missed while AgentsCommander was closed`."** The occurrence fell while AC was not running. AC records it and does **not** deliver it late. Use `run now` from the Loops section if you want it delivered anyway.
+
+**"I got `Loop "<name>" is pending until the coordinator is idle` and nothing since."** The coordinator has been busy ever since. The delivery is still queued and goes out when it goes idle. If you want the prompt to interrupt instead, switch the Loop to force inject.
+
+**"A Loop opened a session I had closed."** Expected. An exited or terminal-less coordinator is respawned before delivery. Disable the Loop to stop that.
+
+**"`Create` stays greyed out."** One of the required fields is empty, or the cron preview is not in its ready state. The preview must show `Next run: <time>` before `Create` enables.
+
+**"The workgroup picker is empty."** The project has no workgroup with a verified coordinator, and the modal says so. Create the coordinator, then reopen the modal.
+
+## See also
+
+- [`loop` CLI reference](../reference/cli.md#loop) - every flag, and the JSON each subcommand prints
+- [Non-stop mode](non-stop-mode.md) - the other way AC acts on a workgroup without you
+- [Concepts](../concepts.md) - coordinator, workgroup, and session

--- a/docs/features/remote-web-ui.md
+++ b/docs/features/remote-web-ui.md
@@ -44,7 +44,7 @@ Two things the reference is explicit about and this page will not soften. **A fi
 
 ## What the browser UI can do
 
-The served page is **the full AgentsCommander UI**: it renders the same sidebar and the same terminal pane you use on the desktop, side by side with a draggable divider, running over a WebSocket transport rather than the Tauri one. Event payloads are byte-equivalent across the two transports, so the browser is not a reduced view of your sessions.
+The served page is **the full AgentsCommander UI**: it renders the same sidebar and terminal components you use on the desktop, side by side with a draggable divider, running over a WebSocket transport rather than the Tauri one. It is the same interface, not a reduced view of your sessions. The session-selection event is pinned by a test to carry the same payload on both transports; other events are not covered by that guarantee, and terminal output travels as a binary frame rather than JSON.
 
 What is not there:
 

--- a/docs/features/remote-web-ui.md
+++ b/docs/features/remote-web-ui.md
@@ -1,0 +1,90 @@
+# Remote web UI
+
+For developers who want AgentsCommander in a browser, on the machine itself or from another device on a network they trust. After this page you can start the embedded server, reach it from a second device, and understand exactly what you are exposing when you do.
+
+AC ships an embedded HTTP and WebSocket server. Turn it on and it serves the AgentsCommander interface to a browser: the same sidebar, the same terminals, over a WebSocket transport instead of the desktop IPC. It is **off by default** and bound to `127.0.0.1`.
+
+## What it does
+
+The server is part of the running app, not a separate process. While it runs, a browser pointed at its address gets the live interface for the sessions that app is managing: the same rows, the same terminal output, the same input.
+
+The listener is the same one described by the `webServer*` settings. It is **not** the [control-plane API](control-plane-api.md), which is a separate opt-in listener with its own port, its own bind address and its own tokens. The two do not configure each other, and turning one on does not turn the other on.
+
+One consequence deserves stating before anything else: **terminal content can contain passwords, tokens, source code, prompts and personal data, and the web server performs no automatic redaction.** Anything a session prints is visible to anyone who can reach and authenticate to the listener.
+
+## Turning it on
+
+The globe button in the sidebar titlebar carries a status dot and opens the web server menu. The button's tooltip tells you the state at a glance:
+
+| Tooltip | State |
+|---|---|
+| `Web server stopped` | Not listening. |
+| `Web server running on port <n>` | Listening, and this AC instance owns the listener. |
+| `Port <n> is in use` | Something is listening on that port, and it is not this instance. |
+| `Web server status unavailable` | AC could not read the status. |
+
+The menu repeats the state as `Running`, `Listening`, `Stopped`, `Port in use` or `Unknown`, shows the base URL it would serve (`http://<bind>:<port>`), and gives you the controls: a toggle that starts or stops the server and writes `webServerEnabled` for you, a restart, a port editor, and an action that opens the served page in your browser.
+
+The port editor validates before saving. A value outside 1 to 65535 is refused with `Port must be 1 to 65535`, and saving a new port restarts a running server so the change takes effect.
+
+**The bind address has no UI.** `webServerBind` is edited in the per-instance `settings.json` while AC is closed. That is deliberate: the bind address is what decides whether anything outside the machine can reach the listener.
+
+## Connecting from another device
+
+Everything you need is already in the settings reference, and it is worth reading before you widen the bind: see [Web Remote Access on a trusted LAN](../reference/settings.md#web-remote-access-on-a-trusted-lan) for the full procedure.
+
+The shape of it:
+
+1. Close AC and set `webServerBind` to the host's real private LAN IPv4 address, plus the port you chose, in the per-instance `settings.json`. A concrete private address is preferred over `0.0.0.0`, which listens on every interface.
+2. Restart AC and start the server from the menu.
+3. If the host firewall blocks the client, add an inbound rule for that TCP port only, scoped to the Private profile, the selected address and port, and the intended client address or subnet.
+4. From the second device, browse to the host and port and authenticate.
+
+Two things the reference is explicit about and this page will not soften. **A firewall rule permits reachability; it does not authenticate a user.** And external access is an opt-in that exposes live terminal content to every party that can reach and authenticate to the listener.
+
+## What the browser UI can do
+
+The served page is **the full AgentsCommander UI**: it renders the same sidebar and the same terminal pane you use on the desktop, side by side with a draggable divider, running over a WebSocket transport rather than the Tauri one. Event payloads are byte-equivalent across the two transports, so the browser is not a reduced view of your sessions.
+
+What is not there:
+
+- **No desktop titlebar.** The web view has no native window frame, so the sidebar left/right preset appears as a compact toggle anchored to the terminal pane instead.
+- **Only the sidebar and the terminal.** The served page renders those two. AC's separate windows, the Resource Monitor, Watchers, the Spec Board and the Guide, are desktop windows and are not part of the page you are served.
+
+## Authentication
+
+The credential is the per-instance `web-token.txt` file, which AC writes next to the binary. It is **separate** from the CLI `master-token.txt` and separate again from control-plane API client tokens; the three are not interchangeable.
+
+Treat that token, and any URL or browser state carrying it, as a password: use it only with a trusted client, and never commit it or paste it into tickets, chat, logs or screenshots.
+
+Obtain and use it through the existing local Web Remote Access flow. **Do not invent a URL parameter or a token-rotation procedure**; the settings reference says this in as many words, and this page will not describe one it cannot point to.
+
+For the wider picture of what an agent and a remote caller can reach, see [Security model](../security.md).
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `webServerEnabled` | Whether the embedded HTTP and WebSocket server runs. `false` by default. |
+| `webServerPort` | The listening port. The default is platform-specific per binary suffix. Editable from the web server menu. |
+| `webServerBind` | The bind address. `"127.0.0.1"` by default. No UI: edit it in `settings.json` while AC is closed. |
+
+See [Settings reference](../reference/settings.md#web-server-opt-in) for the field types and the LAN procedure.
+
+## Troubleshooting
+
+**"The menu says `Port in use` and the server will not start."** Another process, often an older AC instance, holds that port. The menu reports `Port is already in use` when a start attempt hits it. Pick a different port in the editor, or stop whatever owns the current one.
+
+**"I stopped the server and the menu says `Port is still in use`."** The stop completed on AC's side but something is still listening on the port. That is the ambiguous case the status dot shows; check for another instance before reusing the port.
+
+**"The menu says `Web server status unavailable`."** AC could not read the listener status at all, so it reports `Unknown` rather than guessing. Reopen the menu to retry.
+
+**"The local listener works and the second device cannot reach it."** Re-check, in this order: the selected private address, the port, the network profile, the firewall remote scope, and that both devices are on the same trusted LAN. A listener bound to `127.0.0.1` is not reachable from any other device, by design.
+
+**"I want to stop exposing this."** Turn the server off from the menu and remove the narrowly scoped firewall allowance you added. Leaving the listener off when you do not need it is the recommendation in the settings reference, not an extra precaution.
+
+## See also
+
+- [Security model](../security.md) - what a remote caller can reach and what is out of scope
+- [Control-plane API](control-plane-api.md) - the other opt-in listener, for machine clients
+- [Settings reference](../reference/settings.md#web-server-opt-in) - the `webServer*` keys and the LAN procedure

--- a/docs/features/resource-monitor.md
+++ b/docs/features/resource-monitor.md
@@ -1,0 +1,111 @@
+# Resource monitor
+
+For developers running enough agents at once to worry about memory. After this page you can read what each agent group is consuming, set the thresholds that count as too much, and decide whether AC warns you or kills the group.
+
+The Resource Monitor samples every agent session and its child processes, shows what each one is using, and compares the numbers against thresholds you set. A watchdog acts on those thresholds: it either surfaces the state and leaves the processes alone, or it terminates the offending session's whole process group.
+
+## What it measures
+
+The unit of measurement is the **agent group**: one agent session plus the processes it spawned. AC reports per group:
+
+- Its identity: the session name, and the project, workgroup and agent role it belongs to.
+- Its state, and the last error if the group has one.
+- How many processes it contains, and whether AC could observe the descendants at all.
+- Private bytes, working set bytes and CPU percent.
+- Its network state and a one-line network summary.
+
+Above the groups, AC reports application-wide figures: the app's own private and working-set bytes, how many agent groups are active against the configured limit, and an overall state that folds in the network state.
+
+Private bytes is the number the thresholds compare against, for both the group total and each individual process.
+
+## Turning it on
+
+`resourceMonitorEnabled` is the master switch and is **on by default**. With it off, the window still opens but reports nothing and shows the banner `Resource monitoring is disabled.`
+
+The switch does more than blank the display. The watchdog reads the same key and stops on every tick while it is false, so turning the monitor off also turns the watchdog off. There is no way to run the watchdog without the monitor.
+
+The monitor also needs the platform to support process-tree enforcement. Where that support is missing, the watchdog does nothing at all whatever action you configure, even though the readings still appear.
+
+## The Resource Monitor window
+
+The window is titled `Resource Monitor` and has three controls in its header: `Refresh` takes a fresh sample immediately, `Settings` opens the `Resources` tab of the Settings dialog, and `Detach` (see the next section) appears only when the monitor is embedded in the main window.
+
+A strip of four tiles summarizes the whole app:
+
+| Tile | What it shows |
+|---|---|
+| `State` | The overall state, folding in the network state. |
+| `Active Agents` | Active agent groups against the configured maximum. |
+| `App Private` | AC's own private bytes, with the working set alongside. |
+| `Network` | The network state and its summary line. |
+
+Below that, the `Agents` section lists the groups. A filter bar narrows the list by status (all, active or inactive), by project, by workgroup and by agent role; while any filter is on, the header reads `Showing <n> of <total>`. The header also carries `Last update <time>`. Selecting a group row expands it to the processes inside that group, and a group whose kill is allowed can be terminated from here after a confirmation.
+
+The list refreshes on a timer: every 2 seconds while active and every 10 seconds when idle, dropping to 15 seconds when `resourceBackoffPolling` is on. When a sample fails, the window shows `Snapshot failed: <error>`; with `resourceKeepLastSnapshot` on it keeps the previous reading on screen under `Showing last snapshot from <time>.` instead of blanking.
+
+## Attaching it to the main window
+
+The monitor renders in either of two places: its own window, or the central pane of the main window in place of the terminal. `mainResourceMonitorAttached` records which, defaults to `false`, and is restored at startup, so the layout you left is the layout you come back to.
+
+When it is embedded, the header gains a `Detach` button, tooltipped `Detach to a separate window`. Pressing it opens the standalone window and returns the main window's central pane to the terminal.
+
+## The watchdog: thresholds and actions
+
+Keep two ideas apart. **The thresholds decide whether a group is over the line. `resourceWatchdogAction` decides what AC does about it.** They are not a mapping: every threshold is evaluated on every tick, whatever the action is set to.
+
+Three thresholds are evaluated, against groups in the running state only:
+
+| Threshold key | Compared against |
+|---|---|
+| `agentGroupWarnPrivateBytes` | the group's total private bytes |
+| `agentGroupKillPrivateBytes` | the group's total private bytes |
+| `agentProcessKillPrivateBytes` | each individual process's private bytes |
+
+A group needs killing when it crosses either kill threshold, the group one or the per-process one. It needs warning when it crosses the warn threshold or already needs killing.
+
+`resourceWatchdogAction` has exactly two values:
+
+| Value | What AC does |
+|---|---|
+| `"warn"` | Computes and surfaces the threshold state. It terminates nothing. This is the default. |
+| `"killGroup"` | Does the same, and additionally terminates the process group of every session that needs killing. |
+
+Two consequences that surprise people:
+
+**There is no per-process kill.** Crossing `agentProcessKillPrivateBytes` marks the group, and the whole session's process group is terminated. AC identifies the offending processes but does not terminate them individually, so one runaway child takes its session down with it.
+
+**`"warn"` is not "AC never touches my processes".** Groups that were quarantined by an earlier kill are still reclaimed under `"warn"`, on every tick. That cleanup is deliberately outside the action gate, because a leaked slot has to be reclaimed even on a default install. What `"warn"` guarantees is that no *threshold crossing* terminates anything.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `resourceMonitorEnabled` | Master switch for the monitor and the watchdog. `true` by default. |
+| `maxConcurrentAgentProcesses` | The cap the `Active Agents` tile counts against. `32` by default. |
+| `resourceWatchdogAction` | `"warn"` or `"killGroup"`. `"warn"` by default. |
+| `agentGroupWarnPrivateBytes` | Group private bytes at which the group warns. 8 GiB by default. |
+| `agentGroupKillPrivateBytes` | Group private bytes at which the group needs killing. 12 GiB by default. |
+| `agentProcessKillPrivateBytes` | Private bytes of a single process at which its whole group needs killing. 12 GiB by default. |
+| `resourceKeepLastSnapshot` | Whether a failed sample keeps the previous reading on screen. `true` by default. |
+| `resourceBackoffPolling` | Whether the sampling interval backs off while idle. `true` by default. |
+| `mainResourceMonitorAttached` | Whether the monitor occupies the main window's central pane. `false` by default. |
+
+See [Settings reference](../reference/settings.md#resource-monitor) for types and exact defaults.
+
+## Troubleshooting
+
+**"The window says `Resource monitoring is disabled.`"** `resourceMonitorEnabled` is `false`. Turn it back on; note that the watchdog was off too while it was.
+
+**"Nothing is ever killed, and the action is `killGroup`."** Two checks. First, the platform must support process-tree enforcement; without it the watchdog returns on every tick and no action value changes that. Second, `resourceMonitorEnabled` must be true, because the watchdog rides on it.
+
+**"A session died and it was nowhere near the group threshold."** Look at `agentProcessKillPrivateBytes`. One process over that limit takes down the whole group, and the group total can be well under `agentGroupKillPrivateBytes` when that happens.
+
+**"I set `warn` and AC still terminated something."** Quarantine reclamation runs under `warn` as well. It only touches groups a previous kill already left behind, never a group that has merely crossed a threshold now.
+
+**"The numbers stopped moving and the window says `Showing last snapshot from <time>.`"** Sampling failed and `resourceKeepLastSnapshot` is holding the previous reading so the panel does not blank. `Snapshot failed: <error>` names the cause; press `Refresh` after fixing it.
+
+## See also
+
+- [App windows](app-windows.md) - the monitor as one of AC's separate windows
+- [Settings reference](../reference/settings.md#resource-monitor) - the resource keys and their types
+- [Session auto-close](session-auto-close.md) - the other way a session shuts down without you

--- a/docs/features/session-auto-close.md
+++ b/docs/features/session-auto-close.md
@@ -47,6 +47,10 @@ The badge changes color as idle time grows:
 | At or above the yellow threshold (default 30m) | Yellow |
 | At or above the red threshold (default 60m) | Red |
 
+You set both thresholds yourself. `coordinatorIdleBadgeYellowMinutes` (default `30`) is the idle minute count at which the badge turns yellow, and `coordinatorIdleBadgeRedMinutes` (default `60`) is the count at which it turns red.
+
+Both keys change **the badge color only**. They do not move the auto-close timeout: that stays `coordinatorAutoCloseMinutes`. Raising the red threshold to `120` while the timeout stays at `60` gives you a team that is closed while its badge is still yellow, so keep the red threshold at or below the timeout if you want the red badge to mean "about to close".
+
 The badge is **informational and always on**. It shows even when auto-close is turned off, so you can monitor idle teams without letting AC close them.
 
 ## The AUTO-CLOSED badge
@@ -54,6 +58,18 @@ The badge is **informational and always on**. It shows even when auto-close is t
 When auto-close fires and the session it destroys is the team's **coordinator**, AC stamps that coordinator row with an **AUTO-CLOSED** badge. This is your record that the team was closed by the timeout, not by you.
 
 If only a non-coordinator member is reaped while the coordinator survives (the coordinator was spared by a grace window or a late user message), the surviving coordinator keeps its idle counter and is **not** stamped. The AUTO-CLOSED badge means specifically "this coordinator's own session was auto-closed."
+
+## Coordinator cascade close
+
+Cascade close is the other way a team's sessions go down together, and it is **the one you trigger**. When you close a coordinator yourself, `coordinatorCascadeCloseEnabled` decides whether AC also closes that team's member sessions. It is `true` by default, so closing a coordinator closes the team.
+
+The cascade covers the members of that coordinator's team that have a live PTY, and never the coordinator's own siblings in other teams. Dormant and already-exited member rows are left alone: there is nothing to terminate.
+
+If at least one live member is still working (it is not waiting for your input), AC does not close anything yet. It reports how many members are busy and asks you to confirm, so a cascade never silently kills an agent mid-task.
+
+Set the key to `false` and only the coordinator closes. Its members keep running as independent sessions, which is what you want when you are restarting a coordinator and do not want its agents to lose their PTYs.
+
+This key does **not** change what auto-close does. Auto-close closes coordinators and agent-owned member sessions on the rules described above, whatever `coordinatorCascadeCloseEnabled` is set to.
 
 ## Settings
 
@@ -64,8 +80,9 @@ These keys live in `settings.json` (see the [settings reference](../reference/se
 | `coordinatorAutoCloseEnabled` | bool | `true` | Master switch. When false, AC never auto-closes a team (the badge still shows). |
 | `coordinatorAutoCloseMinutes` | number | `60` | Idle minutes before a team is closed. `0` also disables auto-close. |
 | `coordinatorAutoCloseSkipTelegramAssigned` | bool | `false` | When true, auto-close skips sessions with Telegram assigned. Other sessions keep following the normal auto-close rules. |
-| `coordinatorIdleBadgeYellowMinutes` | number | `30` | Idle minutes at which the badge turns yellow. |
-| `coordinatorIdleBadgeRedMinutes` | number | `60` | Idle minutes at which the badge turns red. |
+| `coordinatorCascadeCloseEnabled` | bool | `true` | When true, closing a coordinator yourself also closes its team's live member sessions. When false, only the coordinator closes. It does not affect auto-close. |
+| `coordinatorIdleBadgeYellowMinutes` | number | `30` | Idle minutes at which the badge turns yellow. Badge color only. |
+| `coordinatorIdleBadgeRedMinutes` | number | `60` | Idle minutes at which the badge turns red. Badge color only. |
 
 Out of the box (`coordinatorAutoCloseEnabled` true, `coordinatorAutoCloseMinutes` 60), a team that sits idle for more than an hour is closed automatically.
 

--- a/docs/features/sidebar-guide.md
+++ b/docs/features/sidebar-guide.md
@@ -22,6 +22,8 @@ Because membership is a pattern rather than a list, a workgroup created later jo
 
 **Favorites** is the rail's own cross-project section, listed above the project sections and collapsible independently. Its collapsed state is `railFavoritesCollapsed`.
 
+You mark one from the rail itself: right-click a rail entry and the menu offers `Edit`, which opens the groups editor, and `Favorite`. The same entry reads `Unfavorite` once the group is marked, so the label always tells you what pressing it will do. Only a group entry and the built-in non-stop entry can be favorited; the menu shows that second item for nothing else.
+
 One group is built in and cannot be removed: the non-stop group, described in [Non-stop mode](non-stop-mode.md).
 
 ## Raise hand
@@ -45,6 +47,14 @@ The panel is a tree. Projects contain workgroups and teams; those contain agents
 A replica row shows the replica's path as its tooltip and carries the indicators and controls for that replica: the idle badge, the repo badges from branch discovery, and the per-session controls for voice, detaching and Telegram. The Telegram control opens its own bot menu.
 
 Right-clicking a row opens a context menu, and AC builds a different one depending on whether the row has an active session or is an inactive replica.
+
+**With an active session**, the menu offers `Restart Session`, `Coding Agent`, `Open Replica's Folder` (tooltipped with the path it will open), one entry per repository AC discovered in the replica, `Open Matrix folder` when the replica has an Agent Matrix behind it, then `Open in new window`, which reads `Re-attach to main` when the session is already detached, an entry to add the replica to a group, and `Clear task title`.
+
+**On an inactive replica** the same menu appears without the two entries that need a running session: no `Restart Session` and no detach toggle.
+
+`Clear task title` is disabled when there is nothing to clear, and says which case you are in through its tooltip: `Clear task title`, or `Nothing to clear`.
+
+Right-clicking a project row instead gives you the project's own menu, which is where `Archive Project` lives. See [Project archiving](project-archiving.md).
 
 ## What a session row shows
 

--- a/docs/features/sidebar-guide.md
+++ b/docs/features/sidebar-guide.md
@@ -2,7 +2,14 @@
 
 For developers who want to read the sidebar rather than click around it. After this page you know what each rail entry, row, badge and indicator means, and which page owns the feature behind it.
 
-The sidebar has two parts: a rail of group entries down one edge, and the project panel that lists projects, workgroups, replicas and sessions. This page is the map. Where a badge belongs to a feature with its own page, this page says what the badge means and sends you there.
+The sidebar has three parts: a rail of group entries down one edge, the project panel that lists projects, workgroups, replicas and sessions, and an action bar of toggles across the top. This page is the map. Where a badge belongs to a feature with its own page, this page says what the badge means and sends you there.
+
+Four of the action bar's toggles change what the panel shows, and each tooltip tells you what pressing it will do rather than what is on:
+
+- `Show Home` and `Hide Home` swap the central pane between Home and the terminal.
+- `Show recent coordinators first` and `Show coordinators in default order` reorder the coordinator list. It persists as [`coordSortByActivity`](../reference/settings.md#window--ui).
+- `Show category sections` and `Hide category sections` toggle the panel's category grouping.
+- `Always keep selected workgroup visible` pins the selected workgroup in view. It persists as [`alwaysShowSelectedWorkgroup`](../reference/settings.md#window--ui).
 
 ## The workgroup rail
 

--- a/docs/features/sidebar-guide.md
+++ b/docs/features/sidebar-guide.md
@@ -1,0 +1,132 @@
+# Sidebar guide
+
+For developers who want to read the sidebar rather than click around it. After this page you know what each rail entry, row, badge and indicator means, and which page owns the feature behind it.
+
+The sidebar has two parts: a rail of group entries down one edge, and the project panel that lists projects, workgroups, replicas and sessions. This page is the map. Where a badge belongs to a feature with its own page, this page says what the badge means and sends you there.
+
+## The workgroup rail
+
+The rail shows one entry per group. An entry stands for a **set of workgroups**, not a single one: selecting it shows the workgroups that belong to that group.
+
+Each entry has two lines. The first carries the group's name, preceded by a raise-hand indicator when one applies. The second carries a counter, preceded by a running dot when something in the group is working. Hovering an entry shows a tooltip naming the project folder and the workgroups the entry covers.
+
+Entries you created are draggable, so you can reorder them; the built-in ones are not. Right-clicking an entry opens its context menu, and the selected entry is marked as pressed for assistive technology.
+
+The rail collapses by section. Clicking a project section header collapses it, and AC remembers which ones you collapsed in `railCollapsedProjects`. The cross-project Favorites section has its own collapsed state, `railFavoritesCollapsed`. Both are written only by the dedicated rail collapse action, so an unrelated settings save cannot lose them.
+
+## Favorites and groups
+
+A **group** is a named set of workgroups. You edit groups in the `Edit groups` modal, where each group has two fields: `Group name`, and `Group regex`, the pattern that decides which workgroups belong to it. A new group starts named `Group 1`, `Group 2` and so on. A group can also carry a sound alert, whose length is set in seconds.
+
+Because membership is a pattern rather than a list, a workgroup created later joins the group on its own if its name matches. That is the point of the regex, and it is also the thing to check when a workgroup shows up in a group you did not expect.
+
+**Favorites** is the rail's own cross-project section, listed above the project sections and collapsible independently. Its collapsed state is `railFavoritesCollapsed`.
+
+One group is built in and cannot be removed: the non-stop group, described in [Non-stop mode](non-stop-mode.md).
+
+## Raise hand
+
+A raised hand means **a coordinator is asking for your attention**. The indicator appears on the rail entry for the group the coordinator is in, with the tooltip and accessible label `A coordinator raised its hand`, and on the replica row in the project panel.
+
+An agent raises its own hand; you never raise it for it. It calls the CLI from inside its session:
+
+```bash
+agentscommander raise-hand --token "$AGENTSCOMMANDER_TOKEN" --root "$AGENTSCOMMANDER_ROOT"
+```
+
+The daemon accepts it only when the caller's token belongs to a **live coordinator session with a visible `TASK.md` title slot**. Stdout is exactly `true` or `false`.
+
+**It is cleared by real user input to that session, and by nothing else.** It survives an app restart. Clicking the row, selecting it, or looking at it does not lower the hand: type something to the session.
+
+## The project panel
+
+The panel is a tree. Projects contain workgroups and teams; those contain agents and replicas; a replica contains its sessions.
+
+A replica row shows the replica's path as its tooltip and carries the indicators and controls for that replica: the idle badge, the repo badges from branch discovery, and the per-session controls for voice, detaching and Telegram. The Telegram control opens its own bot menu.
+
+Right-clicking a row opens a context menu, and AC builds a different one depending on whether the row has an active session or is an inactive replica.
+
+## What a session row shows
+
+A session row packs several indicators. Each belongs to a feature documented elsewhere; this is the key:
+
+| Indicator | What it means | Page |
+|---|---|---|
+| Status dot | The session's lifecycle state | [Concepts: Session](../concepts.md#session) |
+| Profile drift badge | The session's coding-agent profile no longer matches its definition | [Coding Agent Profiles](coding-agent-profiles.md#drift-the-outdated-badge) |
+| Context badge | How much of the agent's context window is used | [Context tracking](context-tracking.md) |
+| Idle badge and AUTO-CLOSED badge | How long the team has been idle, and that auto-close already closed it | [Session auto-close](session-auto-close.md) |
+| Mic | Voice capture for that session | [Voice-to-text](voice-to-text.md) |
+| Telegram | A bridge is attached to that session | [Telegram bridge](telegram-bridge.md) |
+| Git branch | The session's current branch and whether its repository is dirty | The next section |
+
+The row also carries the actions for the session: close, detach, Telegram and the file explorer.
+
+## The git branch badge
+
+AC polls each session's repository in the background and shows the branch on the row.
+
+**Dirty means one of two things**, and the distinction matters: either the working tree has uncommitted changes, or `HEAD` is not contained by the cached origin tracking, which is what you see when you have committed locally and not pushed. A clean tree with unpushed commits still reads as dirty, on purpose.
+
+A repository in a state with no branch name, such as a detached `HEAD` or a rebase in progress, shows no branch rather than a guess.
+
+Two settings shape the polling. `gitSweepConcurrency` is how many repositories the sweeper inspects at once, clamped to 1 through 4; `1`, the default, is strictly sequential and is what bounds concurrent `git.exe` processes. `gitSweepMinIntervalSecs` is a lower bound on one sweeper round, clamped to 1 through 3600. The effective period is the larger of that bound and the round's own duration, so on a large set of workgroups the round duration dominates and the setting never fires.
+
+Both are manual-only, with no UI, and take effect on the next restart.
+
+## The agent picker
+
+The picker opens for one target and is titled `Assign profile for <target>`, naming the replica or session it will act on. Despite the name, it is the coding-agent **profile assignment** dialog: it lists your configured coding agents, sorted by label, and assigns a profile letter to the target.
+
+The apply scope decides how far the assignment reaches: this replica, every replica of the same kind, or the whole workgroup. A wider scope shows a preview of how many targets it would overwrite and requires you to confirm in as many words, for example `I understand this overwrites 4 replicas of this kind`. You can also ask AC to restart the matching sessions after writing the selection.
+
+See [Coding Agent Profiles](coding-agent-profiles.md) for what a profile is and how the letters resolve.
+
+## Quick coding-agent configuration
+
+This inline panel configures a coding agent without opening Settings. It offers the known coding agents as one-tap presets, each button labelled `Select <agent>` for assistive technology, plus a custom entry where you supply the label and command yourself. When it succeeds it confirms with the agent's name, for example `claude configured!`.
+
+It writes the same coding agent catalog as the Settings `Coding Agents` tab; the tab is where you edit an existing agent's environment rows, backend, profiles and seeds. See [Coding agents](../integrations/coding-agents.md) for the full configuration surface.
+
+## Branch and repo discovery
+
+For a workgroup replica, AC discovers the repositories inside it and shows one badge per repository. The badge text is the repository's label, and its branch when one is known, as `label/branch`.
+
+The badge's tooltip carries the repository's source path plus its status. When the repository is dirty it reads `<path> (local work not confirmed by cached origin tracking)`, and when AC could not determine the status it reads `<path> (status unknown)`.
+
+The panel updates from the `ac_discovery_branch_updated` event, so a branch you switch in a terminal appears here without a refresh.
+
+## Zoom
+
+The zoom control sits in the titlebar as a group labelled `UI zoom`: a `Zoom out` button, the current percentage, and a `Zoom in` button. Steps are 10 percentage points, and the range runs from **50% to 300%**. Each button disables at its end of the range.
+
+The value persists per window. `mainZoom`, `terminalZoom`, `sidebarZoom` and `guideZoom` each default to `1.0`, which is 100%.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `gitSweepConcurrency` | How many repositories the git sweeper inspects at once. `1` by default, clamped to 1 through 4. |
+| `gitSweepMinIntervalSecs` | Lower bound in seconds on one sweeper round. `10` by default, clamped to 1 through 3600. |
+
+See [Settings reference](../reference/settings.md#git-status-sweeper) for both, including why raising the concurrency is rarely the fix.
+
+## Troubleshooting
+
+**"A workgroup appeared in a group I did not put it in."** Group membership is a regex over workgroup names, not a list. Check the group's `Group regex` in the `Edit groups` modal against the new workgroup's name.
+
+**"The raise-hand indicator will not go away."** It is cleared by real user input to that session and survives restarts. Clicking or selecting the row is not input; send the session something.
+
+**"A branch badge says dirty and `git status` says the tree is clean."** Dirty also covers `HEAD` not being contained by the cached origin tracking, which is the ordinary state after committing without pushing.
+
+**"A session row shows no branch at all."** The repository is in a state with no branch name, such as a detached `HEAD` or a rebase in progress. AC shows nothing rather than guessing.
+
+**"My rail sections keep collapsing themselves."** They are remembered on purpose, in `railCollapsedProjects` and `railFavoritesCollapsed`. Expanding a section rewrites the setting.
+
+**"The zoom buttons are greyed out."** You are at an end of the range: zoom stops at 50% and at 300%.
+
+## See also
+
+- [App windows](app-windows.md) - the windows the sidebar opens beside itself
+- [Concepts](../concepts.md) - project, workgroup, replica, session and coordinator
+- [Coding agents](../integrations/coding-agents.md) - the catalog the picker and the quick panel write

--- a/docs/features/spec-board.md
+++ b/docs/features/spec-board.md
@@ -1,0 +1,96 @@
+# Spec Board
+
+For developers who keep a diagram next to the code and want a coding agent to edit it. After this page you can open a Spec Board on a Mermaid file, watch it render as you type, recover an earlier version from a snapshot, and hand the file to an agent without leaving the board.
+
+The Spec Board is a separate AC window holding one Mermaid file: source on one side, the rendered diagram on the other. It saves to a real file in your repo, snapshots your edits as you go, and notices when something else changes the file underneath you.
+
+## What a Spec Board is
+
+A Spec Board is one document, backed by one file on disk, open in its own window. The document holds the file's text, the diagram parsed out of it, and the state AC needs to protect your work: whether it has unsaved changes, whether the file on disk has moved ahead of you, and its snapshot history.
+
+The file is a Mermaid file. The board expects exactly one diagram in it, which is what lets the preview render without you choosing anything.
+
+Because the board is a window rather than a panel, it survives independently of the sidebar: opening a board does not take over the main window, and closing the board does not touch your sessions.
+
+## Turning it on
+
+The Spec Board is **off by default**. Set `specBoardEnabled` to `true` in `settings.json` and the Spec Board button appears in the sidebar toolbar; that button is what opens the window.
+
+`specBoardEnabled` is a manual-only field. Edit it while AC is closed, or reload settings before you use any Settings save path, otherwise the next in-memory save can clobber your change.
+
+One caveat worth knowing: the key controls the toolbar entry point only. It is not an access-control or a security boundary, and the backend Spec Board commands stay callable whatever it is set to.
+
+## The editing window
+
+The toolbar sits across the top of the board:
+
+| Button | What it does |
+|---|---|
+| `New` | Starts a new document. The board closes the previous one for you. |
+| `Open` | Opens a file picker and loads the file you choose. |
+| `Save` | Writes the current text to the document's file. With no path yet, it asks where to save. It is disabled while a saved document has no unsaved changes. |
+| `Save As` | Always asks for a destination and saves there. |
+| `Ask Agent` | Opens the panel described below. Disabled until the document has a path. |
+| `-`, `Reset Zoom`, `+` | Zoom the preview out, back to 100 percent with the pan reset, and in. |
+
+The preview renders the diagram from the source as you edit. You can also zoom it with the mouse wheel and pan it by dragging with the left button, which is usually faster than the toolbar buttons for a large diagram.
+
+When the source does not parse, the preview **keeps the last diagram it rendered** and reports the parser's message instead of blanking. That is intentional: a half-typed edit should not make your diagram disappear.
+
+## Snapshots
+
+The board snapshots your work as you edit, without you asking. An edit schedules a snapshot 750 milliseconds later, and the snapshot is skipped if the content is identical to the last one taken, so holding a key down does not fill the history with duplicates.
+
+Each snapshot records an id, a label, when it was created, what produced it, the full text, the diagram source, and a hash of the content. Snapshots live in a per-document snapshot directory, not inside the file you are editing.
+
+Restoring a snapshot loads it into the open document and marks the document as having unsaved changes. It does **not** write to disk. Nothing is committed to your file until you save, so you can look at an older version and change your mind.
+
+## Conflicts and unsaved work
+
+Two dialogs protect the file, and each says exactly what it is protecting.
+
+**Something else changed the file.** The board watches the file it has open. When the file changes underneath you, a banner appears reading `File changed externally.` with three buttons:
+
+- `Apply External` takes what is now on disk and replaces what is in the board.
+- `Keep Mine` keeps your text and leaves the file on disk alone until you save.
+- `Save As` writes your text somewhere else, so neither version is lost.
+
+This is the banner you get when a coding agent edits the file you asked it to edit. Reaching for `Apply External` is the normal answer there.
+
+**You are closing with unsaved changes.** The board asks `You have unsaved changes. Do you want to save before closing?` with `Save`, `Discard` and `Cancel`. `Cancel` returns you to the board and closes nothing.
+
+## Asking an agent about the spec
+
+`Ask Agent` sends the file to a running session instead of pasting the diagram into a terminal by hand.
+
+The panel opens with the heading `Ask Agent`, a session picker starting on `Select a session...`, and an instruction box with the placeholder `Instructions...`. Choose the session, describe the change, and press `Send`.
+
+What AC sends is a prompt naming the file's absolute path, your request, and two standing instructions to the agent: keep exactly one Mermaid diagram in the file, and save the file when done. The board watches that file, so the diagram updates when the agent saves.
+
+`Ask Agent` stays disabled until the document has a path. An agent cannot edit a file that does not exist yet, so save the board first.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `specBoardEnabled` | Whether the Spec Board button appears in the sidebar toolbar. `false` by default. It gates the entry point only, not the backend commands. |
+
+See [Settings reference](../reference/settings.md#window--ui) for the group this key belongs to and for how manual-only fields behave.
+
+## Troubleshooting
+
+**"There is no Spec Board button in the toolbar."** `specBoardEnabled` is `false`, which is the default. Set it to `true` while AC is closed. If you edited it while AC was running, the next in-memory save may have written the old value back.
+
+**"The preview stopped updating and shows an error."** The source no longer parses. The board reports the parser's message, or `Parse error` when the parser gives none, and keeps the previous diagram on screen so you can compare. Fix the source and the preview catches up on its own.
+
+**"The preview is empty and says `Failed to load Mermaid parser.`"** The Mermaid parser did not load in that window. Close the board and open it again; nothing in your file causes this.
+
+**"`Ask Agent` is greyed out."** The document has no path yet. Save it, then the button enables.
+
+**"An operation failed with `Spec board document not found: <id>`."** The board is acting on a document the backend has already closed, which happens if the window was reopened behind the operation. Open the file again and retry.
+
+## See also
+
+- [App windows](app-windows.md) - the other windows AC opens beside the main one
+- [Settings reference](../reference/settings.md#window--ui) - `specBoardEnabled` and its neighbours
+- [Concepts](../concepts.md) - sessions, workgroups, and the vocabulary this page uses

--- a/docs/features/watchers.md
+++ b/docs/features/watchers.md
@@ -87,7 +87,7 @@ There is **nothing on the terminal**: no toast, no modal. If you are waiting for
 
 Matches land in a separate window titled `Watcher Activity`.
 
-The window is scoped: a selector at the top chooses one agent session or `All agents`. The scope decides both what is fetched and how much is kept: **500 rows for a single session, 100 across all of them**.
+The window is scoped: a selector at the top chooses one agent session or `All agents`. The scope decides what is fetched and how much is kept, and the cap is **per session in both scopes**: 500 rows per session when you scope to one, 100 rows per session under `All agents`. Ten agents in the wider scope therefore retain up to a thousand rows between them, not a hundred.
 
 Each row carries the watcher id, the agent it fired on, the workgroup, and the matched text; selecting a row expands it. Four filters narrow the list, by watcher, by agent, by workgroup, and by free text, and they combine. Alongside the rows the window reports which watchers are currently active, which are degraded, whether the activity was truncated, and how many frames may have been missed.
 

--- a/docs/features/watchers.md
+++ b/docs/features/watchers.md
@@ -1,0 +1,121 @@
+# Watchers
+
+For developers who want to know when a pattern appears in an agent's terminal, across every agent rather than one at a time. After this page you can configure a watcher, choose the mode and the deduplication that fit what you are matching, read the activity window, and work out why a watcher you configured is not running.
+
+A watcher is a pattern AC matches against the terminal output of your agent sessions. Watchers live at the root of `settings.json`, keyed by watcher id, so one pattern can apply to every agent at once. Matches land in the Watcher Activity window.
+
+## What a watcher is
+
+A watcher is a context-scrape pattern with an id, a mode, and rules about which agents it reaches and what counts as a repeat.
+
+Two properties are worth understanding before anything else:
+
+- **A watcher reaches agents, not sessions you open by hand.** Only agent sessions are registered with the watcher engine, exactly as with the context scraper. A plain shell has a terminal but never a watcher.
+- **A watcher is root-level.** The per-agent `contextRegex` can only describe one agent's reading. A watcher can apply to every configured agent, which is the shape `contextRegex` cannot express.
+
+A malformed entry does not take the rest down with it. AC skips that one watcher, writes one log line, and leaves every other watcher and every other setting working.
+
+## The two modes: state and occurrence
+
+`mode` is required and has two values, and picking the wrong one is the most common way to get surprising activity.
+
+| Mode | What it means |
+|---|---|
+| `state` | A **reading**. It is idempotent and gated: the same state observed again is the same state, not a new event. |
+| `occurrence` | An **event**. Every match that the frame diff declares evaluable counts as its own occurrence. |
+
+Use `state` for something that is true or false at a moment, such as a status line. Use `occurrence` for something that happens, such as a warning being printed. Deduplication, below, applies to occurrence matching.
+
+## Deduplication
+
+Two settings decide when two matches are "the same one":
+
+- `dedupe` picks what is compared: `row` (the default), `capture`, or `none`.
+- `dedupeWindowMs` is how long that comparison holds, in milliseconds. The default is `2000`.
+
+The window is capped at **60000 ms**, and an oversized value is **clamped, not rejected**. Configure `dedupeWindowMs: 600000` and the watcher still runs, with a one-minute window and this log line:
+
+```text
+[watchers] watcher '<id>' asks for a 600000 ms dedupe window; clamping to 60000 ms
+```
+
+That is worth knowing before you conclude that a long window is not working: it is working, at 60 seconds.
+
+## Commands a watcher can run
+
+The `commands` field does not tell a watcher to run a command. It is a **selector**: it decides which coding-agent commands the watcher reaches. A watcher matches patterns; it never executes anything.
+
+| `commands` value | Which agents the watcher reaches |
+|---|---|
+| Absent or `null` (the default) | Every configured agent. |
+| A list of commands | Only agents whose `command` executable stem matches an entry exactly. |
+| An empty list | No agent at all. |
+
+Matching is on the executable stem, so `claude` matches an agent launched as `claude --effort max`.
+
+If any entry in the list is not a command, AC **skips the whole watcher**:
+
+```text
+[watchers] watcher '<id>' is being skipped: its commands selector entry '<token>' is not a command. A watcher with an unreadable selector reaches nobody, never everybody
+```
+
+The refusal to guess is deliberate. A typo in one selector entry must never silently widen a pattern to every agent you run.
+
+## The watcher budget
+
+Each agent runs at most **eight** watchers. The number is a compile-time constant with no settings key behind it, and it is **per agent, not global**: configure thirty watchers if you want, and each individual agent runs at most eight of the ones that reach it.
+
+At the limit nothing is rejected, dropped or evicted. The overflow watchers stay configured, stay valid, and do not run on that agent. The same watcher can be over budget on one agent and running happily on another.
+
+**Which eight win: watcher id order, ascending.** Watchers are resolved in key order, and the first eight that reach an agent are the ones that run. That has a consequence worth stating plainly: **renaming a watcher can change which watchers run**, because the id is the sort key.
+
+Disabled watchers never consume budget. A watcher with `enabled: false` is skipped before the candidate list is built, silently, because that is a state you chose rather than a problem.
+
+You can observe the limit in exactly two places:
+
+1. **One log line per agent**, naming every displaced id in a single line:
+
+   ```text
+   [watchers] agent '<agent id>' is over the 8-watcher budget; these are configured but not running on it: <id>,<id>,...
+   ```
+
+2. **A notice in Settings**, appended to the watcher's reach description: ` Not running on <agent labels> (budget).` It is empty when the watcher is disabled or when nothing was displaced.
+
+There is **nothing on the terminal**: no toast, no modal. If you are waiting for a popup to tell you a watcher is not running, you will wait forever.
+
+## The Watchers window
+
+Matches land in a separate window titled `Watcher Activity`.
+
+The window is scoped: a selector at the top chooses one agent session or `All sessions`. The scope decides both what is fetched and how much is kept: **500 rows for a single session, 100 for all sessions**.
+
+Each row carries the watcher id, the agent it fired on, the workgroup, and the matched text; selecting a row expands it. Four filters narrow the list, by watcher, by agent, by workgroup, and by free text, and they combine. Alongside the rows the window reports which watchers are currently active, which are degraded, whether the activity was truncated, and how many frames may have been missed.
+
+The window remembers its own position and size. That geometry is what `watchersGeometry` holds, which is why the window reopens where you left it.
+
+## Settings
+
+| Key | What it controls |
+|---|---|
+| `watchers` | The watcher patterns, keyed by watcher id. `{}` by default. Resolved in key order against the eight-watcher budget. |
+| `watchersGeometry` | Position and size of the Watcher Activity window. `null` by default. |
+
+See [Settings reference](../reference/settings.md#watchers) for the full `WatcherConfig` shape, field by field. This page explains the behavior rather than repeating the schema.
+
+## Troubleshooting
+
+**"I configured a watcher and it never fires on one agent."** Check the budget first. Look for `[watchers] agent '<agent id>' is over the 8-watcher budget` in the log, and for ` Not running on <agent labels> (budget).` on the watcher in Settings. Watcher ids sort ascending and the first eight win, so an id late in the alphabet is the one that loses.
+
+**"A watcher stopped reaching every agent after I edited it."** Its `commands` selector no longer tokenizes. The log line names the offending entry: `[watchers] watcher '<id>' is being skipped: its commands selector entry '<token>' is not a command`. The whole watcher is skipped, so the symptom is "nothing anywhere", not "nothing on one agent".
+
+**"One watcher broke and now nothing works."** That is not what happens, and the log says so: `[watchers] watcher '<id>' is not a valid watcher and is being skipped; every other watcher and every other setting is unaffected: <detail>`. If everything really did stop, the cause is elsewhere.
+
+**"My long dedupe window is being ignored."** It is being clamped to 60000 ms, and the log line names the value you asked for. Anything above one minute behaves as one minute.
+
+**"The watcher works but I see nothing in the window."** Check the scope selector and the four filters: a filter that hides everything looks exactly like a watcher that never fired. Also check that the session is an agent session; a plain shell is never watched.
+
+## See also
+
+- [Context tracking](context-tracking.md) - the per-agent `contextRegex` reading and its badge
+- [Settings reference](../reference/settings.md#watchers) - the `WatcherConfig` schema
+- [Concepts](../concepts.md) - session, workgroup and agent vocabulary

--- a/docs/features/watchers.md
+++ b/docs/features/watchers.md
@@ -87,7 +87,7 @@ There is **nothing on the terminal**: no toast, no modal. If you are waiting for
 
 Matches land in a separate window titled `Watcher Activity`.
 
-The window is scoped: a selector at the top chooses one agent session or `All sessions`. The scope decides both what is fetched and how much is kept: **500 rows for a single session, 100 for all sessions**.
+The window is scoped: a selector at the top chooses one agent session or `All agents`. The scope decides both what is fetched and how much is kept: **500 rows for a single session, 100 across all of them**.
 
 Each row carries the watcher id, the agent it fired on, the workgroup, and the matched text; selecting a row expands it. Four filters narrow the list, by watcher, by agent, by workgroup, and by free text, and they combine. Alongside the rows the window reports which watchers are currently active, which are degraded, whether the activity was truncated, and how many frames may have been missed.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,6 +2,10 @@
 
 Quick alphabetical reference. For richer explanations of how the pieces fit together, see [Concepts](concepts.md).
 
+## Activity log
+
+An append-only JSONL file recording when each session started working and when it went idle, plus app start, heartbeat and stop records. Off by default, and it holds no terminal content. See [Activity log](features/activity-log.md).
+
 ## Agent
 
 A directory with a role-prompt file at its root (`CLAUDE.md`, `AGENTS.md`, or `GEMINI.md`). The directory IS the agent's identity.
@@ -9,6 +13,10 @@ A directory with a role-prompt file at its root (`CLAUDE.md`, `AGENTS.md`, or `G
 ## Agents Agency
 
 A community library of agent role templates at [@msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents). AC can download a validated cache of the catalog for offline use in the role-template picker.
+
+## Archived project
+
+A project AC still has registered but hides from the sidebar. Archiving moves the path between two lists in `settings.json` and touches no files. See [Project archiving](features/project-archiving.md).
 
 ## Brief
 
@@ -25,6 +33,18 @@ A per-coding-agent option that copies a template config folder (for example `.cl
 ## ConPTY
 
 Windows' native PTY API. AC uses ConPTY via [portable-pty](https://github.com/wez/wezterm/tree/main/pty) on Windows; Unix PTYs on Linux/macOS.
+
+## Context alert
+
+A notice AC injects into a workgroup's coordinator when a member's context usage crosses a threshold the team configured. It fires once per crossing and takes no action on the session. See [Context tracking](features/context-tracking.md).
+
+## Context badge
+
+The `CTX <n>%` badge on a session row, showing how much of that agent's context window is used. It appears only when the session's coding agent has a context pattern configured. See [Context tracking](features/context-tracking.md).
+
+## Control-plane API
+
+A local, opt-in HTTP server inside the daemon that lets a machine client speak the inter-agent control plane over a scoped token instead of the filesystem outbox. See [Control-plane API](features/control-plane-api.md).
 
 ## Coordinator
 
@@ -46,9 +66,17 @@ The PTY component that flags a session as idle after a configurable silence thre
 
 Per-replica directories where an agent receives (`inbox/`) and stages outbound (`outbox/`) messages before the CLI delivers them.
 
+## Loop (Project Loop)
+
+A scheduled prompt delivered to a workgroup's coordinator on a cron expression. See [Concepts](concepts.md#project-loop).
+
 ## Messaging directory
 
 `<workgroup>/messaging/`. Every inter-agent message in a workgroup lives here as a UTC-timestamped markdown file. Never auto-purged.
+
+## Non-stop mode
+
+A per-project group of workgroups AC watches, alerting you when one stops working. See [Concepts](concepts.md#non-stop-mode).
 
 ## Portable instance
 
@@ -74,9 +102,17 @@ The `.ac/` container folder at the project root holding origin agent state, conf
 
 Pseudo-terminal. Each AC session runs in a real PTY (ConPTY on Windows, Unix PTY elsewhere) — not a command runner. Full vt100, interactive prompts, color, the lot.
 
+## Raise hand
+
+A coordinator's request for your attention, raised by the agent itself through the `raise-hand` CLI verb and shown on its rail entry and replica row. It survives restarts and is cleared only by real user input to that session. See [Sidebar guide](features/sidebar-guide.md#raise-hand).
+
 ## Replica
 
 A working copy of an agent inside a workgroup at `wg-<N>-<team>/__agent_<name>/`. Replicas share the canonical agent matrix's `memory/`, `plans/`, `skills/`, and `Role.md`, but have their own scratch space, inbox, outbox, and session artifacts.
+
+## Resource watchdog
+
+The part of the resource monitor that compares each agent group against the configured memory thresholds. It either surfaces the state or terminates the offending session's process group, depending on `resourceWatchdogAction`. See [Resource monitor](features/resource-monitor.md).
 
 ## Role template
 
@@ -98,6 +134,10 @@ Automatic shutdown of an idle team (coordinator plus agent-owned sessions) after
 
 The five tabs in the Settings modal: **General**, **Coding Agents**, **Resources**, **Watchers**, **Integrations**.
 
+## Spec Board
+
+A window holding one Mermaid file, with a live diagram beside its source. See [Concepts](concepts.md#spec-board).
+
 ## Team
 
 A coordinator + worker agents working toward shared goals. Defined in `.ac/_team_<name>/config.json`.
@@ -113,6 +153,10 @@ A UUID issued per session. The CLI shape-validates it; the daemon mailbox identi
 ## Voice-to-text
 
 Push-to-talk transcription via the Google Gemini API. Dictate a prompt; AC writes the transcription into the session's PTY. See [Voice-to-text](features/voice-to-text.md).
+
+## Watcher
+
+A root-level pattern AC matches against agent terminal output, reaching every configured agent unless a selector narrows it. See [Concepts](concepts.md#watcher).
 
 ## Workspace (Deprecated)
 

--- a/docs/home-en.md
+++ b/docs/home-en.md
@@ -24,4 +24,5 @@ Use the Agent Commander / Root Agent when work spans more than one team or workg
 - [Quickstart](quickstart.md) for a guided first team.
 - [Creating agents](agents/creating-agents.md) to define durable roles.
 - [Teams and workgroups](agents/teams-and-workgroups.md) to understand coordinators, workers, and briefs.
+- [Feature index](features/README.md) to find the page for one feature.
 - [Troubleshooting](troubleshooting.md) when a session, message, or launch does not behave as expected.

--- a/docs/integrations/coding-agents.md
+++ b/docs/integrations/coding-agents.md
@@ -83,7 +83,7 @@ On startup AC reads `settings.json → agents[]`. Each entry has:
 
 The default coding-agent catalog includes a Pi entry with command `pi` and instructions file `AGENTS.md`.
 
-**Where `updateCommands` lives.** The catalog is a separate manifest from `settings.json`: it is `agents.json`, inside the per-instance `coding-agents/` directory described in [Directory layout](../reference/directory-layout.md). Each catalog definition can carry `updateCommands`, the commands AC runs to update that tool, and `autoUpdate`; both default to empty and `false` when the manifest omits them. **Neither is a `settings.json` key**, and the CLI exposes the catalog read-only (`coding-agent catalog`). What you set in `settings.json` is your answer to the startup prompt, `agentAutoUpdateByCommand`, described in [Coding agent auto-update](../features/agent-auto-update.md).
+**Where `updateCommands` lives.** The catalog is a separate manifest from `settings.json`: it is `agents.json`, in the project's own `.ac/coding-agents/` directory (see [Directory layout](../reference/directory-layout.md)), seeded per registered project. Each catalog definition can carry `updateCommands`, the commands AC runs to update that tool, and `autoUpdate`; both default to empty and `false` when the manifest omits them. **Neither is a `settings.json` key**, and the CLI exposes the catalog read-only (`coding-agent catalog`). What you set in `settings.json` is your answer to the startup prompt, `agentAutoUpdateByCommand`, described in [Coding agent auto-update](../features/agent-auto-update.md).
 
 ## Switching the coding agent per session
 

--- a/docs/integrations/coding-agents.md
+++ b/docs/integrations/coding-agents.md
@@ -83,6 +83,8 @@ On startup AC reads `settings.json → agents[]`. Each entry has:
 
 The default coding-agent catalog includes a Pi entry with command `pi` and instructions file `AGENTS.md`.
 
+**Where `updateCommands` lives.** The catalog is a separate manifest from `settings.json`: it is `agents.json`, inside the per-instance `coding-agents/` directory described in [Directory layout](../reference/directory-layout.md). Each catalog definition can carry `updateCommands`, the commands AC runs to update that tool, and `autoUpdate`; both default to empty and `false` when the manifest omits them. **Neither is a `settings.json` key**, and the CLI exposes the catalog read-only (`coding-agent catalog`). What you set in `settings.json` is your answer to the startup prompt, `agentAutoUpdateByCommand`, described in [Coding agent auto-update](../features/agent-auto-update.md).
+
 ## Switching the coding agent per session
 
 When you launch a session AC shows a dropdown listing every entry in `agents[]`. Pick one. The choice is remembered as the session's `lastCodingAgent` so subsequent wakeups use the same CLI without asking.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -85,6 +85,7 @@ That's the loop. Every message is a file you can `cat`, `git diff`, and audit.
 - [Concepts](concepts.md) — the vocabulary (agent, team, workgroup, coordinator, brief).
 - [Teams and workgroups](agents/teams-and-workgroups.md) — coordinator authority, brief writing, recovery.
 - [Inter-agent messaging](agents/inter-agent-messaging.md) — the file protocol and the `send` CLI.
+- [Feature index](features/README.md): every feature page, grouped by what it does.
 - [Use cases](use-cases.md) — recipes other people are running.
 - [Troubleshooting](troubleshooting.md) — when something does not work.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -842,7 +842,7 @@ graph TD
 | `sidebar/components/WorkgroupGroupRail.tsx` | Rail with favorites, groups, raise-hand |
 | `sidebar/components/SessionItem.tsx` | Status dot, name, git branch, mic, telegram, detach, close |
 | `sidebar/components/AcDiscoveryPanel.tsx` | Branch and repo discovery panel |
-| `sidebar/components/AgentPickerModal.tsx` | Agent picker for launching a session |
+| `sidebar/components/AgentPickerModal.tsx` | Coding-agent profile assignment modal: assigns a profile to one target, with replica/kind/workgroup scope |
 | `sidebar/components/AgentUpdateOverlay.tsx` | Startup coding-agent update overlay and prompt |
 | `sidebar/components/CodingAgentQuickConfiguration.tsx` | Inline coding-agent configuration |
 | `sidebar/components/ContextBadge.tsx` | Per-session context-usage badge |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -218,7 +218,7 @@ graph TD
 
     PP --> SI["SessionItem.tsx<br/>Status dot, name (inline rename)<br/>git branch, shell path, mic,<br/>detach, telegram, close"]
 
-    AB --> SM["SettingsModal.tsx<br/>tabs: General, Agents, Integrations,<br/>Watchers, API clients, ..."]
+    AB --> SM["SettingsModal.tsx<br/>tabs: General, Coding Agents,<br/>Resources, Watchers, Integrations"]
     SI --> OA["OpenAgentModal.tsx<br/>Repo search → Agent picker → launch"]
 
     subgraph "Sidebar Stores"
@@ -298,15 +298,16 @@ graph LR
 
 ---
 
-## 4. IPC Contract: All Commands
+## 4. IPC Contract: Command Modules
 
-Rust handlers live in `src-tauri/src/commands/`; the frontend invokes them through `shared/ipc.ts`, which routes over a Tauri or WebSocket transport.
+Rust handlers live in `src-tauri/src/commands/`; the frontend invokes them through `shared/ipc.ts`, which routes over a Tauri or WebSocket transport. The table maps each frontend API area to its Rust module and names representative commands; it is not an exhaustive command list.
 
 | Frontend API area | Rust handler | Examples |
 |---|---|---|
 | SessionAPI | `commands/session.rs` | `create_session`, `destroy_session`, `switch_session`, `rename_session`, `list_sessions`, `get_active_session` (selection hydration) |
 | PtyAPI | `commands/pty.rs` | `pty_write`, `pty_resize` |
 | SettingsAPI | `commands/config.rs` | `get_settings`, `update_settings`, `save_debug_logs` |
+| AgentUpdateAPI | `commands/config.rs` | `get_agent_update_status`, `agent_update_answer` |
 | ReposAPI | `commands/repos.rs` | `search_repos` |
 | TelegramAPI | `commands/telegram.rs` | `attach_telegram`, `detach_telegram`, `list_bridges`, `send_test` |
 | WindowAPI | `commands/window.rs` | `detach_terminal`, `close_detached_terminal` |
@@ -811,18 +812,27 @@ graph TD
 | File | Purpose |
 |------|---------|
 | `main.tsx` | Entry, window routing by `?window=` param |
+| `main/App.tsx` | Main window root: central view routing |
+| `main/components/HomeView.tsx` | Home markdown view (fetch, markdown-it, DOMPurify) |
+| `main/components/ErrorModal.tsx` | Global error modal |
+| `main/components/QuitConfirmModal.tsx` | Quit confirmation |
+| `main/stores/centralView.ts`, `main/stores/home.ts`, `main/stores/error-modal.ts` | Main-window state |
+| `main/listeners-central-view.ts`, `main/listeners-home.ts` | Main-window event listeners |
 | `shared/types.ts` | TypeScript interfaces and the invariant-bearing `SessionSelection` union |
 | `shared/session-selection.ts` | Runtime decoder for untrusted selection hydration and events |
 | `shared/ipc.ts` | API wrappers, decoded selection hydration, event listeners |
 | `shared/transport.ts` | Transport abstraction (Tauri vs WebSocket) |
 | `shared/transport-tauri.ts`, `shared/transport-ws.ts` | Concrete transports |
-| `shared/shortcuts.ts` | Global keyboard shortcuts (Ctrl+Shift+W/R) |
+| `shared/shortcuts.ts` | Document-level keyboard shortcuts: Ctrl+Shift+W closes the selected session, Ctrl+Shift+R toggles voice capture. Active only while an AC window has focus. |
 | `shared/constants.ts` | Window type constants |
 | `shared/voice-recorder.ts` | Mic recording → Gemini → PTY inject |
 | `shared/console-capture.ts` | Console monkey-patch, 500 entries buffer |
 | `shared/stores/settings.ts` | Global `AppSettings` signal |
 | `shared/stores/toasts.ts` | Toast host state |
 | `shared/stores/resourceMonitor.ts` | Resource monitor state |
+| `shared/components/ToastHost.tsx` | Toast host rendering |
+| `shared/components/ExternalLinkConfirm.tsx` | External-link confirmation dialog |
+| `shared/external-links.ts`, `shared/github-url.ts` | External-link resolution |
 | `shared/screenshot-hotkey.ts`, `shared/zoom.ts`, `shared/window-geometry.ts` | Window helpers |
 | `sidebar/App.tsx` | Sidebar root: events, shortcuts, bridge subs |
 | `sidebar/stores/sessions.ts` | Session rows plus authoritative selection state |
@@ -831,8 +841,20 @@ graph TD
 | `sidebar/components/ProjectPanel.tsx` | Projects, workgroups and replicas → `SessionItem` |
 | `sidebar/components/WorkgroupGroupRail.tsx` | Rail with favorites, groups, raise-hand |
 | `sidebar/components/SessionItem.tsx` | Status dot, name, git branch, mic, telegram, detach, close |
+| `sidebar/components/AcDiscoveryPanel.tsx` | Branch and repo discovery panel |
+| `sidebar/components/AgentPickerModal.tsx` | Agent picker for launching a session |
+| `sidebar/components/AgentUpdateOverlay.tsx` | Startup coding-agent update overlay and prompt |
+| `sidebar/components/CodingAgentQuickConfiguration.tsx` | Inline coding-agent configuration |
+| `sidebar/components/ContextBadge.tsx` | Per-session context-usage badge |
+| `sidebar/components/ContextTemplateUpdateModal.tsx` | Context-template update flow |
+| `sidebar/components/ProfileOutdatedBadge.tsx` | Profile-drift badge |
+| `sidebar/components/RaiseHandIcon.tsx` | Raise-hand indicator |
+| `sidebar/components/TeamContextAlertsEditor.tsx` | Per-team context-alert thresholds |
+| `sidebar/components/WorkgroupGroupsModal.tsx` | Workgroup group administration |
+| `sidebar/components/ZoomStepper.tsx` | Sidebar zoom control |
+| `sidebar/components/Titlebar.tsx` | Sidebar titlebar: zoom, web-server menu, screenshot chip |
 | `sidebar/components/ActionBar.tsx` | Project creation + Settings gear |
-| `sidebar/components/SettingsModal.tsx` | Settings tabs: General, Agents, Integrations, Watchers, API clients, ... |
+| `sidebar/components/SettingsModal.tsx` | Settings tabs: General, Coding Agents, Resources, Watchers, Integrations |
 | `sidebar/components/OpenAgentModal.tsx` | Repo search → agent picker → launch |
 | `sidebar/components/NewTeamModal.tsx`, `EditTeamModal.tsx`, `NewWorkgroupModal.tsx`, `NewEntityAgentModal.tsx` | Entity creation |
 | `sidebar/components/NewLoopModal.tsx`, `EditLoopModal.tsx` | Loop CRUD UI |

--- a/docs/reference/directory-layout.md
+++ b/docs/reference/directory-layout.md
@@ -54,7 +54,7 @@ The project-scoped tree. AC creates and maintains it, and the project commits it
 
 | Entry | What it is |
 |---|---|
-| `_agent_<name>/` | Agent matrix: one directory per agent, holding `Role.md`, `config.json`, `memory/`, `memory_YYYYMMDD_hhmmss/` (rotated memory archives), `plans/`, and `skills/`. See [Agent Matrix conventions](../agent-matrix-conventions.md) |
+| `_agent_<name>/` | Agent matrix: one directory per agent, holding `Role.md`, `config.json`, `memory/`, `memory_YYYYMMDD_hhmmss/` (rotated memory archives), `plans/`, and `skills/`. See [Agent Matrix conventions](../agent-matrix-conventions.md), and see [Agent Matrix conventions §11](../agent-matrix-conventions.md#11-agent-memory-rotation-at-spawn) for how the archives are made |
 | `_team_<name>/` | Team definitions: `config.json` (members, coordinator, repos) and `conventions.md` |
 | `wg-<N>-<name>/` | Workgroups: `__agent_<name>/` replica directories, `messaging/` (inter-agent message files), `repo-*/` workgroup clones, `TASK*.md` briefs. Project-scoped and shared, but gitignored (`wg-*/`) because the `repo-*` folders are their own git repositories |
 | `competitions/` | Competition packages, one folder per competition with a `MANIFEST.md`. No writer in the current source; treat as hand-managed |
@@ -71,7 +71,7 @@ Per-user instantiation state next to the binary. Everything in this tree is per-
 | `settings.json.lock` | Write lock for settings writers | `config/local_config_io.rs` |
 | `settings.pre-384-v1.json` | Pre-v384 settings backup taken during the settings migration | `config/settings.rs` |
 | `sessions.json` | Session registry | `config/sessions_persistence.rs` |
-| `activity.jsonl` | Activity log | `config/activity_log.rs` |
+| `activity.jsonl` | Activity log, see [Activity log](../features/activity-log.md) | `config/activity_log.rs` |
 | `coordinator_clocks.json` | Coordinator clock state | `config/coordinator_clocks.rs` |
 | `daemon.pid` | PID of the running daemon; the CLI uses it to detect stale sessions | `config/daemon_pid.rs` |
 | `master-token.txt` | CLI master token | `lib.rs` boot |

--- a/docs/reference/directory-layout.md
+++ b/docs/reference/directory-layout.md
@@ -57,6 +57,7 @@ The project-scoped tree. AC creates and maintains it, and the project commits it
 | `_agent_<name>/` | Agent matrix: one directory per agent, holding `Role.md`, `config.json`, `memory/`, `memory_YYYYMMDD_hhmmss/` (rotated memory archives), `plans/`, and `skills/`. See [Agent Matrix conventions](../agent-matrix-conventions.md), and see [Agent Matrix conventions §11](../agent-matrix-conventions.md#11-agent-memory-rotation-at-spawn) for how the archives are made |
 | `_team_<name>/` | Team definitions: `config.json` (members, coordinator, repos) and `conventions.md` |
 | `wg-<N>-<name>/` | Workgroups: `__agent_<name>/` replica directories, `messaging/` (inter-agent message files), `repo-*/` workgroup clones, `TASK*.md` briefs. Project-scoped and shared, but gitignored (`wg-*/`) because the `repo-*` folders are their own git repositories |
+| `coding-agents/` | Coding-agent catalog: `agents.json` (manifest) and `_seed/` (per-tool default config-folder masters). Seeded per registered project; this is the copy AC reads and writes |
 | `competitions/` | Competition packages, one folder per competition with a `MANIFEST.md`. No writer in the current source; treat as hand-managed |
 
 ## `.agentscommander_ac2/` (per-instance, never shared)
@@ -95,7 +96,7 @@ Per-user instantiation state next to the binary. Everything in this tree is per-
 | Entry | What it is |
 |---|---|
 | `instances/<uuid>/outbox/` | App outbox for the current run; AC removes stale instance dirs at boot |
-| `coding-agents/` | Coding-agent catalog: `agents.json` (manifest) and `_seed/` (per-tool default config-folder masters) |
+| `coding-agents/` | Legacy catalog location, kept as a read and seed source only. Since #1318 the catalog AC reads and writes is the project's `.ac/coding-agents/`; nothing is written here |
 | `context-cache/` | Rendered session contexts (`ac-context-*.md`) |
 | `pty-input-locks/` | PTY input serialization locks |
 | `git-guard/` | Windows git guard shim (`git.cmd`, `git-guard.ps1`) that wraps git for guarded subprocesses |

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -1,0 +1,32 @@
+# Keyboard shortcuts
+
+For developers who want the complete list of key combinations AgentsCommander binds, and where each one works. There are three, and two of them only work while an AC window has focus.
+
+## Window shortcuts
+
+| Shortcut | What it does | Where it works |
+|---|---|---|
+| `Ctrl+Shift+W` | Closes the currently selected session. | Any AC window with focus. |
+| `Ctrl+Shift+R` | Toggles voice capture on the selected session. Live sessions only. | Any AC window with focus. |
+
+Both act on **the current selection**, not on the window you are looking at. `Ctrl+Shift+R` does nothing when the selection is not a live session.
+
+## The global screenshot hotkey
+
+The screenshot capture hotkey is **the only OS-global shortcut AgentsCommander registers**. It fires whether or not an AC window has focus, which is the point: you press it while looking at the thing you want to capture.
+
+It is configurable, and it is Windows-only. See [Configure the hotkey](../features/screenshot-capture.md#configure-the-hotkey) for the accepted key combinations, how to change it, and how to check that the registration succeeded.
+
+## Scope
+
+The two shortcuts in the table above are **document-level listeners**, registered on the page inside each AC window. They are active only while an AC window has focus.
+
+They are not OS-global hotkeys. Pressing `Ctrl+Shift+W` in another application closes nothing in AC, and the combinations do not conflict with whatever those applications bind to the same keys.
+
+Both are registered once even when a single page hosts more than one AC surface, so a browser build that shows the sidebar and the terminal together does not run either handler twice.
+
+## See also
+
+- [Screenshot capture](../features/screenshot-capture.md) - the global hotkey, its configuration and its failure modes
+- [Voice-to-text](../integrations/voice.md) - what `Ctrl+Shift+R` starts and how to cancel a recording
+- [Session auto-close](../features/session-auto-close.md) - the other way a session closes

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -77,6 +77,7 @@ A minimal `settings.json`:
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `agents` | `AgentConfig[]` | See example | The dropdown of available coding agents. |
+| `agentAutoUpdateByCommand` | object | `{}` | Per-coding-agent-command answer to the startup update prompt. Keys are coding-agent commands (for example `claude`, `codex`); `true` means AC updates that command at startup without asking again, `false` means it never asks again and never updates. An absent key means AC asks on the next startup. See [Coding agent auto-update](../features/agent-auto-update.md). |
 
 Besides the GUI Settings dialog and Onboarding, `agents[]` has a scriptable writer: the [`coding-agent`](cli.md#coding-agent) CLI verb (`list`/`show`/`catalog`/`add`/`update`/`remove`). It writes safely whether or not the GUI is running.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -121,6 +121,8 @@ Besides the GUI Settings dialog and Onboarding, `agents[]` has a scriptable writ
 
 Seeding is active only when `enabled` is true and `dest` is non-empty. See [Config seed](../features/config-seed.md) for template precedence and token substitution.
 
+See [Context tracking](../features/context-tracking.md).
+
 ### Coding agent profiles
 
 Lettered launch variants (`A`, `B`, `C`, ...) per coding agent. See [Coding Agent Profiles](../features/coding-agent-profiles.md) for the feature; this is the `settings.json` schema.
@@ -189,6 +191,8 @@ Each registered project is stored in two forms: a canonical absolute path (the e
 | `archivedProjectPaths` | string[] | `[]` | Absolute paths of archived (registered but hidden) projects. |
 | `archivedProjectPathsRelativeToInstance` | (string \| null)[] | `[]` | Companion array of `archivedProjectPaths`: same length and order. |
 
+See [Project archiving](../features/project-archiving.md).
+
 **Companion format.** A companion string is relative to the directory of the running executable (see [Portable instances](../features/portable-instances.md#portable-project-paths)), always written with `/` separators on every OS. `.` means the instance folder itself; `..` is allowed as long as it does not climb above the filesystem root. A project on a different Windows drive or UNC share than the binary has no relative form, so its companion slot is `null` and it stays absolute-only.
 
 **Array alignment.** Each plural companion array has exactly the same length and index meaning as its absolute array: slot `i` in `projectPathsRelativeToInstance` is the portable form of `projectPaths[i]`, or `null`. A length mismatch, an orphan companion (a companion present while its absolute field is absent), a wrong-typed field, or a non-null companion beside a `null` primary is structural corruption (see below).
@@ -227,12 +231,16 @@ Each registered project is stored in two forms: a canonical absolute path (the e
 | `resourceKeepLastSnapshot` | bool | `true` | Keep the last snapshot. |
 | `resourceBackoffPolling` | bool | `true` | Use backoff polling. |
 
+See [Resource monitor](../features/resource-monitor.md).
+
 ### Git status sweeper
 
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `gitSweepConcurrency` | number | `1` | How many repositories the global git sweeper inspects at once. Clamped to `1..=4` when read. `1` is strictly sequential, which is what bounds concurrent `git.exe`; raise it to `2` only if one slow repository is delaying the others. |
 | `gitSweepMinIntervalSecs` | number | `10` | Lower bound, in seconds, on one sweeper round. Clamped to `1..=3600` when read; `0` is raised to `1`. The effective period is `max(this, round duration)`, so on a large workgroup set the round duration dominates and this never fires. |
+
+See [Sidebar guide](../features/sidebar-guide.md).
 
 Both are manual-only (no UI) and are read from the in-memory settings, so an edit takes effect on the next **restart**.
 
@@ -317,6 +325,8 @@ See [Telegram bridge setup](../integrations/telegram.md).
 | `webServerPort` | u16 | platform-default per binary suffix | Listening port. |
 | `webServerBind` | string | `"127.0.0.1"` | Bind address. Use `"0.0.0.0"` only if you understand the implications. |
 
+See [Remote web UI](../features/remote-web-ui.md).
+
 #### Web Remote Access on a trusted LAN
 
 Web Remote Access is the embedded HTTP/WebSocket listener controlled by the
@@ -394,6 +404,8 @@ In-daemon control-plane API server for Docker/distributed agents. Default off: n
 | `apiServerPort` | u16 | profile-aware default per binary suffix | Listening port. |
 | `apiServerBind` | string | `"127.0.0.1"` | Bind address. Any non-loopback bind logs a loud startup warning. |
 
+See [Control-plane API](../features/control-plane-api.md).
+
 See [`api-client`](cli.md#api-client) for minting and revoking control-plane client tokens.
 
 ### Brief auto-title
@@ -423,6 +435,8 @@ Root-level context-scrape watcher patterns, keyed by watcher id. A pattern can a
 |---|---|---|---|
 | `watchers` | `{ <id>: WatcherEntry }` | `{}` | Watcher patterns, resolved in key order against an 8-watcher budget. |
 | `watchersGeometry` | object \| null | `null` | Geometry of the watcher activity window. |
+
+See [Watchers](../features/watchers.md).
 
 `WatcherConfig` (one valid entry):
 
@@ -460,6 +474,8 @@ Root-level context-scrape watcher patterns, keyed by watcher id. A pattern can a
 |---|---|---|---|
 | `logLevel` | string \| null | `null` | One of `error`, `warn`, `info`, `debug`, `trace`. Applied live, no restart. An invalid value, a legacy filter string, or `null` falls back to `info`. The `RUST_LOG` env var, if set, overrides this and freezes the live selector until restart. |
 | `activityLogEnabled` | bool | `false` | Enable the activity log. |
+
+See [Activity log](../features/activity-log.md).
 
 See [Log filtering](log-filtering.md).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -27,6 +27,8 @@ When you launch a session, the coding agent inherits:
 - The environment variables of the AC process (including `PATH`, `HOME`, and any keys you may have exported).
 - The user-level filesystem and network permissions you yourself have.
 
+Two opt-in listeners widen who can reach that surface from outside the machine: the [control-plane API](features/control-plane-api.md) and the [remote web UI](features/remote-web-ui.md). Both are off by default and both are described on their own pages.
+
 This is the same surface area the coding agent has when you launch it from your own terminal. AC adds visibility and coordination; it does **not** add a sandbox. If the underlying agent can `rm -rf ~/`, AC will let it.
 
 Pi auto-resume does not add a state-reading boundary. AC does not inspect or copy `~/.pi/agent/`, `PI_CODING_AGENT_SESSION_DIR`, or `--session-dir` paths, and a Pi option that names Claude does not trigger AC's Claude projects-directory probe. AC does not provision Pi credentials or map Pi state into containers. It only adds `--continue` to an eligible configured known-state launch; [Pi remains responsible for session lookup and errors](integrations/coding-agents.md#no-ac-side-pi-state-probe-or-fallback).

--- a/plans/1407-document-missing-features.md
+++ b/plans/1407-document-missing-features.md
@@ -1,0 +1,1270 @@
+# Plan #1407: Document every shipped AgentsCommander feature that has no user-facing documentation
+
+Author: architect, wg-14. Authored 2026-08-17 UTC.
+
+Status: READY_FOR_IMPLEMENTATION
+
+Certified by the architect on 2026-08-17 UTC after consensus round 1. Section 11 is the `dev-rust` enrichment, section 12 the `dev-rust-grinch` adversarial review, and section 13 the architect's disposition of all twelve findings, all of which were accepted and folded into sections 1 to 10.
+
+Issue: [mblua/AgentsCommander#1407](https://github.com/mblua/AgentsCommander/issues/1407).
+
+This is a **documentation-only** plan. It creates 16 new files under `docs/` (14 feature pages, the features index, and one reference page), edits 10 existing files under `docs/` (`reference/architecture.md`, `reference/settings.md`, `reference/directory-layout.md`, `features/session-auto-close.md`, `agent-matrix-conventions.md`, `concepts.md`, `glossary.md`, `quickstart.md`, `home-en.md`, `security.md`), and changes **zero** lines of application code. It adds no crate, no npm dependency, no Rust module, no TypeScript module, no Tauri command, no event, no settings key and no migration. It adds zero module-to-module dependency arcs.
+
+---
+
+## 1. Frozen authority and fail-closed entry gate
+
+The implementation working tree is `repo-AgentsCommander`, branch `docs/1407-document-missing-features`, targeting `main`.
+
+Frozen base SHA: `51e70e47f442109d6b618299b26d95a12801f156`.
+
+Verified on 2026-08-17 UTC: committed `HEAD` equals the frozen SHA, the branch is `docs/1407-document-missing-features`, and `git status --porcelain=v1 --untracked-files=all` was empty.
+
+Branch-name validation was checked against `scripts/validate-branch-name.mjs:15`. The pattern is `^(bug|chore|ci|docs|feat|feature|fix|refactor|style|test)\/([1-9][0-9]*)-([a-z0-9]+(?:-[a-z0-9]+)*)$` with `MAX_SLUG = 50`. `docs/1407-document-missing-features` matches with type `docs`, number `1407`, slug `document-missing-features` (25 characters). The required `validate-branch-name` check will pass.
+
+Root `.gitignore:11` ignores `/plans/`, so this plan file must be force-added: `git add -f plans/1407-document-missing-features.md`. Do not remove or weaken that ignore rule.
+
+Every line number in this plan refers to the frozen SHA above. If a line number no longer matches the quoted text, stop and re-anchor on the quoted text, never on the number.
+
+**Entry gate for each batch.** Before starting any batch, the implementer runs, from the repo root:
+
+```bash
+git rev-parse HEAD
+git branch --show-current
+git status --porcelain=v1 --untracked-files=all
+```
+
+Proceed only if the branch is `docs/1407-document-missing-features` and the only dirty entries are files this plan authorizes. Never rebase onto a moved `main` under this plan without re-certification.
+
+---
+
+## 2. Objective and non-goals
+
+**Objective.** Every shipped feature listed in issue #1407 ends up with product documentation a user can read: a page under `docs/features/`, a section inside an existing doc, or a glossary/concept entry. `docs/features/` gains an index. The four inaccurate or incomplete statements in `docs/reference/architecture.md` are corrected. The one genuinely missing settings key is added to `docs/reference/settings.md`.
+
+**Non-goals, binding on the implementer:**
+
+- Do **not** modify any file under `src/`, `src-tauri/`, `scripts/`, `.github/`, `package.json`, `Cargo.toml`, or `tauri.conf.json`. This plan changes documentation only.
+- Do **not** modify the two inventory message files in `.ac/wg-14-dev-v5-team/messaging/`.
+- Do **not** modify anything under `docs/testing/`. Those are QA scripts, not product documentation, and are explicitly out of scope (confirmed by the tech-lead).
+- Do **not** rename, move, or delete any existing file under `docs/`. Every change to an existing doc is an addition or an in-place correction of a named line.
+- Do **not** renumber the existing H2 sections of `docs/agent-matrix-conventions.md`. `docs/features/coding-agent-profiles.md:169` links to the anchor `#5-profile-path-placeholders`; renumbering would break it.
+- Do **not** create `mkdocs.yml` or any site-generator config. The index is a plain `README.md`.
+- Do **not** document the intentionally hidden internal verbs (`role-experiment`, `test-reset`, `window-info`, `ui-*`). `docs/reference/cli.md:42` declares their exclusion by design.
+- Do **not** add a page for a feature already covered. See section 3.2.
+
+---
+
+## 3. Verified current state
+
+### 3.1 Inputs
+
+Two read-only inventories produced at the frozen SHA, with `path:line` evidence, are the scope input. Do not redo the inventory.
+
+- Backend/CLI: `.ac/wg-14-dev-v5-team/messaging/20260817-184003-wg14-dev-rust-to-wg14-tech-lead-features-doc-gap-inventory.md` (items `C1`-`C6`, `B1`-`B10`).
+- Frontend `src/`: `.ac/wg-14-dev-v5-team/messaging/20260817-183737-wg14-dev-webpage-ui-to-wg14-tech-lead-ui-features-doc-gap-inventory.md` (items `UI-C1`-`UI-C15`, `UI-B1`-`UI-B12`, plus three "docs describe UI wrongly" findings).
+
+Throughout this plan, backend items are cited as `C<n>` / `B<n>` and frontend items as `UI-C<n>` / `UI-B<n>`.
+
+### 3.2 Three corrections to the inventories, verified at the frozen SHA
+
+These three items are **removed from scope**. They are false positives. Each was verified directly against source.
+
+1. **`legacyStartOnlyCoordinators` is not a missing settings key.** `src-tauri/src/config/settings.rs:304-309` carries `#[serde(default, skip_serializing_if = "Option::is_none", rename = "startOnlyCoordinators")]` on `pub legacy_start_only_coordinators: Option<bool>`. The JSON key is `startOnlyCoordinators`, and `docs/reference/settings.md:468` already documents it in the "Migration carriers" table. Nothing to add. This also corrects "established fact" 2 in the Step 4 dispatch: `docs/reference/settings.md` is missing exactly **one** key, not two.
+
+2. **`codex_resolver.rs`, `gemini_resolver.rs` and `wg_delete_diagnostic.rs` do not belong in the IPC contract table.** All three contain zero occurrences of `tauri::command` (verified by counting `tauri::command` per file in `src-tauri/src/commands/`). They are internal helper modules with no IPC surface, so their absence from `docs/reference/architecture.md:305-324` is correct, not a gap. Only the agent-update pair is a genuine omission: `get_agent_update_status` (`src-tauri/src/commands/config.rs:2240-2245`) and `agent_update_answer` (`src-tauri/src/commands/config.rs:2255-2262`), both `#[tauri::command]` and both registered in `src-tauri/src/lib.rs:2930-2931`.
+
+3. **`UI-C9` (profile-outdated badge) is already documented.** `docs/features/coding-agent-profiles.md:124-135` is a section titled `## Drift: the "outdated" badge` that describes the badge text (`⟳ outdated`), its tooltip, the click-to-relaunch behavior, and its persistence rules. The inventory's grep for the literal string `profile outdated` missed it. No new documentation is required.
+
+### 3.3 The documentation tree at the frozen SHA
+
+`docs/features/` holds 11 pages and **no** `README.md`: `coding-agent-profiles.md`, `config-seed.md`, `container-coding-agents.md`, `portable-instances.md`, `screenshot-capture.md`, `seed-manifest.md`, `session-auto-close.md`, `telegram-bridge.md`, `terminal-snapshots.md`, `voice-to-text.md`, `window-capture.md`. There is no `mkdocs.yml` in the repo.
+
+`docs/style-guide.md` is the binding authority for prose. Its six numbered rules, its vocabulary table (`:56-66`), its banned-word list (`:73`, plus "simply", "just", "easily", "easy to use" at `:77`), and its markdown conventions (`:88-92`) apply to every file this plan creates or edits.
+
+`docs/style-guide.md:96-101` sets the new-page-versus-extend rule: a new page is justified when the topic has its own audience, is reusable from multiple other docs, or exceeds roughly 200 lines. Section 4.1 applies that rule item by item.
+
+### 3.4 Facts verified for the corrections
+
+- `src/sidebar/components/SettingsModal.tsx:134-142` declares exactly five tabs: `general` -> "General", `agents` -> "Coding Agents", `resources` -> "Resources", `watchers` -> "Watchers", `integrations` -> "Integrations". There is no "API clients" tab.
+- `src/shared/shortcuts.ts:44-67` registers via `document.addEventListener("keydown", handler)`. The two entries are Ctrl+Shift+W (`requestCoordinatorCloseById` on the current selection) and Ctrl+Shift+R (`voiceRecorder.toggle`, live selections only). Neither is an OS-global hotkey. The only OS-global hotkey is the screenshot one, documented at `docs/features/screenshot-capture.md:112`.
+- `docs/reference/architecture.md:809-854` (table "Frontend (`src/`)") lists `main.tsx` but no file from `src/main/`. `src/main/` contains `App.tsx`, `components/{HomeView,ErrorModal,QuitConfirmModal}.tsx`, `stores/{home,centralView,error-modal}.ts`, `listeners-central-view.ts`, `listeners-home.ts`.
+- `grep -ic cascade docs/features/session-auto-close.md` returns `0`.
+- `grep -rn "agentAutoUpdateByCommand" docs/` returns nothing. The field is `src-tauri/src/config/settings.rs:565` (`agent_auto_update_by_command: BTreeMap<String, bool>`), default empty (`:917`), camelCase round-trip asserted at `:5098-5124`.
+- `src-tauri/src/api/README.md` exists (11.9K, headings: Enabling, Auth, Endpoints (`/api/v1`), Terminal snapshots, Container runtime contract, Versioning, Audit) and is not published under `docs/`. Handler modules: `src-tauri/src/api/handlers/{list_peers,pty_input,send,session_transport,terminal_snapshot,window_screenshot}.rs`.
+- `docs/concepts.md:3` states "Nine terms." and the file has exactly nine H2 sections. Any concept added must update that count.
+
+---
+
+## 4. Decisions
+
+These are the six open questions from the dispatch, resolved. Nothing here is left to the implementer.
+
+### 4.1 Granularity
+
+Rule applied: one page per **feature as a user experiences it**, merging the backend half and the UI half. Anything that is a single paragraph inside an existing feature's story becomes a section in that existing page. Anything that is a one-line definition becomes a glossary or concepts entry.
+
+**14 new pages under `docs/features/`:**
+
+| Page | Merges |
+|---|---|
+| `non-stop-mode.md` | `C1` + `UI-C5` |
+| `spec-board.md` | `C2` + `UI-B1` |
+| `context-tracking.md` | `C3` + `UI-C8` + `UI-C12` |
+| `agent-auto-update.md` | `C4` + `UI-C4` |
+| `project-archiving.md` | `C6` + `UI-B11` |
+| `project-loops.md` | `B1` + `UI-B6` |
+| `resource-monitor.md` | `B2` + `UI-B5` |
+| `remote-web-ui.md` | `B3` + `UI-B8` |
+| `control-plane-api.md` | `B4` |
+| `watchers.md` | `B5` + `UI-B4` |
+| `activity-log.md` | `B7` |
+| `sidebar-guide.md` | `UI-B2` + `UI-B7` + `UI-C11` + `UI-C13` + `UI-C14` + `UI-C15` + `B6` |
+| `app-windows.md` | `UI-C1` + `UI-B3` + `UI-B12` |
+| `notifications-and-dialogs.md` | `UI-C2` + `UI-C3` + `UI-C7` + `UI-C10` + `UI-B9` + `UI-B10` + `B10` |
+
+**1 new page under `docs/reference/`:** `keyboard-shortcuts.md` (`UI-C6`).
+
+**1 new index:** `docs/features/README.md`.
+
+**Sections added to existing pages (no new page):**
+
+| Item | Host page | Why not its own page |
+|---|---|---|
+| `B8` cascade close | `docs/features/session-auto-close.md` | It is a close behavior of the feature that page already owns. |
+| `B9` idle badge thresholds | `docs/features/session-auto-close.md` | That page already has `## The idle badge` (`:34`); it only lacks the two threshold keys. |
+| `C5` memory rotation at spawn | `docs/agent-matrix-conventions.md` | `docs/reference/directory-layout.md:57` already routes readers there for `memory_YYYYMMDD_hhmmss/`. |
+
+**Concepts and glossary only:** the four terms in section 4.4.
+
+**Explicitly dropped:** `legacyStartOnlyCoordinators`, the three non-IPC command modules, and `UI-C9`. See section 3.2.
+
+### 4.2 Page template
+
+Derived from **`docs/features/session-auto-close.md`**, the closest existing match for "a background behavior with settings, badges and failure modes". Its shape is: H1, an audience-and-promise line, a one-paragraph plain summary, behavior H2s, `## Settings`, `## Troubleshooting`, `## See also`.
+
+Every new page under `docs/features/` MUST have, in this order:
+
+1. `# <Feature name>` - sentence case, matching the index row exactly.
+2. **Audience line** - one sentence, "For developers who ...", per `docs/style-guide.md:5`.
+3. **Promise line** - one sentence, "After this page you ..." or equivalent concrete outcome, per `docs/style-guide.md:7-12`. May be merged into the same paragraph as the audience line, as `session-auto-close.md:3` does.
+4. **Summary paragraph** - what AC actually does, in plain prose, before the first H2.
+5. **An opening H2 that answers what the feature does**, named exactly as section 5 lists it for that page. The mechanism in 3 to 8 sentences or a short list.
+6. **An enablement H2**, where section 5 lists one: `## Turning it on` (the exact UI path or settings key that enables it, with expected result) or `## Availability` (for an always-on feature, stated plainly). Where section 5 lists neither, the page has neither.
+7. One or more behavior H2s, one concept per H2 (`docs/style-guide.md:24-26`). Per-page requirements are in section 5.
+8. `## Settings`, **only where section 5 lists it** - a table with columns `Key | What it controls`, one row per related key, and a link to the matching `../reference/settings.md` anchor. Every key in that table must be a real JSON key of `settings.json`. Pages whose configuration does not live in `settings.json` get `## Where the configuration lives` instead, with no `settings.md` link and no key table: D6, D9 (see section 5). Pages with no configuration of their own get neither: D18, D20.
+9. `## Troubleshooting` - at least two entries. Each names a literal symptom (a badge text, an error string, an empty list, a missing window) and the concrete check or fix, per `docs/style-guide.md:41-46`. Omitted only where section 5 omits it: D20.
+10. `## See also` - at least two relative links to other docs.
+
+**Section 5's per-page H2 list is authoritative.** This subsection describes the intent behind the skeleton and the shape each named H2 must take; where the two appear to disagree, section 5 governs the heading text, the count and the order, and criterion 7.2.4 enforces section 5.
+
+Prose rules that apply everywhere: second person, present tense, active voice; no word from the banned list at `docs/style-guide.md:73,77`; every code block carries a language tag; every shown command is followed by what the reader should see (`docs/style-guide.md:39`).
+
+### 4.3 Index: `docs/features/README.md`
+
+Shape:
+
+```markdown
+# Features
+
+For developers looking for the page that covers one AgentsCommander feature. Every feature page lives in this directory; this index is the map.
+
+## Agents and sessions
+| Page | What it covers |
+|---|---|
+| [...](...) | ... |
+
+## Automation
+...
+## Monitoring
+...
+## Remote access
+...
+## Configuration and packaging
+...
+```
+
+Five H2 groups, fixed, in this order, with these members:
+
+- **Agents and sessions** (8): `coding-agent-profiles.md`, `container-coding-agents.md`, `session-auto-close.md`, `agent-auto-update.md`, `sidebar-guide.md`, `app-windows.md`, `notifications-and-dialogs.md`, `voice-to-text.md`.
+- **Automation** (4): `non-stop-mode.md`, `project-loops.md`, `spec-board.md`, `watchers.md`.
+- **Monitoring** (6): `resource-monitor.md`, `context-tracking.md`, `activity-log.md`, `terminal-snapshots.md`, `window-capture.md`, `screenshot-capture.md`.
+- **Remote access** (3): `remote-web-ui.md`, `control-plane-api.md`, `telegram-bridge.md`.
+- **Configuration and packaging** (4): `config-seed.md`, `seed-manifest.md`, `portable-instances.md`, `project-archiving.md`.
+
+Group sizes are 8 + 4 + 6 + 3 + 4 = 25. `voice-to-text.md` sits under "Agents and sessions", not "Remote access": it is a local microphone feature and a reader looking for it will not think of it as remote.
+
+Every row is `| [Title](file.md) | one-sentence description |`. Title matches the page's H1 exactly. Final state: 25 rows (11 existing pages plus 14 new ones). The index itself is never listed as a row.
+
+**Self-creating index.** If `docs/features/README.md` does not exist when a batch runs, the batch creates it with the H1, the audience line and the five H2 group headings above, and then adds only its own rows. A batch never adds a row for a page it did not write. This is what makes Batches 2 to 7 executable in any order from a cold start.
+
+### 4.4 Cross-links
+
+**`docs/concepts.md`** gains four H2 entries, inserted in this order after `## Workgroup` (`:48-52`) and before `## Brief` (`:54`): `## Non-stop mode`, `## Project Loop`, `## Watcher`, `## Spec Board`. Each is 2 to 4 sentences ending in a `See [<page>](features/<page>.md).` link. The lead line at `docs/concepts.md:3` changes "Nine terms." to "Thirteen terms."
+
+**`docs/glossary.md`** gains these H2 entries, each 1 to 3 sentences, inserted so the file stays alphabetically ordered by heading: `## Activity log`, `## Archived project`, `## Context alert`, `## Context badge`, `## Control-plane API`, `## Loop (Project Loop)`, `## Non-stop mode`, `## Raise hand`, `## Resource watchdog`, `## Spec Board`, `## Watcher`. Each entry links to its feature page.
+
+**Where a term lands in both files** - `Non-stop mode`, `Watcher`, `Spec Board`, and `Loop (Project Loop)` against `Project Loop` - the concepts entry is the authoritative definition and the glossary entry is one sentence plus a `See [Concepts](concepts.md#<anchor>).` link. Do not write two independent definitions of the same term. The counts in section 7.3 are unaffected.
+
+**`docs/quickstart.md`** - `## Next steps` (`:83`) gains one bullet: a link to `features/README.md` described as the full feature index.
+
+**`docs/home-en.md`** - `## Useful next steps` (`:22`) gains one bullet linking to `features/README.md`.
+
+**`docs/reference/settings.md`** - each of these `###` groups gains a one-line "See [<page>](../features/<page>.md)." pointer immediately after its table: `Projects` (`:178`) -> `project-archiving.md`; `Resource monitor` (`:216`) -> `resource-monitor.md`; `Git status sweeper` (`:229`) -> `sidebar-guide.md`; `Web server (opt-in)` (`:311`) -> `remote-web-ui.md`; `Control-plane API server (opt-in)` (`:386`) -> `control-plane-api.md`; `Watchers` (`:417`) -> `watchers.md`; `Coding agents` (`:75`) -> `context-tracking.md`; `Logging` (`:456`) -> `activity-log.md`. The `See [Log filtering](log-filtering.md).` line at `:463` stays. That is eight new pointers across seven groups.
+
+The `context-tracking.md` pointer goes on the **`Coding agents`** group, not on `Watchers`. `contextRegex` (`docs/reference/settings.md:94`) is the only `settings.json` key that feeds the context reading and it lives in that group; the `Watchers` group (`:417-437`) holds only `watchers` and `watchersGeometry` plus the `WatcherConfig` shape and carries no context-alert key at all. Pointing `Watchers` at `context-tracking.md` would promise a reader that context-tracking settings live there, and they do not.
+
+**`docs/reference/directory-layout.md`** - the `activity.jsonl` row (`:74`) gains `see [Activity log](../features/activity-log.md)` in its "What it is" cell; the `_agent_<name>/` row (`:57`) gains `see [Agent Matrix conventions §11](../agent-matrix-conventions.md#11-agent-memory-rotation-at-spawn)` after the existing link.
+
+**`docs/security.md`** - `## What an agent can reach` (`:22`) gains one sentence pointing to `features/control-plane-api.md` and `features/remote-web-ui.md` as the surfaces described there. No other change to that file.
+
+### 4.5 The `architecture.md` corrections
+
+Four edits to `docs/reference/architecture.md`. Each is stated as exact old text -> exact new text.
+
+**A1 - `:301` heading plus one missing row.**
+
+Old heading: `## 4. IPC Contract: All Commands`
+New heading: `## 4. IPC Contract: Command Modules`
+
+Old lead sentence (`:303`): `Rust handlers live in \`src-tauri/src/commands/\`; the frontend invokes them through \`shared/ipc.ts\`, which routes over a Tauri or WebSocket transport.`
+New lead sentence: same text, plus a second sentence: `The table maps each frontend API area to its Rust module and names representative commands; it is not an exhaustive command list.`
+
+Add one row, immediately after the `SettingsAPI` row (`:309`):
+
+`| AgentUpdateAPI | \`commands/config.rs\` | \`get_agent_update_status\`, \`agent_update_answer\` |`
+
+Do **not** add rows for `codex_resolver.rs`, `gemini_resolver.rs`, or `wg_delete_diagnostic.rs`. See section 3.2 item 2.
+
+**A2 - `:819` shortcut scope.**
+
+Old cell: `Global keyboard shortcuts (Ctrl+Shift+W/R)`
+New cell: `Document-level keyboard shortcuts: Ctrl+Shift+W closes the selected session, Ctrl+Shift+R toggles voice capture. Active only while an AC window has focus.`
+
+**A3 - Settings tabs. Two edits, both required.**
+
+The false tab list appears twice in this file, and fixing only one ships a page that contradicts itself: a mermaid node claiming an "API clients" tab that does not exist, next to a table listing the five real tabs.
+
+**A3a - the table cell at `:835`.**
+
+Old cell: `Settings tabs: General, Agents, Integrations, Watchers, API clients, ...`
+New cell: `Settings tabs: General, Coding Agents, Resources, Watchers, Integrations`
+
+**A3b - the mermaid node at `:221`.**
+
+Old text: `tabs: General, Agents, Integrations,<br/>Watchers, API clients, ...`
+New text: `tabs: General, Coding Agents,<br/>Resources, Watchers, Integrations`
+
+Change nothing else on line `:221`. **Do not touch `:54`** (`APICLIENT["Control-plane API clients<br/>(containers, scripts)"]`): that text is correct - it names the API's callers, not a Settings tab.
+
+**A4 - `:809-854` frontend table completeness.**
+
+All three insertion points are **inside** the single existing table that starts at `:811`. The header row `| File | Purpose |` and the separator row `|------|---------|` shown in each block below are for readability only: **insert the data rows and nothing else**. Copying a header or separator row into the middle of a live table renders it as an ordinary data row and visibly breaks the table.
+
+Insert these rows, in this order, immediately after the `main.tsx` row (`:813`):
+
+| File | Purpose |
+|------|---------|
+| `main/App.tsx` | Main window root: central view routing |
+| `main/components/HomeView.tsx` | Home markdown view (fetch, markdown-it, DOMPurify) |
+| `main/components/ErrorModal.tsx` | Global error modal |
+| `main/components/QuitConfirmModal.tsx` | Quit confirmation |
+| `main/stores/centralView.ts`, `main/stores/home.ts`, `main/stores/error-modal.ts` | Main-window state |
+| `main/listeners-central-view.ts`, `main/listeners-home.ts` | Main-window event listeners |
+
+Insert these rows immediately after the `shared/stores/resourceMonitor.ts` row (`:825`):
+
+| File | Purpose |
+|------|---------|
+| `shared/components/ToastHost.tsx` | Toast host rendering |
+| `shared/components/ExternalLinkConfirm.tsx` | External-link confirmation dialog |
+| `shared/external-links.ts`, `shared/github-url.ts` | External-link resolution |
+
+Insert these rows immediately after the `sidebar/components/SessionItem.tsx` row (`:833`):
+
+| File | Purpose |
+|------|---------|
+| `sidebar/components/AcDiscoveryPanel.tsx` | Branch and repo discovery panel |
+| `sidebar/components/AgentPickerModal.tsx` | Agent picker for launching a session |
+| `sidebar/components/AgentUpdateOverlay.tsx` | Startup coding-agent update overlay and prompt |
+| `sidebar/components/CodingAgentQuickConfiguration.tsx` | Inline coding-agent configuration |
+| `sidebar/components/ContextBadge.tsx` | Per-session context-usage badge |
+| `sidebar/components/ContextTemplateUpdateModal.tsx` | Context-template update flow |
+| `sidebar/components/ProfileOutdatedBadge.tsx` | Profile-drift badge |
+| `sidebar/components/RaiseHandIcon.tsx` | Raise-hand indicator |
+| `sidebar/components/TeamContextAlertsEditor.tsx` | Per-team context-alert thresholds |
+| `sidebar/components/WorkgroupGroupsModal.tsx` | Workgroup group administration |
+| `sidebar/components/ZoomStepper.tsx` | Sidebar zoom control |
+| `sidebar/components/Titlebar.tsx` | Sidebar titlebar: zoom, web-server menu, screenshot chip |
+
+No row is removed from the table. Nothing else in `architecture.md` changes **except** the mermaid node at `:221` required by A3b.
+
+---
+
+## 5. Document catalog
+
+For each document: target path, feature covered, source evidence, the required H2 headings verbatim, the source files the writer reads to get the facts, and the done criterion.
+
+The writer reads the named source files. When source and inventory disagree, source wins; record the discrepancy in the batch report rather than guessing.
+
+---
+
+### D1. `docs/features/README.md` (new)
+
+- **Covers:** the missing features index (backend inventory §3 item 2).
+- **Evidence:** `20260817-184003-...:84-86`.
+- **Shape:** exactly as specified in section 4.3.
+- **Sources:** the H1 of every page in `docs/features/`.
+- **Done:** file exists; contains the five H2 group headings from section 4.3; at the end of Batch 1 it holds the 11 rows for the existing pages; at the end of Batch 7 it holds 25 rows.
+
+---
+
+### D2. `docs/reference/architecture.md` (edit)
+
+- **Covers:** the four inaccurate or incomplete entries.
+- **Evidence:** `20260817-184003-...:77-82`; `20260817-183737-...:60-62`.
+- **Required edits:** A1, A2, A3a, A3b, A4 from section 4.5. Apply the stated old-text-to-new-text replacements; for A4, insert the data rows only, per the note in 4.5.
+- **Sources:** `src/sidebar/components/SettingsModal.tsx:134-142`; `src/shared/shortcuts.ts:1-70`; `src/main/` tree; `src-tauri/src/commands/config.rs:2240-2262`; `src-tauri/src/lib.rs:2930-2931`.
+- **Done:** `grep -n "IPC Contract: Command Modules" docs/reference/architecture.md` matches; `grep -c "Watchers, API clients" docs/reference/architecture.md` returns 0; `grep -c "Control-plane API clients" docs/reference/architecture.md` returns 1 (line `:54` untouched); `grep -n "AgentUpdateAPI" docs/reference/architecture.md` matches; `grep -n "main/components/HomeView.tsx" docs/reference/architecture.md` matches; `grep -c "Global keyboard shortcuts" docs/reference/architecture.md` returns 0; `grep -c "^|------|---------|" docs/reference/architecture.md` returns 3, the baseline verified at the frozen SHA (the A4 blocks must add no separator row); and `grep -c "^| File | Purpose |" docs/reference/architecture.md` returns 3, likewise the frozen-SHA baseline (no duplicated header row).
+
+---
+
+### D3. `docs/reference/settings.md` (edit, Batch 1 part)
+
+- **Covers:** `C4`, the one genuinely missing key.
+- **Evidence:** `20260817-184003-...:38,47`.
+- **Required edit:** add one row to the `### Coding agents` table (`:75-122`):
+  `| \`agentAutoUpdateByCommand\` | object | \`{}\` | Per-coding-agent-command answer to the startup update prompt. Keys are coding-agent commands (for example \`claude\`, \`codex\`); \`true\` means AC updates that command at startup without asking again, \`false\` means it never asks again and never updates. An absent key means AC asks on the next startup. See [Coding agent auto-update](../features/agent-auto-update.md). |`
+- **Sources:** `src-tauri/src/config/settings.rs:560-566`, `:917`, `:5098-5124`.
+- **Done:** `grep -n "agentAutoUpdateByCommand" docs/reference/settings.md` matches exactly once.
+- **Note:** `legacyStartOnlyCoordinators` is explicitly **not** added. See section 3.2 item 1.
+
+---
+
+### D4. `docs/features/session-auto-close.md` (edit, Batch 1 part)
+
+- **Covers:** `B8` (cascade close) and `B9` (idle badge thresholds).
+- **Evidence:** `20260817-184003-...:69,70`.
+- **Required edits:**
+  1. Insert a new H2 `## Coordinator cascade close` immediately before `## Settings` (`:58`). It states what `coordinatorCascadeCloseEnabled` does: whether closing a coordinator also closes its team's member sessions, what happens when it is off, and its default. Minimum 4 sentences.
+  2. Extend the existing `## The idle badge` section (`:34-51`) with the two configurable thresholds `coordinatorIdleBadgeYellowMinutes` and `coordinatorIdleBadgeRedMinutes`: what each controls, their defaults, and that they change only the badge color, not the auto-close timeout.
+  3. Add both new keys plus `coordinatorCascadeCloseEnabled` to the existing `## Settings` table.
+- **Sources:** `docs/reference/settings.md:267-279`; `src-tauri/src/config/settings.rs` (search `coordinator_cascade_close_enabled`, `coordinator_idle_badge_yellow_minutes`, `coordinator_idle_badge_red_minutes`); the cascade-close implementation reachable from those symbols.
+- **Done:** `grep -ic cascade docs/features/session-auto-close.md` returns a value greater than 0; `grep -c "coordinatorIdleBadgeYellowMinutes" docs/features/session-auto-close.md` returns a value greater than 0.
+
+---
+
+### D5. `docs/agent-matrix-conventions.md` (edit, Batch 1 part)
+
+- **Covers:** `C5` (automatic `memory/` rotation at spawn).
+- **Evidence:** `20260817-184003-...:39`.
+- **Required edit:** append a new H2 **at the end of the file, after line 551** (the last line at the frozen SHA), titled exactly `## 11. Agent memory rotation at spawn`. `:525` is the heading of section 10, not its end; do not insert there. Do not renumber any existing section, and do not "restore numbering order" among the nine unnumbered H2s that sit inside template content (`## Core Concepts`, `## Source of Truth`, `## Agent Memory Rule`, `## What You Must NEVER Do`, and others) - they are quoted material, not document structure. Required content:
+  - what rotates: the origin Agent Matrix's `memory/` directory becomes `memory_YYYYMMDD_hhmmss/`;
+  - when: at agent spawn;
+  - the no-op case: an empty `memory/` is not rotated;
+  - the repair case: an absent `memory/` is recreated, not rotated;
+  - the refusal cases: a junction at `memory/`, and a non-directory or otherwise non-rotatable matrix root;
+  - what the agent should do about it: archives are read-only history, never edited or deleted by the agent.
+- **Sources:** `src-tauri/src/config/agent_memory.rs` - `rotate_origin_memory_at_spawn`, `rotate_memory_dir`, and the tests `rotate_memory_dir_refuses_a_junction_at_memory`, `rotate_memory_dir_absent_memory_is_repaired_not_rotated`, `resolve_rotatable_matrix_root_rejects_plain_directory`.
+- **Done:** `grep -n "^## 11. Agent memory rotation at spawn" docs/agent-matrix-conventions.md` matches; `grep -c "memory_YYYYMMDD_hhmmss" docs/agent-matrix-conventions.md` returns a value greater than 0; `grep -c "^## 5. Profile Path Placeholders" docs/agent-matrix-conventions.md` still returns 1.
+
+---
+
+### D6. `docs/features/non-stop-mode.md` (new)
+
+- **Covers:** `C1` + `UI-C5`.
+- **Evidence:** `20260817-184003-...:35`; `20260817-183737-...:25`.
+- **Required H2s:** `## What it does`, `## Turning it on`, `## What the watchdog does`, `## Scope: per workgroup`, `## Where the configuration lives`, `## Troubleshooting`, `## See also`.
+- **Content requirements:**
+  - `## Turning it on` must give both UI paths - the rail button and the project-panel checkbox - naming the visible control.
+  - `## Scope: per workgroup` must state that non-stop is set per workgroup, not globally, and how the display name is derived.
+  - `## Where the configuration lives` replaces a `## Settings` section. **There is no non-stop key in `settings.json`**: `grep -c nonStop docs/reference/settings.md` returns 0 at the frozen SHA, and the configuration is per project in `src-tauri/src/config/project_settings.rs`. This section says that, names the file, and links to no `settings.md` anchor. Do not invent `nonStopEnabled`, `nonStopToleranceSeconds`, `nonStopWatchdogIntervalSeconds`, or any other key.
+  - `## What the watchdog does` is governed by section 12.14, which supersedes the blanket prohibition in section 11.5. It **may** state: AC checks once a second; an episode fires once, after the disparity has lasted the tolerance configured for that workgroup; and a workgroup whose frontend stops reporting for more than three minutes is disarmed rather than fired. It **must not** state a tolerance value, must not state the frontend keepalive interval, and must not describe what firing does downstream - stop at "fires" and link out. Do not cite `fireable` (`non_stop_watchdog.rs:430-433`): it is inside a test module.
+- **Sources:** `src-tauri/src/commands/non_stop.rs`; `src-tauri/src/loops/non_stop_watchdog.rs`; `src-tauri/src/config/project_settings.rs` (`default_non_stop_name`, `non_stop_defaults_none_for_legacy_json`, `legacy_non_stop_json_defaults_favorite_false`); `src/sidebar/watchdog/non-stop-watchdog-client.ts`; `src/sidebar/components/WorkgroupGroupRail.tsx` (`nonStopButtonFor`); `src/sidebar/components/ProjectPanel.tsx` (`nonStopChecked`); `src/sidebar/stores/workgroup-groups.ts` (`addWorkgroupToNonStop`, `defaultNonStop`, `nonStopDisplayName`).
+- **See also (minimum):** `project-loops.md`, `../concepts.md`.
+- **Backend enrichment:** section 11.5. The cadence question is **not answered**; do not state one.
+
+---
+
+### D7. `docs/features/spec-board.md` (new)
+
+- **Covers:** `C2` + `UI-B1`.
+- **Evidence:** `20260817-184003-...:36`; `20260817-183737-...:43`.
+- **Required H2s:** `## What a Spec Board is`, `## Turning it on`, `## The editing window`, `## Snapshots`, `## Conflicts and unsaved work`, `## Asking an agent about the spec`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## Turning it on` names the `specBoardEnabled` gate and the action-bar entry point. `## The editing window` covers the toolbar and the Mermaid preview. `## Conflicts and unsaved work` covers the conflict banner and the save-before-close modal, including what each says.
+- **Sources:** `src-tauri/src/commands/spec_board.rs` (`spec_board_new`, `spec_board_open`, `spec_board_save`, `spec_board_close`, `spec_board_pick_open`, `spec_board_pick_save`, `spec_board_update_content`, `spec_board_list_snapshots`); `src-tauri/src/config/settings.rs:897` area for `specBoardEnabled`; `src/spec-board/components/{SpecBoardEditor,SpecBoardToolbar,MermaidPreview,AskAgentPanel,ConflictBanner,SaveBeforeCloseModal}.tsx`; events `spec_board_changed / conflict / file_missing` (`docs/reference/architecture.md:346`).
+- **See also (minimum):** `app-windows.md`, `../reference/settings.md`.
+
+---
+
+### D8. `docs/features/agent-auto-update.md` (new)
+
+- **Covers:** `C4` + `UI-C4`.
+- **Evidence:** `20260817-184003-...:38`; `20260817-183737-...:24`.
+- **Required H2s:** `## What it does`, `## The startup prompt`, `## How your answer is remembered`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## The startup prompt` must quote the visible overlay and prompt behavior, including that Enter and Esc both answer No. `## How your answer is remembered` must explain the per-command map, that the answer is persisted before the update is attempted, and what an absent key means. Troubleshooting must cover the late-answer case where the prompt already closed.
+- **Sources:** `src-tauri/src/agent_update.rs` (`AgentUpdateGate::{register_prompt, resolve_answer, was_prompted, mark_started, drop_pending, snapshot}`); `src-tauri/src/commands/config.rs:2238-2262`; `src-tauri/src/config/settings.rs:560-566`, `:917`; `src/sidebar/components/AgentUpdateOverlay.tsx:20-108`; `src/sidebar/agent-update.ts`; `src/sidebar/update-toast.ts`.
+- **See also (minimum):** `../reference/settings.md`, `../integrations/coding-agents.md`.
+
+---
+
+### D9. `docs/features/project-loops.md` (new)
+
+- **Covers:** `B1` + `UI-B6`.
+- **Evidence:** `20260817-184003-...:62`; `20260817-183737-...:48`.
+- **Required H2s:** `## What a Loop is`, `## Creating a Loop`, `## Scheduling`, `## Delivery: what happens when a Loop fires`, `## Busy sessions and respawn`, `## Where the configuration lives`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## Creating a Loop` covers both the UI modals and a pointer to the CLI section that already exists at `docs/reference/cli.md:838`. `## Busy sessions and respawn` must state the liveness and respawn rules in user terms. Do not duplicate the CLI flag reference; link to it. `## Where the configuration lives` replaces a `## Settings` section: **there is no loop key in `settings.json`** (`grep -c loops docs/reference/settings.md` returns 0 at the frozen SHA). Loops are created and stored through the CLI and the UI, not through `settings.json`. Say that, and link to `../reference/cli.md#loop` rather than to `settings.md`.
+- **Sources:** `src-tauri/src/loops/{scheduler,delivery,events}.rs` (`loop_candidate_is_live`, `loop_candidate_should_respawn`, `loop_delivery_config_matches`); `src-tauri/src/commands/loops.rs`; `src/sidebar/components/{NewLoopModal,EditLoopModal}.tsx`; `src/sidebar/components/loop-modal-helpers.ts`; `src/sidebar/loop-event-toast.ts`; `docs/reference/cli.md:838-864`.
+- **See also (minimum):** `../reference/cli.md`, `non-stop-mode.md`.
+
+---
+
+### D10. `docs/features/resource-monitor.md` (new)
+
+- **Covers:** `B2` + `UI-B5`.
+- **Evidence:** `20260817-184003-...:63`; `20260817-183737-...:47`.
+- **Required H2s:** `## What it measures`, `## Turning it on`, `## The Resource Monitor window`, `## Attaching it to the main window`, `## The watchdog: thresholds and actions`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## The watchdog: thresholds and actions` must enumerate both accepted values of `resourceWatchdogAction` and state exactly what each does. **It must not say "which threshold triggers which action"**: per section 11.1 the three thresholds do not map onto the two action values. Write it as: the thresholds decide *whether* the group is over the line; `resourceWatchdogAction` decides *what AC does about it*. The section must also carry the two non-obvious facts from 11.1 - there is no per-process kill (crossing the per-process threshold kills the whole session group), and `Warn` still reclaims quarantined groups. Read the JSON spellings of the two values from `src-tauri/src/config/settings.rs:249-256` and `src/shared/types.ts`; do not copy spellings from this plan. `## The Resource Monitor window` must name the columns the window shows.
+- **Sources:** `src-tauri/src/resource_monitor/{registry,types,watchdog,windows}.rs`; `src-tauri/src/commands/resource_monitor.rs`; `src/resource-monitor/App.tsx`; `src/shared/stores/resourceMonitor.ts`; `docs/reference/settings.md:216-228`, `:256`.
+- **See also (minimum):** `app-windows.md`, `../reference/settings.md`.
+- **Backend enrichment:** section 11.1. It corrects the "which threshold triggers which action" clause above, which is misleading as written.
+
+---
+
+### D11. `docs/features/watchers.md` (new)
+
+- **Covers:** `B5` (the watcher engine) + `UI-B4` (the Watchers window).
+- **Evidence:** `20260817-184003-...:66`; `20260817-183737-...:46`.
+- **Required H2s:** `## What a watcher is`, `## The two modes: state and occurrence`, `## Deduplication`, `## Commands a watcher can run`, `## The watcher budget`, `## The Watchers window`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## The watcher budget` must state that the budget of 8 is **per agent, not global** (per section 11.2): a user can configure any number of watchers, and each individual agent runs at most eight of the ones that reach it. It must state that nothing is rejected, dropped or evicted at the limit - overflow watchers stay configured and simply do not run on that agent - that the winners are the first eight in ascending watcher-id order (so renaming a watcher can change which ones run), and that disabled watchers never consume budget. Quote the three observable surfaces from 11.2: the single per-agent log line, the Settings notice ` Not running on <agent labels> (budget).`, and the absence of any terminal toast. `## Deduplication` must state that an oversized `dedupeWindowMs` is clamped to 60000, not rejected. `## Troubleshooting` uses the two skip cases from 11.2 (an unreadable `commands` selector entry, and an invalid watcher entry), quoting their literal log lines. `## The Watchers window` must explain the activity window that `watchersGeometry` persists. Do not restate the settings schema line by line; `docs/reference/settings.md:417-437` already does that well - link to it and explain the behavior instead.
+- **Sources:** `src-tauri/src/pty/watchers/{dedupe,frame,history,pattern,mod}.rs`; `src-tauri/src/pty/context_scrape/{mod,pattern,rows}.rs`; `src/watchers/App.tsx`; `src/watchers/activity.ts`; `src/watchers/components/WatchersTitlebar.tsx`; `docs/reference/settings.md:417-437`.
+- **See also (minimum):** `context-tracking.md`, `../reference/settings.md`.
+- **Backend enrichment:** section 11.2. The budget is **per agent**, not global; the plan text above must be read with that correction.
+
+---
+
+### D12. `docs/features/context-tracking.md` (new)
+
+- **Covers:** `C3` + `UI-C8` + `UI-C12`.
+- **Evidence:** `20260817-184003-...:37`; `20260817-183737-...:28,32`.
+- **Required H2s:** `## What it tracks`, `## The context badge`, `## Context alerts`, `## Setting thresholds for a team`, `## The injected alert message`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:**
+  - `## Context alerts` must state the accepted range (1 to 100), that values are normalized and sorted, and that alerts are disabled by default. Per section 12.13 it **must** also state the firing semantics: the injection fires **once per crossing** and does not repeat while the session stays above the threshold; a session that drops below and climbs back alerts again. Do not write "once per session" or "once per threshold, ever". Name the four re-arm paths from 12.13.
+  - `## The injected alert message` must name the `context-alert` template id and point at the `injected-messages reseed` documentation at `docs/reference/cli.md:631,637`. It **must not** state a polling interval: the 30-second `CONTEXT_ALERT_MAINTENANCE_INTERVAL` is maintenance bookkeeping, not the sampling cadence, and the retry delays at `context_alerts.rs:26-27` are internal delivery mechanics that do not belong on the page.
+  - `## Setting thresholds for a team` must describe the per-team editor in the team modals, and must state that the thresholds are stored in the team configuration, not in `settings.json`.
+  - `## Settings` carries exactly **one** row: `contextRegex` (`docs/reference/settings.md:94`, in the `Coding agents` group), the per-agent pattern that produces the reading. There is no `contextAlerts` key in `settings.json` (`grep -c contextAlert docs/reference/settings.md` returns 0 at the frozen SHA); do not add one, and do not link this page to the `Watchers` group.
+  - `## Troubleshooting` must include the case from 12.13: a reading above 100 percent is rejected with a `log::error!` and produces no alert, so the log is where the reason is.
+- **Sources:** `src-tauri/src/session/context_alerts.rs`; `src-tauri/src/commands/entity_creation.rs:5346-5360` (`normalize_context_alert_percentages`); `src-tauri/src/cli/workgroup.rs` (`cli_team_builder_defaults_context_alerts_to_disabled`); `src-tauri/src/config/injected_messages.rs` (`default_context_alert_template_is_pinned`); `src-tauri/src/cli/team.rs`; `src/sidebar/components/ContextBadge.tsx`; `src/sidebar/components/session-context.ts`; `src/sidebar/components/TeamContextAlertsEditor.tsx`; `src/sidebar/components/team-context-alerts.ts`.
+- **See also (minimum):** `watchers.md`, `../reference/cli.md`.
+- **Backend enrichment:** section 11.6. Whether the alert fires once per crossing or repeats is **not answered**; do not state either.
+
+---
+
+### D13. `docs/features/remote-web-ui.md` (new)
+
+- **Covers:** `B3` + `UI-B8`.
+- **Evidence:** `20260817-184003-...:64`; `20260817-183737-...:50`.
+- **Required H2s:** `## What it does`, `## Turning it on`, `## Connecting from another device`, `## What the browser UI can do`, `## Authentication`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## What the browser UI can do` must state plainly that the served page is the full AgentsCommander UI (sidebar plus terminal) running over a WebSocket transport, and name what is not available in the browser build. `## Authentication` must reference the web token and point to `docs/security.md`. Do not duplicate the firewall and LAN guidance at `docs/reference/settings.md:315-374`; link to it.
+- **Sources:** `src-tauri/src/web/{auth,broadcast,commands,embedded,event_broadcast,mod}.rs`; `src/browser/App.tsx`; `src/shared/transport-ws.ts`; `src/sidebar/components/WebServerMenu.tsx`; `docs/reference/settings.md:311-385`; `docs/security.md`.
+- **See also (minimum):** `../security.md`, `control-plane-api.md`.
+
+---
+
+### D14. `docs/features/control-plane-api.md` (new)
+
+- **Covers:** `B4`.
+- **Evidence:** `20260817-184003-...:65`.
+- **Required H2s:** `## What it is`, `## Turning it on`, `## Authentication`, `## Endpoints`, `## Authorization and audit`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## Endpoints` must have one subsection or table row per handler: `pty_input`, `session_transport`, `send`, `list_peers`, `terminal_snapshot`, `window_screenshot`, each with its purpose and a link to the deeper page where one exists (`terminal-snapshots.md`, `window-capture.md`). The page is a **rewrite for users**, not a copy of `src-tauri/src/api/README.md`: the README stays where it is and this page is written from it plus the handler modules, in the house voice and template. Do not restate the settings schema at `docs/reference/settings.md:386-397`; link to it.
+- **Sources:** `src-tauri/src/api/README.md`; `src-tauri/src/api/handlers/{list_peers,pty_input,send,session_transport,terminal_snapshot,window_screenshot,mod}.rs`; `docs/reference/cli.md:646` (`api-client` mint/revoke/list); `docs/security.md:52-116`.
+- **See also (minimum):** `terminal-snapshots.md`, `window-capture.md`, `../security.md`.
+
+---
+
+### D15. `docs/features/activity-log.md` (new)
+
+- **Covers:** `B7`.
+- **Evidence:** `20260817-184003-...:68`.
+- **Required H2s:** `## What it records`, `## Turning it on`, `## Where the file lives`, `## Record format`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## Record format` must show one real JSONL line in a fenced `json` block and name every field. `## Where the file lives` must point at `docs/reference/directory-layout.md` for the per-instance directory rule rather than restating it.
+- **Sources:** `src-tauri/src/config/activity_log.rs`; `docs/reference/directory-layout.md:74`; `docs/reference/settings.md:461`.
+- **See also (minimum):** `../reference/directory-layout.md`, `../reference/log-filtering.md`.
+
+---
+
+### D16. `docs/features/project-archiving.md` (new)
+
+- **Covers:** `C6` + `UI-B11`.
+- **Evidence:** `20260817-184003-...:40`; `20260817-183737-...:53`.
+- **Required H2s:** `## What archiving does`, `## Archiving a project`, `## What blocks an archive`, `## Unarchiving`, `## Auto-unarchive`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## What blocks an archive` must present blockers as **one deduplicated list**, not two features (correction from section 11.3): pending spawns whose cwd is inside the project and live sessions whose working directory is inside the project both feed the same "open session(s)" count, and names are deduplicated across the two. It must state the two exclusions - Root Agent sessions never block, and a running session with no PTY does not block - because otherwise the count will not match what the user sees in the sidebar. `## Auto-unarchive` must explain why the modal appears on its own and what confirming it does. `## Troubleshooting` must quote the literal blocker text from 11.3 verbatim, in both its shapes (three or fewer named blockers, and the "and `<m>` more" shape), and must carry the post-write rollback case as a separate entry, including the appended suffix `The project could not be restored automatically (<error>). Open Archived Projects to restore it.`
+- **Sources:** `src-tauri/src/config/archive_gate.rs` (`archived_root_for_cwd`, `probe_spawn_refusal_for_archived_root`, `auto_unarchive_registration_validates_the_archived_root`, `auto_unarchive_registration_coalesces_when_project_is_no_longer_archived`, `raw_project_path_containing_returns_the_matching_archived_root`); `src-tauri/src/commands/ac_discovery.rs` (`archive_blockers_names_live_pty_sessions_under_project`, `archive_project_inner_pending_spawn_mark_blocks_precheck`); `src/sidebar/components/{ArchivedProjectsModal,AutoUnarchiveModal}.tsx`; `src/sidebar/stores/auto-unarchive.ts`; `docs/reference/settings.md:188-212`.
+- **See also (minimum):** `../reference/settings.md`, `sidebar-guide.md`.
+- **Backend enrichment:** section 11.3. It carries the literal blocker text and corrects the pending-spawn claim above.
+
+---
+
+### D17. `docs/features/sidebar-guide.md` (new)
+
+- **Covers:** `UI-B2`, `UI-B7`, `UI-C11`, `UI-C13`, `UI-C14`, `UI-C15`, and `B6`.
+- **Evidence:** `20260817-183737-...:44,49,31,33,34,35`; `20260817-184003-...:67`.
+- **Required H2s:** `## The workgroup rail`, `## Favorites and groups`, `## Raise hand`, `## The project panel`, `## What a session row shows`, `## The git branch badge`, `## The agent picker`, `## Quick coding-agent configuration`, `## Branch and repo discovery`, `## Zoom`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements.** Every behavior H2 has one, so no section is left as a heading plus a filename:
+  - `## The workgroup rail` - what the rail is, what one rail entry represents, and how collapsing works. Quote the visible label or `title`/`aria-label` of the rail entry from `WorkgroupGroupRail.tsx`.
+  - `## Favorites and groups` - how a user marks a workgroup as a favorite and what changes when they do; what a group is and how membership is edited through `WorkgroupGroupsModal.tsx`. Quote the visible control text for both.
+  - `## Raise hand` - what a raised hand signals about a session, who raises it and how it is lowered. Quote the icon's tooltip or `aria-label` from `RaiseHandIcon.tsx`. If the source does not settle who raises it, say only what the source settles and report the gap.
+  - `## The project panel` - the tree the panel renders (project, workgroup, replica, session) and what the row-level context menu offers. Name the entries by their visible text.
+  - `## What a session row shows` - enumerates the row indicators and links out rather than duplicating: status dot -> `../concepts.md#session`; profile drift -> `coding-agent-profiles.md#drift-the-outdated-badge`; context badge -> `context-tracking.md`; idle and AUTO-CLOSED badges -> `session-auto-close.md`; mic -> `voice-to-text.md`; Telegram -> `telegram-bridge.md`.
+  - `## The git branch badge` - AC polls each session's git branch and dirty state on an interval; names `gitSweepConcurrency` and `gitSweepMinIntervalSecs` and states what the dirty indicator means.
+  - `## The agent picker` - when the picker opens, what it lists, and what selecting an entry does. Quote the modal title from `AgentPickerModal.tsx`.
+  - `## Quick coding-agent configuration` - what this inline panel lets a user change without opening Settings, and how it relates to the Settings `Coding Agents` tab. Quote the visible heading or button text from `CodingAgentQuickConfiguration.tsx`, and link to `../integrations/coding-agents.md`.
+  - `## Branch and repo discovery` - what the panel shows about a replica's repos and branch, and that it updates from the `ac_discovery_branch_updated` event. Quote the badge text from `replica-repo-badges.ts`.
+  - `## Zoom` - the control's range and that the value persists.
+  - `## Settings` - `gitSweepConcurrency` and `gitSweepMinIntervalSecs` only, linked to `../reference/settings.md#git-status-sweeper`. Do not add a key for the rail, groups, favorites or zoom without first confirming it exists in `docs/reference/settings.md`.
+- **Sources:** `src/sidebar/components/WorkgroupGroupRail.tsx`; `src/sidebar/components/RaiseHandIcon.tsx`; `src/sidebar/stores/rail-collapse.ts`; `src/sidebar/components/ProjectPanel.tsx`; `src/sidebar/components/SessionItem.tsx`; `src/sidebar/components/WorkgroupGroupsModal.tsx`; `src/sidebar/components/AgentPickerModal.tsx`; `src/sidebar/components/CodingAgentQuickConfiguration.tsx`; `src/sidebar/components/AcDiscoveryPanel.tsx`; `src/sidebar/components/replica-repo-badges.ts`; `src/sidebar/components/ZoomStepper.tsx`; `src/shared/zoom.ts`; `src-tauri/src/pty/git_watcher.rs`; `docs/reference/settings.md:229-237`.
+- **See also (minimum):** `app-windows.md`, `../concepts.md`.
+
+---
+
+### D18. `docs/features/app-windows.md` (new)
+
+- **Covers:** `UI-C1`, `UI-B3`, `UI-B12`.
+- **Evidence:** `20260817-183737-...:21,45,54`.
+- **Required H2s:** `## The window map`, `## Sidebar`, `## Main window and Home`, `## Terminal`, `## Guide`, `## Other windows`, `## Troubleshooting`, `## See also`.
+- **Content requirements:** `## The window map` is a table with columns `Window | What it is for | How to open it`, one row per window: Sidebar, Main, Terminal (including detached), Guide, Watchers, Resource Monitor, Spec Board, Screenshot overlay. `## Main window and Home` describes the Home markdown view, its refresh control, and its loading, error and retry states. `## Terminal` describes the titlebar, the status bar, the workgroup task title and status from `TASK.md`, the task-clean confirmation, and the last-prompt display, linking to `voice-to-text.md` for the mic. `## Guide` describes the Tutorial and Hints tabs and states that the tutorial covers the same ground as `../quickstart.md`. `## Other windows` is one short paragraph per remaining window, each linking to its own feature page. This page has no settings keys of its own, so it has **no** `## Settings` section.
+- **Sources:** `src/main/App.tsx`; `src/main/components/HomeView.tsx`; `src/main/stores/home.ts`; `src/guide/App.tsx`; `src/guide/components/{TutorialTab,HintsTab}.tsx`; `src/terminal/components/{Titlebar,StatusBar,WorkgroupTask,TaskCleanConfirmModal,LastPrompt}.tsx`; `src/terminal/prompt-input-capture.ts`; `docs/reference/architecture.md:809-854`.
+- **See also (minimum):** `sidebar-guide.md`, `../reference/keyboard-shortcuts.md`.
+
+---
+
+### D19. `docs/features/notifications-and-dialogs.md` (new)
+
+- **Covers:** `UI-C2`, `UI-C3`, `UI-C7`, `UI-C10`, `UI-B9`, `UI-B10`, and `B10`.
+- **Evidence:** `20260817-183737-...:22,23,27,30,51,52`; `20260817-184003-...:71`.
+- **Required H2s:** `## Toasts`, `## The error modal`, `## Quitting the app`, `## Opening an external link`, `## Onboarding`, `## Restart prompt`, `## Root Agent banner`, `## Context-template updates`, `## Sounds`, `## Settings`, `## Troubleshooting`, `## See also`.
+- **Content requirements.** Every section names the visible title or button text, so a reader who sees the dialog can find its section by matching what is on screen:
+  - `## Toasts` - severities, whether a toast is sticky or auto-dismisses, and how to dismiss one.
+  - `## The error modal` - what raises it, what it shows, and how it is dismissed. Quote the modal's visible title from `ErrorModal.tsx`.
+  - `## Quitting the app` - what the confirmation asks and what each button does. Quote both button labels from `QuitConfirmModal.tsx`.
+  - `## Opening an external link` - which links trigger the confirmation, what it says, and what happens on each choice. Quote the dialog text from `ExternalLinkConfirm.tsx`.
+  - `## Onboarding` - when the modal appears, what it asks for, and what dismissing it persists. Quote the visible heading from `OnboardingModal.tsx`. Note that `docs/testing/02-onboarding-and-coding-agents.md` records a known `onboardingDismissed` issue (#505); do not restate it as current behavior without confirming it in source.
+  - `## Restart prompt` - what change asks for a restart and what the prompt offers. Quote its text from `RestartPromptModal.tsx`.
+  - `## Root Agent banner` - what the banner announces, when it is visible, and what its action does. Quote the banner text from `RootAgentBanner.tsx`, and link to the Root Agent entry in `../glossary.md`.
+  - `## Context-template updates` - what triggers the modal, what it proposes to update, and what accepting it writes. Quote its title from `ContextTemplateUpdateModal.tsx` and link to `../agent-matrix-conventions.md`.
+  - `## Sounds` - covers `soundsEnabled` and `teamIdleBeepEnabled` and states that both default to `true` (pinned by four tests in `src-tauri/src/config/settings.rs`, per section 11.4). The trigger and the gating are **already published** in the repo's own settings reference at `docs/reference/settings.md:252-253`: `soundsEnabled` is the master switch for all app-emitted sounds, and `teamIdleBeepEnabled` beeps when a team transitions from busy to all-idle and is gated by `soundsEnabled`. The page restates exactly that and no more. **Do not state a debounce**, a repeat interval, or any per-session behavior: section 11.4 established that no Rust symbol implements the beep and none of that is settled. Before writing, confirm the busy-to-all-idle transition in `src/` (the frontend computes it from `waitingForInput`); if source contradicts `settings.md:252-253`, write nothing on the trigger and report the contradiction as a defect in the settings reference.
+  - `## Settings` - `soundsEnabled` (`docs/reference/settings.md:252`) and `teamIdleBeepEnabled` (`:253`), linked to `../reference/settings.md`. Both were verified present at the frozen SHA.
+- **Sources:** `src/shared/components/ToastHost.tsx`; `src/shared/stores/toasts.ts`; `src/main/components/{ErrorModal,QuitConfirmModal}.tsx`; `src/main/stores/error-modal.ts`; `src/main/listeners-central-view.ts`; `src/shared/components/ExternalLinkConfirm.tsx`; `src/shared/external-links.ts`; `src/shared/github-url.ts`; `src/sidebar/components/{OnboardingModal,RestartPromptModal,RootAgentBanner,ContextTemplateUpdateModal}.tsx`; `src-tauri/src/config/settings.rs` (search `sounds_enabled`, `team_idle_beep_enabled`); `docs/agent-matrix-conventions.md:24-70`.
+- **See also (minimum):** `app-windows.md`, `../reference/settings.md`.
+- **Backend enrichment:** section 11.4. The two sound keys and their defaults are settled; the beep's trigger and debounce are **not** decided in Rust.
+
+---
+
+### D20. `docs/reference/keyboard-shortcuts.md` (new)
+
+- **Covers:** `UI-C6`, plus the correction context behind A2.
+- **Evidence:** `20260817-183737-...:26,61`.
+- **Required H2s:** `## Window shortcuts`, `## The global screenshot hotkey`, `## Scope`, `## See also`.
+- **Content requirements:** `## Window shortcuts` is a table `Shortcut | What it does | Where it works` with exactly two rows: `Ctrl+Shift+W` closes the currently selected session, `Ctrl+Shift+R` toggles voice capture on the selected live session. `## Scope` states that these are document-level listeners, active only while an AC window has focus, and that they are not OS-global. `## The global screenshot hotkey` is one paragraph that states it is the only OS-global hotkey and links to `../features/screenshot-capture.md#configure-the-hotkey`. This page has no settings table.
+- **Sources:** `src/shared/shortcuts.ts:1-70`; `docs/features/screenshot-capture.md:53-109`; `docs/integrations/voice.md:41`.
+- **See also (minimum):** `../features/screenshot-capture.md`, `../integrations/voice.md`.
+
+---
+
+### D21. Cross-link edits (Batch 8)
+
+Exactly the edits specified in section 4.4, applied to `docs/concepts.md`, `docs/glossary.md`, `docs/quickstart.md`, `docs/home-en.md`, `docs/reference/settings.md`, `docs/reference/directory-layout.md`, and `docs/security.md`.
+
+- **Done:** each grep in section 7.3 matches.
+
+---
+
+## 6. Implementation order: eight batches
+
+Each batch is independently executable from a cold start, in any order. A batch's only prerequisites are this plan file, the two inventory messages, and the repo at the frozen SHA on the working branch.
+
+Batches 2 through 7 each add their own rows to `docs/features/README.md`. That file does not exist at the frozen SHA and is created by D1 in Batch 1, so the self-creating rule in section 4.3 is what makes the independence claim true: a batch that finds no index creates it with the H1, the audience line and the five H2 group headings, and adds only its own rows. Without that rule these batches would depend on Batch 1 having run first. Nothing else in any batch depends on another batch.
+
+**Batch 1 - Corrections and the index.** Documents: D1 (index seeded with the 11 existing pages), D2, D3, D4, D5. Files touched: `docs/features/README.md` (new), `docs/reference/architecture.md`, `docs/reference/settings.md`, `docs/features/session-auto-close.md`, `docs/agent-matrix-conventions.md`.
+
+**Batch 2 - Non-stop, Spec Board, auto-update.** Documents: D6, D7, D8. Plus three rows in D1.
+
+**Batch 3 - Loops and resources.** Documents: D9, D10. Plus two rows in D1.
+
+**Batch 4 - Watchers and context.** Documents: D11, D12. Plus two rows in D1.
+
+**Batch 5 - Remote surfaces and the activity log.** Documents: D13, D14, D15. Plus three rows in D1.
+
+**Batch 6 - Archiving and the sidebar.** Documents: D16, D17. Plus two rows in D1.
+
+**Batch 7 - Windows, dialogs, shortcuts.** Documents: D18, D19, D20. Plus two rows in D1 (D20 is a reference page and is **not** listed in the features index).
+
+**Batch 8 - Cross-links and completeness.** Document: D21. Plus the completeness checks in section 7.4.
+
+---
+
+## 7. Acceptance criteria
+
+All commands are run from the repo root on branch `docs/1407-document-missing-features`.
+
+**What these criteria do and do not guarantee.** Criteria 7.1 to 7.4 are mechanical: they test existence, heading text, heading order, counts, vocabulary, link resolution and identifier provenance. **They cannot tell a true sentence from a plausible invented one.** A page with every required heading present, each holding one confident and fabricated paragraph, passes all of them. That is why section 5 names, per page, the source files and the literal strings the writer must read, why criteria 7.2.7 and 7.2.9 exist, and why 7.5 makes the writer produce a provenance list as an artifact rather than an assumption. Treat 7.5 as the criterion that carries the truth burden; the rest guard shape.
+
+### 7.1 Global, checked at the end of every batch
+
+1. `git status --porcelain=v1 --untracked-files=all` lists only files this plan authorizes for that batch. This is the primary guard and it works whether or not the batch has committed.
+2. `git diff --name-only 51e70e47f442109d6b618299b26d95a12801f156 -- src src-tauri scripts .github package.json Cargo.toml src-tauri/tauri.conf.json` returns empty. No application code, build config or CI changed. Compare against the literal frozen SHA, **not** `$(git merge-base HEAD origin/main)`: on this branch the merge base is `HEAD` itself, which makes the diff empty by construction, and the clone is shallow (`git rev-parse --is-shallow-repository` returns `true`), so a moved `origin/main` can make `merge-base` fail outright. Omitting `HEAD` from the command includes the working tree, so the check holds before the batch commits.
+3. `git diff --name-only 51e70e47f442109d6b618299b26d95a12801f156 -- docs/testing` returns empty.
+4. For every file created or edited in the batch: `grep -inE "revolutionary|unleash|supercharge|next-gen|AI-powered|game-changing|blazing-fast|seamless|magical|agentic" <file>` returns no matches.
+5. For every file created or edited in the batch: `grep -inE "\bsimply\b|\beasily\b|easy to use" <file>` returns no matches.
+6. Every relative link **the batch added** resolves. For each added `](target)`, strip everything from the first `#` onward, then `test -e` the remaining path. Scope the check to added links only: a broken link that already exists in a file the batch touched is not this batch's defect. Do **not** run `test -e` on the full target - the plan mandates anchored links (`../concepts.md#session`, `coding-agent-profiles.md#drift-the-outdated-badge`, `../features/screenshot-capture.md#configure-the-hotkey`, `../agent-matrix-conventions.md#11-agent-memory-rotation-at-spawn`) and `test -e` fails on every one of them.
+7. Every anchor the batch added resolves. For each added `](target#anchor)`, slugify the target file's `^#{1,6} ` headings (lowercase, drop punctuation, spaces to hyphens) and require the anchor to match one. The four anchors named in 7.1.6 were verified to resolve at the frozen SHA; this check keeps them resolving.
+
+### 7.2 Per new page (D6 to D20)
+
+For each page at path `P`:
+
+1. `test -f P` succeeds.
+2. `head -1 P` is a single `# ` heading.
+3. Line 3 of `P` is a non-empty paragraph (the audience and promise line).
+4. `grep -c "^## " P` returns the exact count of required H2s listed for that document in section 5, and `grep "^## " P` returns them in the listed order with the listed text.
+5. `grep -c "^## See also" P` returns 1, and the `## See also` block contains at least two `](` links.
+6. For every page except D20: `grep -c "^## Troubleshooting" P` returns 1, and that section contains at least two entries. D18 is **not** exempt: its required-H2 list in section 5 includes `## Troubleshooting`.
+7. For every page with a `## Settings` H2: that section contains a markdown table and at least one link into `docs/reference/settings.md`. Pages with `## Where the configuration lives` instead (D6, D9) must contain **no** link into `docs/reference/settings.md` from that section.
+8. `grep -c "$(basename P)" docs/features/README.md` returns 1 for every page under `docs/features/`. D20 is exempt: it is a reference page.
+9. **Settings-key provenance.** For every backtick-quoted identifier matching `^[a-z][A-Za-z0-9]*$` inside a page's `## Settings` table, `grep -c "<identifier>" docs/reference/settings.md` returns at least 1. An identifier that returns 0 is an invented key and fails the batch. This is the check that would have caught `nonStopEnabled`, `nonStopToleranceSeconds` and `nonStopWatchdogIntervalSeconds`, none of which exist.
+
+### 7.3 Per edit
+
+- D2: the five greps in section 5, D2 "Done".
+- D3: `grep -c "agentAutoUpdateByCommand" docs/reference/settings.md` returns 1. `grep -c "legacyStartOnlyCoordinators" docs/reference/settings.md` returns 0.
+- D4: `grep -ic cascade docs/features/session-auto-close.md` is greater than 0; `grep -c "coordinatorCascadeCloseEnabled" docs/features/session-auto-close.md` is greater than 0; `grep -c "coordinatorIdleBadgeYellowMinutes" docs/features/session-auto-close.md` is greater than 0.
+- D5: `grep -c "^## 11. Agent memory rotation at spawn" docs/agent-matrix-conventions.md` returns 1; `grep -c "^## 5. Profile Path Placeholders" docs/agent-matrix-conventions.md` returns 1.
+- D21 concepts: `grep -c "^## Non-stop mode" docs/concepts.md` returns 1; same for `^## Project Loop`, `^## Watcher`, `^## Spec Board`. `grep -c "Nine terms" docs/concepts.md` returns 0; `grep -c "Thirteen terms" docs/concepts.md` returns 1.
+- D21 glossary: `grep -c "^## " docs/glossary.md` returns 42 (31 existing plus 11 new).
+- D21 quickstart and home: `grep -c "features/README.md" docs/quickstart.md` returns 1; `grep -c "features/README.md" docs/home-en.md` returns 1.
+- D21 settings pointers: `grep -c "\.\./features/" docs/reference/settings.md` returns 20. The baseline at the frozen SHA is 12 (verified); section 4.4 adds 8 pointers across seven groups. If the baseline has moved, the implementer recomputes it at the start of Batch 8 and asserts baseline plus 8, reporting both numbers. Also: `grep -c "context-tracking.md" docs/reference/settings.md` returns 1, and that occurrence is in the `Coding agents` group, not in `Watchers`.
+- D21 directory-layout: `grep -c "features/activity-log.md" docs/reference/directory-layout.md` returns 1; `grep -c "#11-agent-memory-rotation-at-spawn" docs/reference/directory-layout.md` returns 1.
+- D21 security: `grep -c "features/control-plane-api.md" docs/security.md` returns 1.
+
+### 7.4 Completeness, checked once in Batch 8
+
+1. `ls docs/features/*.md | wc -l` returns 26 (25 feature pages plus `README.md`).
+2. `grep -c "^| \[" docs/features/README.md` returns 25.
+3. For every `docs/features/*.md` except `README.md`: its basename appears exactly once in `docs/features/README.md`.
+4. Every item in the scope checklist below has at least one covering document. The implementer verifies this list item by item and reports it in full:
+
+   `C1` D6 - `C2` D7 - `C3` D12 - `C4` D8 + D3 - `C5` D5 - `C6` D16
+   `B1` D9 - `B2` D10 - `B3` D13 - `B4` D14 - `B5` D11 - `B6` D17 - `B7` D15 - `B8` D4 - `B9` D4 - `B10` D19
+   `UI-C1` D18 - `UI-C2` D19 - `UI-C3` D19 - `UI-C4` D8 - `UI-C5` D6 - `UI-C6` D20 - `UI-C7` D19 - `UI-C8` D12 - `UI-C9` already documented, out of scope - `UI-C10` D19 - `UI-C11` D17 - `UI-C12` D12 - `UI-C13` D17 - `UI-C14` D17 - `UI-C15` D17
+   `UI-B1` D7 - `UI-B2` D17 - `UI-B3` D18 - `UI-B4` D11 - `UI-B5` D10 - `UI-B6` D9 - `UI-B7` D17 - `UI-B8` D13 - `UI-B9` D19 - `UI-B10` D19 - `UI-B11` D16 - `UI-B12` D18
+   architecture corrections: D2 (A1, A2, A3a, A3b, A4)
+
+### 7.5 Literal provenance, reported per batch
+
+The criteria above test shape. This one tests whether the writer read the source, and it is the only criterion that bears on truth.
+
+For every page the batch wrote, the batch report lists **every literal the page quotes** - settings key, UI control label, badge text, tooltip, error string, log line, file path, threshold value - with the `path:line` in `src/`, `src-tauri/`, `docs/reference/settings.md` or an existing `docs/` page where it was read. A literal with no `path:line` is not published: remove it from the page and report the gap instead.
+
+The batch is not done until that list is complete. Two consequences the writer must accept:
+
+- **An omitted sentence is correctable; a published wrong string is not.** Where section 5 or section 11 says a fact is unconfirmed, leave the sentence out and report it. Never supply a plausible value to fill a required section.
+- **Section 5's "source wins over inventory" is operationalised here.** If source contradicts an inventory item or a content requirement in this plan, write what source says and record the contradiction in the batch report.
+
+---
+
+## 8. Dependency-cycle gate
+
+Applied per the `verify-no-dependency-cycles` skill.
+
+**Module arcs added by this plan: zero.** This plan changes no file under `src/` or `src-tauri/`. It adds no import, no `use`, no `mod`, no function call, and no type reference in any compiled source. It therefore adds no module-to-module reference, cannot grow or join an SCC, and cannot add an arc that crosses a previously-clean SCC boundary.
+
+**Criterion state:** `cyclicSccs` unchanged (no arcs added or removed), SCC member sets identical, zero cross-boundary arcs, arc record byte-identical. The detector is not required to run because the change set contains no source file; criterion 7.1.2 (`git diff --name-only 51e70e47f442109d6b618299b26d95a12801f156 -- src src-tauri scripts .github package.json Cargo.toml src-tauri/tauri.conf.json` returns empty) is the objective check that this precondition held.
+
+**Role and layering hygiene:** no module gains an `AppHandle` or `tauri` dependency; no transport-taking function is introduced or moved; no pure predicate changes layer. Not applicable, because no module changes.
+
+**Verdict on the gate: PASS.**
+
+---
+
+## 9. Risks and their bounds
+
+1. **A writer restates a settings schema instead of explaining the feature.** Bound: sections 5 D11, D13, D14, D16 explicitly forbid duplicating the schema and require a link instead. The `## Settings` table is capped at `Key | What it controls`, which cannot carry a full schema.
+
+2. **A writer documents a behavior that does not exist.** Bound: every document names the exact source files to read, and section 5 states "source wins over inventory; record the discrepancy". Nothing in section 5 asks the writer to trust the inventory's prose over code.
+
+3. **Page count grows the docs tree faster than the index.** Bound: each of Batches 2 through 7 adds its own index rows, and criterion 7.4.3 fails if any page is missing from the index.
+
+4. **`docs/agent-matrix-conventions.md` anchor breakage.** Bound: section 2 forbids renumbering and criterion 7.3 D5 asserts `## 5. Profile Path Placeholders` still exists.
+
+5. **The glossary count in criterion 7.3 is brittle.** If a future commit lands a glossary entry before Batch 8, the expected 42 changes. Bound: the implementer recomputes the baseline with `grep -c "^## " docs/glossary.md` at the start of Batch 8 and asserts baseline plus 11, reporting both numbers.
+
+6. **Scope pressure to also fix `docs/testing/*` or publish `src-tauri/src/api/README.md` verbatim.** Bound: section 2 forbids both. D14 requires a user-facing rewrite, not a copy, and leaves the in-code README in place.
+
+---
+
+## 10. Open questions for the enrichment pass - all closed
+
+Posed for `dev-rust` and `dev-rust-grinch`. Status after the Step 5 and Step 6 passes. All six are closed for certification purposes; none blocks a batch.
+
+| # | Question | Status |
+|---|---|---|
+| 1 | D10: is the value set of `resourceWatchdogAction` closed and enumerable, and does each value have a distinct observable effect? | **Answered** by 11.1. Exactly two values. The three thresholds do **not** map onto them; section 5 D10 was corrected. |
+| 2 | D11: is the 8-watcher budget a hard constant, and what happens at the limit? | **Answered** by 11.2. Hard constant, **per agent**; nothing is rejected or evicted; the first eight in id order run. Section 5 D11 was corrected. |
+| 3 | D12: does `context-alert` fire once per crossing or repeat while above? | **Answered** by 12.13. Once per crossing, latched per threshold, four re-arm paths. Section 11.6's prohibition is lifted; section 5 D12 now carries the semantics. |
+| 4 | D6: does the non-stop watchdog have a user-visible cadence or timeout, and what stops it? | **Answered** by 12.14. Backend Tokio loop, 1s tick, stopped only by application shutdown, one shot per episode against a per-episode tolerance, self-disarming after 180s. `dev-rust`'s frontend-polling hypothesis is refuted and must not be carried forward. Section 11.5's prohibition is lifted, bounded by the four limits in 12.14. |
+| 5 | D16: what is the literal blocker text? | **Answered** by 11.3, in both shapes, plus the rollback suffix. Section 5 D16 was corrected: the blockers are one deduplicated list, not two features. |
+| 6 | D19: is the team idle beep debounced, and does `soundsEnabled` gate it? | **Closed, not by new source evidence.** 11.4 established that no Rust symbol implements the beep. The gating and the trigger are already published in the repo's own settings reference (`docs/reference/settings.md:252-253`), which section 5 D19 now restates and no more. The debounce stays unstated. If the writer's `src/` check contradicts `settings.md:252-253`, that is a defect in the settings reference, to be reported rather than propagated. |
+
+**No question remains that would change a decision in sections 1 to 9.**
+
+---
+
+## 11. Backend enrichment (dev-rust)
+
+Added by `dev-rust` on 2026-08-17 UTC as the Step 5 enrichment pass. This section is **additive**. It changes no batch, no document list, no acceptance criterion, and no decision in sections 1 to 10. It does not certify the plan.
+
+All evidence below was read at the frozen SHA `51e70e47f442109d6b618299b26d95a12801f156` through the Codebase Memory graph (gate `ready`, `head_sha` matched the frozen SHA) plus one text search. Every claim carries a `path:line` anchor. Where a fact could not be established, this section says so instead of supplying a plausible one.
+
+**Reading rule for the writer:** where section 11 contradicts a content requirement in section 5, section 11 wins, because it is anchored to source. Where section 11 says a fact is unconfirmed, the writer must not state that fact at all; leave the sentence out and report it, rather than inventing a value.
+
+---
+
+### 11.1 D10: the resource watchdog (answers open question 1)
+
+**The value set of `resourceWatchdogAction` is closed and has exactly two members.**
+
+`src-tauri/src/config/settings.rs:253-256`:
+
+```rust
+pub enum ResourceWatchdogAction {
+    Warn,
+    KillGroup,
+}
+```
+
+The default is `Warn`, from `default_resource_watchdog_action` at `src-tauri/src/config/settings.rs:811-813`.
+
+**Not confirmed: the two JSON string spellings.** The `serde` attributes sit above `:253` and were not read. Do **not** write `"warn"` and `"killGroup"` from this plan. Read `src-tauri/src/config/settings.rs:249-256` and the matching `ResourceWatchdogAction` type in `src/shared/types.ts` before writing the values into the page, and use exactly what is there.
+
+**Yes, each value has a distinct observable effect, but the effect is narrower than section 5 implies.**
+
+`src-tauri/src/resource_monitor/watchdog.rs:118-169` (`run_tick`) is the whole decision path:
+
+- `:123-124` the tick returns immediately unless `watchdog_eligible` holds. That is `supports_process_tree_enforcement()` (`:105-107`), so on a platform or backend without process-tree enforcement the watchdog does nothing at all, whatever the action is.
+- `:125-127` the tick also returns immediately when `resourceMonitorEnabled` is false. The watchdog is not independently switchable: it rides on the resource monitor being on.
+- `:142-149` the kill dispatch is the **only** thing gated on the action. It runs only when `cfg.resource_watchdog_action == ResourceWatchdogAction::KillGroup`.
+- `:159-168` quarantine retry cleanup runs on **every** action, `Warn` included. The in-code comment at `:136-140` states this explicitly and warns that turning the action gate into an early return would break it.
+
+So: `Warn` computes and surfaces the threshold state and never terminates anything. `KillGroup` does the same and additionally terminates the offending session's process group. Both keep reclaiming quarantined groups.
+
+**Correction to section 5, D10.** The content requirement says the page must state "which threshold triggers which action". That framing is wrong and would produce a false sentence. The three thresholds do not map onto the two action values. `evaluate_watchdog_groups` (`src-tauri/src/resource_monitor/watchdog.rs:387-431`) computes all three flags on every tick regardless of the configured action:
+
+| Flag | Threshold compared | Scope |
+|---|---|---|
+| `group_warn` | `limits.group_warn_private_bytes` vs the group's private bytes (`:398-400`) | the whole agent group |
+| `group_kill` | `limits.group_kill_private_bytes` vs the group's private bytes (`:401-403`) | the whole agent group |
+| `process_kill` | `limits.process_kill_private_bytes` vs each process's private bytes (`:404-414`) | any single process in the group |
+
+`kill_required` is `group_kill || process_kill` (`:415`) and `warn_required` is `group_warn || kill_required` (`:416`). Only groups in state `Running` are evaluated at all (`:394-396`).
+
+Write it as: the thresholds decide *whether* the group is over the line; `resourceWatchdogAction` decides *what AC does about it*.
+
+**Two further facts the page should carry, both non-obvious and both easy to get wrong:**
+
+1. **There is no per-process kill.** Crossing the per-process threshold kills the whole session group. `run_tick` passes only `decision.session_id` to `submit_watchdog_kill` (`src-tauri/src/resource_monitor/watchdog.rs:146`); the offending pids are collected (`:404-414`) but are not what gets terminated.
+2. **`Warn` is not "do nothing".** Quarantined groups are still reclaimed under `Warn` (`:159-168`). A user who sets `Warn` to stop AC from touching processes will still see quarantine cleanup happen.
+
+---
+
+### 11.2 D11: the watcher budget (answers open question 2)
+
+**Yes, 8 is a hard constant, and it is per agent, not global.**
+
+`src-tauri/src/pty/watchers/mod.rs:94`:
+
+```rust
+pub const WATCHERS_PER_AGENT_BUDGET: usize = 8;
+```
+
+It is a compile-time constant with no settings key behind it. The budget is applied once per agent inside the per-agent loop of `resolve_watchers` (`src-tauri/src/pty/watchers/mod.rs:160-304`), at the `running.len() < WATCHERS_PER_AGENT_BUDGET` check (`:270-274`).
+
+**Correction to section 5, D11.** The content requirement says "`## The watcher budget` must state the fixed budget of 8". Left as-is a writer will read that as a global cap on how many watchers exist. It is not. A user can configure any number of watchers; each individual agent runs at most eight of the ones that reach it.
+
+**At the limit, nothing is rejected, dropped or evicted.** The overflow watchers stay configured, stay valid, and simply do not run on that agent. They are collected into `over_budget` (`:273`) and returned in the `AgentResolution` (`:296-301`). The same watcher can be over budget on one agent and running on another.
+
+**What the user actually observes at the limit, in three places:**
+
+1. **One log line per agent**, naming every dropped id in a single line (`:276-287`):
+   `[watchers] agent '<agent id>' is over the 8-watcher budget; these are configured but not running on it: <id>,<id>,...`
+   The test at `:2734` pins that the dropped ids are one line, not one line each.
+2. **A Settings notice**, appended to the watcher's reach description: ` Not running on <agent labels> (budget).`, from `watcherBudgetNotice` at `src/sidebar/components/settings-watchers.ts:286-295`. It is empty when the watcher is disabled or nothing was displaced.
+3. **Nothing on the terminal.** There is no toast and no modal on this path.
+
+**Which eight win: watcher id order, ascending.** `resolve_watchers` iterates the `BTreeMap<String, WatcherEntry>` of watchers (`:167`), so candidates are considered in ascending watcher-id order and the first eight that reach the agent are the ones that run. Test `only_the_first_eight_watchers_in_key_order_run_on_one_agent` (`src-tauri/src/pty/watchers/mod.rs:2716-2739`) builds `w01` to `w12` and asserts `w01` to `w08` run and `w09` to `w12` are over budget. State this plainly: renaming a watcher can change which ones run.
+
+**Disabled watchers never consume budget.** `:185-188` skips a watcher whose `enabled` is false before the candidate list is built, silently and by design (the in-code comment at `:185-186` calls it a state the user chose, not a problem).
+
+**Two more facts for `## Deduplication` and `## Troubleshooting`, both from `resolve_watchers`:**
+
+- The dedupe window is clamped, not rejected. `MAX_DEDUPE_WINDOW_MS: u64 = 60_000` at `src-tauri/src/pty/watchers/mod.rs:101`; a larger configured value is clamped with the log line `[watchers] watcher '<id>' asks for a <n> ms dedupe window; clamping to 60000 ms` (`:221-233`).
+- A watcher whose `commands` selector contains an entry that is not a command is **skipped entirely**, and never widened to every agent. Log line: `[watchers] watcher '<id>' is being skipped: its commands selector entry '<token>' is not a command. A watcher with an unreadable selector reaches nobody, never everybody` (`:206-215`). An invalid watcher entry is likewise skipped alone, with `[watchers] watcher '<id>' is not a valid watcher and is being skipped; every other watcher and every other setting is unaffected: <detail>` (`:171-181`). These are the best `## Troubleshooting` entries available for this page: they are literal symptoms with a literal cause.
+
+---
+
+### 11.3 D16: what blocks an archive, and the literal text (answers open question 5)
+
+**Yes, the blocker text originates in Rust.** `archive_blocked_message` at `src-tauri/src/commands/ac_discovery.rs:2865-2888`. It has exactly two shapes, and it names at most three blockers (`const MAX_NAMED: usize = 3` at `:2866`):
+
+- Three or fewer blockers:
+  `Cannot archive: <n> open session(s) in this project (<name>, <name>, <name>). Close them first.`
+- More than three blockers:
+  `Cannot archive: <n> open session(s) in this project (<name>, <name>, <name>, and <m> more). Close them first.`
+
+`<n>` is the total blocker count, `<m>` is `<n>` minus 3. Quote these verbatim in `## Troubleshooting`; do not paraphrase the count parentheses.
+
+**Correction to section 5, D16.** The content requirement splits the blockers into "live PTY sessions under the project block it" and "a pending spawn under an archived root is refused", as if those were two different features. They are one list. `archive_blockers` (`src-tauri/src/commands/ac_discovery.rs:2834-2863`) builds a single `Vec<String>` from two passes over the same snapshot:
+
+1. `:2838-2848` pending spawns whose cwd is inside the project, contributing `pending.label`.
+2. `:2850-2861` sessions that are live (`session_is_live(&s.status, has_pty)`) and whose working directory is inside the project, contributing `session.name`.
+
+Both feed the same "open session(s)" count in the same message. Names are deduplicated across the two passes (`seen.insert`, `:2845` and `:2858`), which the test `archive_blockers_dedupes_pending_mark_and_live_record_by_name` pins.
+
+**Two exclusions the page should state, because a user will otherwise see a count that does not match what the sidebar shows:**
+
+- **Root Agent sessions never block an archive**, neither by their `is_root_agent` flag nor by their directory name (`:2841-2843` and `:2852-2854`, via `is_root_agent_cwd`). Tests: `archive_blockers_ignores_root_agent_session`, `archive_blockers_ignores_root_agent_by_dir_name_when_flag_is_false`, `archive_blockers_ignores_pending_root_agent_by_dir_name`.
+- **A running session with no PTY does not block** (`session_is_live` takes `has_pty`, `:2855`). Test: `archive_blockers_ignores_running_session_with_no_pty`. An exited session under the project does not block either: `archive_blockers_ignores_exited_session_under_project`.
+
+**There is a second check after the write, and it can roll the archive back.** `archive_project_inner_with_settings_path` (`src-tauri/src/commands/ac_discovery.rs:2900-2986`) checks blockers, writes the archive, then re-snapshots and re-checks (`:2924-2926`). If a session became live in between, AC unarchives the project, emits the unarchive event, reseeds the project catalog, and still returns the same `archive_blocked_message` (`:2930-2971`). If that rollback itself fails, the returned string is the blocked message with a suffix appended (`:2978-2983`):
+
+`<the blocked message> The project could not be restored automatically (<error>). Open Archived Projects to restore it.`
+
+That suffix is a distinct `## Troubleshooting` entry: the project is archived, the user did not want it archived, and the fix is the Archived Projects modal.
+
+---
+
+### 11.4 D19: the sound keys (partial answer to open question 6)
+
+**Confirmed in Rust: both keys exist and both default to `true`.** `src-tauri/src/config/settings.rs` carries `sounds_enabled` and `team_idle_beep_enabled`, pinned by four tests in the same file: `sounds_enabled_defaults_true_when_missing_from_json`, `sounds_enabled_round_trips_through_serde`, `team_idle_beep_enabled_defaults_true_when_missing_from_json`, `team_idle_beep_enabled_round_trips_through_serde`. There is a setter command `set_sounds_enabled` in `src-tauri/src/commands/config.rs`.
+
+**Not confirmed, and not confirmable in Rust: the debounce and the master-switch relationship.** No Rust symbol implements the beep. The only backend surface is storing and serving the two booleans. Whether `teamIdleBeepEnabled` is additionally gated on `soundsEnabled`, and whether the beep is debounced across repeated busy-to-idle transitions, is decided in the frontend.
+
+**Consequence for section 5, D19.** The content requirement says `## Sounds` must state "the exact trigger for the team idle beep: the transition from busy to all-idle across a team". That sentence is **unverified from the backend** and must not be written on this plan's authority. Route it to `dev-webpage-ui` before Batch 7, or drop the precision and describe only the two settings keys and their defaults, which are settled.
+
+---
+
+### 11.5 D6: the non-stop watchdog (open question 4 NOT answered)
+
+**Confirmed:** `src-tauri/src/loops/non_stop_watchdog.rs` exists at the frozen SHA, so section 5's source list for D6 is valid. `src-tauri/src/commands/non_stop.rs` exists and exposes `non_stop_report`. The per-project configuration lives in `src-tauri/src/config/project_settings.rs` (`default_non_stop_name`, `populated_non_stop`, plus the tests section 5 already names), which supports the `## Scope: per workgroup` requirement as written.
+
+**Not answered: the cadence, the timeout, and what stops the watchdog.** I could not establish any of the three within the evidence budget. `src-tauri/src/loops/non_stop_watchdog.rs` contributes no symbol matching `non_stop` to the call graph, so its entry point could not be located without a further pass.
+
+One observation that is **not** an answer but bounds the next pass: the only symbol in the tree whose name binds "non-stop" to "watchdog" is the frontend `startNonStopWatchdogClient` at `src/sidebar/watchdog/non-stop-watchdog-client.ts`. If the user-visible cadence is a frontend polling interval rather than a backend loop, this question belongs to `dev-webpage-ui`, not to `dev-rust`. That is a hypothesis, not a finding. Do not write it into a page.
+
+**Binding instruction for the writer:** `## What the watchdog does` must be written without any interval, timeout, or retry number until this is resolved. An omitted sentence is correctable; a published wrong interval is not.
+
+---
+
+### 11.6 D12: context-alert firing semantics (open question 3 NOT answered)
+
+**Confirmed:** `src-tauri/src/session/context_alerts.rs` exists at the frozen SHA, so section 5's source list for D12 is valid. `normalize_context_alert_percentages` is in `src-tauri/src/commands/entity_creation.rs`, and `cli_team_builder_defaults_context_alerts_to_disabled` is in `src-tauri/src/cli/workgroup.rs`, both as section 5 states.
+
+**Not answered: whether the `context-alert` injection fires once per threshold crossing or repeats while above the threshold.** `src-tauri/src/session/context_alerts.rs` yielded no matching symbol in the call graph, so the firing path could not be reached within the evidence budget.
+
+**Binding instruction for the writer:** `## Context alerts` and `## The injected alert message` must describe the thresholds, the accepted range, the normalization and the template id, and must say nothing about repetition. Do not write "once", do not write "repeatedly", and do not write "each time it crosses". Leave the behavior out and flag it in the batch report.
+
+---
+
+### 11.7 Position on the two reversals in section 3.2
+
+**Item 1, `legacyStartOnlyCoordinators`: architect is right, and the reason is stronger than "already documented".**
+
+Confirmed at `src-tauri/src/config/settings.rs`: the `rename = "startOnlyCoordinators"` attribute is at `:307` and the field `pub legacy_start_only_coordinators: Option<bool>` is at `:309`. So the JSON key is `startOnlyCoordinators`, exactly as section 3.2 states.
+
+The stronger reason: this is not a settings key a user can set at all. It is a one-way migration carrier for issue #248. `:2068` takes the value out of the struct, `:2072` translates it to `restoreCoordinatorWakeState` and logs `[settings-migration] #248 - translated legacy startOnlyCoordinators=<v> -> restoreCoordinatorWakeState=<v>`, and when both are present on disk the new value wins and the legacy one is dropped (`:2077`). The round-trip test at `:6223` asserts the serialized output does **not** contain `startOnlyCoordinators`: write it into `settings.json` and it disappears on the next save.
+
+Documenting it as a settable key would have been an error, not a redundancy. `docs/reference/settings.md:468` placing it under "Migration carriers" is the correct treatment. My inventory was wrong on this item and I withdraw it.
+
+**Item 2, the three non-IPC modules: architect is right, confirmed by count.**
+
+`codex_resolver.rs`, `gemini_resolver.rs` and `wg_delete_diagnostic.rs` in `src-tauri/src/commands/` contain zero occurrences of `tauri::command` at the frozen SHA. They have no IPC surface and do not belong in the table at `docs/reference/architecture.md:305-324`. My inventory was wrong on this item and I withdraw it.
+
+**One supporting fact for edit A1.** `src-tauri/src/commands/` holds 23 `.rs` files at the frozen SHA, while the table lists a small subset. That is exactly why A1's new lead sentence ("it is not an exhaustive command list") is the right fix and why adding rows for non-IPC modules would have made the table worse. A1 as written is correct; keep it.
+
+---
+
+### 11.8 Evidence budget and what a further pass would cost
+
+Codebase Memory gate: `ready`, project `D-0_repos-...-repo-AgentsCommander`, `head_sha` `51e70e47f442109d6b618299b26d95a12801f156`, matching the frozen SHA. Twenty graph operations plus both reserve operations were spent, and the single permitted text fallback was spent on exact-text items that the graph does not index (a `serde` rename attribute, two `const` values, and an attribute-macro count). Both reserve operations returned empty, which is why 11.5 and 11.6 are unanswered rather than guessed.
+
+Resolving 11.5 and 11.6 needs one further evidence pass with a fresh budget, scoped to two files: `src-tauri/src/loops/non_stop_watchdog.rs` and `src-tauri/src/session/context_alerts.rs`. Neither blocks Batch 1 through Batch 3. D12 lands in Batch 4 and D6 in Batch 2, so both need an answer before those batches are written, or the affected sentences must be omitted per the binding instructions above.
+
+---
+
+## 12. Grinch Review (dev-rust-grinch)
+
+Added by `dev-rust-grinch` on 2026-08-17 UTC as the Step 6 adversarial pass. This section is **additive**. It changes no batch, no
+document list, no acceptance criterion and no decision in sections 1 to 11, and it does **not** certify the plan. The architect is the
+only certifier.
+
+Read at the frozen SHA `51e70e47f442109d6b618299b26d95a12801f156` (verified: committed `HEAD` equals it, branch is
+`docs/1407-document-missing-features`, `git status --porcelain=v1 --untracked-files=all` empty). Rust evidence came through the
+Codebase Memory graph (gate `ready`, `head_sha` matched); markdown under `docs/` is not indexed by the graph and was read directly.
+
+**Precedence.** Where section 12 contradicts sections 1 to 11, section 12 states the contradiction and proposes a fix; it does not
+overrule the architect. Where section 12 reports a verified fact with a `path:line`, that fact is authority for the writer, on the same
+footing as section 11.
+
+### 12.0 Sections 1 to 11 that I re-verified and found correct
+
+Stated so the architect can see what the review actually covered, not only what it broke.
+
+- The four `architecture.md` anchors A1 to A4 all exist verbatim at the frozen SHA: `## 4. IPC Contract: All Commands` (`:301`), the
+  lead sentence (`:303`), the `SettingsAPI` row (`:309`), the `main.tsx` row (`:813`), `Global keyboard shortcuts (Ctrl+Shift+W/R)`
+  (`:819`, exactly one occurrence), `Settings tabs: General, Agents, Integrations, Watchers, API clients, ...` (`:835`), the
+  `shared/stores/resourceMonitor.ts` row (`:825`) and the `sidebar/components/SessionItem.tsx` row (`:833`). **A1 to A4 are
+  applyable as written.**
+- Every line anchor in section 4.4 is correct: `settings.md:178/216/229/311/386/417/456/463`, `session-auto-close.md:34/58`,
+  `agent-matrix-conventions.md:525`, `quickstart.md:83`, `home-en.md:22`, `security.md:22`, `directory-layout.md:57/74`,
+  `cli.md:42/631/637/646/838`, `coding-agent-profiles.md:124/169`, `screenshot-capture.md:112`.
+- Every baseline count in section 7 is correct at the frozen SHA: `docs/features/*.md` = 11, `grep -c "^## " docs/glossary.md` = 31
+  (so 42 = 31 + 11 holds), `grep -c "^## " docs/concepts.md` = 9 with `docs/concepts.md:3` reading "Nine terms.",
+  `grep -c "\.\./features/" docs/reference/settings.md` = 12 (so 20 = 12 + 8 holds).
+- The index arithmetic in sections 4.3 and 6 closes: 11 + 3 + 2 + 2 + 3 + 2 + 2 = 25 rows, and the five groups in 4.3 have
+  7 + 4 + 6 + 4 + 4 = 25 members.
+- The three anchors the plan asks writers to link to all exist: `## Drift: the "outdated" badge` in `coding-agent-profiles.md`,
+  `## Session` in `concepts.md`, `## Configure the hotkey` in `screenshot-capture.md`. `docs/integrations/voice.md:41` says exactly
+  what D20 relies on. The `docs/concepts.md` H2 order puts `## Workgroup` immediately before `## Brief`, so 4.4's insertion point is real.
+- Section 3.2's three reversals and section 11.7's confirmation of them hold.
+
+### 12.1 `grep -c "API clients"` cannot return 0, and A3 leaves the page contradicting itself
+
+- **What:** criterion 7.3/D2 requires `grep -c "API clients" docs/reference/architecture.md` to return 0. The string appears **three**
+  times at the frozen SHA, and A3 corrects only one of them.
+  - `:54` - `APICLIENT["Control-plane API clients<br/>(containers, scripts)"]`. Correct text. Must not be touched.
+  - `:221` - `AB --> SM["SettingsModal.tsx<br/>tabs: General, Agents, Integrations,<br/>Watchers, API clients, ..."]`. This is the
+    **same false tab list A3 exists to correct**, inside a mermaid node.
+  - `:835` - the table cell A3 fixes.
+- **Why:** two concrete failures. First, the criterion is unsatisfiable: the writer either fails Batch 1 or edits `:54` and breaks a
+  correct diagram node to make a grep go quiet. Second, and worse if the writer stops at A3: `architecture.md` ships a diagram at
+  `:221` claiming a non-existent "API clients" tab and a table at `:835` listing the five real tabs, on the same page. A reader who
+  trusts the diagram goes looking for a tab that does not exist. That is exactly the plausible-and-false defect this plan is meant to
+  remove, published under the plan's own authority.
+- **Fix:** extend A3 to a second edit at `:221`, replacing `tabs: General, Agents, Integrations,<br/>Watchers, API clients, ...` with
+  `tabs: General, Coding Agents,<br/>Resources, Watchers, Integrations`; and change the criterion to
+  `grep -c "Watchers, API clients" docs/reference/architecture.md` returns 0, which is specific to the defect and leaves `:54` alone.
+  Section 4.5's closing sentence "Nothing else in `architecture.md` changes" must be amended to allow this second edit, or it forbids
+  the fix its own criterion demands.
+
+### 12.2 Three pages are required to have a `## Settings` section for which no settings key exists
+
+- **What:** criterion 7.2.7 requires every page with a `## Settings` H2 to contain a markdown table **and at least one link into
+  `docs/reference/settings.md`**. Section 5 gives `## Settings` to D6, D9 and D12. At the frozen SHA, `docs/reference/settings.md`
+  contains, case-sensitively: `nonStop` 0 times, `loops` 0 times, `contextAlert` 0 times, `contextScrape` 0 times.
+- **Why:** a writer working cold from this plan reaches `## Settings` on `non-stop-mode.md`, finds the section mandatory and the table
+  mandatory, finds nothing in `settings.md` to point at, and writes a plausible key. `nonStopEnabled`, `nonStopToleranceSeconds` and
+  `nonStopWatchdogIntervalSeconds` are all names a competent writer would produce and all three are false. Non-stop configuration is
+  per project, in `src-tauri/src/config/project_settings.rs`, not in `settings.json` (section 11.5 already says the config lives there;
+  it does not draw the consequence). Loop configuration is likewise not a `settings.json` key. This is the single most expensive defect
+  in the plan: it does not merely permit an invented key, it makes inventing one the cheapest way to pass the criteria.
+- **Aggravating factor for D12.** Section 4.4 adds a pointer from the `### Watchers` group of `settings.md` (`:417`) to **both**
+  `watchers.md` and `context-tracking.md`. That group contains only `watchers` and `watchersGeometry` plus the `WatcherConfig` shape.
+  It carries no context-alert key at all. The pointer promises a reader that context-tracking settings live there. They do not.
+- **Fix:** three changes.
+  1. Add D6, D9 and D12 to the section 4.2 item 8 list of pages that legitimately have no `## Settings` H2, and remove `## Settings`
+     from their required-H2 lists in section 5 - or replace it with `## Where the configuration lives`, pointing at project settings
+     and at the relevant UI, with no `settings.md` link.
+  2. Drop `context-tracking.md` from the `### Watchers` pointer in section 4.4, and recompute the 7.3 expectation from 20 to 19.
+  3. Add a criterion that would have caught this class by itself, cheap and objective: for every new page, every backtick-quoted
+     identifier that matches `^[a-z][A-Za-z0-9]*$` inside its `## Settings` table must return at least one hit in
+     `docs/reference/settings.md`. This is runnable and falsifiable, and it is the only proposed check in this review that tests
+     whether a page says something true.
+
+### 12.3 Section 7 cannot fail a page that is entirely fabricated
+
+- **What:** section 7.1 states "Every criterion is a command with a stated expected result. There is no subjective quality bar." Both
+  halves are wrong, and the second is dangerous.
+- **Why:** every criterion in 7.1 to 7.4 tests existence, heading text, heading order, counts, banned vocabulary and link resolution.
+  Not one tests whether a sentence is true. A page with all required H2s present, each holding one confident and invented paragraph,
+  passes 7.1, 7.2, 7.3 and 7.4 in full. Combine that with 12.2 and the incentive points the wrong way. Published documentation is read
+  as authoritative; a wrong settings key or a wrong badge string costs more than a missing page, because a missing page is visibly
+  missing and a wrong one is not.
+  The claim of full objectivity is also false on its own terms: 7.2.6 "contains at least two entries", 7.2.7 "contains a markdown
+  table", and D4's "Minimum 4 sentences" are not commands with stated expected results.
+- **Fix:** add to section 7.2 a per-page criterion that the batch report lists, for every literal the page quotes - settings key, UI
+  control label, badge text, error string, file path - the `path:line` in `src/`, `src-tauri/` or `docs/reference/settings.md` it was
+  read from, and that the batch is not done until that list is complete. Combined with 12.2's identifier check this converts "did the
+  writer read the source" from an assumption into an artifact. Also drop or reword the "no subjective quality bar" sentence: a plan
+  that overstates its own guarantees is read as covering more than it does.
+
+### 12.4 Batches 2 to 7 are not independently executable from a cold start
+
+- **What:** section 6 states "Each batch is independently executable from a cold start. A batch's only prerequisites are this plan file,
+  the two inventory messages, and the repo at the frozen SHA on the working branch." Batches 2 to 7 each append rows to
+  `docs/features/README.md`, which does not exist at the frozen SHA and is created by D1 in Batch 1.
+- **Why:** run Batch 4 first, on a fresh checkout, with only the plan. There is no `docs/features/README.md` to append to. The writer
+  either creates a partial index holding two rows and the five H2 group headings - which then collides with Batch 1 - or skips the
+  index rows and fails criterion 7.2.8 (`grep -c "$(basename P)" docs/features/README.md` returns 1) for both pages. Section 6's own
+  supporting sentence, "Batches 2 through 7 each append their rows to `docs/features/README.md`, so no batch depends on a later one",
+  answers a different question than the claim it is defending: forward independence is not cold-start independence.
+- **Fix:** either state plainly that Batch 1 is a prerequisite of Batches 2 to 7 and only Batch 1 and Batch 8 are order-free relative
+  to each other, or add one sentence to section 4.3: "If `docs/features/README.md` does not exist, the batch creates it with the H1,
+  the audience line and the five H2 group headings from this section, and adds only its own rows." The second option costs one
+  sentence and makes the section 6 claim true.
+
+### 12.5 A4's insertion blocks corrupt the table they are inserted into
+
+- **What:** section 4.5, edit A4, gives three insertion blocks. Each is written as a complete markdown table, header row
+  `| File | Purpose |` and separator `|------|---------|` included. All three insertion points (`:813`, `:825`, `:833`) are inside the
+  single existing table that starts at `:811`.
+- **Why:** a writer copying A4 verbatim - which is what "verbatim" in D2's Required edits instructs - drops a second header row and a
+  second separator row into the middle of a live table, three times. Markdown renders both as ordinary data rows. The published table
+  gains three rows reading `File | Purpose` and three rows of dashes. The edit is applyable, passes every criterion in 7.3/D2
+  (`grep -n "main/components/HomeView.tsx"` still matches), and produces a visibly broken table.
+- **Fix:** add one sentence to A4: "The header and separator rows shown below are for readability only. Insert the data rows, and
+  nothing else, into the existing table."
+
+### 12.6 Criterion 7.1.6 fails on the links the plan itself mandates
+
+- **What:** 7.1.6 checks every relative link by "extracting `](...)` targets and testing each with `test -e`". Section 5 D17 mandates
+  `coding-agent-profiles.md#drift-the-outdated-badge` and `../concepts.md#session`; D20 mandates
+  `../features/screenshot-capture.md#configure-the-hotkey`; section 4.4 mandates
+  `../agent-matrix-conventions.md#11-agent-memory-rotation-at-spawn`; `docs/features/coding-agent-profiles.md:169` already carries
+  `../agent-matrix-conventions.md#5-profile-path-placeholders`.
+- **Why:** `test -e 'coding-agent-profiles.md#drift-the-outdated-badge'` fails. Run literally, the criterion fails every batch that
+  obeys its own content requirements. An implementer who notices will "fix" it by deleting the anchors, which silently destroys D17's
+  entire design - D17's `## What a session row shows` is specified as link-outs precisely so it does not duplicate six other pages.
+  A second, opposite failure mode: 7.1.6 also runs over pre-existing links in the existing files a batch touches, so a broken link
+  already on `settings.md` fails a batch the writer did not cause.
+- **Fix:** strip everything from `#` onward before `test -e`, and scope the check to links the batch added. Optionally add an anchor
+  check, since the anchors are load-bearing: slugify the target file's `^#{1,6} ` headings (lowercase, drop punctuation, spaces to
+  hyphens) and require a match. I verified all four anchors above resolve correctly today, so the design is sound; only the check is wrong.
+
+### 12.7 Criteria 7.1.2 and 7.1.3 do not currently guard anything
+
+- **What:** both criteria are `git diff --name-only $(git merge-base HEAD origin/main) HEAD -- <paths>`. At the frozen SHA on this
+  branch, `git merge-base HEAD origin/main` returns `51e70e47f442109d6b618299b26d95a12801f156`, which is `HEAD` itself, so the diff is
+  empty by construction. The clone is also shallow (`git rev-parse --is-shallow-repository` returns `true`).
+- **Why:** three failures. First, until a batch commits, the criterion returns empty whether or not `src-tauri/` was modified - and
+  nothing in section 6 or 7 tells the implementer to commit per batch, so "checked at the end of every batch" can be a no-op every
+  time. The real guard is 7.1.1 (`git status --porcelain`), which is already there; 7.1.2 adds the appearance of a second guard and
+  none of the substance. Second, on a shallow clone a moved `origin/main` can make `merge-base` fail outright; a failing command in a
+  criterion list reads as "returned empty" to a hurried implementer. Third, the pathspec is `src src-tauri scripts package.json`, but
+  section 2 also forbids modifying `.github/`, `Cargo.toml` and `tauri.conf.json`, which no criterion covers.
+- **Fix:** compare against the literal frozen SHA rather than a computed merge-base - `git diff --name-only
+  51e70e47f442109d6b618299b26d95a12801f156 -- <paths>`, which needs no `origin/main` and works on a shallow clone - drop `HEAD` so the
+  working tree is included, and extend the pathspec to `src src-tauri scripts .github package.json Cargo.toml
+  src-tauri/tauri.conf.json`.
+
+### 12.8 Section 4.2's mandatory skeleton contradicts section 5 for twelve of the fifteen new pages
+
+- **What:** 4.2 says every new page under `docs/features/` MUST have, in order, item 5 `## What it does` and item 6 exactly one of
+  `## Turning it on` or `## Availability`. Section 5 gives a differently named opening H2 to D7, D9, D10, D11, D12, D14, D15, D16,
+  D17, D18, D19 and D20, and gives **neither** `## Turning it on` nor `## Availability` to D11, D17, D18, D19 and D20.
+- **Why:** criterion 7.2.4 enforces section 5's exact count, text and order, so section 5 wins mechanically. But a writer reads
+  section 4.2 first - it is the page template, and it says MUST - adds `## What it does` to `spec-board.md`, and fails 7.2.4 with a
+  count mismatch and no diagnostic pointing at the cause. The writer's most likely repair is to distrust section 5, which is the
+  section anchored to the inventory.
+- **Fix:** reword 4.2 item 5 as "an opening H2 that answers what the feature does, named exactly as section 5 lists it for this page",
+  and 4.2 item 6 as "where section 5 lists `## Turning it on` or `## Availability`, exactly one of the two is present". State once, in
+  4.2, that section 5's H2 list is authoritative and 4.2 describes intent.
+
+### 12.9 The 7.2.6 Troubleshooting exemption names the wrong page
+
+- **What:** 7.2.6 exempts D18 and D20 from the `## Troubleshooting` check. D18's required-H2 list in section 5 **includes**
+  `## Troubleshooting`. Only D20 lacks it.
+- **Why:** three parts of the plan now disagree about one page: 4.2 item 9 makes Troubleshooting mandatory, section 5 D18 lists it,
+  7.2.6 exempts it. 7.2.4 will still catch its absence, so this is not a correctness hole - it is a signal to the writer that D18 may
+  skip a section it is required to have, on a page that already has the loosest content requirements in the plan (see 12.10).
+- **Fix:** exempt D20 only.
+
+### 12.10 D17 and D19 are the two pages mapped in name only, and they carry fourteen inventory items between them
+
+The tech lead asked for items mapped in name but not in substance. These are they.
+
+- **What:** D17 `sidebar-guide.md` covers seven inventory items (`UI-B2`, `UI-B7`, `UI-C11`, `UI-C13`, `UI-C14`, `UI-C15`, `B6`)
+  across ten behavior H2s, and section 5 gives content requirements for exactly three of them: `## What a session row shows`,
+  `## The git branch badge`, `## Zoom`. `## The workgroup rail`, `## Favorites and groups`, `## Raise hand`, `## The project panel`,
+  `## The agent picker`, `## Quick coding-agent configuration` and `## Branch and repo discovery` get a source file in the Sources
+  list and nothing else. D19 `notifications-and-dialogs.md` covers seven items across eleven H2s with content requirements for two
+  (`## Toasts`, `## Sounds`) - and section 11.4 has already voided half of the `## Sounds` requirement.
+- **Why:** every other document in section 5 states what a section must say, which is what makes "source wins over inventory"
+  actionable. For these seventeen H2s the writer has a heading and a filename. Compare D16, where the plan names the literal blocker
+  text, or D8, where it names the Enter/Esc behavior. A writer who is confident and cold will fill `## Raise hand` and
+  `## Root Agent banner` from the heading plus a skim, and section 7 will pass it. These two pages are where the plan's
+  plausible-and-false risk actually concentrates, and they are also the two largest pages, which is the worst combination.
+- **Fix:** either add one content-requirement sentence per unspecified H2 - naming the visible control or string the section must
+  quote - or split D17 and D19 so no page carries more than three or four inventory items without per-section requirements. This is
+  the finding I would not waive. It does not block Batch 1 through Batch 5; D17 lands in Batch 6 and D19 in Batch 7.
+
+### 12.11 Three terms are defined twice with no stated relationship
+
+- **What:** section 4.4 adds `## Non-stop mode`, `## Watcher` and `## Spec Board` to **both** `docs/concepts.md` and
+  `docs/glossary.md`. The plan does not say how the two definitions relate.
+- **Why:** two independently written definitions of one term drift on the first edit that touches only one of them, and a reader who
+  finds both cannot tell which is authoritative. The plan is otherwise careful about this - 4.1's whole granularity rule exists to
+  avoid duplication, and D11, D13, D14 and D16 are explicitly forbidden from restating the settings schema.
+- **Fix:** one sentence in 4.4: the glossary entry is one sentence plus a link to the concepts entry, and the concepts entry is the
+  authoritative definition. Nothing else changes; the counts in 7.3 stay as they are.
+
+### 12.12 Two smaller items
+
+1. **`agent-matrix-conventions.md` append point.** Section 5 D5 says "append a new H2 at the end of the file, after section 10
+   (`:525`)". `:525` is the *heading* `## 10. CLI Reference for Agent Management`; the file is 551 lines. "After section 10 (`:525`)"
+   reads two ways and one of them puts the new H2 at line 526, in the middle of section 10. The file also contains nine unnumbered
+   H2s (`## Core Concepts`, `## Source of Truth`, `## Agent Memory Rule`, `## What You Must NEVER Do`, and others) sitting inside
+   template content, so a writer who tries to "restore numbering order" has plenty of room to do damage. **Fix:** say "append at the
+   end of the file, after line 551 at the frozen SHA". Criterion 7.3/D5 already protects the `## 5. Profile Path Placeholders` anchor.
+2. **Index grouping.** Section 4.3 files `voice-to-text.md` under **Remote access**, alongside the web UI, the control-plane API and
+   the Telegram bridge. Voice-to-text is a local microphone feature. A reader browsing the index for it will look under "Agents and
+   sessions". Cosmetic, but the index is a published navigation surface and it costs one line to move. **Fix:** move it to "Agents and
+   sessions" (making the groups 8 / 4 / 6 / 3 / 4), or leave it and accept the mismatch knowingly.
+
+### 12.13 Open question 3 ANSWERED: `context-alert` fires once per crossing
+
+This closes the gap section 11.6 left open. **The binding instruction in section 11.6 is lifted**: `docs/features/context-tracking.md`
+may now state the firing semantics below, and only these.
+
+`src-tauri/src/session/context_alerts.rs:803-839` (`evaluate_numeric_sample`) is the whole decision. Each configured threshold carries
+its own latch, `LatchState::Armed` or `LatchState::Latched`:
+
+- when the reading is **below** the threshold, that threshold's latch is set back to `Armed` (`:815-816`);
+- when the reading is **at or above** the threshold and the latch is `Armed`, the latch becomes `Latched` and the threshold is queued
+  as newly crossed, unless a delivery for that same threshold is still outstanding (`:817-821`);
+- a `Latched` threshold is skipped on every later sample, so nothing is queued while the session stays above it.
+
+**So: the injection fires once per crossing. It does not repeat while the session stays above the threshold.** Thresholds crossed in
+the same reading are queued together, sorted ascending, and delivered as one batch (`:826-836`).
+
+**What re-arms it, all four paths:**
+
+1. the reading drops back below that threshold (`:815-816`) - the normal case, and the only one a user controls directly;
+2. the session ends (`ContextSample::SessionOver`, `src-tauri/src/session/context_alerts.rs:485-487`);
+3. the session is reported unavailable and the runtime confirms it is no longer live (`:488-497`), or the member policy resolves to
+   `Disabled` or `PermanentIneligible` (`:571-581`) - all of which drop the session's state, latches included;
+4. the session's identity fingerprint changes (`:549-553`), which also drops all latches for that session.
+
+**Writing rules for D12, to keep the page from over-promising:**
+
+- Do **not** write "once per session" or "once per threshold, ever". It is once per crossing, and a session that drops below and
+  climbs back alerts again. Say that explicitly - it is the behavior a user will observe and be surprised by.
+- Do **not** state a polling interval for context readings. The actor's 30-second `CONTEXT_ALERT_MAINTENANCE_INTERVAL`
+  (`src-tauri/src/session/context_alerts.rs:24`) is maintenance and retry bookkeeping, not the sampling cadence; the samples arrive on
+  a channel from a producer this review did not read. Writing "AC checks every 30 seconds" would be plausible and false.
+- Retry delays exist (`FIRST_RETRY_DELAY` 5s at `:26`, `MAX_RETRY_DELAY` 60s at `:27`) and are internal delivery mechanics. They are
+  not user-facing and should not appear on the page.
+- A reading above 100 percent is rejected with a `log::error!` and no alert (`:502-509`). Worth one `## Troubleshooting` line: if no
+  alert arrives, the log is where the reason is.
+
+### 12.14 Open question 4 ANSWERED: the non-stop watchdog is a backend loop, and `dev-rust`'s hypothesis is refuted
+
+This closes the gap section 11.5 left open. **The binding instruction in section 11.5 is lifted, with the limits stated below.**
+
+Section 11.5's hypothesis - that the user-visible cadence might be a frontend polling interval in
+`src/sidebar/watchdog/non-stop-watchdog-client.ts`, making this a `dev-webpage-ui` question - is **wrong, and should not be carried
+forward**. `src-tauri/src/loops/non_stop_watchdog.rs` does contain the loop. The earlier search missed it because the functions are
+named `start`, `tick`, `fire`, `report` and `bot`; none of them contains the string `non_stop`, so a name search for `non_stop` returns
+nothing from that file. A text search for `non_stop_watchdog` returns all six.
+
+**The backend loop** - `src-tauri/src/loops/non_stop_watchdog.rs:202-212` (`start`):
+
+```rust
+pub fn start(app: AppHandle, state: NonStopWatchdogState, shutdown: ShutdownSignal) {
+    tauri::async_runtime::spawn(async move {
+        let mut interval = tokio::time::interval(TICK_INTERVAL);
+        loop {
+            tokio::select! {
+                _ = shutdown.token().cancelled() => break,
+                _ = interval.tick() => tick(&app, &state).await,
+            }
+        }
+    });
+}
+```
+
+- **Cadence:** `TICK_INTERVAL` is `Duration::from_secs(1)` (`src-tauri/src/loops/non_stop_watchdog.rs:37`). One tick per second.
+- **What stops it:** cancellation of the application `ShutdownSignal`, and nothing else. There is no timeout on the loop, no retry
+  count, and no user-facing off switch on the loop itself - turning non-stop off for a workgroup empties what the tick finds, it does
+  not stop the tick.
+
+**The timeout the user actually sets is not a constant** - `collect_fireable`, `src-tauri/src/loops/non_stop_watchdog.rs:145-176`:
+
+- an episode fires when `now - disparity_since >= Duration::from_secs(ep.report.tolerance_seconds)` (`:170-174`).
+  `tolerance_seconds` arrives on the report, so it is per episode and configurable, **not** a backend constant.
+- firing sets `ep.fired = true` (`:171`), and `:165-167` skips any episode already fired. **One shot per episode**, like the context
+  alerts, not a repeat.
+- **Self-heal:** an armed episode whose last report is older than `REPORT_STALENESS_CEILING` -
+  `Duration::from_secs(180)` at `:42` - is disarmed (`disparity_since = None`, `fired = false`, `:148-159`) with the log line
+  `[non-stop] '<project path>' disarmed: no frontend report for >180s (frontend gone)`. The in-code comment at `:146-147` states the
+  design intent: "Never trips for a live minimized episode (keepalive <= ~60s << 180s)."
+
+**Writing rules for D6, which replace section 11.5's blanket prohibition:**
+
+- `## What the watchdog does` **may** now state: AC checks once a second; an episode fires once, after the disparity has lasted the
+  episode's tolerance; and a workgroup whose frontend stops reporting for more than three minutes is disarmed rather than fired.
+- It **must not** state a tolerance value. `tolerance_seconds` comes from the frontend report and this review did not establish its
+  default or its UI control. Describe it as "the tolerance configured for the workgroup" and stop there.
+- It **must not** state the frontend keepalive interval as fact. The `~60s` figure is from an in-code comment, not from the frontend
+  source, and comments are not evidence. If D6 needs it, route the question to `dev-webpage-ui` for
+  `src/sidebar/watchdog/non-stop-watchdog-client.ts`.
+- It **must not** describe what firing does downstream. `fire`, `report` and `bot` in the same file were not read. `## What the
+  watchdog does` should stop at "fires" and link out rather than guess at a notification, a Telegram message or a session wake.
+- `fireable` at `:430-433` is inside a test module. Do not cite it as production behavior.
+
+### 12.15 Evidence budget
+
+Codebase Memory gate `ready`, project `D-0_repos-AgentsCommander_iac-.ac-wg-14-dev-v5-team-repo-AgentsCommander`, `head_sha`
+`51e70e47f442109d6b618299b26d95a12801f156`, matching the frozen SHA. Twelve of twenty graph operations spent. **No reserve graph
+operation was spent.** The single permitted fallback was spent on one `rg` for `const ... : Duration` across
+`non_stop_watchdog.rs` and `context_alerts.rs`, because the graph indexes callables and not constants. Markdown under `docs/` is not
+in the graph and was read directly; every count and anchor in section 12.0 comes from that reading.
+
+Both open questions this pass inherited are now closed. Open questions 1, 2, 5 and 6 in section 10 were answered by section 11, except
+the frontend half of question 6, which section 11.4 correctly routes to `dev-webpage-ui` and which this pass did not touch.
+
+**This review does not certify the plan.** Findings 12.1, 12.2, 12.4, 12.5, 12.6 and 12.10 are defects I would expect resolved before
+the plan is certified; 12.3, 12.7, 12.8, 12.9, 12.11 and 12.12 are weaknesses the architect may knowingly accept.
+
+---
+
+## 13. Architect resolution and certification (consensus round 1)
+
+Recorded by the architect on 2026-08-17 UTC, as the design authority. Sections 11 and 12 are enrichment and review; this section is the disposition, and sections 1 to 10 above have already been amended to match it.
+
+**All twelve findings are accepted. None is rejected, none is knowingly waived.** Six were argued as blocking and six as optional; the six optional ones were cheap to fix and each removed a way for a cold writer to go wrong, so there was no reason to carry them.
+
+Before resolving, the architect independently re-verified the four load-bearing facts at the frozen SHA: `API clients` occurs at `docs/reference/architecture.md:54`, `:221` and `:835`; `nonStop`, `loops`, `contextAlert` and `contextScrape` each return 0 in `docs/reference/settings.md`; `git merge-base HEAD origin/main` returns the frozen SHA itself and `git rev-parse --is-shallow-repository` returns `true`; `docs/agent-matrix-conventions.md` is 551 lines with `## 10. CLI Reference for Agent Management` at `:525`. All four hold as reported.
+
+### 13.1 Disposition
+
+| Finding | Verdict | Where it landed |
+|---|---|---|
+| 12.1 `architecture.md` self-contradiction | **Accepted** | 4.5 A3 split into A3a (`:835`) and A3b (`:221`), with `:54` explicitly protected; 4.5's closing sentence amended; D2 criterion changed to `grep -c "Watchers, API clients"` returns 0 plus `grep -c "Control-plane API clients"` returns 1. |
+| 12.2 `## Settings` for keys that do not exist | **Accepted, with one variation** | D6 and D9 get `## Where the configuration lives` and no `settings.md` link. D12 **keeps** `## Settings` with exactly one row, `contextRegex` (`docs/reference/settings.md:94`), which is a real key the review did not probe for; its per-team thresholds are routed to `## Setting thresholds for a team`. New criterion 7.2.9 enforces identifier provenance. |
+| 12.3 section 7 cannot fail a fabricated page | **Accepted** | The "no subjective quality bar" claim is deleted and replaced by an explicit statement of what the criteria do and do not guarantee. New criterion 7.5 makes literal provenance a reported artifact. |
+| 12.4 batches not cold-start independent | **Accepted** | 4.3 gains the self-creating index rule; section 6's independence claim now names it as the reason the claim is true. |
+| 12.5 A4 corrupts the table | **Accepted** | A4 gains the insert-data-rows-only note; D2 gains two baseline criteria (`^\|------\|---------\|` returns 3, `^\| File \| Purpose \|` returns 3), both verified at the frozen SHA. |
+| 12.6 criterion 7.1.6 fails on mandated anchors | **Accepted** | 7.1.6 rewritten to strip from `#` onward and to scope to links the batch added; new 7.1.7 adds the slugified anchor check, since the anchors are load-bearing. |
+| 12.7 7.1.2 and 7.1.3 guard nothing | **Accepted** | Both now diff against the literal frozen SHA with no `HEAD`, and the pathspec is extended to `.github`, `Cargo.toml` and `src-tauri/tauri.conf.json`. Section 8's citation of 7.1.2 updated to match. |
+| 12.8 4.2 contradicts section 5 | **Accepted** | 4.2 items 5, 6, 8 and 9 reworded to defer to section 5, with an explicit "section 5 is authoritative" statement. |
+| 12.9 Troubleshooting exemption names the wrong page | **Accepted** | 7.2.6 exempts D20 only, and says so. |
+| 12.10 D17 and D19 mapped in name only | **Accepted** | Both entries now carry one content requirement per behavior H2, each naming the visible control, label or string the section must quote and the file to read it from. No page was split: the requirements, not the page size, were the defect. |
+| 12.11 three terms defined twice | **Accepted** | 4.4 states the concepts entry is authoritative and the glossary entry is one sentence plus a link. Counts unchanged. |
+| 12.12 append point and index grouping | **Accepted, both** | D5 now says "after line 551" and warns against renumbering the nine unnumbered template H2s. `voice-to-text.md` moved to "Agents and sessions"; groups are 8 / 4 / 6 / 3 / 4 = 25. |
+
+### 13.2 Corrections carried from section 11 into section 5
+
+Section 11 declared itself additive and left three wrong content requirements standing in section 5, protected only by a precedence rule. Finding 12.8 showed that a cold writer reads the earlier section first, so the wrong requirements were corrected in place rather than left to precedence: D10 (thresholds do not map onto actions), D11 (the budget is per agent), D16 (blockers are one deduplicated list), D19 (`## Sounds`), plus D6 and D12, which now carry the semantics closed by 12.13 and 12.14.
+
+### 13.3 What this certification does not cover
+
+- **Truth of the prose is not certifiable in advance.** Criterion 7.5 shifts it to a reported artifact per batch; it does not eliminate it. The two pages where the residual risk concentrates are D17 and D19, now bounded by per-H2 requirements.
+- **The frontend half of open question 6** (whether the busy-to-all-idle trigger published at `docs/reference/settings.md:252-253` matches `src/`) is a verification the writer performs in Batch 7, not a fact this plan asserts.
+- **Baselines drift.** Four criteria carry frozen-SHA baselines (glossary 31, settings `../features/` 12, architecture separator rows 3, header rows 3). Each says how to recompute if the base moves.
+
+### 13.4 Verdict
+
+The dependency-cycle gate is unchanged and remains **PASS**: the change set contains no source file, so zero module arcs are added, `cyclicSccs` is unchanged, SCC member sets are identical, and the arc record is byte-identical.
+
+Status: READY_FOR_IMPLEMENTATION
+
+This certification freezes the bytes of this file. Any later edit, however small, invalidates it and requires recertification with a new digest.


### PR DESCRIPTION
Closes #1407.

Documents every shipped AgentsCommander feature that had no user-facing page, plus the corrections to `docs/reference/architecture.md` that the inventory turned up. Documentation only: no application code, build config, CI or QA script changes anywhere in the range.

## What landed

21 new documents and a features index, written against an architect-certified plan and delivered in eight batches:

| Area | Pages |
|---|---|
| Agents and sessions | `session-auto-close`, `agent-auto-update`, `sidebar-guide`, `app-windows`, `notifications-and-dialogs` |
| Automation | `non-stop-mode`, `project-loops`, `spec-board`, `watchers` |
| Monitoring | `resource-monitor`, `context-tracking`, `activity-log` |
| Remote access | `remote-web-ui`, `control-plane-api` |
| Configuration and packaging | `project-archiving` |
| Reference | `keyboard-shortcuts`, plus edits to `settings.md`, `architecture.md`, `directory-layout.md` |

Plus `docs/features/README.md` as the index (25 rows), cross-links from `concepts.md`, `glossary.md`, `quickstart.md`, `home-en.md`, `security.md`, and the `updateCommands` explanation in `docs/integrations/coding-agents.md`.

## How it was verified

Every published literal — settings key, label, badge text, error string, log line, threshold, key chord — carries a `path:line` it was read from. A literal without one was not published; several were deliberately left out rather than guessed.

An adversarial review read the whole range against the frozen plan and sampled roughly 180 literals, all 33 `## Settings` keys, every quoted log line and error string, every key chord, and every mechanism claim on the network, authentication, watchdog and archiving surfaces. It found six defects. All six are fixed, and each fix was re-verified against source:

- the Watchers scope selector renders `All agents`, not `All sessions`;
- the row cap is per session in both scopes, not a total;
- the non-stop rail and the project panel disagree after a rename, and the two fallback names are named;
- the coding-agent catalog lives in `<project>/.ac/coding-agents/`, and the per-instance row in `directory-layout.md` is corrected to the legacy read/seed source it now is;
- the browser-build payload guarantee is scoped to the one event a test pins, with terminal output noted as a binary frame;
- all six Loop toasts carry the backend message, not five.

Acceptance criteria were re-run independently at HEAD: scope guard empty, 0 broken links, 0 broken anchors, heading structure matching the specification page by page, and all 33 settings keys resolving to real fields in `src-tauri/src/config/settings.rs`.

## Issues filed along the way

Defects found while documenting, each with source evidence, none fixed here:

- #1415 — the agent auto-update overlay ships Spanish strings in an otherwise English UI
- #1417 — the New Loop modal cannot set the `skip` busy-coordinator policy
- #1419 — the context-alert help text promises observed usage the pinned template never sends
- #1420 — `api/README.md` omits `session-transport` and the Windows window-screenshot route
- #1428 — `settings.md` lists the deprecated `sidebarZoom` beside three live zoom keys

The implementation plan is included at `plans/1407-document-missing-features.md`.
