### PR TITLE
refactor(context): C4 - {{AGENT_REPOS}} / # Agent Repos, with a frozen alias (#1369)

### DIFF
--- a/docs/agent-matrix-conventions.md
+++ b/docs/agent-matrix-conventions.md
@@ -64,7 +64,7 @@ The global template must preserve these mandatory runtime tokens for matrix agen
 | `{{WRITE_RESTRICTIONS}}` | Runtime write restrictions and allowed scopes |
 | `{{DELEGATED_TASK_REPORTING}}` | Required completion/blocker reporting instructions |
 | `{{SKILLS_SECTION}}` | Runtime skill index |
-| `{{WORKSPACE_REPOS}}` | Repo list rendered from the replica config `repos` field |
+| `{{AGENT_REPOS}}` | Repo list rendered from the replica config `repos` field |
 | `{{CLI_CONTEXT}}` | CLI binary and help usage rules |
 | `{{SESSION_CREDENTIALS}}` | Environment-variable credential rules |
 | `{{INTER_AGENT_MESSAGING}}` | Peer discovery and file-based messaging instructions |
@@ -83,6 +83,7 @@ Legacy custom templates also support these older runtime tokens:
 | `{{PEER_NAME_FORMAT}}` | Peer-name format for the current session type |
 | `{{SEND_MESSAGE_INSTRUCTIONS}}` | File-based send instructions for the current session type |
 | `{{SKILLS_SECTION}}` | Runtime skill index and warnings |
+| `{{WORKSPACE_REPOS}}` | Pre-#1369 spelling of `{{AGENT_REPOS}}`; still rendered in place, with no duplicate block |
 
 Removing a token is allowed if you intentionally do not want that dynamic section included in generated contexts.
 
@@ -286,7 +287,7 @@ Workgroups are isolated working environments created when a team needs to work o
 
 | Field | Description |
 |---|---|
-| `context` | Array of context sources. `$AGENTSCOMMANDER_CONTEXT` is the AC-injected global template, and it is valid **only for Agent Matrix and workgroup context**; the Root Agent ignores it (see #979 above) and any occurrence is stripped from the Root `config.json` during provisioning. The Role.md entry defines this agent's personality. `$REPOS_WORKSPACE_INFO` is deprecated; repo context is rendered through `{{WORKSPACE_REPOS}}` inside `$AGENTSCOMMANDER_CONTEXT`. |
+| `context` | Array of context sources. `$AGENTSCOMMANDER_CONTEXT` is the AC-injected global template, and it is valid **only for Agent Matrix and workgroup context**; the Root Agent ignores it (see #979 above) and any occurrence is stripped from the Root `config.json` during provisioning. The Role.md entry defines this agent's personality. `$REPOS_WORKSPACE_INFO` is deprecated; repo context is rendered through `{{AGENT_REPOS}}` inside `$AGENTSCOMMANDER_CONTEXT`. |
 | `identity` | Path to the parent agent folder. This is the canonical identity — the workgroup agent is a replica of this. |
 | `repos` | Relative paths to the repo clones inside this workgroup. |
 

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -6,7 +6,7 @@ use crate::config::ac_root::{ensure_authoritative_ac_root, find_ac_root_ancestor
 
 pub const ROLE_MD_FILENAME: &str = "Role.md";
 pub const WG_REPLICA_REQUIRED_CONTEXT: &[&str] = &["$AGENTSCOMMANDER_CONTEXT"];
-const DEPRECATED_REPOS_WORKSPACE_CONTEXT: &str = "$REPOS_WORKSPACE_INFO";
+const DEPRECATED_REPOS_INFO_CONTEXT: &str = "$REPOS_WORKSPACE_INFO";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WgReplicaIdentity {
@@ -314,7 +314,7 @@ pub fn normalize_wg_replica_context_entries(
     }
 
     for entry in existing_context {
-        if entry == DEPRECATED_REPOS_WORKSPACE_CONTEXT
+        if entry == DEPRECATED_REPOS_INFO_CONTEXT
             || required_prefix.contains(&entry.as_str())
             || is_identity_role_context_entry(entry)
         {

--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -133,6 +133,42 @@ You are running inside an AgentsCommander session - a terminal session manager t
 {{INTER_AGENT_MESSAGING}}
 "#;
 
+/// #1369 (C4): `get_default_agent_template()` exactly as it shipped from #1005
+/// S6 (token minimization, v2) through base commit 8f272a76, frozen so a
+/// pristine v2 `Context.AgentsCommander.md` on disk keeps being recognized
+/// (project auto-update AND standalone root retirement) after the v3
+/// `{{AGENT_REPOS}}` rename. Never edit. Provenance: the raw literal at
+/// 8f272a76 is len 567, sha256
+/// e5861a9f011967e96e5515f858e1643f7fdf161511ad909fe86ddb4ce1a0cff7; pinned by
+/// `global_pre_agent_repos_snapshot_is_byte_exact` against those externally
+/// captured values, never against this const itself.
+///
+/// Do NOT replace this literal with `include_str!`: a raw string literal
+/// normalizes `\r\n` to `\n` at compile time and `include_str!` does not.
+const GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS: &str = r#"# AgentsCommander Context
+
+You are running inside an AgentsCommander session - a terminal session manager coordinating multiple AI agents.
+
+## Core Concepts
+
+- **Team**: the logical capability and organization. It defines membership, who coordinates, and which repos are available.
+- **Workgroup**: a runtime replica of a team for a specific task. It contains replica agents and `repo-*` working repos.
+
+{{WRITE_RESTRICTIONS}}
+
+{{DELEGATED_TASK_REPORTING}}
+
+{{SKILLS_SECTION}}
+
+{{WORKSPACE_REPOS}}
+
+{{CLI_CONTEXT}}
+
+{{SESSION_CREDENTIALS}}
+
+{{INTER_AGENT_MESSAGING}}
+"#;
+
 /// #1005 S4: `get_default_coordinator_template()` exactly as it shipped from
 /// #684 (raise-hand) through base commit 1dd0b58, frozen as the second legacy
 /// snapshot so a pristine v2 `Context.coordinator.md` on disk keeps being
@@ -380,7 +416,7 @@ fn project_specs() -> [SeededContextTemplateSpec; 2] {
             id: "global",
             filename: crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME,
             label: "AgentsCommander shared context",
-            current_version: 2,
+            current_version: 3,
             current_content: crate::config::session_context::get_default_agent_template,
             is_known_generated: is_known_generated_global_template,
             project_actionable: true,
@@ -435,6 +471,7 @@ fn actionable_project_spec_by_filename(
 fn is_known_generated_global_template(content: &str) -> bool {
     content == crate::config::session_context::get_default_agent_template()
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
+        || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
 }
 
 /// #979: exact recognition of a STANDALONE (app-config) generated global context.
@@ -451,6 +488,7 @@ fn is_known_generated_global_template(content: &str) -> bool {
 fn is_known_generated_standalone_global_template(content: &str) -> bool {
     content == crate::config::session_context::get_default_agent_template()
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
+        || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
         || content == STANDALONE_GLOBAL_CONTEXT_BEFORE_CORE_CONCEPTS
 }
 
@@ -1930,6 +1968,12 @@ mod tests {
         assert!(is_known_generated_global_template(
             GLOBAL_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
         ));
+        assert!(is_known_generated_global_template(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
+        ));
+        assert!(is_known_generated_standalone_global_template(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
+        ));
         assert!(
             !is_known_generated_global_template(
                 COORDINATOR_CONTEXT_TEMPLATE_BEFORE_CROSS_WORKGROUP_RULE
@@ -2237,9 +2281,205 @@ mod tests {
             .expect("read seeded state");
         let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
         assert_eq!(
-            parsed["templates"]["global"]["currentVersion"], 2,
-            "global current_version must be bumped to 2 by the S6 rewrite"
+            parsed["templates"]["global"]["currentVersion"], 3,
+            "global current_version must be bumped to 3 by the #1369 {{AGENT_REPOS}} rename"
         );
+    }
+
+    /// #1369 (C4) AC-4.3: the frozen v2 global snapshot must stay byte-identical
+    /// to what the #1005 S6..8f272a76 builds shipped. Expected values captured
+    /// externally from the raw literal AT base commit 8f272a76, never from this
+    /// const.
+    #[test]
+    fn global_pre_agent_repos_snapshot_is_byte_exact() {
+        assert_eq!(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS.len(),
+            567,
+            "frozen v2 global snapshot must be the 8f272a76 bytes"
+        );
+        assert_eq!(
+            hash_text(GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS),
+            "e5861a9f011967e96e5515f858e1643f7fdf161511ad909fe86ddb4ce1a0cff7",
+            "frozen v2 global snapshot changed; it must stay byte-identical to what shipped"
+        );
+    }
+
+    /// #1369 (C4) AC-4.5-C: population C, the edge case - a pristine v2 on disk
+    /// with NO `global` state entry. Failing-first proof for the v3 rename
+    /// (assert_ne), BOTH recognizers, the version bump, and the auto-upgrade.
+    #[test]
+    fn read_sync_updates_pre_agent_repos_global_template() {
+        assert_ne!(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS,
+            crate::config::session_context::get_default_agent_template(),
+            "the v3 rename must actually change the template or the freeze is pointless"
+        );
+        assert!(
+            is_known_generated_global_template(GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS),
+            "project recognizer must accept the frozen v2 bytes"
+        );
+        assert!(
+            is_known_generated_standalone_global_template(
+                GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
+            ),
+            "standalone (retirement) recognizer must accept the frozen v2 bytes"
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+        std::fs::write(
+            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS,
+        )
+        .expect("write pristine v2 global");
+
+        let published_at = fixed_publication_time();
+        let publications =
+            sync_for_read_at(&ac_root, GLOBAL_CONTEXT_TEMPLATE_FILENAME, published_at);
+        assert_one_publication(
+            &publications,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+
+        let content = std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read global");
+        assert_eq!(
+            content,
+            crate::config::session_context::get_default_agent_template(),
+            "pristine v2 Context.AgentsCommander.md must auto-upgrade"
+        );
+        let state = std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+            .expect("read seeded state");
+        let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 3);
+        assert!(
+            scan_project_context_template_updates(temp.path(), &ac_root)
+                .expect("scan updates")
+                .is_empty(),
+            "an auto-upgraded pristine template must not leave a pending update"
+        );
+    }
+
+    /// #1369 (C4) AC-4.5-B: population B, the dominant one - a pristine v2 on
+    /// disk PLUS a `global` state entry whose `lastSeededSha256` is the v2 hash,
+    /// which is what any project seeded by a normal build carries. Without the
+    /// freeze this yields 1 pending update, i.e. the modal telling the user that
+    /// a file they never touched "appears customized".
+    #[test]
+    fn read_sync_updates_pre_agent_repos_global_template_with_state_entry() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+        std::fs::write(
+            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS,
+        )
+        .expect("write pristine v2 global");
+        let mut state = SeededContextTemplateState::default();
+        state.templates.insert(
+            "global".to_string(),
+            SeededContextTemplateEntry {
+                template_id: "global".to_string(),
+                current_version: 2,
+                last_seeded_sha256: Some(hash_text(GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS)),
+                last_observed_sha256: None,
+                ignored_default_sha256: None,
+                ignored_observed_sha256: None,
+            },
+        );
+        persist_state(&ac_root, &state).expect("persist v2 state entry");
+
+        let published_at = fixed_publication_time();
+        let publications =
+            sync_for_read_at(&ac_root, GLOBAL_CONTEXT_TEMPLATE_FILENAME, published_at);
+        assert_one_publication(
+            &publications,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read global"),
+            crate::config::session_context::get_default_agent_template(),
+            "a pristine v2 with a trusted state entry must auto-upgrade silently"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+                .expect("read seeded state"),
+        )
+        .expect("parse seeded state");
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 3);
+        assert!(
+            scan_project_context_template_updates(temp.path(), &ac_root)
+                .expect("scan updates")
+                .is_empty(),
+            "the dominant population must never be accused of having customized the file"
+        );
+    }
+
+    /// #1369 (C4) AC-4.8a: the whole flow the update modal drives, minus the
+    /// pixels. A v2 template with a trusted state entry and ONE user edit is a
+    /// genuine customization, so it must surface as a pending update carrying the
+    /// v3 digest and version, and overwriting must land the v3 bytes on disk and
+    /// in the state.
+    #[test]
+    fn customized_pre_agent_repos_global_template_scans_and_overwrites_to_v3() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+        let customized = format!("{GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS}\n\nMY OWN NOTE\n");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), &customized)
+            .expect("write customized v2 global");
+        let mut state = SeededContextTemplateState::default();
+        state.templates.insert(
+            "global".to_string(),
+            SeededContextTemplateEntry {
+                template_id: "global".to_string(),
+                current_version: 2,
+                last_seeded_sha256: Some(hash_text(GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS)),
+                last_observed_sha256: None,
+                ignored_default_sha256: None,
+                ignored_observed_sha256: None,
+            },
+        );
+        persist_state(&ac_root, &state).expect("persist v2 state entry");
+
+        let update = scan_project_context_template_updates(temp.path(), &ac_root)
+            .expect("scan updates")
+            .pop()
+            .expect("pending update");
+        let v3_sha = hash_text(crate::config::session_context::get_default_agent_template());
+        assert_eq!(update.filename, GLOBAL_CONTEXT_TEMPLATE_FILENAME);
+        assert_eq!(update.current_default_sha256, v3_sha);
+        assert_eq!(update.current_default_version, 3);
+
+        let result = overwrite_context_template_with_default(
+            &ac_root,
+            &update.filename,
+            &update.current_file_sha256,
+            &update.current_default_sha256,
+        )
+        .expect("overwrite");
+
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read global"),
+            crate::config::session_context::get_default_agent_template()
+        );
+        assert_eq!(
+            std::fs::read_to_string(result.backup_path).expect("read backup"),
+            customized
+        );
+        let parsed: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+                .expect("read seeded state"),
+        )
+        .expect("parse seeded state");
+        assert_eq!(parsed["templates"]["global"]["lastSeededSha256"], v3_sha);
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 3);
     }
 
     #[test]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -202,6 +202,13 @@ pub(crate) const CONTEXT_TOKEN_GLOBAL: &str = "$AGENTSCOMMANDER_CONTEXT";
 /// Special token in context[] that generates workspace repo info from the "repos" field.
 const CONTEXT_TOKEN_REPOS: &str = "$REPOS_WORKSPACE_INFO";
 
+/// #1369 (C4): the pre-rename spelling of `{{AGENT_REPOS}}`. These bytes are on
+/// users' disks: the token was written into every seeded
+/// `.ac/Context.AgentsCommander.md` from #658 through v2, and a customized or
+/// user-ignored template is preserved by `sync_one_template` and never
+/// auto-upgraded. The alias therefore has NO expiry. Never edit.
+const LEGACY_AGENT_REPOS_PLACEHOLDER: &str = "{{WORKSPACE_REPOS}}";
+
 /// Filename for the agent role definition, auto-injected from the identity matrix.
 const ROLE_MD_FILENAME: &str = "Role.md";
 const SKILLS_DIR_NAME: &str = "skills";
@@ -1543,29 +1550,29 @@ pub fn git_ceiling_directories_for_session_root(cwd: &str) -> Option<String> {
 /// sentence name the Root Agent instead of a workgroup replica. `is_root_agent`
 /// is `is_root_agent_path`, which no matrix or WG root satisfies, so every
 /// non-root rendering stays byte-identical to before.
-fn workspace_repos_empty_block(is_root_agent: bool) -> &'static str {
+fn agent_repos_empty_block(is_root_agent: bool) -> &'static str {
     if is_root_agent {
-        "# Workspace Repos\n\nNo repos configured for the Root Agent.\n"
+        "# Agent Repos\n\nNo repos configured for the Root Agent.\n"
     } else {
-        "# Workspace Repos\n\nNo repos configured for this replica.\n"
+        "# Agent Repos\n\nNo repos configured for this replica.\n"
     }
 }
 
-fn workspace_repos_header(is_root_agent: bool) -> &'static str {
+fn agent_repos_header(is_root_agent: bool) -> &'static str {
     if is_root_agent {
-        "# Workspace Repos\n\n\
+        "# Agent Repos\n\n\
          You are the Root Agent. Your code repos are listed below; you MUST change into the \
          appropriate repo directory before any code work (git, file edits, builds).\n\n\
          ## Repos\n\n"
     } else {
-        "# Workspace Repos\n\n\
+        "# Agent Repos\n\n\
          You are working inside a workgroup replica. Your code repos are listed below; you MUST change into the \
          appropriate repo directory before any code work (git, file edits, builds).\n\n\
          ## Repos\n\n"
     }
 }
 
-fn render_workspace_repos_string(
+fn render_agent_repos_string(
     cwd_path: &std::path::Path,
     config: Option<&serde_json::Value>,
     repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
@@ -1576,7 +1583,7 @@ fn render_workspace_repos_string(
     // and the Docker mounts cannot disagree. A local session (repo_mounts = None)
     // keeps today's host-path rendering, byte-for-byte.
     if let Some(resolution) = repo_mounts {
-        return render_workspace_repos_containerized(resolution, is_root_agent);
+        return render_agent_repos_containerized(resolution, is_root_agent);
     }
     let repos = config
         .and_then(|config| config.get("repos"))
@@ -1585,10 +1592,10 @@ fn render_workspace_repos_string(
         .unwrap_or_default();
 
     if repos.is_empty() {
-        return workspace_repos_empty_block(is_root_agent).to_string();
+        return agent_repos_empty_block(is_root_agent).to_string();
     }
 
-    let mut md = String::from(workspace_repos_header(is_root_agent));
+    let mut md = String::from(agent_repos_header(is_root_agent));
 
     for repo_val in &repos {
         let rel = match repo_val.as_str() {
@@ -1622,21 +1629,21 @@ fn render_workspace_repos_string(
     md
 }
 
-/// #935 - render the injected "Workspace Repos" block for a CONTAINER session
+/// #935 - render the injected "Agent Repos" block for a CONTAINER session
 /// from the resolved mounts. Container paths (/repos/repo-X) are shown, never the
 /// Windows host path, which does not resolve inside the container (defect D2). The
 /// branch is still detected host-side from the canonical host path.
-fn render_workspace_repos_containerized(
+fn render_agent_repos_containerized(
     resolution: &crate::pty::container_repos::RepoMountResolution,
     is_root_agent: bool,
 ) -> String {
     use crate::pty::container_repos::RepoOutcome;
 
     if resolution.entries.is_empty() {
-        return workspace_repos_empty_block(is_root_agent).to_string();
+        return agent_repos_empty_block(is_root_agent).to_string();
     }
 
-    let mut md = String::from(workspace_repos_header(is_root_agent));
+    let mut md = String::from(agent_repos_header(is_root_agent));
 
     for entry in &resolution.entries {
         match &entry.outcome {
@@ -2472,7 +2479,7 @@ You are running inside an AgentsCommander session - a terminal session manager c
 
 {{SKILLS_SECTION}}
 
-{{WORKSPACE_REPOS}}
+{{AGENT_REPOS}}
 
 {{CLI_CONTEXT}}
 
@@ -2557,8 +2564,13 @@ fn render_agent_context_template_inner(
     let mut template = template.to_string();
     let signals = TemplateTokenSignals::capture(&template);
     for placeholder in MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS {
-        if template.contains(placeholder) {
-            // Token present: the replace chain below fills it in place.
+        if template.contains(placeholder)
+            || mandatory_placeholder_aliases(placeholder)
+                .iter()
+                .any(|alias| template.contains(alias))
+        {
+            // Token (or a frozen legacy spelling of it) present: the replace
+            // chain below fills it in place.
             continue;
         }
         // #658: a legacy template wrote this section's prose without its coarse
@@ -2588,6 +2600,26 @@ fn render_agent_context_template_inner(
         template.push_str(placeholder);
     }
 
+    let agent_repos = render_agent_repos_string(cwd_path, config, repo_mounts, is_root_agent);
+    // #1369 (C4): a template may carry the current token, the frozen legacy
+    // alias, or - pathologically, if a user pasted both - the two of them.
+    // Exactly one block must be emitted, so the alias renders the block only
+    // when the current token is absent. Computed AFTER the mandatory loop,
+    // because that loop may have appended the current token.
+    //
+    // This guard is LOAD-BEARING and must never be deleted as dead defensive
+    // code: it is the single reason the both-tokens case cannot emit two
+    // blocks. Removing it while keeping the `mandatory_placeholder_aliases`
+    // arm renders TWO `# Agent Repos` blocks with no raw placeholder left, so
+    // `assert_no_raw_template_placeholders` stays green and the only test in
+    // the suite that notices is
+    // `agent_repos_both_tokens_render_exactly_one_block` (AC-2.3).
+    let legacy_repos_replacement = if template.contains("{{AGENT_REPOS}}") {
+        ""
+    } else {
+        agent_repos.as_str()
+    };
+
     template
         .replace("{{AGENT_ROOT}}", agent_root)
         .replace("{{MATRIX_SECTION}}", &rendered.matrix_section)
@@ -2615,10 +2647,8 @@ fn render_agent_context_template_inner(
             "{{INTER_AGENT_MESSAGING}}",
             &render_inter_agent_messaging_block(&rendered),
         )
-        .replace(
-            "{{WORKSPACE_REPOS}}",
-            &render_workspace_repos_string(cwd_path, config, repo_mounts, is_root_agent),
-        )
+        .replace(LEGACY_AGENT_REPOS_PLACEHOLDER, legacy_repos_replacement)
+        .replace("{{AGENT_REPOS}}", &agent_repos)
         .replace(
             "{{DELEGATED_TASK_REPORTING}}",
             DEFAULT_DELEGATED_TASK_REPORTING,
@@ -3007,7 +3037,7 @@ const MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS: &[&str] = &[
     "{{SESSION_CREDENTIALS}}",
     "{{CLI_CONTEXT}}",
     "{{SKILLS_SECTION}}",
-    "{{WORKSPACE_REPOS}}",
+    "{{AGENT_REPOS}}",
     "{{DELEGATED_TASK_REPORTING}}",
 ];
 
@@ -3024,10 +3054,21 @@ fn mandatory_section_heading(placeholder: &str) -> Option<&'static str> {
         "{{SESSION_CREDENTIALS}}" => "## Session credentials",
         "{{CLI_CONTEXT}}" => "## CLI executable",
         "{{SKILLS_SECTION}}" => "## Skills",
-        "{{WORKSPACE_REPOS}}" => "# Workspace Repos",
+        "{{AGENT_REPOS}}" => "# Agent Repos",
         "{{DELEGATED_TASK_REPORTING}}" => "## Delegated Task Reporting",
         _ => return None,
     })
+}
+
+/// #1369 (C4): pre-rename spellings that still SATISFY a mandatory placeholder.
+/// A template on disk carrying only the legacy token must not receive a second,
+/// appended copy of the same block; the replace chain fills the legacy token in
+/// place. Empty for every other placeholder.
+fn mandatory_placeholder_aliases(placeholder: &str) -> &'static [&'static str] {
+    match placeholder {
+        "{{AGENT_REPOS}}" => &[LEGACY_AGENT_REPOS_PLACEHOLDER],
+        _ => &[],
+    }
 }
 
 /// True when `template` already contains the section that `placeholder` would
@@ -3116,7 +3157,7 @@ fn coarse_section_dedup_safe(
         // Coarse dynamic lists: reaching the append branch means the coarse token
         // is absent, so any inline copy is a baked/stale list -> never dedup,
         // always append the current block.
-        "{{SKILLS_SECTION}}" | "{{WORKSPACE_REPOS}}" => false,
+        "{{SKILLS_SECTION}}" | "{{AGENT_REPOS}}" => false,
         _ => false,
     }
 }
@@ -3194,8 +3235,7 @@ fn render_root_runtime_prologue_inner(
     // invariant in `default_context_dynamic_values` debug-asserts exactly that.
     let rendered = default_context_dynamic_values(agent_root, None, skills_section, is_root_agent);
     let write_restrictions = render_write_restrictions_block(agent_root, &rendered);
-    let workspace_repos =
-        render_workspace_repos_string(cwd_path, config, repo_mounts, is_root_agent);
+    let agent_repos = render_agent_repos_string(cwd_path, config, repo_mounts, is_root_agent);
     let inter_agent_messaging = render_inter_agent_messaging_block(&rendered);
 
     // Nine blocks (#979 G4): the heading and Core Concepts reproduce the built-in
@@ -3209,7 +3249,7 @@ fn render_root_runtime_prologue_inner(
         &write_restrictions,
         DEFAULT_DELEGATED_TASK_REPORTING,
         skills_section,
-        &workspace_repos,
+        &agent_repos,
         DEFAULT_CLI_CONTEXT,
         DEFAULT_SESSION_CREDENTIALS,
         &inter_agent_messaging,
@@ -4004,7 +4044,14 @@ fn looks_like_generated_legacy_default_context(normalized: &str) -> bool {
     if normalized.contains("{{") || normalized.contains("}}") {
         return false;
     }
-    if normalized.contains("## Core Concepts") || normalized.contains("# Workspace Repos") {
+    // #1369 (C4): both spellings. `# Workspace Repos` is frozen: it is what
+    // contexts rendered by v1/v2 builds carry on disk. `# Agent Repos` is what
+    // this build renders. Neither is in `is_known_legacy_default_heading`, so
+    // this guard is a fast path, not the only rejection - AC-3 pins that.
+    if normalized.contains("## Core Concepts")
+        || normalized.contains("# Workspace Repos")
+        || normalized.contains("# Agent Repos")
+    {
         return false;
     }
 
@@ -4250,7 +4297,7 @@ mod tests {
             1
         );
         assert_eq!(count_context_occurrences(out, "## Skills"), 1);
-        assert_eq!(count_context_occurrences(out, "# Workspace Repos"), 1);
+        assert_eq!(count_context_occurrences(out, "# Agent Repos"), 1);
         assert_eq!(count_context_occurrences(out, "## CLI executable"), 1);
         assert_eq!(count_context_occurrences(out, "## Session credentials"), 1);
         assert_eq!(
@@ -4264,7 +4311,7 @@ mod tests {
     /// Compact mirror of the real stale-hybrid `Context.AgentsCommander.md`: the
     /// governance sections written INLINE with fine-grained tokens, but WITHOUT
     /// the coarse `{{...}}` tokens the current renderer expects, and without an
-    /// inline `# Workspace Repos` section. The Golden Rule heading carries a
+    /// inline `# Agent Repos` section. The Golden Rule heading carries a
     /// trailing descriptor (exercises the prefix match) and the Self-discovery
     /// prose carries the realistic backtick reference to `## Inter-Agent
     /// Messaging` (exercises line-anchoring over `contains`).
@@ -4384,9 +4431,9 @@ Run list-peers-lean.
         );
         // The fine-grained tokens inside the inline copy are still filled.
         assert_no_raw_template_placeholders(&out);
-        // {{WORKSPACE_REPOS}} had neither token nor inline section, so the safety
+        // {{AGENT_REPOS}} had neither token nor inline section, so the safety
         // net must still append it exactly once.
-        assert_eq!(count_section_headings(&out, "# Workspace Repos"), 1);
+        assert_eq!(count_section_headings(&out, "# Agent Repos"), 1);
     }
 
     #[test]
@@ -4529,8 +4576,8 @@ For peer discovery, the sections below (`## Inter-Agent Messaging` and `### List
                 ("{{CLI_CONTEXT}}", DEFAULT_CLI_CONTEXT.to_string()),
                 ("{{SKILLS_SECTION}}", no_skill_section()),
                 (
-                    "{{WORKSPACE_REPOS}}",
-                    render_workspace_repos_string(Path::new(agent_root), None, None, is_root),
+                    "{{AGENT_REPOS}}",
+                    render_agent_repos_string(Path::new(agent_root), None, None, is_root),
                 ),
                 (
                     "{{DELEGATED_TASK_REPORTING}}",
@@ -5400,7 +5447,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             "## GOLDEN RULE",
             "## Delegated Task Reporting",
             "## Skills",
-            "# Workspace Repos",
+            "# Agent Repos",
             "## CLI executable",
             "## Session credentials",
             "## Inter-Agent Messaging",
@@ -5458,20 +5505,20 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         std::fs::create_dir_all(&repo).expect("create repo");
         let config = serde_json::json!({ "repos": ["repo-demo"] });
 
-        let non_root = render_workspace_repos_string(temp.path(), Some(&config), None, false);
+        let non_root = render_agent_repos_string(temp.path(), Some(&config), None, false);
         assert!(non_root.contains("You are working inside a workgroup replica."));
         assert!(!non_root.contains("You are the Root Agent."));
         assert_eq!(
-            render_workspace_repos_string(temp.path(), None, None, false),
-            "# Workspace Repos\n\nNo repos configured for this replica.\n"
+            render_agent_repos_string(temp.path(), None, None, false),
+            "# Agent Repos\n\nNo repos configured for this replica.\n"
         );
 
-        let as_root = render_workspace_repos_string(temp.path(), Some(&config), None, true);
+        let as_root = render_agent_repos_string(temp.path(), Some(&config), None, true);
         assert!(as_root.contains("You are the Root Agent."));
         assert!(!as_root.contains("You are working inside a workgroup replica."));
         assert_eq!(
-            render_workspace_repos_string(temp.path(), None, None, true),
-            "# Workspace Repos\n\nNo repos configured for the Root Agent.\n"
+            render_agent_repos_string(temp.path(), None, None, true),
+            "# Agent Repos\n\nNo repos configured for the Root Agent.\n"
         );
     }
 
@@ -5936,7 +5983,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             assert!(out.contains("## Inter-Agent Messaging"));
             assert!(out.contains("## CLI executable"));
             assert!(out.contains("## Session credentials"));
-            assert!(out.contains("# Workspace Repos"));
+            assert!(out.contains("# Agent Repos"));
             assert_no_raw_template_placeholders(&out);
         }
     }
@@ -6080,7 +6127,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(content.contains("## GOLDEN RULE"));
         assert!(content.contains("## Delegated Task Reporting"));
         assert!(content.contains("## Skills"));
-        assert!(content.contains("# Workspace Repos"));
+        assert!(content.contains("# Agent Repos"));
         assert!(content.contains("## CLI executable"));
         assert!(content.contains("## Session credentials"));
         assert!(content.contains("## Inter-Agent Messaging"));
@@ -7190,7 +7237,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
-    fn workspace_repos_placeholder_uses_repaired_replica_config() {
+    fn agent_repos_placeholder_via_legacy_token_uses_repaired_replica_config() {
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
@@ -7225,10 +7272,14 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(content.contains("repo-Example"));
         assert_contains_canonical_path(&content, &repo_dir);
         assert!(!content.contains("No repos configured"));
+        assert!(
+            content.starts_with("# Agent Repos"),
+            "legacy token was appended instead of rendered in place"
+        );
     }
 
     #[test]
-    fn workspace_repos_placeholder_uses_missing_context_repaired_to_global() {
+    fn agent_repos_placeholder_uses_missing_context_repaired_to_global() {
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
@@ -7241,7 +7292,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         std::fs::create_dir_all(&repo_dir).expect("create repo dir");
         std::fs::write(
             ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            "{{WORKSPACE_REPOS}}",
+            "{{AGENT_REPOS}}",
         )
         .expect("write repos-only template");
         std::fs::write(
@@ -7273,7 +7324,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
     }
 
     #[test]
-    fn workspace_repos_placeholder_uses_empty_context_repaired_to_global() {
+    fn agent_repos_placeholder_uses_empty_context_repaired_to_global() {
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
@@ -7286,7 +7337,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         std::fs::create_dir_all(&repo_dir).expect("create repo dir");
         std::fs::write(
             ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            "{{WORKSPACE_REPOS}}",
+            "{{AGENT_REPOS}}",
         )
         .expect("write repos-only template");
         std::fs::write(
@@ -7315,6 +7366,122 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             repaired["context"],
             serde_json::json!(["$AGENTSCOMMANDER_CONTEXT"])
         );
+    }
+
+    /// #1369 (C4) AC-2: render `template` as the whole global template of a
+    /// replica that has one repo, end to end through
+    /// `materialize_agent_context_file`, and return the materialized bytes. Same
+    /// shape as the three legacy-token tests above; kept local to the alias
+    /// cases so those tests stay untouched.
+    fn render_repos_only_template(template: &str) -> String {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        let matrix_root = ac_root.join("_agent_dev-rust");
+        let replica_root = ac_root
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        let repo_dir = ac_root.join("wg-19-dev-team").join("repo-Example");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        std::fs::create_dir_all(&repo_dir).expect("create repo dir");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), template)
+            .expect("write repos-only template");
+        std::fs::write(
+            replica_root.join("config.json"),
+            r#"{"identity":"../../_agent_dev-rust","context":["$AGENTSCOMMANDER_CONTEXT"],"repos":["../repo-Example"]}"#,
+        )
+        .expect("write replica config");
+
+        let materialized = materialize_agent_context_file(
+            &path_string(&replica_root),
+            ManagedContextTarget::Codex,
+            false,
+        )
+        .expect("materialize context")
+        .expect("context path");
+        std::fs::read_to_string(materialized).expect("read materialized context")
+    }
+
+    /// AC-2 case 2.1: the current token renders exactly one block.
+    #[test]
+    fn agent_repos_current_token_renders_exactly_one_block() {
+        let content = render_repos_only_template("{{AGENT_REPOS}}");
+
+        assert_eq!(count_section_headings(&content, "# Agent Repos"), 1);
+        assert_no_raw_template_placeholders(&content);
+        assert!(content.contains("## Repos"));
+        assert!(content.contains("repo-Example"));
+    }
+
+    /// AC-2 case 2.2 (the issue's AC#2 verbatim): a template carrying ONLY the
+    /// pre-#1369 token renders exactly one block, and the legacy token itself
+    /// does not survive into the prompt.
+    #[test]
+    fn agent_repos_legacy_token_renders_exactly_one_block() {
+        let content = render_repos_only_template("{{WORKSPACE_REPOS}}");
+
+        assert_eq!(count_section_headings(&content, "# Agent Repos"), 1);
+        assert_no_raw_template_placeholders(&content);
+        assert!(content.contains("## Repos"));
+        assert!(content.contains("repo-Example"));
+        assert!(!content.contains("{{WORKSPACE_REPOS}}"));
+    }
+
+    /// AC-2 case 2.3: both tokens in one template still emit exactly one block.
+    /// This is the ONLY detector of a deleted `legacy_repos_replacement` guard:
+    /// without it two `# Agent Repos` blocks are emitted with no raw
+    /// placeholder left, so `assert_no_raw_template_placeholders` stays green.
+    #[test]
+    fn agent_repos_both_tokens_render_exactly_one_block() {
+        let content = render_repos_only_template("{{AGENT_REPOS}}\n\n{{WORKSPACE_REPOS}}");
+
+        assert_eq!(count_section_headings(&content, "# Agent Repos"), 1);
+        assert_no_raw_template_placeholders(&content);
+    }
+
+    /// #1369 (C4) AC-3: the #664 heuristic's verdict is invariant across the
+    /// rename. Neither spelling is in the closed `is_known_legacy_default_heading`
+    /// list, so a rendered context carrying either heading is rejected whether or
+    /// not the fast-path guard in `looks_like_generated_legacy_default_context`
+    /// names it.
+    #[test]
+    fn legacy_default_heuristic_rejects_both_repos_headings() {
+        assert!(!is_known_legacy_default_heading("# Workspace Repos"));
+        assert!(!is_known_legacy_default_heading("# Agent Repos"));
+
+        // The reconstruction re-derives the skills section from the matrix root
+        // it extracts out of the content, so the fixture must be built with the
+        // index of a REAL root, exactly as the #664 healing tests do.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        let matrix_root = ac_root.join("_agent_dev-rust");
+        let replica_root = ac_root
+            .join("wg-19-dev-team")
+            .join("__agent_dev-rust");
+        std::fs::create_dir_all(&matrix_root).expect("create matrix root");
+        std::fs::create_dir_all(&replica_root).expect("create replica root");
+        let skills_section =
+            render_skills_section(&discover_skill_index(Some(&path_string(&matrix_root))));
+        let legacy = legacy_rendered_default_context_for_compat(
+            &path_string(&replica_root),
+            Some(&path_string(&matrix_root)),
+            &skills_section,
+        );
+        // Positive control: without either heading this fixture IS recognized,
+        // so the two assertions below cannot pass vacuously.
+        assert!(looks_like_generated_legacy_default_context(
+            &normalize_context_for_compat(&legacy)
+        ));
+
+        for heading in ["# Workspace Repos", "# Agent Repos"] {
+            let with_heading = format!("{legacy}\n\n{heading}\n\nNo repos configured.\n");
+            assert!(
+                !looks_like_generated_legacy_default_context(&normalize_context_for_compat(
+                    &with_heading
+                )),
+                "a rendered context carrying {heading} must never be treated as a stale generated default"
+            );
+        }
     }
 
     #[test]
@@ -7346,12 +7513,12 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         )
         .expect("parse repaired config");
 
-        assert!(content.contains("# Workspace Repos"));
+        assert!(content.contains("# Agent Repos"));
         assert_eq!(
             repaired["context"],
             serde_json::json!(["$AGENTSCOMMANDER_CONTEXT"])
         );
-        assert_eq!(content.matches("# Workspace Repos").count(), 1);
+        assert_eq!(content.matches("# Agent Repos").count(), 1);
     }
 
     #[test]
@@ -8083,7 +8250,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         assert!(content.contains("## GOLDEN RULE"));
         assert!(content.contains("## Delegated Task Reporting"));
         assert!(content.contains("## Skills"));
-        assert!(content.contains("# Workspace Repos"));
+        assert!(content.contains("# Agent Repos"));
         assert!(content.contains("## CLI executable"));
         assert!(content.contains("## Session credentials"));
         assert!(content.contains("## Inter-Agent Messaging"));
@@ -9677,8 +9844,8 @@ mod token_accounting {
         );
         let write_restrictions = super::render_write_restrictions_block(FAKE_REPLICA_ROOT, &values);
         let messaging = super::render_inter_agent_messaging_block(&values);
-        let workspace_repos =
-            super::render_workspace_repos_string(Path::new(FAKE_REPLICA_ROOT), None, None, false);
+        let agent_repos =
+            super::render_agent_repos_string(Path::new(FAKE_REPLICA_ROOT), None, None, false);
 
         println!();
         println!("## #1005 token accounting (chars, chars/4)");
@@ -9703,18 +9870,18 @@ mod token_accounting {
             super::DEFAULT_DELEGATED_TASK_REPORTING.len(),
         );
         print_row(
-            "block: workspace repos header (A6, replica variant)",
-            super::workspace_repos_header(false).len(),
+            "block: agent repos header (A6, replica variant)",
+            super::agent_repos_header(false).len(),
         );
         print_row(
-            "block: workspace repos header (A6, root variant)",
-            super::workspace_repos_header(true).len(),
+            "block: agent repos header (A6, root variant)",
+            super::agent_repos_header(true).len(),
         );
         print_row(
             "block: skills section (A5, synthetic 2 skills)",
             skills.len(),
         );
-        print_row("block: workspace repos (A6, empty)", workspace_repos.len());
+        print_row("block: agent repos (A6, empty)", agent_repos.len());
         print_row(
             "block: self-maintenance (A8)",
             super::SELF_MAINTENANCE_AUTO_SECTION.len(),

--- a/src-tauri/src/pty/container_repos.rs
+++ b/src-tauri/src/pty/container_repos.rs
@@ -108,7 +108,7 @@ fn read_repos_array(replica_root: &Path) -> Vec<String> {
 /// which is already per-agent: plan Sec 2) into container mounts.
 ///
 /// Entries are resolved as `canonicalize(replica_root.join(entry))` - the SAME
-/// base and join `render_workspace_repos_string` uses (`session_context.rs:1275`).
+/// base and join `render_agent_repos_string` uses (in `config::session_context`).
 /// Do NOT change the base: a different one reintroduces D2 (the mount and the
 /// injected context disagreeing).
 ///


### PR DESCRIPTION
Closes #1369.

Item C4 of the "workspace" rename epic (#1366). This is the occurrence with the widest audience: **every agent reads it in its prompt, in every session**.

| Before | After |
| --- | --- |
| `{{WORKSPACE_REPOS}}` | `{{AGENT_REPOS}}` |
| `# Workspace Repos` | `# Agent Repos` |
| `workspace_repos_header()` | `agent_repos_header()` |
| `DEPRECATED_REPOS_WORKSPACE_CONTEXT` | `DEPRECATED_REPOS_INFO_CONTEXT` |

## Why the rename is the small part

The token **lives on disk in real users' projects**, feeds a heuristic, and is pinned by byte-exact snapshots. The risk here is not renaming too much — it is breaking existing installs silently. Two failure modes that compile, pass clippy, and no census can see:

1. **Renaming without an alias.** A project whose `.ac/Context.AgentsCommander.md` still holds `{{WORKSPACE_REPOS}}` would render an unexpanded literal and fire the mandatory-placeholder append. So the old token is aliased, **permanently** — there is no release in which a preserved customized template stops existing.
2. **Changing the default's bytes without freezing the old ones.** Every pristine v2 template on disk would stop being recognized as product-generated. The default is frozen as `GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS` (567 bytes, `e5861a9f…`), registered in **both** recognizers, and `current_version` bumped 2 → 3.

## The two silent failure modes have disjoint detectors

This is the part worth reading. The change has exactly two ways to break invisibly, and each has **one** detector — a different one:

- **Alias arm removed** → the block renders *appended at the end* instead of in place. Caught **only** by a position assertion.
- **Replacement guard removed** → **two** `# Agent Repos` blocks, with no raw placeholder left, so `assert_no_raw_template_placeholders` never sees it. Caught **only** by the both-tokens test.

The mutation probe is therefore two mutations with two targets. Verified against the full suite: each one turns **exactly one test of 3527 red**, and they are different tests. The guard is load-bearing and now says so in the code, so a future refactor doesn't delete it as dead defence.

## What the issue got wrong, found by running it

- `$REPOS_WORKSPACE_INFO` is **not** renamed. Measured: the value is inert, the product never writes it, and its four consumers exist only to discard it. Adding `$REPOS_AGENT_INFO` would create a second deprecated token to support forever in exchange for nothing observable. The Rust identifier is renamed; the value stays.
- The claimed "0 collisions" is 1 case-insensitively (a doc comment), so every oracle here is case-sensitive.
- Risk O3 does not materialize: the heuristic's guard turned out to be redundant against a closed heading list that contains neither spelling. Measured across twelve combinations; the verdict is invariant. The guard is still extended to both spellings, by intent rather than by behaviour, and pinned by a test.
- The "duplicate block" described in the issue is not what happens without an alias — that produces an unexpanded literal *plus* one appended block. The real duplicate has a different trigger, which is the guard above.

## Verification

All ten acceptance criteria ran against the base before being written. Ten criteria in this epic turned out to be impossible as written, and **all ten were found by running or reading them, never by reasoning about them** — including one in this item that asked a tester to read a sha256 the modal does not render.

- **Digests**: the v2 body has **five independent derivations by three methods**, and a full-history walk over 314 commits confirmed that **exactly one byte-string has ever coexisted with `current_version == 2`** — so this freezes one predecessor, not N.
- **Both populations** of the update path are covered: with and without a state entry. The one *with* is the dominant one, and without the freeze it would show the user a modal claiming their untouched file "appears customized".
- **The update flow was exercised end to end** against a build of this branch: modal contents verified literally, then the digest, the `.bak`, and the state entry verified **on disk**.
- **Census**: `workspace_repos` 27 → 0, `# Agent Repos` 0 → 26, and the deferred spellings invariant. The −48 total is reconciled *against the diff*, line by line, not by subtracting totals.
- Full CI gates green on the merged tree; the dependency-cycle arc record regenerates byte-identical.

## Notes for review

- The test count is **3529 / 3506** here. Of that, +8 is this branch and **+13 comes from `settings.rs` on main**; a tree without a built `dist/` reads 2 lower, since two tests sit behind `has_embedded_dist`.
- `docs/agent-matrix-conventions.md` is the one file this branch and main both touched. The merge is the exact union — verified in both directions, with the four `.rs` files byte-identical by blob SHA to the reviewed commit.

## Follow-ups filed from findings made here

#1395 (that same doc contradicts itself on removing mandatory tokens), #1396 (one historical template body is recognized by nobody and silently never updates), #1397 (the update is recorded before the user decides, so closing the modal drops it silently).

Out of scope by decision: two Agent Matrix sites outside this repo still name the old heading and are coordinated separately; `docs/features/container-coding-agents.md:71` belongs to #1389, which owns both its obsolete claim and its stale term.
