### PR TITLE
feat: add statusline branch to Claude context suggestion (refs #1434)

### DIFF
--- a/src/shared/profile-utils.ts
+++ b/src/shared/profile-utils.ts
@@ -406,7 +406,7 @@ export function defaultInstructionsFilename(command: string): string {
   return "AGENTS.md";
 }
 
-export const CLAUDE_CONTEXT_REGEX = String.raw`^ {2}Context [░█]+ (\d{1,3})%`;
+export const CLAUDE_CONTEXT_REGEX = String.raw`(?:\[[^\]]+\] ctx|^ {2}Context [░█]+) (\d{1,3})%`;
 export const CODEX_CONTEXT_REGEX = String.raw`^ {2}(?:.*· )?Context (\d{1,3})% used`;
 export const PI_CONTEXT_REGEX = String.raw`^(?:.*? )?(\d{1,3})\.\d%/`;
 


### PR DESCRIPTION
Adds a statusline branch to `CLAUDE_CONTEXT_REGEX` so the suggested Claude Code context pattern reads the percentage from both the native block-bar row (`  Context ░█… N%`, branch kept byte-identical) and a custom statusline row (`[model · effort] ctx N%`). Single shared capture group 1 with trailing `%` preserves the scraper's fail-closed truncation behavior.

Closes #1434

## Verification (Express path)

- Before-literal verified byte-for-byte (`od -c`) prior to the edit; post-edit bytes confirmed (block glyphs untouched, LF ending).
- `npx tsc --noEmit`: exit 0.
- `npx vitest run src/shared/profile-utils.test.ts`: 40/40 passed, assertions unchanged.
- Diff is exactly one line in one file; no tests or docs required changes.
- Combined regex validated empirically by dev-rust against `regex` 1.12.3 with the real scraper fixtures (bottom-up row scan, leftmost match, `u8 <= 100`, truncation fail-closed) plus statusline rows and near-misses (`5h 7%`, `7d 24%`, `ctx N/A`).
- Shipper build: N/A - Express path (non-visual change).