### PR TITLE
docs: record the workspace strings that stay (refs #1371, #1372, #1373)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -162,6 +162,14 @@ A root-level pattern AC matches against agent terminal output, reaching every co
 
 *Deprecated alias.* See **Project AC Root**.
 
+## Workspace (kept exceptions)
+
+Three "workspace" spellings survive the rename to **Project AC Root** on purpose. Each belongs to someone else's vocabulary (the Rust toolchain, the Codex CLI, the container ecosystem) rather than to AC's product vocabulary, so renaming one would break a build, a flag, or an image instead of clarifying anything. **Do not rename them.** If an audit turns them up, the migration is not half-finished: these are the documented exceptions (epic #1366).
+
+- **`[workspace]` and `--workspace`, Cargo's vocabulary** (#1372). The root `Cargo.toml` declares the Rust workspace with this key, and `--workspace` is how a Cargo command (`cargo clippy --workspace`, for example) targets every member crate. Cargo has no alternative spelling; changing the key breaks the build.
+- **`workspace-write`, the Codex CLI's vocabulary** (#1373). A value of Codex's `--sandbox` flag, as in `codex --sandbox workspace-write`. AC only passes it through: it arrives in a coding agent's profile command, and AC's own UI shows it just as an example placeholder in Settings. Renaming the value breaks the flag.
+- **`/workspace`, the container ecosystem's convention** (#1371). The path inside AC's Docker container where the replica root is bind-mounted, defined as `DEFAULT_CONTAINER_WORKDIR` in `src-tauri/src/pty/container_runtime.rs`. Docker does not impose the path, but devcontainers, Cloud Build and GitPod all mount the checkout at `/workspace`, and tools running inside a container expect to find it there. Kept by user decision of 2026-08-19.
+
 ## Workgroup
 
 A team's activation for a specific task. Lives at `.ac/wg-<N>-<team>/` with replicas of every team member.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -164,11 +164,11 @@ A root-level pattern AC matches against agent terminal output, reaching every co
 
 ## Workspace (kept exceptions)
 
-Three "workspace" spellings survive the rename to **Project AC Root** on purpose. Each belongs to someone else's vocabulary (the Rust toolchain, the Codex CLI, the container ecosystem) rather than to AC's product vocabulary, so renaming one would break a build, a flag, or an image instead of clarifying anything. **Do not rename them.** If an audit turns them up, the migration is not half-finished: these are the documented exceptions (epic #1366).
+Three "workspace" spellings survive the rename to **Project AC Root** on purpose. Each belongs to someone else's vocabulary (the Rust toolchain, the Codex CLI, the container ecosystem) rather than to AC's product vocabulary, so renaming one would break a build, a flag, or an image instead of clarifying anything. **Do not rename these three.** Any other `workspace` occurrence is not a fourth exception: it is legacy pending rename under epic #1366, not vocabulary to imitate.
 
-- **`[workspace]` and `--workspace`, Cargo's vocabulary** (#1372). The root `Cargo.toml` declares the Rust workspace with this key, and `--workspace` is how a Cargo command (`cargo clippy --workspace`, for example) targets every member crate. Cargo has no alternative spelling; changing the key breaks the build.
+- **`[workspace]` and `--workspace`, Cargo's vocabulary** (#1372). The root `Cargo.toml` declares the Rust workspace with this key, and `--workspace` is how a Cargo command targets every member crate: AC's CI gates every pull request on `cargo clippy --workspace --all-targets`. Cargo has no alternative spelling; changing the key breaks the build.
 - **`workspace-write`, the Codex CLI's vocabulary** (#1373). A value of Codex's `--sandbox` flag, as in `codex --sandbox workspace-write`. AC only passes it through: it arrives in a coding agent's profile command, and AC's own UI shows it just as an example placeholder in Settings. Renaming the value breaks the flag.
-- **`/workspace`, the container ecosystem's convention** (#1371). The path inside AC's Docker container where the replica root is bind-mounted, defined as `DEFAULT_CONTAINER_WORKDIR` in `src-tauri/src/pty/container_runtime.rs`. Docker does not impose the path, but devcontainers, Cloud Build and GitPod all mount the checkout at `/workspace`, and tools running inside a container expect to find it there. Kept by user decision of 2026-08-19.
+- **`/workspace`, the container ecosystem's convention** (#1371). The path inside AC's Docker container where the replica root is bind-mounted, defined as `DEFAULT_CONTAINER_WORKDIR` in `src-tauri/src/pty/container_runtime.rs`. Docker does not impose the path, but Cloud Build and GitPod both mount the checkout at `/workspace`, and tools running inside a container expect to find it there. Kept by user decision of 2026-08-19.
 
 ## Workgroup
 


### PR DESCRIPTION
Records, in one `docs/glossary.md` entry (`## Workspace (kept exceptions)`), the three "workspace" spellings that deliberately survive epic #1366 and must never be renamed:

- Cargo `[workspace]` / `--workspace` — Rust toolchain vocabulary (#1372).
- Codex `--sandbox workspace-write` — third-party CLI value AC passes through verbatim (#1373).
- `/workspace` container mount path — container-ecosystem convention, kept by user decision of 2026-08-19 (#1371).

Docs-only: two commits, `docs/glossary.md` is the single file touched.

**Review trail:** authored by technical-writer (`bde2b26a`, reworked in `a0cb1e80`); cold-start verification by dev-rust. Round 1: FAIL — the entry claimed the migration was not half-finished, contradicted by the pending #1368 delivery-2 surface (O1/O5/O6/O7, 437 AC-owned lines), plus a devcontainers imprecision. Round 2 after rework: PASS — the entry now labels any other occurrence "legacy pending rename under epic #1366", devcontainers dropped, and the new CI claim (`cargo clippy --workspace --all-targets` gates every PR) verified against `pr-regression-gates.yml` and the active ruleset. Non-blocking nit N1 (narrowing "any other occurrence" to AC's own source) noted and accepted.

Epic #1366 stays open: #1368's delivery 2 (O1/O5/O6/O7) is still pending and has no tracking issue yet.

Closes #1371
Closes #1372
Closes #1373
