### PR TITLE
fix: close-session waits once for the daemon response (refs #1440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This file follows a lightweight [Keep a Changelog](https://keepachangelog.com/en
 
 - **The context-alert message injected into a coordinator's terminal is now operator-editable**, and its visible prefix changes from `[AgentsCommander context alert]` to `[AC context alert]`. The wording lives in `injected-messages.toml`, next to the executable in the config directory, alongside a read-only `injected-messages.default.toml` reference. Markdown is preserved byte for byte, the placeholders are `%MEMBER%`, `%WORKGROUP%`, `%THRESHOLDS%` and the optional `%OBSERVED%`, and an entry you have edited is never overwritten by an upgrade. `injected-messages reseed --id <id>` (or `--all`) restores a shipped default, taking a timestamped backup first. ([#1157](https://github.com/mblua/AgentsCommander/issues/1157))
 
+### Fixed
+
+- **`close-session` no longer reports a false timeout on graceful closes.** The CLI's delivery-confirmation wait was hardcoded to 30s while a graceful close takes ~30s per session, so 97.9% of graceful closes exited 1 as "delivery confirmation timeout" despite succeeding moments later. The CLI now runs a single wait for the daemon's response (still fast-failing on rejection), budgets `--timeout` + 60 seconds (default 90s, matching `send --confirm-timeout`), and when the wait expires it exits 2 ("outcome unknown": the close keeps running server-side) instead of a fabricated exit 1. Timeout messages now print both UUIDs with correct labels (`request` vs `message`). ([#1440](https://github.com/mblua/AgentsCommander/issues/1440))
+
 ## 0.20.0 – 2026-07-23
 
 Large release covering everything merged since `0.10.0` (616 commits across ~110 PRs). Headlines: **containerized coding agents** (Docker / "Camino 2" backend), an **in-daemon Control Plane API**, a **coding-agent catalog overhaul** (Hermes / Cursor CLI / Pi), **live context-usage visibility** (CTX badges + alerts), **workgroup UI Groups** (Telegram-style sidebar rail), a **single self-contained web-server executable**, plus a deep PTY/terminal reliability and settings-persistence hardening pass.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,7 @@ All subcommands return:
 
 - `0` — success
 - `1` — error (auth, IO, routing, validation)
-- `2` — special: outcome unknown. Used by `close-session` when delivery succeeded but no response landed in the poll window, by `self-handoff-and-clear` / `self-handoff-and-switch` when the daemon never acknowledged the request, by `raise-hand` when the response is malformed or missing within the timeout, and by `purge-wg` when the response is unparseable.
+- `2` — special: outcome unknown. Used by `close-session` when no response landed in the wait window (delivery confirmed or not), by `self-handoff-and-clear` / `self-handoff-and-switch` when the daemon never acknowledged the request, by `raise-hand` when the response is malformed or missing within the timeout, and by `purge-wg` when the response is unparseable.
 - `3` — `purge-wg` only: gate rejected (one or more peers are busy)
 - `4` — `purge-wg` only: a destroy failed after the gate passed
 
@@ -688,13 +688,13 @@ Default behaviour: graceful shutdown — AC injects the coding agent's exit comm
 | `--token` | Yes | Session token. |
 | `--root` | Yes | Coordinator's root directory. |
 | `--to` | Yes | Target agent name. |
-| `--timeout` | No | Seconds to wait for graceful exit before force-kill. |
+| `--timeout` | No | Seconds to wait for graceful exit before force-kill, per session (default 30). The CLI waits this plus 60 seconds for the daemon's response; the timeout does not cancel the operation. |
 
 Exit codes:
 
 - `0` — known status (`closed`, `already_closed`, `no_match`, `restore_in_progress`).
-- `1` — auth or IO failure.
-- `2` — outcome unknown (delivered, no response in the poll window).
+- `1` — auth, IO, or rejection failure.
+- `2` — outcome unknown (no response within `--timeout` + 60 seconds; the close keeps running server-side).
 
 Only coordinators of the target's team can close. The master/root token bypasses the check.
 

--- a/src-tauri/src/cli/close_session.rs
+++ b/src-tauri/src/cli/close_session.rs
@@ -307,8 +307,18 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
 
     loop {
         if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
+            // §1440 F1: the daemon writes this file with std::fs::write (no
+            // atomic rename) and, in the common case, TWICE (mailbox.rs
+            // handle_close_session, §224 A.6 dual-write: the outbox-derived
+            // write and the resolved-sender write land on the same file,
+            // with an .await in between), so a poll tick can observe it
+            // empty or truncated. An artifact that does not parse yet is
+            // NOT a terminal verdict: keep polling; the next tick reads the
+            // completed file. A genuinely malformed response (daemon bug)
+            // or a persistent read failure therefore reports exit 2 at the
+            // deadline instead of an immediate 2 (or a fabricated 1).
+            if let Ok(content) = std::fs::read_to_string(&response_path) {
+                if serde_json::from_str::<serde_json::Value>(&content).is_ok() {
                     crate::cli_println!("{}", content);
                     // §224 G7 — print a human-readable prose line for no_match
                     // / already_closed / restore_in_progress so AC #2's
@@ -316,13 +326,10 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
                     // even when callers don't parse the JSON.
                     print_status_prose(&content);
                     // §224 G2 — validate the daemon's contract: known status
-                    // → exit 0; unparseable / missing / unknown status → exit 2.
+                    // → exit 0; missing / unknown status → exit 2. (Content
+                    // that does not parse never reaches this call: the §1440
+                    // F1 gate above keeps polling instead.)
                     return interpret_close_response_exit_code(&content);
-                }
-                Err(e) => {
-                    log::error!("failed to read response: {}", e);
-                    eprintln!("Error: failed to read response: {}", e);
-                    return 1;
                 }
             }
         }

--- a/src-tauri/src/cli/close_session.rs
+++ b/src-tauri/src/cli/close_session.rs
@@ -7,6 +7,44 @@ use crate::phone::types::OutboxMessage;
 
 use super::send::agent_name_from_root;
 
+/// §1440: colchon fijo de la espera de response, sumado a `--timeout`.
+/// Cubre pickup (p90 10.1s observado), el probe de restore (5s), el
+/// overshoot del handler sobre `--timeout` (max +3.5s observado) y la
+/// escritura del response. Default total: 30 + 60 = 90s, igual que el
+/// default de `send --confirm-timeout`. No escala con la cantidad de
+/// sesiones del target: el CLI no la conoce (el daemon resuelve el target
+/// recien en handle_close_session y cierra secuencialmente, ~`--timeout`
+/// por sesion); expirar reporta "outcome unknown" (exit 2), no fallo.
+const RESPONSE_WAIT_OVERHEAD_SECS: u64 = 60;
+
+fn response_wait_budget(timeout_secs: u32) -> std::time::Duration {
+    std::time::Duration::from_secs(u64::from(timeout_secs) + RESPONSE_WAIT_OVERHEAD_SECS)
+}
+
+/// §1440: mensaje de expiracion de la espera unica. `delivered_seen` decide
+/// el sabor: el daemon termino y el response no aparecio donde el CLI
+/// pollea, o no hay todavia rastro terminal del mensaje. Ambos ids van
+/// etiquetados con su artefacto: `request` = responses/<request_id>.json,
+/// `message` = outbox|delivered/<msg_id>.json y las lineas de app.log.
+fn format_no_response_error(
+    budget_secs: u64,
+    request_id: &str,
+    msg_id: &str,
+    delivered_seen: bool,
+) -> String {
+    if delivered_seen {
+        format!(
+            "close-session delivered but daemon did not write a response within {}s; outcome unknown (request {}, message {})",
+            budget_secs, request_id, msg_id
+        )
+    } else {
+        format!(
+            "close-session: no confirmation within {}s; outcome unknown (request {}, message {} still queued or in progress). The daemon may still be closing sessions in the background: closing several sessions takes about sessions x --timeout seconds and this wait budgets one. Verify with list-peers-lean before retrying.",
+            budget_secs, request_id, msg_id
+        )
+    }
+}
+
 /// Pure: decide CLI exit code from the daemon's response body.
 /// §224 G2 — exit codes:
 ///   0  — known status (closed | already_closed | no_match | restore_in_progress).
@@ -16,14 +54,15 @@ use super::send::agent_name_from_root;
 ///        from "daemon refused".
 ///
 /// Note: this contract applies only when the daemon successfully wrote a
-/// response file the CLI could read. The orthogonal "delivered but response
-/// timed out" path at the end of `execute()` is NOT routed through this
-/// helper — see the response-poll loop. That fallback ALSO returns exit 2
-/// (§224 G-IMPL-3): if delivery succeeded but no response appeared in the
-/// poll window, the session's state is unknown (daemon crashed mid-handle,
-/// response landed at an undeliverable path, or in-flight). "Outcome
-/// unknown" belongs in the exit-2 class — exit 0 here would re-create the
-/// silent-success surface #224 was filed to eliminate.
+/// response file the CLI could read. The orthogonal no-response path at the
+/// end of `execute()` is NOT routed through this helper; see the single
+/// response-poll loop (§1440). That fallback ALSO returns exit 2 (§224
+/// G-IMPL-3): if no response appeared within the wait budget, whether or not
+/// the message reached delivered/, the session's state is unknown (daemon
+/// crashed mid-handle, response landed at an undeliverable path, still in
+/// flight, or still queued). "Outcome unknown" belongs in the exit-2 class;
+/// exit 0 or a fabricated failure here would re-create the silent-success /
+/// false-timeout surfaces #224 and #1440 were filed to eliminate.
 fn interpret_close_response_exit_code(content: &str) -> i32 {
     let resp: serde_json::Value = match serde_json::from_str(content) {
         Ok(v) => v,
@@ -75,7 +114,11 @@ The master/root token bypasses this check.\n\n\
 BEHAVIOR: By default, graceful shutdown is used — an exit command is injected into \
 the agent's PTY (e.g., /exit for Claude Code) and the system waits for clean exit. \
 If the agent doesn't exit within --timeout seconds, it falls back to force-kill. \
-Use --force to skip graceful shutdown and kill immediately.\n\n\
+Use --force to skip graceful shutdown and kill immediately. \
+The CLI waits --timeout + 60 seconds for the daemon's response. A target with several \
+sessions is closed sequentially (about --timeout each) and can outlast the wait: exit 2 \
+then means outcome unknown, the close keeps running server-side and is not cancelled; \
+verify with list-peers-lean.\n\n\
 DISCOVERY: Use `list-peers-lean` to get valid agent names. The `name` field of \
 each entry is the canonical FQN to pass to --target.")]
 pub struct CloseSessionArgs {
@@ -100,7 +143,8 @@ pub struct CloseSessionArgs {
     #[arg(long)]
     pub force: bool,
 
-    /// Graceful shutdown timeout in seconds per session (default: 30)
+    /// Graceful shutdown timeout in seconds per session (default: 30). The CLI also waits
+    /// this plus 60 seconds for the daemon's response.
     #[arg(long, default_value = "30")]
     pub timeout: u32,
 }
@@ -240,7 +284,14 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
         return 1;
     }
 
-    // Poll for delivery confirmation
+    // §1440: espera unica del veredicto terminal del daemon. El daemon escribe
+    // rejected/<msg_id>.reason.txt al rechazar (antes de tocar sesiones),
+    // responses/<request_id>.json al terminar, y mueve el mensaje a delivered/
+    // SOLO DESPUES de escribir el response (ultima linea de
+    // handle_close_session). Pollear el response subsume la vieja espera de
+    // "delivery confirmation", cuyo presupuesto fijo de 30s expiraba durante
+    // cierres graceful normales de ~30s y reportaba un timeout falso (97.9%
+    // de los graceful, #1440).
     let delivered_path = outbox_dir
         .join("delivered")
         .join(format!("{}.json", msg_id));
@@ -248,43 +299,11 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
         .join("rejected")
         .join(format!("{}.reason.txt", msg_id));
 
-    let confirm_timeout = std::time::Duration::from_secs(30);
-    let confirm_poll = std::time::Duration::from_millis(250);
-    let start = std::time::Instant::now();
-
-    loop {
-        if delivered_path.exists() {
-            break;
-        }
-        if rejected_reason_path.exists() {
-            let reason = std::fs::read_to_string(&rejected_reason_path)
-                .unwrap_or_else(|_| "unknown reason".to_string());
-            let trimmed = reason.trim();
-            log::error!("close-session rejected — {}", trimmed);
-            eprintln!("Error: close-session rejected — {}", trimmed);
-            return 1;
-        }
-        if start.elapsed() >= confirm_timeout {
-            log::error!(
-                "delivery confirmation timeout after 30s (request {} may still be pending)",
-                msg_id
-            );
-            eprintln!(
-                "Error: delivery confirmation timeout after 30s (request {} may still be pending)",
-                msg_id
-            );
-            return 1;
-        }
-        std::thread::sleep(confirm_poll);
-    }
-
-    // Wait for response with session details.
-    // Timeout must exceed graceful shutdown timeout + processing overhead.
     let responses_dir = ac_dir.join("responses");
     let response_path = responses_dir.join(format!("{}.json", request_id));
-    let resp_timeout = std::time::Duration::from_secs((args.timeout + 15) as u64);
-    let resp_poll = std::time::Duration::from_millis(500);
-    let resp_start = std::time::Instant::now();
+    let budget = response_wait_budget(args.timeout);
+    let poll = std::time::Duration::from_millis(250);
+    let start = std::time::Instant::now();
 
     loop {
         if response_path.exists() {
@@ -307,26 +326,33 @@ pub fn execute(args: CloseSessionArgs) -> i32 {
                 }
             }
         }
-        if resp_start.elapsed() >= resp_timeout {
-            // §224 G-IMPL-3 — Delivery confirmed but no response in
-            // `resp_timeout`. The session's terminal state is UNKNOWN:
-            // the daemon may have crashed mid-handle, the response may
-            // have landed at an undeliverable path (G-IMPL-2 + a non-
-            // enumerable --root), or it may simply be in flight.
-            //
-            // Exit 2 ("outcome unknown") per the truth table in
-            // `interpret_close_response_exit_code` — exit 0 here would
-            // be a silent-success regression of #224. Prose to stderr,
-            // not stdout, so script consumers don't mistake it for the
-            // happy-path JSON.
-            eprintln!(
-                "Error: close-session delivered but daemon did not write a response within {}s — outcome unknown (request {})",
-                resp_timeout.as_secs(),
-                request_id
+        if rejected_reason_path.exists() {
+            let reason = std::fs::read_to_string(&rejected_reason_path)
+                .unwrap_or_else(|_| "unknown reason".to_string());
+            let trimmed = reason.trim();
+            log::error!("close-session rejected — {}", trimmed);
+            eprintln!("Error: close-session rejected — {}", trimmed);
+            return 1;
+        }
+        if start.elapsed() >= budget {
+            // §1440 / §224 G-IMPL-3: no response within the budget. The
+            // session's terminal state is UNKNOWN: the daemon may still be
+            // closing sessions, may have crashed mid-handle, or the response
+            // may have landed at an undeliverable path (G-IMPL-2 + a non-
+            // enumerable --root). Exit 2 ("outcome unknown"), never a
+            // fabricated failure. Prose to stderr, not stdout, so script
+            // consumers don't mistake it for the happy-path JSON.
+            let m = format_no_response_error(
+                budget.as_secs(),
+                &request_id,
+                &msg_id,
+                delivered_path.exists(),
             );
+            log::error!("{}", m);
+            eprintln!("Error: {}", m);
             return 2;
         }
-        std::thread::sleep(resp_poll);
+        std::thread::sleep(poll);
     }
 }
 
@@ -420,5 +446,27 @@ mod tests {
         print_status_prose(r#"{"status":"unknown"}"#);
         print_status_prose(r#"{"no_status_at_all":true}"#);
         print_status_prose(r#"{"status":42}"#);
+    }
+    // ── §1440 ──
+
+    // §1440 D.1: presupuesto derivado de --timeout
+    #[test]
+    fn response_wait_budget_adds_fixed_overhead() {
+        assert_eq!(response_wait_budget(30).as_secs(), 90);
+        assert_eq!(response_wait_budget(120).as_secs(), 180);
+        assert_eq!(response_wait_budget(0).as_secs(), 60);
+    }
+
+    // §1440 D.2: los ids van etiquetados con su artefacto en ambos sabores
+    #[test]
+    fn no_response_error_labels_both_ids_in_both_flavors() {
+        let m = format_no_response_error(90, "rid-1", "mid-1", false);
+        assert!(m.contains("no confirmation within 90s"));
+        assert!(m.contains("request rid-1"));
+        assert!(m.contains("message mid-1"));
+        let m = format_no_response_error(90, "rid-1", "mid-1", true);
+        assert!(m.contains("did not write a response within 90s"));
+        assert!(m.contains("request rid-1"));
+        assert!(m.contains("message mid-1"));
     }
 }

--- a/src-tauri/tests/cli_close_session.rs
+++ b/src-tauri/tests/cli_close_session.rs
@@ -208,6 +208,16 @@ while ((Get-Date) -lt $deadline) {
     [System.IO.File]::WriteAllText((Join-Path $deliveredDir "$($message.id).json"), $messageBody, $utf8NoBom)
     Remove-Item -LiteralPath $messagePath -Force -ErrorAction SilentlyContinue
 
+    if ($Mode -eq 'respond-staged') {
+      # 1440 F1: el daemon escribe el response sin rename atomico y dos veces
+      # (dual-write 224 A.6), asi que el archivo existe truncado durante una
+      # ventana. Aca la ventana es determinista: 600ms (mas de dos ticks del
+      # poll de 250ms del CLI) con un prefijo que no parsea.
+      New-Item -ItemType Directory -Force -Path $ResponsesDir | Out-Null
+      Set-Content -LiteralPath (Join-Path $ResponsesDir "$($message.requestId).json") -Value '{"' -NoNewline -Encoding ascii
+      Start-Sleep -Milliseconds 600
+    }
+
     New-Item -ItemType Directory -Force -Path $ResponsesDir | Out-Null
     $responseBody = Get-Content -LiteralPath $ResponseBodyPath -Raw -ErrorAction Stop
     [System.IO.File]::WriteAllText((Join-Path $ResponsesDir "$($message.requestId).json"), $responseBody, $utf8NoBom)
@@ -286,7 +296,8 @@ impl SimulatorHandle {
 
 /// §1440: `mode` is "respond" (write delivered/ + responses/) or "reject"
 /// (write rejected/<msg_id>.reason.txt, no contract validation, no response),
-/// mirroring the daemon's two terminal outcomes.
+/// mirroring the daemon's two terminal outcomes. "respond-staged" is
+/// "respond" with the response left torn for 600ms first (§1440 F1).
 fn spawn_daemon_simulator(
     _tmp: &Path,
     outbox_dir: &Path,
@@ -473,6 +484,17 @@ fn simulate_daemon_response(
     std::fs::write(delivered_dir.join(format!("{}.json", msg_id)), &body)
         .map_err(|e| e.to_string())?;
     let _ = std::fs::remove_file(&msg_path);
+
+    if mode == "respond-staged" {
+        // §1440 F1: el daemon escribe el response sin rename atomico y dos
+        // veces (dual-write §224 A.6), asi que el archivo existe truncado
+        // durante una ventana. Aca la ventana es determinista: 600ms (mas de
+        // dos ticks del poll de 250ms del CLI) con un prefijo que no parsea.
+        std::fs::create_dir_all(responses_dir).map_err(|e| e.to_string())?;
+        std::fs::write(responses_dir.join(format!("{}.json", request_id)), "{\"")
+            .map_err(|e| e.to_string())?;
+        std::thread::sleep(Duration::from_millis(600));
+    }
 
     std::fs::create_dir_all(responses_dir).map_err(|e| e.to_string())?;
     std::fs::write(
@@ -841,6 +863,46 @@ fn close_session_rejected_exits_one_with_reason() {
     assert!(
         !stdout.contains("\"status\""),
         "no response JSON must reach stdout on rejection; got: {}",
+        stdout
+    );
+}
+
+// §1440 F1: el daemon escribe el response sin atomicidad y (en el caso
+// comun) dos veces; respond-staged materializa la ventana: el archivo
+// existe 600ms (mas de dos ticks de poll de 250ms) con un prefijo torn
+// antes de tener el JSON completo. Sin el parse-gate de 5.1.8, un tick
+// lee el torn, imprime basura en stdout y sale 2 sobre un cierre exitoso.
+#[test]
+fn close_session_staged_response_write_still_exits_zero() {
+    let tmp = Tmp::new("close-staged");
+    let fix = build_fixture(tmp.path(), "hank-staged");
+    let target = "proj:wg-1-test/hank-staged";
+    let body = format!(
+        "{{\"action\":\"close-session\",\"target\":\"{}\",\"status\":\"closed\",\"sessions_closed\":1,\"session_ids\":[\"7\"],\"requested_by\":\"tester\"}}",
+        target
+    );
+
+    let (code, stdout, stderr, _sim_out, _sim_err) = run_close_session_in_mode(
+        tmp.path(),
+        &fix,
+        body.clone(),
+        target,
+        "5",
+        "respond-staged",
+    );
+
+    assert_eq!(
+        code,
+        Some(0),
+        "a staged (non-atomic) response write must still exit 0.
+stdout: {}
+stderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.starts_with(&body),
+        "stdout must begin with the complete response JSON (no torn prefix may reach stdout); got: {}",
         stdout
     );
 }

--- a/src-tauri/tests/cli_close_session.rs
+++ b/src-tauri/tests/cli_close_session.rs
@@ -122,7 +122,8 @@ param(
   [Parameter(Mandatory=$true)][string]$ExpectedTarget,
   [Parameter(Mandatory=$true)][string]$ExpectedTo,
   [Parameter(Mandatory=$true)][int]$ExpectedTimeoutSec,
-  [Parameter(Mandatory=$true)][int]$TimeoutSec
+  [Parameter(Mandatory=$true)][int]$TimeoutSec,
+  [string]$Mode = 'respond'
 )
 
 $deadline = (Get-Date).AddSeconds($TimeoutSec)
@@ -154,6 +155,20 @@ while ((Get-Date) -lt $deadline) {
       $lastReadinessError = "message visible but missing requestId at ${messagePath}"
       Start-Sleep -Milliseconds 50
       continue
+    }
+
+    if ($Mode -eq 'reject') {
+      # 1440: el daemon rechaza antes de validar force/timeout y escribe la
+      # reason ANTES del JSON espejado (mailbox.rs reject_message).
+      $rejectedDir = Join-Path $OutboxDir 'rejected'
+      New-Item -ItemType Directory -Force -Path $rejectedDir | Out-Null
+      $utf8NoBomReject = New-Object System.Text.UTF8Encoding($false)
+      $reasonBody = Get-Content -LiteralPath $ResponseBodyPath -Raw -ErrorAction Stop
+      [System.IO.File]::WriteAllText((Join-Path $rejectedDir "$($message.id).reason.txt"), $reasonBody, $utf8NoBomReject)
+      [System.IO.File]::WriteAllText((Join-Path $rejectedDir "$($message.id).json"), $messageBody, $utf8NoBomReject)
+      Remove-Item -LiteralPath $messagePath -Force -ErrorAction SilentlyContinue
+      Write-Output $message.id
+      exit 0
     }
 
     if ($message.action -ne 'close-session') {
@@ -269,6 +284,9 @@ impl SimulatorHandle {
     }
 }
 
+/// §1440: `mode` is "respond" (write delivered/ + responses/) or "reject"
+/// (write rejected/<msg_id>.reason.txt, no contract validation, no response),
+/// mirroring the daemon's two terminal outcomes.
 fn spawn_daemon_simulator(
     _tmp: &Path,
     outbox_dir: &Path,
@@ -276,6 +294,7 @@ fn spawn_daemon_simulator(
     response_body: &str,
     expected_target: &str,
     expected_timeout_secs: &str,
+    mode: &str,
 ) -> SimulatorHandle {
     #[cfg(target_os = "windows")]
     {
@@ -305,6 +324,8 @@ fn spawn_daemon_simulator(
                 expected_timeout_secs,
                 "-TimeoutSec",
                 "20",
+                "-Mode",
+                mode,
             ])
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -319,6 +340,7 @@ fn spawn_daemon_simulator(
         let responses_for_thread = responses_dir.to_path_buf();
         let response_owned = response_body.to_string();
         let target_owned = expected_target.to_string();
+        let mode_owned = mode.to_string();
         let timeout_secs = expected_timeout_secs
             .parse::<u32>()
             .expect("test timeout secs must parse");
@@ -330,6 +352,7 @@ fn spawn_daemon_simulator(
                 &response_owned,
                 &target_owned,
                 timeout_secs,
+                &mode_owned,
                 Duration::from_secs(20),
             );
             let _ = tx.send(result);
@@ -345,6 +368,7 @@ fn simulate_daemon_response(
     response_body: &str,
     expected_target: &str,
     expected_timeout_secs: u32,
+    mode: &str,
     overall_timeout: Duration,
 ) -> Result<String, String> {
     let start = Instant::now();
@@ -425,6 +449,22 @@ fn simulate_daemon_response(
         break (path, body, msg, msg_id, request_id);
     };
 
+    if mode == "reject" {
+        // §1440: el daemon rechaza antes de validar el contrato y antes de
+        // tocar sesiones; escribe la reason primero y nunca un response.
+        let rejected_dir = outbox_dir.join("rejected");
+        std::fs::create_dir_all(&rejected_dir).map_err(|e| e.to_string())?;
+        std::fs::write(
+            rejected_dir.join(format!("{}.reason.txt", msg_id)),
+            response_body,
+        )
+        .map_err(|e| e.to_string())?;
+        std::fs::write(rejected_dir.join(format!("{}.json", msg_id)), &body)
+            .map_err(|e| e.to_string())?;
+        let _ = std::fs::remove_file(&msg_path);
+        return Ok(msg_id);
+    }
+
     validate_close_session_message(&msg, expected_target, expected_timeout_secs)
         .map_err(|e| format!("contract violation in {:?}: {}", msg_path, e))?;
 
@@ -476,6 +516,29 @@ fn run_close_session_with_simulator(
     target: &str,
     timeout_secs: &str,
 ) -> (Option<i32>, String, String, String, String) {
+    run_close_session_in_mode(tmp, fix, response_body, target, timeout_secs, "respond")
+}
+
+/// §1440: same run, but the simulator rejects the message instead of
+/// responding; `reason` is written to rejected/<msg_id>.reason.txt.
+fn run_close_session_expecting_rejection(
+    tmp: &Path,
+    fix: &Fixture,
+    reason: String,
+    target: &str,
+    timeout_secs: &str,
+) -> (Option<i32>, String, String, String, String) {
+    run_close_session_in_mode(tmp, fix, reason, target, timeout_secs, "reject")
+}
+
+fn run_close_session_in_mode(
+    tmp: &Path,
+    fix: &Fixture,
+    response_body: String,
+    target: &str,
+    timeout_secs: &str,
+    mode: &str,
+) -> (Option<i32>, String, String, String, String) {
     let stem = fix.bin.file_stem().unwrap().to_string_lossy().to_string();
     let ac_dir = fix.agent_root.join(format!(".{}", stem));
     let outbox_dir = ac_dir.join("outbox");
@@ -489,6 +552,7 @@ fn run_close_session_with_simulator(
         &response_body,
         target,
         timeout_secs,
+        mode,
     );
 
     let out = Command::new(&fix.bin)
@@ -739,6 +803,44 @@ fn close_session_incoherent_response_exits_two() {
     assert!(
         stdout.contains("new_unrecognized_status"),
         "stdout must include daemon JSON; got: {}",
+        stdout
+    );
+}
+
+#[test]
+fn close_session_rejected_exits_one_with_reason() {
+    let tmp = Tmp::new("close-rejected");
+    let fix = build_fixture(tmp.path(), "hank-unauthorized");
+    let target = "proj:wg-1-test/hank-unauthorized";
+
+    let (code, stdout, stderr, _sim_out, _sim_err) = run_close_session_expecting_rejection(
+        tmp.path(),
+        &fix,
+        "close-session target unresolvable: nope".to_string(),
+        target,
+        "5",
+    );
+
+    assert_eq!(
+        code,
+        Some(1),
+        "a rejected close-session must exit 1.\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stderr.contains("close-session rejected"),
+        "stderr must carry the rejection prefix; got: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("target unresolvable: nope"),
+        "stderr must carry the daemon reason; got: {}",
+        stderr
+    );
+    assert!(
+        !stdout.contains("\"status\""),
+        "no response JSON must reach stdout on rejection; got: {}",
         stdout
     );
 }


### PR DESCRIPTION
Closes #1440

## What was wrong

`close-session` exited 1 with `delivery confirmation timeout after 30s` on **142 of 145** graceful closes (97.9%) — while the session did close moments later. The failure message was the normal outcome, not a race.

The CLI's first wait was a hardcoded 30s that polled for the `outbox/delivered/` marker. The daemon writes that marker on the *last line* of `handle_close_session`, after the shutdown completes and after the response file. So a wait named "delivery confirmation" was actually timing the entire close, which takes p50 30.65s. The CLI's second wait (`--timeout + 15`) was sized correctly for this but was never reached: 383 delivery timeouts in `app.log`, 0 occurrences of `did not write a response within`.

## What changed

CLI-only. `mailbox.rs` and `send.rs` are untouched (verified by blob hash).

- The two chained waits collapse into a single 250ms poll over `responses/<request_id>.json` and `rejected/<msg_id>.reason.txt`. The rejection fast-fail is preserved.
- Budget is `--timeout + 60` (90s by default, matching `send --confirm-timeout`), derived from the flag rather than hardcoded. It deliberately does **not** scale with session count: the CLI cannot know N before the daemon resolves the target, and the daemon closes sessions serially. Expiring is now exit **2** ("outcome unknown", the close keeps running server-side) instead of a false exit 1, aligning with the exit-code taxonomy the file already used.
- The error text now labels both UUIDs correctly. It previously said `request` while interpolating `msg_id`, so the printed id could not locate `responses/<request_id>.json`.
- **Parse gate:** a response file that cannot be read or does not parse is not terminal — the loop keeps polling. Removing the `delivered/` barrier had made a torn-read window reachable that the barrier previously made impossible (the daemon writes the response non-atomically, twice, to the same path in the common case). Without this, a tick landing in that window produced a false exit 2 — or a false exit 1 on a split multi-byte character — plus a truncated JSON fragment on stdout. Parsing now happens before printing.

## Review

Grinch reviewed the full range and initially returned **FAIL** on the torn-read window, which sent the plan back to the architect for recertification; the parse gate is the result. Final verdict **PASS** on `b19ee18..126c6f1` plus a focused PASS on the merge commit.

The new integration test is deterministic, not probabilistic: the simulator leaves the response truncated for 600ms (more than two 250ms poll ticks) before writing the full JSON. Reverting `close_session.rs` to the pre-gate commit makes it fail 5/5 with `left: Some(2), right: Some(0)` and `{"` on stdout; with the gate it passes 10/10.

## Verification

`cargo check` exit 0. `cargo clippy --all-targets -- -D warnings` exit 0, zero warnings. 13 unit + 8 integration tests pass (1.37s). No `use` lines changed in either Rust file, so the module dependency graph is unchanged. Re-run independently by both dev-rust and grinch on the merge commit.

## Not in scope

This fixes the report, not the speed. A close still costs ~30s because the injected `/exit` never drives the session to `Exited` within the poll window — `app.log` has 327 `graceful timeout ... falling back to force` lines and 0 `session exited gracefully` lines, so every "graceful" close is really a 30s wait followed by a force-kill.

The same false-timeout string with the same crossed id is still live in `raise-hand`, `self-clear` and `self-switch` — tracked in #1445.

No shipper build: non-visual change.