### PR TITLE
fix(#1438): corpse-aware kill verification so Terminated is reachable

### DIFF
--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -36,8 +36,19 @@ pub trait ProcessTreeBackend: Send + Sync + 'static {
         true
     }
 
+    /// Reports the tree as the OS snapshot saw it. Identity resolution here is
+    /// corpse-TOLERANT: an exited-but-still-queryable process keeps its identity
+    /// (see #1438 G1); liveness filtering belongs to `observe_identity`.
     fn observe_tree(&self, root: ProcessIdentity) -> Result<ObservedProcessTree, ResourceError>;
+    /// `Ok(Some(identity))` means a live process with that identity exists now. An
+    /// exited process that is still queryable through open handles MUST yield
+    /// `Ok(None)` (#1438).
     fn observe_identity(&self, pid: u32) -> Result<Option<ProcessIdentity>, ResourceError>;
+    /// MUST return `Ok(Terminated)` when the target verifiably exited, including when
+    /// other handles keep the corpse queryable. `Err` is reserved for a target that
+    /// demonstrably survives or cannot be verified. Every `TerminateOutcome` variant a
+    /// real backend can produce needs at least one real-process test producing it
+    /// (#1438 Decision 3).
     fn terminate_verified(
         &self,
         process: &ObservedProcess,
@@ -578,8 +589,9 @@ impl ResourceMonitorState {
     /// target SEED, never the verification: when true (app-shutdown bulk cleanup) the
     /// accumulated `observed_processes` set is skipped and only the fresh `observe_tree`
     /// is targeted, so the reaper does not walk hundreds of stale-dead PIDs (each of
-    /// which would force a full toolhelp snapshot). The Job Object kill already
-    /// terminated the live tree at shutdown, so the fresh set is normally empty.
+    /// which would force a full toolhelp snapshot). The fresh set is normally empty
+    /// because PTY teardown has already run by then; AC creates no job object of its
+    /// own (`pty/job.rs` is unused in production as of #1438).
     ///
     /// #1151 - `expected_quarantined_root` is the same kind of knob for AUTHORITY rather
     /// than targets: a caller-supplied binding that narrows which registration this kill
@@ -662,9 +674,11 @@ impl ResourceMonitorState {
             (
                 group.root_identity,
                 if fresh_targets_only {
-                    // #632 B2a - at shutdown, ignore the accumulated set entirely;
-                    // target only the fresh live tree captured below. The Job Object
-                    // kill already terminated the tree, so this is normally empty.
+                    // #632 B2a - at shutdown, ignore the accumulated set entirely; target
+                    // only the fresh live tree captured below, which is normally empty
+                    // because PTY teardown has already run. AC creates no job object of
+                    // its own (`pty/job.rs` is unused in production as of #1438), so this
+                    // fresh walk is the only source of targets on this path.
                     Vec::new()
                 } else {
                     group
@@ -828,6 +842,31 @@ impl ResourceMonitorState {
         // #647 D: flag an AV/EDR ACCESS_DENIED (exact `win32 error 5`) so the UI can
         // add the exclusion guidance; the per-PID detail stays in `message`.
         let blocked_by_security = quarantined && has_access_denied_signature(&errors);
+        // #1438 - a quarantined session-destroy is the evidence trail for the separate
+        // locked-directory defect: dump the full deduped target list once, so a follow-up
+        // ticket can name the holder instead of guessing. Gated to SessionDestroy because
+        // retry_orphaned_quarantine forwards ResourceKillReason::Watchdog, so a stuck
+        // group cannot multiply the line.
+        if quarantined && matches!(reason, ResourceKillReason::SessionDestroy) {
+            let tree = targets
+                .iter()
+                .map(|p| {
+                    format!(
+                        "pid={} exe={} ppid={:?} depth={} kill_allowed={}",
+                        p.identity.pid, p.exe_name, p.parent_pid, p.depth, p.kill_allowed
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" | ");
+            log::warn!(
+                "[resource-monitor] quarantine-tree session={} reason={} root_pid={} targets={}: {}",
+                session_id,
+                reason.as_log_reason(),
+                root_identity.pid,
+                targets.len(),
+                tree
+            );
+        }
         let state = if quarantined {
             ResourceGroupState::Quarantined
         } else {

--- a/src-tauri/src/resource_monitor/registry.rs
+++ b/src-tauri/src/resource_monitor/registry.rs
@@ -589,9 +589,10 @@ impl ResourceMonitorState {
     /// target SEED, never the verification: when true (app-shutdown bulk cleanup) the
     /// accumulated `observed_processes` set is skipped and only the fresh `observe_tree`
     /// is targeted, so the reaper does not walk hundreds of stale-dead PIDs (each of
-    /// which would force a full toolhelp snapshot). The fresh set is normally empty
-    /// because PTY teardown has already run by then; AC creates no job object of its
-    /// own (`pty/job.rs` is unused in production as of #1438).
+    /// which would force a full toolhelp snapshot). The Job Object kill has already
+    /// terminated each jobbed session's live tree at shutdown (`kill_all_jobs()` runs
+    /// before this path; jobs are created per child in `spawn_sync`, `pty/job.rs`), so
+    /// the fresh set is normally empty; its survivors are job-less sessions' trees.
     ///
     /// #1151 - `expected_quarantined_root` is the same kind of knob for AUTHORITY rather
     /// than targets: a caller-supplied binding that narrows which registration this kill
@@ -674,11 +675,13 @@ impl ResourceMonitorState {
             (
                 group.root_identity,
                 if fresh_targets_only {
-                    // #632 B2a - at shutdown, ignore the accumulated set entirely; target
-                    // only the fresh live tree captured below, which is normally empty
-                    // because PTY teardown has already run. AC creates no job object of
-                    // its own (`pty/job.rs` is unused in production as of #1438), so this
-                    // fresh walk is the only source of targets on this path.
+                    // #632 B2a - at shutdown, ignore the accumulated set entirely; target only the
+                    // fresh live tree captured below. It is normally empty because the Job Object
+                    // kill has already terminated each jobbed session's tree (lib.rs fires
+                    // kill_all_jobs() before this path runs; jobs are created per child at spawn,
+                    // pty/job.rs), so this fresh walk exists to catch job-less survivors and is
+                    // the only source of targets on this path. Targets commonly resolve
+                    // AlreadyGone here; killed=0 is the expected, correct record (#1438).
                     Vec::new()
                 } else {
                     group

--- a/src-tauri/src/resource_monitor/windows.rs
+++ b/src-tauri/src/resource_monitor/windows.rs
@@ -10,7 +10,7 @@ mod platform {
     use super::*;
     use windows_sys::Win32::Foundation::{
         CloseHandle, GetLastError, ERROR_NO_MORE_FILES, FILETIME, HANDLE, INVALID_HANDLE_VALUE,
-        WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+        STILL_ACTIVE, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
     };
     use windows_sys::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
@@ -20,8 +20,9 @@ mod platform {
         K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS, PROCESS_MEMORY_COUNTERS_EX,
     };
     use windows_sys::Win32::System::Threading::{
-        GetCurrentProcess, GetProcessTimes, OpenProcess, TerminateProcess, WaitForSingleObject,
-        PROCESS_QUERY_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, PROCESS_VM_READ,
+        GetCurrentProcess, GetExitCodeProcess, GetProcessTimes, OpenProcess, TerminateProcess,
+        WaitForSingleObject, PROCESS_QUERY_INFORMATION, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE,
+        PROCESS_VM_READ,
     };
 
     pub struct PlatformProcessTreeBackend;
@@ -58,7 +59,7 @@ mod platform {
                 |pid| {
                     *identity_cache
                         .entry(pid)
-                        .or_insert_with(|| observe_identity(pid).ok().flatten())
+                        .or_insert_with(|| observe_identity_queryable(pid).ok().flatten())
                 },
                 |pid| process_memory(pid).unwrap_or_default(),
             ))
@@ -88,10 +89,15 @@ mod platform {
             };
             let ok = unsafe { TerminateProcess(handle.raw(), 1) };
             if ok == 0 {
-                return verify_identity_exited(
-                    process.identity,
-                    last_error("TerminateProcess failed").to_string(),
-                );
+                let failure = last_error("TerminateProcess failed").to_string();
+                // #1438 - ERROR_ACCESS_DENIED here is usually STATUS_PROCESS_IS_TERMINATING:
+                // the process is already tearing itself down. Give it the same grace the
+                // success path gets so verification sees the settled state. The wait result
+                // is deliberately ignored: a target that is still alive after it produces
+                // the same Err, carrying the original message, so blocked_by_security still
+                // fires on a genuine denial.
+                let _ = unsafe { WaitForSingleObject(handle.raw(), 2_000) };
+                return verify_identity_exited(process.identity, failure);
             }
             let wait_result = unsafe { WaitForSingleObject(handle.raw(), 2_000) };
             let failure = match wait_result {
@@ -296,7 +302,12 @@ mod platform {
         Ok(entries)
     }
 
-    fn observe_identity(pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+    /// #1438 - shared probe body: open the pid and read its creation time, returning
+    /// the OPENED HANDLE alongside the identity so the caller can keep querying the
+    /// SAME handle. The handle must be shared rather than re-opened per query: a
+    /// second `OpenProcess` between two reads could land on a recycled pid and report
+    /// the new occupant's state as the old identity's.
+    fn query_identity(pid: u32) -> Result<Option<(OwnedHandle, ProcessIdentity)>, ResourceError> {
         let handle = match open_process(pid, PROCESS_QUERY_INFORMATION) {
             Ok(handle) => handle,
             Err(err) => {
@@ -323,10 +334,49 @@ mod platform {
             let err = last_error("GetProcessTimes failed");
             return if pid_exists(pid)? { Err(err) } else { Ok(None) };
         }
-        Ok(Some(ProcessIdentity {
-            pid,
-            creation_time_100ns: filetime_to_u64(creation),
-        }))
+        Ok(Some((
+            handle,
+            ProcessIdentity {
+                pid,
+                creation_time_100ns: filetime_to_u64(creation),
+            },
+        )))
+    }
+
+    /// #1438 - corpse-AWARE probe: `Ok(Some(identity))` means a LIVE process with that
+    /// identity exists right now. A process that has exited yields `Ok(None)` even while
+    /// open handles elsewhere keep the corpse queryable (Windows keeps a terminated
+    /// process openable, with its creation time intact, for as long as ANY handle to it
+    /// exists, which is what made `Ok(Terminated)` unreachable). Every kill and verify
+    /// path uses this: the terminate pre-check, `verify_identity_exited`, the trait
+    /// method, the registry's `!kill_allowed` checks and second-chance drain, and every
+    /// watchdog retry.
+    fn observe_identity(pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+        let Some((handle, identity)) = query_identity(pid)? else {
+            return Ok(None);
+        };
+        let mut exit_code: u32 = 0;
+        let ok = unsafe { GetExitCodeProcess(handle.raw(), &mut exit_code) };
+        if ok == 0 {
+            let err = last_error("GetExitCodeProcess failed");
+            return if pid_exists(pid)? { Err(err) } else { Ok(None) };
+        }
+        if exit_code != STILL_ACTIVE as u32 {
+            // Exited; open handles elsewhere merely keep the corpse queryable.
+            return Ok(None);
+        }
+        Ok(Some(identity))
+    }
+
+    /// #1438 G1 - corpse-TOLERANT resolver for the tree walk: returns the identity of
+    /// any process that is still queryable, INCLUDING one that has exited but is kept
+    /// queryable by open handles elsewhere. The tree walk's question is "what did the OS
+    /// snapshot contain", never "is this alive right now", and answering it with the
+    /// corpse-aware probe would let a root that exits mid-walk fail the root guard and
+    /// drop its whole subtree from the target set. Kill and verify paths must use
+    /// `observe_identity` instead.
+    fn observe_identity_queryable(pid: u32) -> Result<Option<ProcessIdentity>, ResourceError> {
+        Ok(query_identity(pid)?.map(|(_handle, identity)| identity))
     }
 
     fn process_memory(pid: u32) -> Result<ProcessMemory, ResourceError> {
@@ -388,6 +438,7 @@ mod platform {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::process::{Command, Stdio};
 
         fn entry(pid: u32, parent_pid: u32, exe: &str) -> ProcessEntry {
             ProcessEntry {
@@ -566,6 +617,73 @@ mod platform {
                 !probed.contains(&2000) && !probed.contains(&2001),
                 "identity resolver must not touch processes outside the subtree, probed={probed:?}"
             );
+        }
+
+        /// #1438 - real-process guard for the corpse-aware probe, following the
+        /// `pty/job.rs` real-process precedent. The `Child` is deliberately kept in
+        /// scope and un-waited: its open process handle keeps the terminated process
+        /// queryable, which is the exact production condition (the PTY layer holds the
+        /// same kind of handle) that made `Ok(Terminated)` unreachable.
+        #[test]
+        fn terminate_verified_reports_terminated_then_already_gone_for_real_process() {
+            let mut child = Command::new("ping")
+                .args(["-n", "30", "127.0.0.1"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn ping child");
+            let pid = child.id();
+
+            let backend = PlatformProcessTreeBackend::new();
+            let live = backend
+                .observe_identity(pid)
+                .expect("observe live child")
+                .expect("a live child must resolve to an identity");
+            assert!(
+                observe_identity(pid).expect("probe live child").is_some(),
+                "negative control: a live process must be observable to the kill path"
+            );
+
+            let observed = ObservedProcess {
+                identity: live,
+                parent_pid: None,
+                parent_identity: None,
+                exe_name: "ping.exe".to_string(),
+                depth: 0,
+                private_bytes: None,
+                working_set_bytes: None,
+                cpu_percent: None,
+                kill_allowed: true,
+            };
+
+            assert_eq!(
+                backend
+                    .terminate_verified(&observed)
+                    .expect("first terminate must verify the exit"),
+                TerminateOutcome::Terminated
+            );
+
+            // The `Child` handle is still held here: the exact production condition.
+            assert!(
+                observe_identity(pid).expect("probe corpse").is_none(),
+                "a corpse must not be observable to the kill path"
+            );
+            assert!(
+                observe_identity_queryable(pid)
+                    .expect("resolve corpse")
+                    .is_some(),
+                "a corpse must stay queryable to the tree resolver (#1438 G1)"
+            );
+
+            assert_eq!(
+                backend
+                    .terminate_verified(&observed)
+                    .expect("retry must not error"),
+                TerminateOutcome::AlreadyGone,
+                "a watchdog retry over a dead target must converge without TerminateProcess"
+            );
+
+            child.wait().expect("reap the child");
         }
     }
 }


### PR DESCRIPTION
Closes #1438.

## The defect

`kill_group` reported `killed=0` in **every one of 901 records** in a local `app.log`, with 427 groups quarantined and 18,208 `kill-failed` lines. It looked like the kill was failing. It was not.

`terminate_verified` (`resource_monitor/windows.rs`) opened a handle, called `TerminateProcess`, waited successfully, and then verified death **while still holding its own handle to the corpse**. A terminated Windows process keeps a valid pid and a queryable creation time for as long as any handle to it is open, so `observe_identity` re-read the corpse's identical creation time and declared the kill a failure. `TerminateOutcome::Terminated` was **unreachable by construction**, and `killed` is pushed only on that variant.

Proven, not inferred: a local Win32 probe reproduced the sequence (`GetExitCodeProcess` returned 1, not 259 `STILL_ACTIVE`), and production confirmed it independently — of the 395 sessions where a `[pty] child-exit` record exists to compare against, the "failing" pid set includes the PTY child pid in **395 of 395** while the PTY layer separately reports that pid as exited. A second `TerminateProcess` on a corpse fails with `ERROR_ACCESS_DENIED`, which splits the population by mechanism rather than by string shape: **993 of 1013 session-destroy failures were false, 20 are genuine timeouts.**

Two consequences fixed with it: the `blocked_by_security` flag was reporting antivirus interference on phantom errors (`win32 error 5` here is `STATUS_PROCESS_IS_TERMINATING`, not AV), and quarantined groups never set `permit_released`, so the watchdog retried the same corpses forever — 16,975 lines collapsing to 21 distinct tuples, one pid logged 902 times, each retry holding a resource slot.

## The change

- **Probe split.** `query_identity` holds the old body and returns the opened handle with the identity; `observe_identity` adds `GetExitCodeProcess` **on that same handle** and returns `Ok(None)` for a corpse; `observe_identity_queryable` drops the handle and skips the exit check. The shared handle is load-bearing: an exit-code check on a *re-opened* handle could land on a reused pid and misread the new occupant's `STILL_ACTIVE`.
- **Tree walk stays corpse-tolerant.** `observe_tree`'s memoizing closure routes to `observe_identity_queryable`, so its output is byte-identical to the base commit on every input. Without this, a root exiting mid-walk would flip from "subtree walked" to "subtree dropped", and the swallowed error would make the group report `quarantined=false, state=Terminated, permit_released=true, targets=0 killed=0` — a clean verified kill that killed nothing, silently orphaning the tree at app shutdown. Caught in adversarial review before implementation.
- **Grace wait.** On a failed `TerminateProcess`, wait up to 2 s on the already-held handle before verifying, so `STATUS_PROCESS_IS_TERMINATING` settles instead of quarantining.
- **Instrumentation.** On a quarantined `session-destroy`, one warn dumping the full observed tree (pid, exe, ppid, depth, `kill_allowed`) instead of only the failing pids — the diagnostic the follow-up work needs.
- **Comment corrections.** Two `#632 B2a` comments restored to a truthful Job Object justification, naming where jobs are created and fired.

No registry, state-machine, permit or watchdog changes. `FakeProcessTreeBackend` untouched. `AlreadyGone` is explicitly **not** counted as killed.

## Verification

- **New real-process test**, `#[cfg(windows)]`, landed **first on the unmodified backend** so the red is real: it failed with the exact predicted message `pid N is still alive after termination`, then passed after the change. It asserts `observe_identity == None` **and** `observe_identity_queryable == Some` with the spawned `Child` handle still held — the real production condition.
- **Discriminating check.** With the exit-code check reverted *and* the naive `if wait_result == WAIT_OBJECT_0 { return Ok(Terminated) }` shortcut added, the test still fails on `a corpse must not be observable to the kill path`. The guard rejects the smaller wrong implementation that would have destroyed the 20 genuine timeout detections.
- `cargo check --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --lib --bins --tests`: all exit 0. Lib `3515 passed; 0 failed; 23 ignored` of 3538 — baseline 3537 plus the new test. No existing test changed behaviour, in particular none of the fake-backed registry/watchdog anchors.
- **Dependency structure unchanged:** modules 190→190, module edges 3640→3640, cycles 1→1, the 85-member SCC identical member-by-member, zero new module arcs, `module-arcs.txt` byte-identical. Functions 4240→4242 — exactly the two new free functions.

## Review

Architect-certified plan (`plans/1438-kill-verification-corpse-aware-observe.md`), enriched by `dev-rust` and adversarially reviewed by `dev-rust-grinch`.

Review returned **FAIL** on the first pass, and the finding was real: the plan had specified a comment asserting `pty/job.rs` was unused in production. It is not — jobs are created per ConPTY child in `spawn_sync`, again for agent-update step children, and fired on both the app-shutdown and resource-kill paths. The false claim originated in a call-graph trace that does not record a function reference passed to `.and_then(...)`; the tool showed **zero** callers for a function whose body is `TerminateJobObject`. The plan was corrected, re-certified, and the comment landed truthfully. Second review: **PASS**, every clause verified against source.

Note for whoever watches this in production: because the Job Object kill fires before `kill_group_inner` on the shutdown and resource-kill paths, targets are frequently already corpses at the pre-check, so `killed=0, quarantined=false, all targets AlreadyGone` is the **expected and correct** common outcome there. A low `killed` count is not a failed fix.

## Not fixed here

The replica agent-config directory that stays locked after a successful kill (#1433) is a separate defect and this does not fix it: in three traced cases the kill worked, the PTY child was independently reported exited, and the directory was still locked 578 ms later, held by something that was never a target. Job-object adoption is a **disproven** hypothesis for it — jobs already fire on those paths. The instrumentation added here is what will name the actual holder.
