### PR TITLE
fix: apply clippy 1.98 chunks_exact_to_as_chunks suggestions at 10 sites (refs #1474)

### DIFF
--- a/crates/session-bridge/src/bin/agentscommander-api-helper.rs
+++ b/crates/session-bridge/src/bin/agentscommander-api-helper.rs
@@ -605,9 +605,9 @@ fn sha256_hex(input: &[u8]) -> String {
         padded.push(0);
     }
     padded.extend_from_slice(&bit_len.to_be_bytes());
-    for chunk in padded.chunks_exact(64) {
+    for chunk in padded.as_chunks::<64>().0 {
         let mut words = [0_u32; 64];
-        for (index, bytes) in chunk.chunks_exact(4).enumerate() {
+        for (index, bytes) in chunk.as_chunks::<4>().0.iter().enumerate() {
             words[index] = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
         }
         for index in 16..64 {

--- a/src-tauri/src/commands/wg_delete_diagnostic.rs
+++ b/src-tauri/src/commands/wg_delete_diagnostic.rs
@@ -1444,7 +1444,9 @@ fn read_remote_utf16_path(
 
     let bytes = read_remote_bytes(handle, buffer, length)?;
     let wide: Vec<u16> = bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|b| u16::from_le_bytes([b[0], b[1]]))
         .collect();
     let cwd = strip_long_prefix_str(String::from_utf16_lossy(&wide).trim_end_matches('\0'));

--- a/src-tauri/src/config/seed_manifest.rs
+++ b/src-tauri/src/config/seed_manifest.rs
@@ -797,7 +797,9 @@ fn parse_lower_hex_bytes(serialized: &str) -> Result<Vec<u8>, SeedManifestError>
     }
     serialized
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|digits| {
             let text = std::str::from_utf8(digits).map_err(|error| {
                 SeedManifestError::Validation(format!("invalid unix_bytes_hex: {error}"))
@@ -849,7 +851,9 @@ fn parse_windows_hex_components(serialized: &str) -> Result<Vec<Vec<u16>>, SeedM
     }
     let units = serialized
         .as_bytes()
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|digits| {
             let text = std::str::from_utf8(digits).map_err(|error| {
                 SeedManifestError::Validation(format!("invalid windows_utf16_hex: {error}"))

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -2050,7 +2050,7 @@ fn raw_privileged_probe(bytes: &[u8]) -> bool {
 
     for little_endian in [true, false] {
         let mut ascii = Vec::with_capacity(bytes.len() / 2);
-        for chunk in bytes.chunks_exact(2) {
+        for chunk in bytes.as_chunks::<2>().0 {
             let unit = if little_endian {
                 u16::from_le_bytes([chunk[0], chunk[1]])
             } else {
@@ -2247,7 +2247,9 @@ fn decode_outbox_snapshot(bytes: &[u8]) -> Result<String, ()> {
             return Err(());
         }
         let units: Vec<u16> = body
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
             .collect();
         String::from_utf16(&units).map_err(|_| ())
@@ -2257,7 +2259,9 @@ fn decode_outbox_snapshot(bytes: &[u8]) -> Result<String, ()> {
             return Err(());
         }
         let units: Vec<u16> = body
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
             .collect();
         String::from_utf16(&units).map_err(|_| ())
@@ -11057,7 +11061,9 @@ fn read_text_bom_tolerant(path: &Path) -> Result<String, String> {
             path
         );
         let u16_data: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
         Ok(String::from_utf16_lossy(&u16_data))
@@ -11067,7 +11073,9 @@ fn read_text_bom_tolerant(path: &Path) -> Result<String, String> {
             path
         );
         let u16_data: Vec<u16> = bytes[2..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| u16::from_be_bytes([c[0], c[1]]))
             .collect();
         Ok(String::from_utf16_lossy(&u16_data))


### PR DESCRIPTION
## Summary

Fix the pre-existing clippy 1.98.0 lint `chunks_exact_to_as_chunks` at 10 sites across 4 files (toolchain auto-updated in CI from 1.97.1 to 1.98.0 on 2026-08-20, breaking every PR's rust-regression jobs). Each site rewritten with the lint's own machine suggestion (`as_chunks::<N>().0` / `.0.iter()`), behavior identical:

- `src-tauri/src/config/seed_manifest.rs` (800, 852)
- `src-tauri/src/phone/mailbox.rs` (2053, 2250, 2260, 11060, 11070)
- `src-tauri/src/commands/wg_delete_diagnostic.rs` (1447, `#[cfg(windows)]`)
- `crates/session-bridge/src/bin/agentscommander-api-helper.rs` (608, 610)

## Reviews

- Architect plan certified (Lite), amended from 7 to 10 sites after empirical verification that the windows job (the only one running `cargo clippy --workspace`) fires 3 additional sites.
- Grinch review: PASS, non-visual, no findings; byte-exact vs plan, behavior equivalence traced site by site.

## Verification

- `cargo test` from `src-tauri`: 3793 passed, 28 ignored
- `cargo test -p session-bridge`: 38 passed (pins sha256_hex digests)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Dependency-cycle gate: zero module arcs added/removed

Closes #1474