### PR TITLE
docs: correct 0.30.0 changelog coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ This file follows a lightweight [Keep a Changelog](https://keepachangelog.com/en
 - Sequenced local TASK writes against session snapshots by owning workgroup ([#1477](https://github.com/mblua/AgentsCommander/pull/1477)).
 - Used loopback URLs when opening a browser for wildcard web-server binds ([#1485](https://github.com/mblua/AgentsCommander/pull/1485)).
 - Logged a warning when seed rendering panics during terminal-output activation ([#1460](https://github.com/mblua/AgentsCommander/pull/1460)).
+- Stopped replica config seeding from persisting `replica_config_file` rows in `seed-manifest.toml`, while retaining support for reading and later pruning legacy rows ([#1487](https://github.com/mblua/AgentsCommander/pull/1487)).
 
 ### Security
 


### PR DESCRIPTION
## Summary

- Corrects the `0.30.0` changelog after the first release-metadata PR raced with `main`.
- Adds the missing `Fixed` entry for #1487.
- Keeps the corrective diff to one inserted line in `CHANGELOG.md`.

## Release race evidence

- Prior PR: #1486
- Prior reviewed base: `fe06bf4cb36b45658b8418c805f5d416189e0999`
- Actual first parent of merge commit `585208d079ef582ba7669035a0057a78954b7679`: `7170a71221be841b64e9ef02a2034b46598ff98b`
- Corrective frozen base: `585208d079ef582ba7669035a0057a78954b7679`
- Corrective head: `11429614652a9c645b32eee9aef23cf8c20cb46f`

## Certification

- Certified plan SHA-256: `A4CE61448E8A9B193ED87D033558E04FB2AF2D81CB32BC99A2289AC4337EFB87`
- Fresh first-parent ledger: 113 rows; 58 categorized + 55 intentionally omitted; 0 unresolved.
- Raw ledger SHA-256: `B857E45381B5AB44EC20CEEC57C3EAC98CC3876EBED428C3600D3E9BF777DCC9`
- Coverage audit SHA-256: `7412C020BB2D9134C84BAF28B39436B4DAEC6BD622A3E54561979CB2F4A401AB`
- Consolidated audit SHA-256: `33806CADB2A52606CECE3661DA0ABF27DD7F8C3CE6FB2C72DA6F843C9920B32D`
- Independent review: PASS; no findings.
- Visual classification: non-visual.

## Validation

- `npm run version:check`
- `npm run typecheck`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check`

Refs #1481.
