### PR TITLE
fix: align PTY geometry before terminal attach (#1528)

### DIFF
--- a/src/terminal/App.workflow.test.tsx
+++ b/src/terminal/App.workflow.test.tsx
@@ -436,20 +436,16 @@ describe("TerminalApp workflow", () => {
       expect(hasPtyResizeCall(fake, SESSION_A, 120, 30)).toBe(false);
       expect(fake.callsFor("get_screen_snapshot")).toHaveLength(0);
 
-      // #973. The snapshot resized xterm to the PTY's size, and the re-fit then
-      // puts xterm back to the tile's size. But the PTY was ALREADY told that
-      // size — by the mount fit, before `fake.clearCalls()` — and it never moved
-      // since. Re-sending it is exactly the redundant resize #973 removed.
-      //
-      // The assertion requires the end state: xterm is back at the fitted size,
-      // and the PTY was not spoken to for nothing.
+      // The only post-clear resize comes from the {second priming frame,
+      // settle} pair and carries the fitted grid. The pre-seed imposition lands
+      // before `fake.clearCalls()`; the 120x30 snapshot grid is never echoed.
       await waitFor(() =>
         expect({ cols: terminal.cols, rows: terminal.rows }).toEqual({
           cols: fitViewport.cols,
           rows: fitViewport.rows,
         })
       );
-      expect(fake.callsFor("pty_resize")).toHaveLength(0);
+      expect(fake.callsFor("pty_resize")).toHaveLength(1);
       expect(terminal.writes).toHaveLength(1);
     } finally {
       rendered.cleanup();
@@ -621,10 +617,16 @@ describe("TerminalApp workflow", () => {
     try {
       await waitFor(() => expect(xterm.instances).toHaveLength(1));
       await waitFor(() => expect(fake.callsFor("get_screen_snapshot")).toHaveLength(0));
+      await waitFor(() =>
+        expect(fake.callsFor("activate_terminal_output")).toHaveLength(1)
+      );
 
       fake.emitFromBackend("session_switched", userLiveSelection(SESSION_B, 2));
       await waitFor(() => expect(xterm.instances).toHaveLength(2));
       expect(fake.callsFor("get_screen_snapshot")).toHaveLength(0);
+      await waitFor(() =>
+        expect(fake.callsFor("activate_terminal_output")).toHaveLength(2)
+      );
 
       fake.emitFromBackend("session_switched", userLiveSelection(SESSION_A, 3));
       await waitFor(() => {
@@ -637,7 +639,9 @@ describe("TerminalApp workflow", () => {
       // Each selection attaches once and seeds from that attach; the legacy
       // snapshot surface stays untouched. Switching away detached first.
       expect(fake.callsFor("get_screen_snapshot")).toHaveLength(0);
-      expect(fake.callsFor("activate_terminal_output")).toHaveLength(3);
+      await waitFor(() =>
+        expect(fake.callsFor("activate_terminal_output")).toHaveLength(3)
+      );
       expect(fake.callsFor("detach_terminal_output")).toHaveLength(2);
     } finally {
       rendered.cleanup();

--- a/src/terminal/components/TerminalView.attachment.test.tsx
+++ b/src/terminal/components/TerminalView.attachment.test.tsx
@@ -39,6 +39,7 @@ interface FakeTerminalInstance {
   element: HTMLElement | null;
   writes: number[][];
   screen: number[][];
+  resizes: { cols: number; rows: number }[];
   resets: number;
   disposed: boolean;
   buffer: {
@@ -52,6 +53,7 @@ interface FakeTerminalInstance {
   scrollToBottomCalls: number;
   pendingWriteCallbacks: Array<() => void>;
   writeThrows: boolean;
+  resize(cols: number, rows: number): void;
 }
 
 const xterm = vi.hoisted(() => ({
@@ -63,6 +65,8 @@ const xterm = vi.hoisted(() => ({
   autoCompleteWrites: true,
 }));
 
+const fitViewport = vi.hoisted(() => ({ cols: 80, rows: 24 }));
+
 vi.mock("@xterm/xterm", () => ({
   Terminal: class implements FakeTerminalInstance {
     cols = 80;
@@ -70,6 +74,7 @@ vi.mock("@xterm/xterm", () => ({
     element: HTMLElement | null = null;
     writes: number[][] = [];
     screen: number[][] = [];
+    resizes: { cols: number; rows: number }[] = [];
     resets = 0;
     disposed = false;
     buffer: {
@@ -88,7 +93,9 @@ vi.mock("@xterm/xterm", () => ({
       xterm.instances.push(this);
     }
 
-    loadAddon(): void {}
+    loadAddon(addon?: { activate?: (terminal: FakeTerminalInstance) => void }): void {
+      addon?.activate?.(this);
+    }
     open(element: HTMLElement): void {
       this.element = element;
     }
@@ -143,6 +150,7 @@ vi.mock("@xterm/xterm", () => ({
       return { dispose: () => {} };
     }
     resize(cols: number, rows: number): void {
+      this.resizes.push({ cols, rows });
       this.cols = cols;
       this.rows = rows;
     }
@@ -151,10 +159,22 @@ vi.mock("@xterm/xterm", () => ({
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: class {
-    activate(): void {}
-    fit = vi.fn();
+    private terminal: FakeTerminalInstance | null = null;
+
+    activate(terminal: FakeTerminalInstance): void {
+      this.terminal = terminal;
+    }
+
+    fit = vi.fn(() => {
+      const terminal = this.terminal;
+      if (!terminal) return;
+      if (terminal.cols === fitViewport.cols && terminal.rows === fitViewport.rows) {
+        return;
+      }
+      terminal.resize(fitViewport.cols, fitViewport.rows);
+    });
     proposeDimensions(): { cols: number; rows: number } {
-      return { cols: 80, rows: 24 };
+      return { cols: fitViewport.cols, rows: fitViewport.rows };
     }
   },
 }));
@@ -275,6 +295,8 @@ describe("TerminalView attachment (#1363)", () => {
       instance.writeThrows = false;
     }
     xterm.instances.length = 0;
+    fitViewport.cols = 80;
+    fitViewport.rows = 24;
     warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     debug = vi.spyOn(console, "debug").mockImplementation(() => {});
   });
@@ -314,8 +336,9 @@ describe("TerminalView attachment (#1363)", () => {
       // Switch back before the detach settles, then let it settle.
       terminalStore.setActiveSessionForTests(SESSION_A);
       detachGate.resolve();
-      await flushPromises();
-      await flushPromises();
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_A])
+      );
 
       // B was visible for a moment but never attached: its transition was
       // superseded before it could issue one.
@@ -540,6 +563,9 @@ describe("TerminalView attachment (#1363)", () => {
 
       terminalStore.setActiveSessionForTests(SESSION_B);
       await waitFor(() => expect(detachedSessionIds(fake)).toEqual([SESSION_A]));
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B])
+      );
 
       terminalStore.setActiveSessionForTests(SESSION_A);
       await waitFor(() => expect(terminal.writes).toHaveLength(2));
@@ -612,9 +638,11 @@ describe("TerminalView attachment (#1363)", () => {
       for (const instance of instancesFor(SESSION_A)) {
         expect(instance.writes).toEqual([SNAP, LIVE]);
       }
-      for (const instance of instancesFor(SESSION_B)) {
-        expect(instance.writes).toEqual([SNAP]);
-      }
+      await waitFor(() => {
+        for (const instance of instancesFor(SESSION_B)) {
+          expect(instance.writes).toEqual([SNAP]);
+        }
+      });
     } finally {
       rendered.cleanup();
     }
@@ -662,14 +690,22 @@ describe("TerminalView attachment (#1363)", () => {
       await waitFor(() => expect(instancesFor(SESSION_A)[0]?.writes).toHaveLength(1));
       const terminal = instancesFor(SESSION_A)[0];
 
-      // Priming: the first attach settle schedules `scheduleViewportSync`,
-      // whose two rAF frames are setTimeout(0) under the DOM stubs, so
-      // waitFor's real sleeps flush them. Exactly one pty_resize carries the
-      // fit dims: `lastSentViewport` now equals what the re-attach will refit.
-      await waitFor(() => expect(resizesOfA()).toEqual([{ cols: 80, rows: 24 }]));
+      // The priming sync, pre-seed imposition, and the
+      // {second priming frame, settle} pair each contribute one send in the
+      // harness ordering. All carry this window's fitted grid.
+      await waitFor(() =>
+        expect(resizesOfA()).toEqual([
+          { cols: 80, rows: 24 },
+          { cols: 80, rows: 24 },
+          { cols: 80, rows: 24 },
+        ])
+      );
 
       terminalStore.setActiveSessionForTests(SESSION_B);
       await waitFor(() => expect(detachedSessionIds(fake)).toEqual([SESSION_A]));
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B])
+      );
 
       // Segment the invoke log: only re-attach calls count from here on.
       const resizesBeforeReattach = resizesOfA().length;
@@ -679,12 +715,13 @@ describe("TerminalView attachment (#1363)", () => {
         expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B, SESSION_A])
       );
 
-      // The attach settled with no seed; flushing the sync's two rAF frames
-      // must re-impose this window's grid on the PTY. Without the dedup-key
-      // invalidation the refit equals the primed key and this send never
-      // happens: the incident geometry, and this wait times out.
+      // The pre-seed imposition and the {second priming frame, seedless
+      // resync} pair each re-impose this window's grid. Without the dedup-key
+      // invalidation the refit equals the primed key and these sends disappear:
+      // the incident geometry returns, and this wait times out.
       await waitFor(() =>
         expect(resizesOfA().slice(resizesBeforeReattach)).toEqual([
+          { cols: 80, rows: 24 },
           { cols: 80, rows: 24 },
         ])
       );
@@ -789,7 +826,12 @@ describe("TerminalView attachment (#1363)", () => {
     setupTransport(fake);
     const attachGate = deferred<PtyScreenSnapshot | null>();
     const resizeGate = deferred<void>();
-    fake.onInvoke("pty_resize", () => resizeGate.promise);
+    fake.onInvoke("pty_resize", (args) => {
+      if (Number(args.cols) === 81 && Number(args.rows) === 27) {
+        return resizeGate.promise;
+      }
+      return undefined;
+    });
     fake.onInvoke("activate_terminal_output", (args) => {
       const sessionId = String(args.sessionId);
       if (sessionId === SESSION_A) {
@@ -812,15 +854,23 @@ describe("TerminalView attachment (#1363)", () => {
       await waitFor(() => expect(attachedSessionIds(fake)).toEqual([SESSION_A]));
       const terminal = instancesFor(SESSION_A)[0];
 
-      // While the fetch is held, the priming sync imposes the pre-snapshot
-      // grid (80x24). jsdom's rAF is tick-driven (not timer-driven), so the
-      // second sync frame runs on the next tick: queue our own frame behind
-      // it, proving both frames have run (the second deduplicates) before the
-      // attach resolves.
-      await waitFor(() => expect(resizesOfA()).toEqual([{ cols: 80, rows: 24 }]));
+      // The priming sync and the awaited pre-seed imposition carry the
+      // pre-snapshot grid. The second sync frame deduplicates against the key
+      // re-primed by the pre-seed send.
+      await waitFor(() =>
+        expect(resizesOfA()).toEqual([
+          { cols: 80, rows: 24 },
+          { cols: 80, rows: 24 },
+        ])
+      );
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-      expect(resizesOfA()).toEqual([{ cols: 80, rows: 24 }]);
+      expect(resizesOfA()).toEqual([
+        { cols: 80, rows: 24 },
+        { cols: 80, rows: 24 },
+      ]);
 
+      fitViewport.cols = 81;
+      fitViewport.rows = 27;
       attachGate.resolve({
         sessionId: SESSION_A,
         data: SNAP,
@@ -865,6 +915,230 @@ describe("TerminalView attachment (#1363)", () => {
       expect(settled).toContain("resize=sent");
     } finally {
       rendered.cleanup();
+    }
+  });
+
+  it("sends the fitted container grid to the PTY before requesting the seed snapshot", async () => {
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fitViewport.cols = 100;
+    fitViewport.rows = 30;
+    fake.onInvoke("activate_terminal_output", (args) => ({
+      sessionId: String(args.sessionId),
+      data: SNAP,
+      rows: 30,
+      cols: 100,
+      sequence: 0,
+    }));
+
+    terminalStore.setActiveSessionForTests(SESSION_A);
+    const rendered = renderWithFakeTransport(() => <TerminalView />, fake);
+    try {
+      await waitFor(() =>
+        expect(instancesFor(SESSION_A)[0]?.scrollToBottomCalls).toBe(1)
+      );
+      const terminal = instancesFor(SESSION_A)[0];
+      const fittedResize = fake.callsFor("pty_resize").find(
+        (call) =>
+          String(call.args.sessionId) === SESSION_A &&
+          Number(call.args.cols) === 100 &&
+          Number(call.args.rows) === 30
+      );
+      const seedRequest = fake
+        .callsFor("activate_terminal_output")
+        .find((call) => String(call.args.sessionId) === SESSION_A);
+      if (!fittedResize || !seedRequest) {
+        throw new Error("expected the fitted resize and seed request");
+      }
+
+      expect(fake.calls.indexOf(fittedResize)).toBeLessThan(fake.calls.indexOf(seedRequest));
+      expect({ cols: terminal.cols, rows: terminal.rows }).toEqual({ cols: 100, rows: 30 });
+      expect(terminal.resizes).toEqual([{ cols: 100, rows: 30 }]);
+
+      const settled = debug.mock.calls
+        .map((call: unknown[]) => String(call[0]))
+        .find((line: string) =>
+          line.startsWith("[terminal] attach " + SESSION_A + " settled:")
+        );
+      expect(settled).toContain("cols=100");
+      expect(settled).toContain("rows=30");
+      expect(settled).toContain("snapshotCols=100");
+      expect(settled).toContain("snapshotRows=30");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("initial attach ends with the same geometry as detach -> reattach", async () => {
+    xterm.autoCompleteWrites = false;
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fitViewport.cols = 100;
+    fitViewport.rows = 30;
+    fake.onInvoke("activate_terminal_output", (args) => ({
+      sessionId: String(args.sessionId),
+      data: String(args.sessionId) === SESSION_A ? MULTIVIEW : SNAP,
+      rows: 30,
+      cols: 100,
+      sequence: 0,
+    }));
+
+    terminalStore.setActiveSessionForTests(SESSION_A);
+    const rendered = renderWithFakeTransport(() => <TerminalView />, fake);
+    try {
+      await waitFor(() => expect(instancesFor(SESSION_A)[0]?.writes).toEqual([MULTIVIEW]));
+      const terminal = instancesFor(SESSION_A)[0];
+      simulateParsedHistory(terminal, 120);
+      completeWriteCallbacks(terminal);
+      await waitFor(() => expect(terminal.scrollToBottomCalls).toBe(1));
+
+      const initialGeometry = {
+        cols: terminal.cols,
+        rows: terminal.rows,
+        viewportY: terminal.buffer.active.viewportY,
+        baseY: terminal.buffer.active.baseY,
+        bufferLength: terminal.buffer.active.length,
+      };
+
+      terminalStore.setActiveSessionForTests(SESSION_B);
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B])
+      );
+      terminalStore.setActiveSessionForTests(SESSION_A);
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B, SESSION_A])
+      );
+      await waitFor(() => expect(terminal.writes).toEqual([MULTIVIEW, MULTIVIEW]));
+
+      simulateParsedHistory(terminal, 120);
+      completeWriteCallbacks(terminal);
+      await waitFor(() => expect(terminal.scrollToBottomCalls).toBe(2));
+
+      expect({
+        cols: terminal.cols,
+        rows: terminal.rows,
+        viewportY: terminal.buffer.active.viewportY,
+        baseY: terminal.buffer.active.baseY,
+        bufferLength: terminal.buffer.active.length,
+      }).toEqual(initialGeometry);
+      expect(terminal.buffer.active.viewportY).toBe(terminal.buffer.active.baseY);
+      expect(terminal.screen).toEqual([MULTIVIEW]);
+
+      const settled = debug.mock.calls
+        .map((call: unknown[]) => String(call[0]))
+        .filter((line: string) =>
+          line.startsWith("[terminal] attach " + SESSION_A + " settled:")
+        );
+      expect(settled).toHaveLength(2);
+      for (const line of settled) {
+        expect(line).toContain("cols=100");
+        expect(line).toContain("rows=30");
+        expect(line).toContain("snapshotCols=100");
+        expect(line).toContain("snapshotRows=30");
+      }
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("snapshot replay never resizes a populated buffer on the aligned path", async () => {
+    xterm.autoCompleteWrites = false;
+    const fake = new FakeTransport();
+    setupTransport(fake);
+    fitViewport.cols = 100;
+    fitViewport.rows = 30;
+    const attachGate = deferred<PtyScreenSnapshot | null>();
+    fake.onInvoke("activate_terminal_output", () => attachGate.promise);
+
+    terminalStore.setActiveSessionForTests(SESSION_A);
+    const rendered = renderWithFakeTransport(() => <TerminalView />, fake);
+    try {
+      await waitFor(() => expect(attachedSessionIds(fake)).toEqual([SESSION_A]));
+      const terminal = instancesFor(SESSION_A)[0];
+
+      expect(terminal.resizes).toEqual([{ cols: 100, rows: 30 }]);
+      expect(terminal.writes).toEqual([]);
+
+      // Let the original second priming frame dedup while the snapshot is
+      // still gated. Once the snapshot clears the key, the settle send is the
+      // observable `sent` outcome pinned below.
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+      attachGate.resolve({
+        sessionId: SESSION_A,
+        data: SNAP,
+        rows: 30,
+        cols: 100,
+        sequence: 0,
+      });
+      await waitFor(() => expect(terminal.writes).toEqual([SNAP]));
+      expect(terminal.resizes).toEqual([{ cols: 100, rows: 30 }]);
+
+      completeWriteCallbacks(terminal);
+      await waitFor(() => expect(terminal.scrollToBottomCalls).toBe(1));
+      const settled = debug.mock.calls
+        .map((call: unknown[]) => String(call[0]))
+        .find((line: string) =>
+          line.startsWith("[terminal] attach " + SESSION_A + " settled:")
+        );
+      expect(settled).toContain("cols=100");
+      expect(settled).toContain("rows=30");
+      expect(settled).toContain("snapshotCols=100");
+      expect(settled).toContain("snapshotRows=30");
+      expect(settled).toContain("resize=sent");
+      expect(terminal.resizes).toEqual([{ cols: 100, rows: 30 }]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  it("initial attach completes without an animation frame while the document is hidden, and settles on restore", async () => {
+    const hiddenDescriptor = Object.getOwnPropertyDescriptor(document, "hidden");
+    Object.defineProperty(document, "hidden", { configurable: true, value: true });
+    let cleanupRendered: (() => void) | null = null;
+
+    try {
+      const fake = new FakeTransport();
+      setupTransport(fake);
+      terminalStore.setActiveSessionForTests(SESSION_A);
+      const rendered = renderWithFakeTransport(() => <TerminalView />, fake);
+      cleanupRendered = rendered.cleanup;
+
+      await flushPromises();
+      await flushPromises();
+      expect(attachedSessionIds(fake)).toEqual([SESSION_A]);
+
+      const currentGridResize = fake
+        .callsFor("pty_resize")
+        .find((call) => String(call.args.sessionId) === SESSION_A);
+      const seedRequest = fake
+        .callsFor("activate_terminal_output")
+        .find((call) => String(call.args.sessionId) === SESSION_A);
+      if (!currentGridResize || !seedRequest) {
+        throw new Error("expected the hidden-path resize and seed request");
+      }
+      expect(fake.calls.indexOf(currentGridResize)).toBeLessThan(
+        fake.calls.indexOf(seedRequest)
+      );
+
+      Object.defineProperty(document, "hidden", { configurable: true, value: false });
+      const terminal = instancesFor(SESSION_A)[0];
+      await waitFor(() => expect(terminal.scrollToBottomCalls).toBe(1));
+      expect(terminal.buffer.active.viewportY).toBe(terminal.buffer.active.baseY);
+      expect(
+        debug.mock.calls
+          .map((call: unknown[]) => String(call[0]))
+          .filter((line: string) =>
+            line.startsWith("[terminal] attach " + SESSION_A + " settled:")
+          )
+      ).toHaveLength(1);
+    } finally {
+      cleanupRendered?.();
+      if (hiddenDescriptor) {
+        Object.defineProperty(document, "hidden", hiddenDescriptor);
+      } else {
+        Reflect.deleteProperty(document, "hidden");
+      }
     }
   });
 
@@ -1394,6 +1668,9 @@ describe("TerminalView attachment (#1363)", () => {
       // Switch away and back: exactly one settle per attach.
       terminalStore.setActiveSessionForTests(SESSION_B);
       await waitFor(() => expect(detachedSessionIds(fake)).toEqual([SESSION_A]));
+      await waitFor(() =>
+        expect(attachedSessionIds(fake)).toEqual([SESSION_A, SESSION_B])
+      );
 
       // Alternate-screen evidence: before the second attach's settle.
       terminal.buffer.active.type = "alternate";

--- a/src/terminal/components/TerminalView.spawn-size.test.tsx
+++ b/src/terminal/components/TerminalView.spawn-size.test.tsx
@@ -324,12 +324,9 @@ describe("TerminalView PTY spawn size (#973)", () => {
       await frames.flush();
       await attachSpawnedSession();
 
-      // #1439 (R1): the attach settle invalidates the viewport dedup key, so
-      // the settle sync sends exactly one resize even though the size never
-      // changed. The #973 guarantee moved with it: the frontend no longer
-      // suppresses the settle send; the backend `resize_instance` dedup answers
-      // this same-size resize with `sent = false`, so no resize reaches the
-      // child while it is starting up.
+      // The drive loop stops at the awaited pre-seed imposition. The backend
+      // `resize_instance` dedup answers this same-size resize with
+      // `sent = false`, so no resize reaches the starting child.
       await driveFramesUntil(
         frames,
         "the settle sync sent",
@@ -339,10 +336,11 @@ describe("TerminalView PTY spawn size (#973)", () => {
         { sessionId: SPAWNED, cols: 74, rows: 23 },
       ]);
 
-      // The second rAF frame and any other queued sync dedup against the
-      // freshly written key: one send per settle, no more.
+      // The original second priming frame sends after the seedless path clears
+      // the key. The seedless resync frames then dedup against that fresh key.
       await frames.flush();
       expect(resizesFor(fake, SPAWNED).map((call) => call.args)).toEqual([
+        { sessionId: SPAWNED, cols: 74, rows: 23 },
         { sessionId: SPAWNED, cols: 74, rows: 23 },
       ]);
 
@@ -374,7 +372,7 @@ describe("TerminalView PTY spawn size (#973)", () => {
     }
   });
 
-  it("resizes once for the drift and once more at the settle, and reports the drift exactly once", async () => {
+  it("resizes for the drift, the pre-seed imposition, and the original second sync frame, and reports the drift exactly once", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fake = new FakeTransport();
     setupTerminalTransport(fake);
@@ -391,23 +389,23 @@ describe("TerminalView PTY spawn size (#973)", () => {
 
       await attachSpawnedSession();
 
-      // Correctness first: the PTY is told the truth. The drift fires one
-      // resize from xterm's onResize, and since #1439 (R1) the attach settle
-      // re-imposes the identical size once more (the settle invalidates the
-      // dedup key; the backend `resize_instance` dedup absorbs the repeat).
-      // Exactly these two named senders: any identical-resize burst beyond
-      // them is still gone, which is what #973 pinned.
+      // Correctness first: the PTY is told the truth. The drift's onResize,
+      // the awaited pre-seed imposition, and the original second priming frame
+      // each carry the fitted size. The seedless resync dedups against the
+      // second frame's fresh key.
       await driveFramesUntil(
         frames,
-        "drift send and settle re-send landed",
-        () => resizesFor(fake, SPAWNED).length >= 2
+        "drift, pre-seed, and second-frame sends landed",
+        () => resizesFor(fake, SPAWNED).length >= 3
       );
       expect(resizesFor(fake, SPAWNED).map((call) => call.args)).toEqual([
+        { sessionId: SPAWNED, cols: 74, rows: 24 },
         { sessionId: SPAWNED, cols: 74, rows: 24 },
         { sessionId: SPAWNED, cols: 74, rows: 24 },
       ]);
       await frames.flush();
       expect(resizesFor(fake, SPAWNED).map((call) => call.args)).toEqual([
+        { sessionId: SPAWNED, cols: 74, rows: 24 },
         { sessionId: SPAWNED, cols: 74, rows: 24 },
         { sessionId: SPAWNED, cols: 74, rows: 24 },
       ]);
@@ -535,9 +533,7 @@ describe("TerminalView PTY spawn size (#973)", () => {
       await createWhileOnScreen(fake);
       const spawned = await attachSpawnedSession();
 
-      // The #1439 (R1) settle send lands and succeeds: exactly one same-size
-      // resize, after which nothing is armed and nothing else in the system
-      // will send for this session until the drag.
+      // The drive loop stops when the awaited pre-seed imposition lands.
       await driveFramesUntil(
         frames,
         "the settle send landed",
@@ -547,22 +543,24 @@ describe("TerminalView PTY spawn size (#973)", () => {
         { sessionId: SPAWNED, cols: 74, rows: 23 },
       ]);
       await frames.flush();
-      expect(resizesFor(fake, SPAWNED)).toHaveLength(1);
+      // The original second priming frame adds one send; the seedless resync
+      // dedups against its fresh key.
+      expect(resizesFor(fake, SPAWNED)).toHaveLength(2);
 
       // The user drags the window. xterm reflows and fires onResize: one resize,
       // long after every scheduled fit has run. It fails.
       spawned.emitResize(74, 24);
 
       await waitFor(
-        () => expect(resizesFor(fake, SPAWNED).length).toBeGreaterThanOrEqual(3),
+        () => expect(resizesFor(fake, SPAWNED).length).toBeGreaterThanOrEqual(4),
         2000
       );
 
       // The attempt and the re-send both carry the size the terminal is actually at.
-      // Nothing but the retry could have produced that third call.
+      // Nothing but the retry could have produced that fourth call.
       const resizes = resizesFor(fake, SPAWNED);
-      expect(resizes[1].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
       expect(resizes[2].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
+      expect(resizes[3].args).toEqual({ sessionId: SPAWNED, cols: 74, rows: 24 });
     } finally {
       rendered.cleanup();
     }
@@ -590,9 +588,10 @@ describe("TerminalView PTY spawn size (#973)", () => {
 
       // A PTY stranded at a size the terminal is not must never be mistaken for
       // a PTY that was resized. When the budget runs out, it says so. In an
-      // all-fail world the #1439 (R1) settle burst alone consumes the whole
-      // budget: one frame-driven send, at most one second-frame repeat, then
-      // PTY_RESIZE_MAX_RETRIES timer re-sends, then this loud line.
+      // all-fail world four frame-driven sends fire: pre-seed, the original
+      // second priming frame, and both seedless-resync frames. The first loud
+      // line comes from the second resync frame; up to three timer retries at
+      // 120/240/360 ms can also fire and log "giving up" before the poll wins.
       await waitFor(
         () =>
           expect(
@@ -604,7 +603,7 @@ describe("TerminalView PTY spawn size (#973)", () => {
       // And the budget is a budget, all of it spent by the settle burst here,
       // not an endless loop against a backend that is gone.
       const settleSends = resizesFor(fake, SPAWNED).length;
-      expect(settleSends).toBeLessThanOrEqual(5);
+      expect(settleSends).toBeLessThanOrEqual(7);
 
       // The user drags the window. First attempts are never budget-gated, so
       // the drag's own send still goes out (and says "giving up" once more),
@@ -621,7 +620,7 @@ describe("TerminalView PTY spawn size (#973)", () => {
         cols: 74,
         rows: 24,
       });
-      expect(resizes.length).toBeLessThanOrEqual(6);
+      expect(resizes.length).toBeLessThanOrEqual(8);
     } finally {
       rendered.cleanup();
     }

--- a/src/terminal/components/TerminalView.tsx
+++ b/src/terminal/components/TerminalView.tsx
@@ -1098,6 +1098,53 @@ const TerminalView: Component<TerminalViewProps> = (props) => {
           return; // the entry went away while this transition was queued
         }
 
+        // #1528 - request the seed snapshot only after this window's fitted
+        // grid is imposed on the PTY. The snapshot then arrives at the fitted
+        // grid, `resizeTerminalForSnapshot` no-ops, the settle `fit()` no-ops,
+        // and replay never resizes a populated buffer: the initial attach
+        // converges on the same geometry as detach -> reattach. Wait one
+        // animation frame so xterm has measured its cells against the
+        // now-visible container (ResizeObserver delivery precedes rAF
+        // callbacks in the same frame); fit to that container; clear the
+        // dedup key so this imposition can never be deduplicated away by a
+        // stale key (#1439) or by the fit's own fire-and-forget onResize
+        // send; then await the typed resize so the backend parser grid is
+        // updated before `attachOutput` captures the snapshot. The frame wait
+        // is skipped while the document is hidden: Chromium/WebView2 suspend
+        // rAF exactly for hidden (minimized/occluded) pages, so a hidden
+        // window must not stall the attach; without the wait the fit no-ops
+        // on unmeasured cells, the send carries the current grid, and the
+        // attach degrades exactly to the status-quo path, converging when the
+        // window becomes visible (G3). Every outcome of the awaited send is
+        // tolerated exactly as the settle tolerates it: "failed" leaves the
+        // PTY at its previous grid (the existing retry and the settle
+        // re-imposition still run), "deduplicated" cannot occur after the key
+        // clear. `attachedSessionId` is deliberately set only AFTER this
+        // block: it means "a backend attachment is pending or active", and
+        // an early return on a superseded or disposed target must not leave
+        // a stale value behind (the "owes a detach" invariant of the chain).
+        if (!document.hidden) {
+          await new Promise<void>((resolve) => {
+            requestAnimationFrame(() => resolve());
+          });
+        }
+        if (
+          desiredSessionId !== target ||
+          registry.get(target) !== entry ||
+          entry.destroyed
+        ) {
+          return;
+        }
+        entry.fitAddon.fit();
+        entry.lastSentViewport = null;
+        await sendPtyResize(target, entry, entry.terminal.cols, entry.terminal.rows);
+        if (
+          desiredSessionId !== target ||
+          registry.get(target) !== entry ||
+          entry.destroyed
+        ) {
+          return;
+        }
         attachedSessionId = target;
         const requestedAt = beginSeed(target, entry);
         try {


### PR DESCRIPTION
## Summary

- Align the PTY to the fitted terminal grid before snapshot seeding for every valid attach.
- Preserve detach/reattach buttons, handlers, detach transactions, Rust code, and snapshot/live ordering.
- Add geometry-faithful attachment regressions and update the certified workflow fixtures.

## Verification

- Attachment tests: 21/21 passed.
- Spawn-size tests: 9/9 passed.
- App workflow tests: 30/30 passed.
- Full frontend suite: 1605/1605 passed.
- Typecheck, frontend dependency check, build, and diff check passed.
- Independent adversarial review: PASS.
- The user tested the pre-merge WG-17 executable from commit 3443418e and reported that the new version appears to work well.

## Delivery hold

PR created at the user's request. Do not merge until separately authorized.

Closes #1528