### PR TITLE
fix: confine replica gate walker to owning project and make --launch truthful (#1535, #1163)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -530,9 +530,9 @@ Behaviour:
 1. Resolves `--project` to a registered project path (paths are rejected).
 2. Creates `<project>/.ac/_agent_<id>/` with the matrix layout (`memory/`, `plans/`, `skills/`, `inbox/`, `outbox/`) and writes `Role.md`. A picked role template's body becomes a `## Role Profile` section, and its `skills/` are copied in.
 3. Requests a sidebar refresh in the running AC app.
-4. If `--launch` is set, writes a session request the running AC app picks up within ~3s.
+4. If `--launch` is set, writes a session request the running AC app picks up within ~3s, then waits up to 30s for the app's per-request result (a `<id>.result.json` sidecar) so the reported launch outcome is truthful: `launched` is `true` only after the app confirms the session. A rejected launch (e.g. `sessionRace`) is reported via `launchStatus: "rejected"` and `launchError`; if no result arrives within the timeout, `launchStatus: "pending"` is reported. Matrix creation stays independent of the launch result (exit code 0 and the matrix fields are always produced).
 
-Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchAgent }`.
+Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchStatus, launchError, launchAgent }` (`launchStatus` is `skipped` | `launched` | `rejected` | `pending`).
 
 See [Creating agents](../agents/creating-agents.md) for richer agent layouts.
 
@@ -557,9 +557,9 @@ agentscommander create-agent-matrix --project MyProject --name "dev-rust" --desc
 | `--root` | No | Accepted for parity with `create-agent`; ignored by the handler. |
 | `--token` | No | Accepted for parity with `create-agent`; ignored by the handler. |
 
-Behaviour is identical to [`create-agent`](#create-agent) above, minus the `--description` trim and empty-check.
+Behaviour is identical to [`create-agent`](#create-agent) above, minus the `--description` trim and empty-check, including the truthful `--launch` contract: the verb writes a session request the running AC app picks up within ~3s and waits up to 30s for the app's result sidecar, reporting `launchStatus` (`skipped` | `launched` | `rejected` | `pending`) and `launchError`; `launched` is `true` only when the app confirmed the session.
 
-Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchAgent }`.
+Output (stdout, JSON): `{ agentPath, agentName, rolePath, launched, launchStatus, launchError, launchAgent }`.
 
 > The CLI verb `create-agent-matrix` is distinct from the in-app New Agent command of the same name. The GUI command shares the same on-disk core but never launches a session and returns only `{ path }`.
 

--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -1,9 +1,20 @@
 use clap::Args;
 use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 use crate::cli::create_agent_matrix;
 use crate::config;
 use crate::config::instance_artifacts::SESSION_REQUESTS_DIR_NAME;
+
+/// Test-only serialization for every test that writes or consumes files in
+/// the process-shared `config_dir()/session-requests/` (the C1-C5 tests here
+/// and the M1-M5 poll tests in `phone::mailbox`). `config_dir()` is a
+/// process-wide `OnceLock`, so those tests share ONE directory; without the
+/// lock a poll test could consume (or delete) another test's request/result
+/// file mid-test.
+#[cfg(test)]
+pub(crate) static SESSION_REQUESTS_TEST_LOCK: std::sync::OnceLock<std::sync::Mutex<()>> =
+    std::sync::OnceLock::new();
 
 #[derive(Args)]
 #[command(after_help = "\
@@ -14,7 +25,7 @@ VALIDATION:\n  \
   --project is a registered AC project folder name from settings.projectPaths. Paths are not accepted.\n  \
   --name is trimmed before use. It must not be empty after trim, and it must not contain path separators (/ or \\) or NUL.\n\n\
 OUTPUT:\n  \
-  Prints the same JSON as create-agent-matrix: agentPath, agentName, rolePath, launched, launchAgent.")]
+  Prints the same JSON as create-agent-matrix: agentPath, agentName, rolePath, launched, launchStatus, launchError, launchAgent.")]
 pub struct CreateAgentArgs {
     /// Registered AC project folder name. Paths are not accepted.
     #[arg(long, value_name = "PROJECT")]
@@ -141,6 +152,116 @@ pub(crate) fn write_session_request(request: &SessionRequest) -> Result<(), Stri
     std::fs::write(&path, json).map_err(|e| format!("Failed to write session request: {}", e))?;
 
     Ok(())
+}
+
+/// #1163 - the outcome the running app recorded for a session request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionRequestResultStatus {
+    Created,
+    Rejected,
+}
+
+/// #1163 - the running app answers each session request with a result sidecar
+/// (`<id>.result.json` in the session-requests dir) so the CLI can report a
+/// truthful launch outcome.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRequestResult {
+    pub id: String,
+    pub status: SessionRequestResultStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `<config_dir>/session-requests/<id>.result.json`
+pub(crate) fn session_request_result_path(config_dir: &Path, id: &str) -> PathBuf {
+    config_dir
+        .join(SESSION_REQUESTS_DIR_NAME)
+        .join(format!("{id}.result.json"))
+}
+
+/// True when `path` is a result sidecar (`<id>.result.json`), never a request.
+pub(crate) fn is_session_request_result_path(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.ends_with(".result"))
+}
+
+/// Mirror of [`write_session_request`] for the result sidecar.
+pub(crate) fn write_session_request_result(result: &SessionRequestResult) -> Result<(), String> {
+    let config_dir = config::config_dir().ok_or("Cannot determine config directory")?;
+    let requests_dir = config_dir.join(SESSION_REQUESTS_DIR_NAME);
+    std::fs::create_dir_all(&requests_dir)
+        .map_err(|e| format!("Failed to create session-requests dir: {}", e))?;
+    let path = session_request_result_path(&config_dir, &result.id);
+    let json = serde_json::to_string_pretty(result)
+        .map_err(|e| format!("Failed to serialize session request result: {}", e))?;
+    std::fs::write(&path, json)
+        .map_err(|e| format!("Failed to write session request result: {}", e))?;
+    Ok(())
+}
+
+/// Read and CONSUME `<id>.result.json`: on success parse and delete the file;
+/// on missing or unparseable, delete-if-present and return `None`.
+pub(crate) fn read_session_request_result(id: &str) -> Option<SessionRequestResult> {
+    let config_dir = config::config_dir()?;
+    let path = session_request_result_path(&config_dir, id);
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => return None,
+    };
+    match serde_json::from_str::<SessionRequestResult>(&content) {
+        Ok(result) => {
+            let _ = std::fs::remove_file(&path);
+            Some(result)
+        }
+        Err(_) => {
+            let _ = std::fs::remove_file(&path);
+            None
+        }
+    }
+}
+
+/// #1163 - how long the CLI waits for the running app's result sidecar before
+/// reporting `pending`. The app polls every 3 s, so a running app answers in
+/// ~3-6 s plus spawn time; 30 s covers slow spawns without hanging scripts.
+pub(crate) const SESSION_REQUEST_RESULT_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(30);
+
+/// #1163 - the CLI's truthful launch verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LaunchOutcome {
+    Pending,
+    Launched { session_id: String },
+    Rejected { error: String },
+}
+
+/// Poll [`read_session_request_result`] every 250 ms until `timeout` elapses;
+/// `Created` → `Launched`, `Rejected` → `Rejected`, deadline → `Pending`.
+pub(crate) fn wait_for_session_request_result(
+    request_id: &str,
+    timeout: std::time::Duration,
+) -> LaunchOutcome {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(result) = read_session_request_result(request_id) {
+            return match result.status {
+                SessionRequestResultStatus::Created => LaunchOutcome::Launched {
+                    session_id: result.session_id.unwrap_or_default(),
+                },
+                SessionRequestResultStatus::Rejected => LaunchOutcome::Rejected {
+                    error: result.error.unwrap_or_default(),
+                },
+            };
+        }
+        if std::time::Instant::now() >= deadline {
+            return LaunchOutcome::Pending;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
 }
 
 #[cfg(test)]
@@ -278,6 +399,10 @@ mod tests {
 
     #[test]
     fn write_session_request_is_still_json_camel_case() {
+        let _guard = SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
         let request = SessionRequest {
             id: format!("test-{}", uuid::Uuid::new_v4().simple()),
             cwd: "C:/repo/.ac/_agent_architect".to_string(),
@@ -302,5 +427,112 @@ mod tests {
         assert!(json.contains("\"agentId\""));
         assert!(!json.contains("session_name"));
         assert!(!json.contains("agent_id"));
+    }
+
+    // #1163: the result sidecar must stay camelCase JSON so the CLI/app
+    // contract is stable.
+    #[test]
+    fn write_session_request_result_is_still_json_camel_case() {
+        let _guard = SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let result = SessionRequestResult {
+            id: format!("test-{}", uuid::Uuid::new_v4().simple()),
+            status: SessionRequestResultStatus::Created,
+            session_id: Some("sess-1".to_string()),
+            error: None,
+        };
+
+        write_session_request_result(&result).expect("write result");
+
+        let path = crate::config::config_dir()
+            .expect("config dir")
+            .join(SESSION_REQUESTS_DIR_NAME)
+            .join(format!("{}.result.json", result.id));
+        let json = std::fs::read_to_string(&path).expect("read result");
+        let _ = std::fs::remove_file(&path);
+
+        assert!(json.contains("\"status\""));
+        assert!(json.contains("\"sessionId\""));
+        assert!(!json.contains("session_id"));
+        assert!(!json.contains("created_at"));
+    }
+
+    #[test]
+    fn read_session_request_result_consumes_and_deletes() {
+        let _guard = SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let result = SessionRequestResult {
+            id: format!("test-{}", uuid::Uuid::new_v4().simple()),
+            status: SessionRequestResultStatus::Created,
+            session_id: Some("sess-1".to_string()),
+            error: None,
+        };
+        write_session_request_result(&result).expect("write result");
+        let path = crate::config::config_dir()
+            .expect("config dir")
+            .join(SESSION_REQUESTS_DIR_NAME)
+            .join(format!("{}.result.json", result.id));
+
+        let read = read_session_request_result(&result.id).expect("read result");
+        assert_eq!(read.status, SessionRequestResultStatus::Created);
+        assert_eq!(read.session_id.as_deref(), Some("sess-1"));
+        assert!(!path.exists(), "consumed result must be deleted");
+    }
+
+    #[test]
+    fn wait_for_session_request_result_returns_launched() {
+        let _guard = SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let result = SessionRequestResult {
+            id: format!("test-{}", uuid::Uuid::new_v4().simple()),
+            status: SessionRequestResultStatus::Created,
+            session_id: Some("sess-1".to_string()),
+            error: None,
+        };
+        write_session_request_result(&result).expect("write result");
+
+        let outcome = wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
+        assert_eq!(
+            outcome,
+            LaunchOutcome::Launched {
+                session_id: "sess-1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn wait_for_session_request_result_returns_rejected() {
+        let _guard = SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let result = SessionRequestResult {
+            id: format!("test-{}", uuid::Uuid::new_v4().simple()),
+            status: SessionRequestResultStatus::Rejected,
+            session_id: None,
+            error: Some("sessionRace".to_string()),
+        };
+        write_session_request_result(&result).expect("write result");
+
+        let outcome = wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
+        assert_eq!(
+            outcome,
+            LaunchOutcome::Rejected {
+                error: "sessionRace".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn wait_for_session_request_result_times_out_as_pending() {
+        let id = format!("test-{}", uuid::Uuid::new_v4().simple());
+        let outcome = wait_for_session_request_result(&id, std::time::Duration::from_millis(300));
+        assert_eq!(outcome, LaunchOutcome::Pending);
     }
 }

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -5,6 +5,14 @@
 //! `SettingsState`. That matches the existing CLI mutation
 //! model: local disk creation is immediate, while launch requests are handed to
 //! the running GUI through the session-request mailbox.
+//!
+//! #1163: the launch outcome is TRUTHFUL. The running app answers each session
+//! request with a `<id>.result.json` sidecar (created/rejected); this verb waits
+//! up to `SESSION_REQUEST_RESULT_TIMEOUT` for it and reports
+//! `launchStatus` (`skipped` | `launched` | `rejected` | `pending`) plus
+//! `launchError` on rejection. `launched` is `true` only when the app confirmed
+//! the session. Matrix creation stays independent of the launch result: exit
+//! code 0 and the matrix fields are always produced.
 
 use clap::Args;
 use serde::{Deserialize, Serialize};
@@ -22,7 +30,7 @@ NOTES:\n  \
   --name is sanitized by the same backend as the UI into a lower-case Matrix id.\n  \
   --role-template must be an id from the same source as the New Agent picker.\n  \
   Invalid templates fail before creating the target Matrix directory.\n  \
-  Output is JSON with agentPath, agentName, rolePath, launched, launchAgent.")]
+  Output is JSON with agentPath, agentName, rolePath, launched, launchStatus, launchError, launchAgent.")]
 pub struct CreateAgentMatrixArgs {
     /// Registered AC project folder name. Paths are not accepted.
     #[arg(long, value_name = "PROJECT")]
@@ -60,7 +68,21 @@ struct CreateAgentMatrixResult {
     agent_name: String,
     role_path: String,
     launched: bool,
+    launch_status: LaunchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    launch_error: Option<String>,
     launch_agent: Option<String>,
+}
+
+/// #1163 - the truthful launch verdict reported by this verb. `launched ==
+/// (launch_status == Launched)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum LaunchStatus {
+    Skipped,
+    Launched,
+    Rejected,
+    Pending,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,6 +168,8 @@ pub(crate) fn execute_matrix_project_create(
     }
 
     let mut launched = false;
+    let mut launch_status = LaunchStatus::Skipped;
+    let mut launch_error: Option<String> = None;
     let mut launch_agent_id: Option<String> = None;
 
     if let Some(requested) = launch {
@@ -158,10 +182,39 @@ pub(crate) fn execute_matrix_project_create(
                 ) {
                     Ok(request) => match create_agent::write_session_request(&request) {
                         Ok(()) => {
-                            launched = true;
+                            // #1163: the request is on disk; the TRUTHFUL
+                            // outcome comes from the running app's result
+                            // sidecar, with a bounded wait. Rejection is
+                            // distinguishable in this command's own output.
                             launch_agent_id = Some(agent.id.clone());
+                            match create_agent::wait_for_session_request_result(
+                                &request.id,
+                                create_agent::SESSION_REQUEST_RESULT_TIMEOUT,
+                            ) {
+                                create_agent::LaunchOutcome::Launched { .. } => {
+                                    launched = true;
+                                    launch_status = LaunchStatus::Launched;
+                                }
+                                create_agent::LaunchOutcome::Rejected { error } => {
+                                    launch_status = LaunchStatus::Rejected;
+                                    launch_error = Some(error.clone());
+                                    eprintln!(
+                                        "Warning: session launch rejected: {}",
+                                        error
+                                    );
+                                }
+                                create_agent::LaunchOutcome::Pending => {
+                                    launch_status = LaunchStatus::Pending;
+                                    eprintln!(
+                                        "Warning: no launch result within {}s (is the AgentsCommander app running?)",
+                                        create_agent::SESSION_REQUEST_RESULT_TIMEOUT.as_secs()
+                                    );
+                                }
+                            }
                         }
                         Err(e) => {
+                            launch_status = LaunchStatus::Rejected;
+                            launch_error = Some(e.clone());
                             eprintln!(
                                 "Warning: agent matrix created but failed to request launch: {}",
                                 e
@@ -169,6 +222,8 @@ pub(crate) fn execute_matrix_project_create(
                         }
                     },
                     Err(e) => {
+                        launch_status = LaunchStatus::Rejected;
+                        launch_error = Some(e.clone());
                         eprintln!(
                             "Warning: agent matrix created but failed to request launch: {}",
                             e
@@ -178,11 +233,14 @@ pub(crate) fn execute_matrix_project_create(
             }
             None => {
                 let available: Vec<&str> = settings.agents.iter().map(|a| a.id.as_str()).collect();
-                eprintln!(
-                    "Warning: agent '{}' not found in settings. Available: {}. Matrix created but not launched.",
+                let message = format!(
+                    "agent '{}' not found in settings. Available: {}. Matrix created but not launched.",
                     requested,
                     available.join(", ")
                 );
+                launch_status = LaunchStatus::Rejected;
+                launch_error = Some(message.clone());
+                eprintln!("Warning: {}", message);
             }
         }
     }
@@ -192,6 +250,8 @@ pub(crate) fn execute_matrix_project_create(
         agent_name: created.display_name,
         role_path,
         launched,
+        launch_status,
+        launch_error,
         launch_agent: launch_agent_id,
     };
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -6678,6 +6678,176 @@ mod tests {
         close_test_coordinator(&app).await;
     }
 
+    // ──────────────────────────────────────────────────────────────────────
+    // #1535 nested-project sessionRace confinement (S1-S2)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// #1535 S1/S2 fixture: `strict_target_fixture` PLUS a nested project with
+    /// its own full workgroup inside `__agent_dev-one`:
+    /// `nested-proj/.ac/{_team_team, _agent_lead2, _agent_inner2,
+    /// wg-2-team/{__agent_lead2, __agent_inner2}}` and the #1535 bug-shaped
+    /// origin dir `nested-proj/.ac/_agent_phase0`. The nested replica
+    /// `config.json` identity is `../../_agent_inner2`; the nested team config
+    /// names the nested origin matrices.
+    fn nested_strict_target_fixture() -> (tempfile::TempDir, String, String, String) {
+        let (temp, first_cwd, _second) = strict_target_fixture();
+        let outer_replica = std::path::PathBuf::from(&first_cwd);
+
+        let nested_ac_root = outer_replica.join("nested-proj").join(".ac");
+        let nested_team = nested_ac_root.join("_team_team");
+        let nested_wg = nested_ac_root.join("wg-2-team");
+        let nested_inner2 = nested_wg.join("__agent_inner2");
+        let nested_origin = nested_ac_root.join("_agent_phase0");
+        for directory in [
+            &nested_team,
+            &nested_ac_root.join("_agent_lead2"),
+            &nested_ac_root.join("_agent_inner2"),
+            &nested_wg.join("__agent_lead2"),
+            &nested_inner2,
+            &nested_origin,
+        ] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        std::fs::write(
+            nested_team.join("config.json"),
+            r#"{"agents":["../_agent_lead2","../_agent_inner2"],"coordinator":"../_agent_lead2"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            nested_inner2.join("config.json"),
+            r#"{"identity":"../../_agent_inner2"}"#,
+        )
+        .unwrap();
+
+        (
+            temp,
+            first_cwd,
+            nested_inner2.to_string_lossy().into_owned(),
+            nested_origin.to_string_lossy().into_owned(),
+        )
+    }
+
+    /// #1535 S1: a create in a nested project (origin dir under an ancestor
+    /// workgroup replica, the exact bug shape) must NOT sessionRace against
+    /// the ANCESTOR replica's live session (pre-fix: `Err("sessionRace")`).
+    #[tokio::test]
+    async fn nested_project_create_does_not_sessionrace_against_ancestor_live_session() {
+        let (temp, first_cwd, _nested_replica, nested_origin) = nested_strict_target_fixture();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(ScriptedSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+        let app = session_test_app(
+            test_settings(),
+            Arc::clone(&session_mgr),
+            Arc::clone(&pty_mgr),
+        );
+
+        // Seed a LIVE session at the OUTER replica; the ancestor's live session
+        // must not gate a nested-project create.
+        create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &first_cwd,
+            CreateSelectionIntent::User,
+        )
+        .await
+        .expect("seed live ancestor WG replica session");
+
+        let created = create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &nested_origin,
+            CreateSelectionIntent::Background,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "nested-project create must not sessionRace against the ancestor session; got Err({e})"
+            )
+        });
+        assert_eq!(created.working_directory, nested_origin);
+        let rows = session_mgr.read().await.list_sessions().await;
+        assert_eq!(rows.len(), 2, "ancestor + nested sessions both exist");
+        assert!(
+            rows.iter().any(|row| row.working_directory == nested_origin),
+            "the nested-project session row must exist"
+        );
+        let _ = temp;
+        close_test_coordinator(&app).await;
+    }
+
+    /// #1535 S2: a nested project with its OWN replica (a) does not race
+    /// against the ancestor's live session, and (b) still gates against its
+    /// own replica's duplicate.
+    #[tokio::test]
+    async fn nested_project_create_gates_against_its_own_replica_only() {
+        let (temp, first_cwd, nested_replica, nested_origin) = nested_strict_target_fixture();
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let backend = Arc::new(ScriptedSpawnBackend::default());
+        let pty_mgr = Arc::new(Mutex::new(crate::pty::manager::PtyManager::new_for_test(
+            backend.clone(),
+        )));
+        let app = session_test_app(
+            test_settings(),
+            Arc::clone(&session_mgr),
+            Arc::clone(&pty_mgr),
+        );
+
+        // (a) Live ancestor session + nested replica create -> Ok (the nested
+        // replica's gate scopes to the nested project, never the ancestor).
+        create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &first_cwd,
+            CreateSelectionIntent::User,
+        )
+        .await
+        .expect("seed live ancestor WG replica session");
+        create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &nested_replica,
+            CreateSelectionIntent::Background,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "nested replica create must not race the ancestor session; got Err({e})"
+            )
+        });
+
+        // (b) A live session on the nested replica itself + another Background
+        // create at the same nested replica -> the nested project's OWN
+        // duplicate still sessionRaces.
+        create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &nested_replica,
+            CreateSelectionIntent::User,
+        )
+        .await
+        .expect("seed live nested replica session");
+        let err = create_target_for_test(
+            &app,
+            &session_mgr,
+            &pty_mgr,
+            &nested_replica,
+            CreateSelectionIntent::Background,
+        )
+        .await
+        .expect_err("the nested replica's own duplicate must still gate");
+        assert_eq!(err, "sessionRace");
+        let _ = (temp, nested_origin);
+        close_test_coordinator(&app).await;
+    }
+
     #[tokio::test]
     async fn restart_after_route_loss_cleans_old_external_state_once_before_replacement() {
         use tauri::Manager;

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -923,6 +923,16 @@ fn verify_replica(
 
 pub(crate) fn strict_wg_replica_anchor_from_cwd(cwd: &Path) -> Result<Option<PathBuf>, String> {
     let cwd_identity = crate::path_identity::verify_directory(cwd)?;
+    // #1535: an anchor binds only when it belongs to the project that owns
+    // the cwd, i.e. its `wg_replica_layout.ac_root` equals the closest `.ac`
+    // ancestor of the cwd. A `__agent_*` replica of an ANCESTOR project is
+    // never an anchor for a nested-project cwd, so the ancestor's live
+    // session can no longer produce a sessionRace false positive.
+    let owning_ac_root = cwd_identity.canonical_path.ancestors().find(|path| {
+        path.file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(crate::config::ac_root::is_ac_root_name)
+    });
     for path in cwd_identity.canonical_path.ancestors() {
         let is_replica = path
             .file_name()
@@ -931,8 +941,28 @@ pub(crate) fn strict_wg_replica_anchor_from_cwd(cwd: &Path) -> Result<Option<Pat
         if !is_replica {
             continue;
         }
-        return crate::config::ac_root::wg_replica_layout_from_agent_dir(path)
-            .map(|layout| layout.map(|_| path.to_path_buf()));
+        // No `.ac` ancestor at all: no project owns the cwd, so no anchor can
+        // bind (every valid wg-replica layout requires an `.ac` root).
+        let Some(owning_ac_root) = owning_ac_root.as_deref() else {
+            return Ok(None);
+        };
+        if !path.starts_with(owning_ac_root) {
+            // The anchor belongs to an ancestor project's `.ac`; it never
+            // binds to this cwd. Keep walking: the cwd's own project may
+            // still hold a valid anchor above the current path.
+            continue;
+        }
+        let Some(layout) = crate::config::ac_root::wg_replica_layout_from_agent_dir(path)?
+        else {
+            continue;
+        };
+        if layout.ac_root != owning_ac_root {
+            // Belt-and-braces: the layout's own root must be the owning root.
+            // Unreachable for real on-disk layouts (a valid layout under the
+            // owning root always reports the owning root), kept as a guard.
+            continue;
+        }
+        return Ok(Some(path.to_path_buf()));
     }
     Ok(None)
 }
@@ -3123,5 +3153,231 @@ mod tests {
         let dir2 = "_team_bar_test_280_3_4";
         assert!(note_missing_team_config(project, dir2));
         assert!(!note_missing_team_config(project, dir2));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #1535 walker confinement (plan §6, T1-T7)
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// #1535 T1: the exact bug shape — a nested project's origin matrix dir
+    /// under an ancestor workgroup replica. The only `__agent_*` ancestor
+    /// (`__agent_alice`) belongs to the ANCESTOR project's `.ac`, so it must
+    /// not bind: the walker returns `Ok(None)` and the sessionRace gate is
+    /// skipped (pre-fix: `Ok(Some(alice))` → false-positive duplicate).
+    #[test]
+    fn strict_wg_replica_anchor_from_cwd_nested_project_origin_cwd_binds_nothing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let nested_origin = temp
+            .path()
+            .join("proj-outer")
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join("nested-proj")
+            .join(".ac")
+            .join("_agent_phase0");
+        std::fs::create_dir_all(&nested_origin).unwrap();
+
+        let anchor = strict_wg_replica_anchor_from_cwd(&nested_origin)
+            .expect("walk must not error");
+        assert_eq!(
+            anchor, None,
+            "the ancestor project's replica must never anchor a nested-project cwd"
+        );
+    }
+
+    /// #1535 T2: a nested project with its OWN replica anchors that replica,
+    /// not the ancestor's.
+    #[test]
+    fn strict_wg_replica_anchor_from_cwd_nested_project_replica_binds_own_anchor() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let alice = temp
+            .path()
+            .join("proj-outer")
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        let bob = alice
+            .join("nested-proj")
+            .join(".ac")
+            .join("wg-2-devs")
+            .join("__agent_bob");
+        for dir in [&alice, &bob] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        let anchor = strict_wg_replica_anchor_from_cwd(&bob).expect("walk must not error");
+        let anchor = anchor.expect("the nested project's own replica must bind");
+        assert_eq!(
+            std::fs::canonicalize(&anchor).unwrap(),
+            std::fs::canonicalize(&bob).unwrap(),
+            "the nested replica must anchor itself, not the ancestor replica"
+        );
+        assert!(
+            !anchor.ends_with("__agent_alice"),
+            "the ancestor replica must not anchor a nested-project cwd"
+        );
+    }
+
+    /// #1535 T3 regression: an ordinary replica cwd still anchors itself.
+    #[test]
+    fn strict_wg_replica_anchor_from_cwd_own_replica_regression() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let alice = temp
+            .path()
+            .join("proj")
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice");
+        std::fs::create_dir_all(&alice).unwrap();
+
+        let anchor =
+            strict_wg_replica_anchor_from_cwd(&alice).expect("walk must not error");
+        assert_eq!(
+            std::fs::canonicalize(&anchor.expect("own replica must bind")).unwrap(),
+            std::fs::canonicalize(&alice).unwrap()
+        );
+    }
+
+    /// #1535 T4 regression: a deeper cwd inside an ordinary replica still
+    /// resolves to the same own anchor.
+    #[test]
+    fn strict_wg_replica_anchor_from_cwd_deeper_cwd_inside_own_replica_regression() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let deep = temp
+            .path()
+            .join("proj")
+            .join(".ac")
+            .join("wg-1-devs")
+            .join("__agent_alice")
+            .join("some")
+            .join("deep")
+            .join("subdir");
+        std::fs::create_dir_all(&deep).unwrap();
+
+        let anchor = strict_wg_replica_anchor_from_cwd(&deep).expect("walk must not error");
+        assert_eq!(
+            std::fs::canonicalize(
+                &anchor.expect("deeper cwd must bind the own replica")
+            )
+            .unwrap(),
+            std::fs::canonicalize(
+                temp.path()
+                    .join("proj")
+                    .join(".ac")
+                    .join("wg-1-devs")
+                    .join("__agent_alice")
+            )
+            .unwrap()
+        );
+    }
+
+    /// #1535 T5/T6/T7 fixture: `strict_target_fixture`-shaped outer project
+    /// (`proj/.ac/{_team_team, _agent_lead, _agent_dev-one, wg-1-team/...}`)
+    /// plus a nested project with its own full workgroup inside
+    /// `__agent_dev-one`: `nested-proj/.ac/{_team_team, _agent_lead2,
+    /// _agent_inner2, wg-2-team/{__agent_lead2, __agent_inner2}}` and an
+    /// origin-only dir `_agent_phase0` (the #1535 bug shape). The nested
+    /// replica `config.json` identity is `../../_agent_inner2`; the nested
+    /// team config names the nested origin matrices.
+    fn nested_strict_target_fixture() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let project = temp.path().join("proj");
+        let ac_root = project.join(".ac");
+        let team = ac_root.join("_team_team");
+        let wg = ac_root.join("wg-1-team");
+        let outer_dev_one = wg.join("__agent_dev-one");
+        for directory in [
+            &team,
+            &ac_root.join("_agent_lead"),
+            &ac_root.join("_agent_dev-one"),
+            &wg.join("__agent_lead"),
+            &outer_dev_one,
+        ] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        std::fs::write(
+            team.join("config.json"),
+            r#"{"agents":["../_agent_dev-one","../_agent_lead"],"coordinator":"../_agent_lead"}"#,
+        )
+        .unwrap();
+        for (replica, identity) in [
+            (&wg.join("__agent_lead"), "../../_agent_lead"),
+            (&outer_dev_one, "../../_agent_dev-one"),
+        ] {
+            std::fs::write(
+                replica.join("config.json"),
+                format!(r#"{{"identity":"{identity}"}}"#),
+            )
+            .unwrap();
+        }
+
+        let nested_ac_root = outer_dev_one.join("nested-proj").join(".ac");
+        let nested_team = nested_ac_root.join("_team_team");
+        let nested_wg = nested_ac_root.join("wg-2-team");
+        let nested_inner2 = nested_wg.join("__agent_inner2");
+        let nested_origin = nested_ac_root.join("_agent_phase0");
+        for directory in [
+            &nested_team,
+            &nested_ac_root.join("_agent_lead2"),
+            &nested_ac_root.join("_agent_inner2"),
+            &nested_wg.join("__agent_lead2"),
+            &nested_inner2,
+            &nested_origin,
+        ] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        std::fs::write(
+            nested_team.join("config.json"),
+            r#"{"agents":["../_agent_lead2","../_agent_inner2"],"coordinator":"../_agent_lead2"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            nested_inner2.join("config.json"),
+            r#"{"identity":"../../_agent_inner2"}"#,
+        )
+        .unwrap();
+
+        (temp, nested_inner2, nested_origin)
+    }
+
+    /// #1535 T5: a nested project's replica resolves to its own verified
+    /// sender identity (project/workgroup/agent of the NESTED project), not
+    /// the ancestor workgroup's.
+    #[test]
+    fn verify_pty_input_replica_cwd_nested_replica_resolves_own_fqn() {
+        let (_temp, nested_inner2, _nested_origin) = nested_strict_target_fixture();
+        let identity = verify_pty_input_replica_cwd(&nested_inner2)
+            .expect("nested replica must resolve its own identity");
+        assert_eq!(identity.canonical_fqn, "nested-proj:wg-2-team/inner2");
+        assert_eq!(identity.project, "nested-proj");
+        assert_eq!(identity.workgroup, "wg-2-team");
+        assert_eq!(identity.agent, "inner2");
+    }
+
+    /// #1535 T6: the #1535 bug-shaped cwd (an origin matrix dir, not a
+    /// replica) resolves to `Err("sender_identity_invalid")` — and never to
+    /// the outer workgroup.
+    #[test]
+    fn verify_pty_input_replica_cwd_nested_origin_cwd_is_invalid() {
+        let (_temp, _nested_inner2, nested_origin) = nested_strict_target_fixture();
+        let err = verify_pty_input_replica_cwd(&nested_origin).expect_err("origin dir must not resolve");
+        assert_eq!(err, "sender_identity_invalid");
+    }
+
+    /// #1535 T7: the create-gate key derives from the NESTED project for a
+    /// nested replica cwd, and is `None` (gate skipped) for the nested origin
+    /// cwd.
+    #[test]
+    fn pty_input_create_gate_key_from_cwd_nested_replica_uses_own_fqn_and_nested_origin_is_none() {
+        let (_temp, nested_inner2, nested_origin) = nested_strict_target_fixture();
+        assert_eq!(
+            pty_input_create_gate_key_from_cwd(&nested_inner2).expect("key must not error"),
+            Some("nested-proj:wg-2-team/inner2".to_string())
+        );
+        assert_eq!(
+            pty_input_create_gate_key_from_cwd(&nested_origin).expect("key must not error"),
+            None
+        );
     }
 }

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -943,7 +943,7 @@ pub(crate) fn strict_wg_replica_anchor_from_cwd(cwd: &Path) -> Result<Option<Pat
         }
         // No `.ac` ancestor at all: no project owns the cwd, so no anchor can
         // bind (every valid wg-replica layout requires an `.ac` root).
-        let Some(owning_ac_root) = owning_ac_root.as_deref() else {
+        let Some(owning_ac_root) = owning_ac_root else {
             return Ok(None);
         };
         if !path.starts_with(owning_ac_root) {
@@ -3234,7 +3234,7 @@ mod tests {
         let anchor =
             strict_wg_replica_anchor_from_cwd(&alice).expect("walk must not error");
         assert_eq!(
-            std::fs::canonicalize(&anchor.expect("own replica must bind")).unwrap(),
+            std::fs::canonicalize(anchor.expect("own replica must bind")).unwrap(),
             std::fs::canonicalize(&alice).unwrap()
         );
     }
@@ -3257,9 +3257,7 @@ mod tests {
 
         let anchor = strict_wg_replica_anchor_from_cwd(&deep).expect("walk must not error");
         assert_eq!(
-            std::fs::canonicalize(
-                &anchor.expect("deeper cwd must bind the own replica")
-            )
+            std::fs::canonicalize(anchor.expect("deeper cwd must bind the own replica"))
             .unwrap(),
             std::fs::canonicalize(
                 temp.path()

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -10840,13 +10840,55 @@ impl MailboxPoller {
             return;
         }
 
+        // #1163: sweep stale result sidecars. The CLI consumes the result it
+        // reads and waits at most `SESSION_REQUEST_RESULT_TIMEOUT` (30 s); a
+        // result older than 5 minutes is litter from a timed-out or crashed
+        // CLI and is removed here (worst case a few KB in an already-ephemeral,
+        // ignored instance-artifact directory).
+        if let Ok(rd) = std::fs::read_dir(&requests_dir) {
+            for entry in rd.filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if !crate::cli::create_agent::is_session_request_result_path(&path) {
+                    continue;
+                }
+                let stale = std::fs::metadata(&path)
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .and_then(|modified| modified.elapsed().ok())
+                    .is_some_and(|age| age >= std::time::Duration::from_secs(5 * 60));
+                if stale {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+
         let entries: Vec<PathBuf> = match std::fs::read_dir(&requests_dir) {
             Ok(rd) => rd
                 .filter_map(|e| e.ok())
                 .map(|e| e.path())
                 .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("json"))
+                // #1163: result sidecars (`<id>.result.json`) are ANSWERS, not
+                // requests; without this exclusion a leftover result file would
+                // be parsed as a `SessionRequest` (parse fails -> spurious
+                // rejected result written for it).
+                .filter(|p| !crate::cli::create_agent::is_session_request_result_path(p))
                 .collect(),
             Err(_) => return,
+        };
+
+        // #1163: answer each request with a result sidecar on every terminal
+        // path (malformed, spawn-rebuild failure, create Ok/Err). Write the
+        // result BEFORE deleting the request: a crash in between leaves a
+        // re-processable request on disk (the pre-existing hazard), never a
+        // lost already-written outcome.
+        let write_result = |result: crate::cli::create_agent::SessionRequestResult| {
+            if let Err(e) = crate::cli::create_agent::write_session_request_result(&result) {
+                log::warn!(
+                    "[session-requests] Failed to write result for '{}': {}",
+                    result.id,
+                    e
+                );
+            }
         };
 
         for path in entries {
@@ -10863,6 +10905,19 @@ impl MailboxPoller {
                     Ok(r) => r,
                     Err(e) => {
                         log::warn!("[session-requests] Failed to parse {:?}: {}", path, e);
+                        // #1163: answer with a rejected result so the CLI can
+                        // distinguish rejection from a missing app. The request
+                        // filename IS `<id>.json`, so the id comes from the stem.
+                        write_result(crate::cli::create_agent::SessionRequestResult {
+                            id: path
+                                .file_stem()
+                                .and_then(|value| value.to_str())
+                                .unwrap_or("unknown")
+                                .to_string(),
+                            status: crate::cli::create_agent::SessionRequestResultStatus::Rejected,
+                            session_id: None,
+                            error: Some(format!("malformed session request: {e}")),
+                        });
                         // Delete malformed file
                         let _ = std::fs::remove_file(&path);
                         continue;
@@ -10904,6 +10959,12 @@ impl MailboxPoller {
                             request.session_name,
                             e
                         );
+                        write_result(crate::cli::create_agent::SessionRequestResult {
+                            id: request.id.clone(),
+                            status: crate::cli::create_agent::SessionRequestResultStatus::Rejected,
+                            session_id: None,
+                            error: Some(e.to_string()),
+                        });
                         let _ = std::fs::remove_file(&path);
                         continue;
                     }
@@ -10919,7 +10980,7 @@ impl MailboxPoller {
                 (request.shell.clone(), request.shell_args.clone(), None)
             };
 
-            match crate::commands::session::create_session_inner(
+            let create_result = crate::commands::session::create_session_inner(
                 app,
                 session_mgr.inner(),
                 pty_mgr.inner(),
@@ -10938,8 +10999,8 @@ impl MailboxPoller {
                 None,
                 crate::commands::session::CreateSelectionIntent::Background,
             )
-            .await
-            {
+            .await;
+            match &create_result {
                 Ok(info) => {
                     log::info!(
                         "[session-requests] Created session '{}' (id={})",
@@ -10955,6 +11016,23 @@ impl MailboxPoller {
                     );
                 }
             }
+
+            // #1163: answer the request with the terminal outcome, then delete.
+            let result = match create_result {
+                Ok(info) => crate::cli::create_agent::SessionRequestResult {
+                    id: request.id.clone(),
+                    status: crate::cli::create_agent::SessionRequestResultStatus::Created,
+                    session_id: Some(info.id),
+                    error: None,
+                },
+                Err(e) => crate::cli::create_agent::SessionRequestResult {
+                    id: request.id.clone(),
+                    status: crate::cli::create_agent::SessionRequestResultStatus::Rejected,
+                    session_id: None,
+                    error: Some(e.to_string()),
+                },
+            };
+            write_result(result);
 
             // Delete processed request file regardless of success/failure
             let _ = std::fs::remove_file(&path);
@@ -11296,6 +11374,7 @@ mod tests {
     struct MailboxMockPtyBackend {
         live: std::sync::Mutex<HashSet<Uuid>>,
         writes: std::sync::Mutex<Vec<(Uuid, Vec<u8>)>>,
+        fail_spawn: std::sync::atomic::AtomicBool,
     }
 
     impl MailboxMockPtyBackend {
@@ -11323,6 +11402,15 @@ mod tests {
             &self,
             spec: BackendSpawnSpec,
         ) -> futures::future::BoxFuture<'_, Result<(), crate::errors::AppError>> {
+            // #1163 M2 - test-only failure switch so a session-request poll can
+            // exercise the rejected-result path end to end.
+            if self.fail_spawn.load(Ordering::SeqCst) {
+                return Box::pin(async move {
+                    Err(crate::errors::AppError::PtyError(
+                        "synthetic spawn failure".to_string(),
+                    ))
+                });
+            }
             Box::pin(async move {
                 self.live.lock().unwrap().insert(spec.id);
                 Ok(())
@@ -20907,6 +20995,334 @@ mod tests {
             .join("poll-pi-busy-clear.reason.txt")
             .exists());
         assert!(mock_pty_writes_for(&app, session_id).is_empty());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #1163 session-request result sidecars (M1-M5)
+    // ──────────────────────────────────────────────────────────────────────
+
+    struct SessionRequestFixture {
+        _temp: tempfile::TempDir,
+        cwd: PathBuf,
+        app: tauri::App<tauri::test::MockRuntime>,
+        backend: Arc<MailboxMockPtyBackend>,
+    }
+
+    /// Build an app that can run the FULL session-request create path
+    /// (`poll_session_requests` → `create_session_inner`): the mailbox states
+    /// plus the selection coordinator, resource monitor, target-gate store and
+    /// related states the create pipeline requires. The cwd is a plain temp
+    /// dir (not a WG replica), so no target-gate / sessionRace machinery
+    /// participates and the create either succeeds or fails purely on the PTY
+    /// backend.
+    fn make_session_request_fixture() -> SessionRequestFixture {
+        let temp = tempfile::TempDir::new().unwrap();
+        let cwd = temp.path().join("session-cwd");
+        std::fs::create_dir_all(&cwd).unwrap();
+
+        let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
+        let (pty_mgr, backend) = make_test_pty_manager();
+        let settings = AppSettings {
+            project_paths: vec![temp.path().to_string_lossy().to_string()],
+            agents: wake_agents(),
+            ..Default::default()
+        };
+        let shutdown = crate::shutdown::ShutdownSignal::new();
+        let coordinator = crate::session::selection::SelectionCoordinator::new(
+            Arc::clone(&session_mgr),
+            shutdown.token().clone(),
+        );
+        let output_senders = Arc::new(Mutex::new(HashMap::new()));
+        let telegram: crate::telegram::manager::TelegramBridgeState = Arc::new(
+            tokio::sync::Mutex::new(
+                crate::telegram::manager::TelegramBridgeManager::new(output_senders),
+            ),
+        );
+        let store_dir = tempfile::TempDir::new().expect("create target-gate store");
+        let message_store = Arc::new(
+            crate::api::message_store::MessageStore::open(
+                store_dir
+                    .path()
+                    .join(crate::api::message_store::DB_FILENAME),
+            )
+            .expect("open target-gate store"),
+        );
+        let target_gate_state = crate::api::message_store::PtyInputTargetGateState::for_root(
+            store_dir.path().to_path_buf(),
+        );
+        let idle_detector = crate::pty::idle_detector::IdleDetector::new(|_| {}, |_| {});
+        let app = tauri::test::mock_builder()
+            .manage(MasterToken::new(MAILBOX_MASTER_TOKEN.into()))
+            .manage(AppOutbox::new(
+                temp.path()
+                    .join(".app-outbox")
+                    .to_string_lossy()
+                    .to_string(),
+            ))
+            .manage(Arc::new(tokio::sync::RwLock::new(settings)))
+            .manage(session_mgr.clone())
+            .manage(pty_mgr)
+            .manage(telegram)
+            .manage(Arc::new(crate::RestoreInProgress(AtomicBool::new(false))))
+            .manage(Arc::new(crate::PendingSelfClear::default()))
+            .manage(idle_detector)
+            .manage(std::sync::Arc::new(
+                crate::session::purge_guard::PurgeGuard::default(),
+            ))
+            .manage(Arc::new(crate::resource_monitor::ResourceMonitorState::new()))
+            .manage(coordinator.clone())
+            .manage(target_gate_state.clone())
+            .manage(shutdown)
+            .manage(crate::DetachedSessionsState::default())
+            .manage(crate::session::warnings::new_session_warning_state())
+            .manage(
+                crate::api::message_store::MessageStoreState::with_store_and_target_gate(
+                    Ok(message_store),
+                    target_gate_state.gate.clone(),
+                ),
+            )
+            .manage(store_dir)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build session request test app");
+        coordinator
+            .start(app.handle().clone())
+            .expect("start coordinator");
+        let bootstrap = coordinator.clone();
+        std::thread::spawn(move || {
+            tauri::async_runtime::block_on(async move {
+                bootstrap
+                    .submit_restore_first()
+                    .await
+                    .expect("open coordinator")
+                    .finish();
+            });
+        })
+        .join()
+        .expect("join coordinator bootstrap");
+
+        SessionRequestFixture {
+            _temp: temp,
+            cwd,
+            app,
+            backend,
+        }
+    }
+
+    fn write_session_request_for_test(
+        cwd: &Path,
+        agent_id: &str,
+    ) -> crate::cli::create_agent::SessionRequest {
+        let request = crate::cli::create_agent::SessionRequest {
+            id: uuid::Uuid::new_v4().to_string(),
+            cwd: cwd.to_string_lossy().to_string(),
+            session_name: "session-request-m-test".to_string(),
+            agent_id: agent_id.to_string(),
+            shell: "codex".to_string(),
+            shell_args: vec!["--yolo".to_string()],
+            requested_profile: None,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        };
+        crate::cli::create_agent::write_session_request(&request).expect("write request");
+        request
+    }
+
+    fn session_request_file_for(id: &str) -> PathBuf {
+        crate::config::config_dir()
+            .expect("config dir")
+            .join(SESSION_REQUESTS_DIR_NAME)
+            .join(format!("{id}.json"))
+    }
+
+    fn session_request_result_file_for(id: &str) -> PathBuf {
+        crate::config::config_dir()
+            .expect("config dir")
+            .join(SESSION_REQUESTS_DIR_NAME)
+            .join(format!("{id}.result.json"))
+    }
+
+    fn read_session_request_result_json(id: &str) -> serde_json::Value {
+        serde_json::from_str(
+            &std::fs::read_to_string(session_request_result_file_for(id)).expect("read result"),
+        )
+        .expect("result json")
+    }
+
+    /// M1: a successful create answers the request with a `created` result
+    /// sidecar carrying the session id, and deletes the request.
+    #[tokio::test]
+    async fn session_request_result_sidecar_written_on_success() {
+        // #1163: `config_dir()` is process-wide — one shared session-requests
+        // dir for every C/M artifact test. Serialize so a poll never consumes
+        // another test's request file mid-test.
+        let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let fixture = make_session_request_fixture();
+        let app = app_handle(&fixture.app);
+        let request = write_session_request_for_test(&fixture.cwd, "codex");
+
+        MailboxPoller::new().poll_session_requests(&app).await;
+
+        let result = read_session_request_result_json(&request.id);
+        assert_eq!(
+            result["status"], "created",
+            "unexpected result: {}",
+            result
+        );
+        let session_id = result["sessionId"]
+            .as_str()
+            .expect("sessionId")
+            .to_string();
+        assert!(!session_id.is_empty());
+        assert!(
+            !session_request_file_for(&request.id).exists(),
+            "request must be deleted after processing"
+        );
+        let session_mgr = app.state::<Arc<tokio::sync::RwLock<SessionManager>>>();
+        let rows = session_mgr.read().await.list_sessions().await;
+        assert_eq!(
+            rows.len(),
+            1,
+            "the session was really created; rows: {:?}",
+            rows.iter()
+                .map(|s| (s.id.clone(), s.name.clone(), s.working_directory.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(rows[0].id, session_id);
+        app.state::<crate::session::selection::SelectionCoordinator>()
+            .close_and_join()
+            .await;
+    }
+
+    /// M2: a failed create (PTY spawn error) answers with a `rejected` result
+    /// carrying the error text, and deletes the request.
+    #[tokio::test]
+    async fn session_request_result_sidecar_written_on_rejection() {
+        let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let fixture = make_session_request_fixture();
+        let app = app_handle(&fixture.app);
+        let request = write_session_request_for_test(&fixture.cwd, "codex");
+        fixture.backend.fail_spawn.store(true, Ordering::SeqCst);
+
+        MailboxPoller::new().poll_session_requests(&app).await;
+
+        let result = read_session_request_result_json(&request.id);
+        assert_eq!(result["status"], "rejected");
+        let error = result["error"].as_str().expect("error text");
+        assert!(error.contains("synthetic spawn failure"), "{error}");
+        assert!(
+            !session_request_file_for(&request.id).exists(),
+            "request must be deleted after processing"
+        );
+        app.state::<crate::session::selection::SelectionCoordinator>()
+            .close_and_join()
+            .await;
+    }
+
+    /// M3: a malformed request file gets a `rejected` result keyed by its
+    /// filename stem, and the request file is deleted.
+    #[tokio::test]
+    async fn malformed_request_writes_rejected_result() {
+        let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let fixture = make_session_request_fixture();
+        let app = app_handle(&fixture.app);
+        let id = uuid::Uuid::new_v4().to_string();
+        let requests_dir = crate::config::config_dir()
+            .expect("config dir")
+            .join(SESSION_REQUESTS_DIR_NAME);
+        std::fs::create_dir_all(&requests_dir).unwrap();
+        std::fs::write(requests_dir.join(format!("{id}.json")), "{ not json !!").unwrap();
+
+        MailboxPoller::new().poll_session_requests(&app).await;
+
+        let result = read_session_request_result_json(&id);
+        assert_eq!(result["status"], "rejected");
+        let error = result["error"].as_str().expect("error text");
+        assert!(error.contains("malformed session request"), "{error}");
+        assert!(
+            !session_request_file_for(&id).exists(),
+            "malformed request must be deleted"
+        );
+    }
+
+    /// M4: a lone result sidecar is never consumed as a request (no delete,
+    /// no spurious rejected result for it).
+    #[tokio::test]
+    async fn result_sidecars_are_not_consumed_as_requests() {
+        let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let fixture = make_session_request_fixture();
+        let app = app_handle(&fixture.app);
+        let id = uuid::Uuid::new_v4().to_string();
+        let result_path = session_request_result_file_for(&id);
+        std::fs::create_dir_all(result_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &result_path,
+            format!(r#"{{"id":"{id}","status":"created","sessionId":"sess-1"}}"#),
+        )
+        .unwrap();
+
+        MailboxPoller::new().poll_session_requests(&app).await;
+
+        assert!(
+            result_path.exists(),
+            "a result sidecar is an ANSWER, never a request; it must stay untouched"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&result_path).unwrap(),
+            format!(r#"{{"id":"{id}","status":"created","sessionId":"sess-1"}}"#)
+        );
+    }
+
+    /// M5: result sidecars older than 5 minutes are swept; fresh ones are
+    /// kept.
+    #[tokio::test]
+    async fn stale_result_sidecars_are_swept() {
+        let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
+            .get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap();
+        let fixture = make_session_request_fixture();
+        let app = app_handle(&fixture.app);
+        let stale_id = uuid::Uuid::new_v4().to_string();
+        let fresh_id = uuid::Uuid::new_v4().to_string();
+        let stale_path = session_request_result_file_for(&stale_id);
+        let fresh_path = session_request_result_file_for(&fresh_id);
+        std::fs::create_dir_all(stale_path.parent().unwrap()).unwrap();
+        for (path, id) in [(&stale_path, &stale_id), (&fresh_path, &fresh_id)] {
+            std::fs::write(
+                path,
+                format!(r#"{{"id":"{id}","status":"created","sessionId":"sess-1"}}"#),
+            )
+            .unwrap();
+        }
+        // Age the stale one 6 minutes (mtime only; `filetime` is not a
+        // dependency, `std::fs::File::set_times` is stable). Windows requires
+        // a WRITE-capable handle to change times.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&stale_path)
+            .unwrap();
+        file.set_times(
+            std::fs::FileTimes::new().set_modified(
+                std::time::SystemTime::now() - std::time::Duration::from_secs(6 * 60),
+            ),
+        )
+        .unwrap();
+
+        MailboxPoller::new().poll_session_requests(&app).await;
+
+        assert!(!stale_path.exists(), "stale result sidecar must be swept");
+        assert!(fresh_path.exists(), "fresh result sidecar must be kept");
     }
 
     #[tokio::test]

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -21149,6 +21149,11 @@ mod tests {
 
     /// M1: a successful create answers the request with a `created` result
     /// sidecar carrying the session id, and deletes the request.
+    // clippy (1.98) `await_holding_lock`: the guard is the test-only
+    // cross-test serialization lock (a std `Mutex` on purpose — the sync
+    // C1-C5 tests in `cli::create_agent` share the same static) and must be
+    // held across the poll await; the tests run single-threaded per process.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn session_request_result_sidecar_written_on_success() {
         // #1163: `config_dir()` is process-wide — one shared session-requests
@@ -21197,6 +21202,7 @@ mod tests {
 
     /// M2: a failed create (PTY spawn error) answers with a `rejected` result
     /// carrying the error text, and deletes the request.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn session_request_result_sidecar_written_on_rejection() {
         let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
@@ -21225,6 +21231,7 @@ mod tests {
 
     /// M3: a malformed request file gets a `rejected` result keyed by its
     /// filename stem, and the request file is deleted.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn malformed_request_writes_rejected_result() {
         let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
@@ -21254,6 +21261,7 @@ mod tests {
 
     /// M4: a lone result sidecar is never consumed as a request (no delete,
     /// no spurious rejected result for it).
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn result_sidecars_are_not_consumed_as_requests() {
         let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK
@@ -21285,6 +21293,7 @@ mod tests {
 
     /// M5: result sidecars older than 5 minutes are swept; fresh ones are
     /// kept.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn stale_result_sidecars_are_swept() {
         let _guard = crate::cli::create_agent::SESSION_REQUESTS_TEST_LOCK

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -747,8 +747,59 @@ fn create_agent_matrix_from_cached_agency_template_seeds_role_without_skills() {
     assert!(!agent_dir.join("skills").join("demo").exists());
 }
 
+/// #1163: watch `config_dir/session-requests/` for the CLI's request file and
+/// answer it with a `<id>.result.json` sidecar exactly like the running app
+/// would. Runs in a background thread; returns once the result is written.
+/// Result sidecars (`*.result.json`) are never treated as requests.
+fn watch_and_answer_session_request(
+    config_dir: &Path,
+    status: &str,
+    session_id: Option<&str>,
+    error: Option<&str>,
+) {
+    let requests_dir = config_dir.join("session-requests");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        if std::time::Instant::now() > deadline {
+            panic!("watcher timed out waiting for a session request");
+        }
+        let request_path = std::fs::read_dir(&requests_dir).ok().and_then(|rd| {
+            rd.filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .find(|p| {
+                    p.extension().and_then(|s| s.to_str()) == Some("json")
+                        && !p
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .is_some_and(|s| s.ends_with(".result"))
+                })
+        });
+        let Some(request_path) = request_path else {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            continue;
+        };
+        let id = request_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .expect("request id")
+            .to_string();
+        let result = serde_json::json!({
+            "id": id,
+            "status": status,
+            "sessionId": session_id,
+            "error": error,
+        });
+        std::fs::write(
+            requests_dir.join(format!("{id}.result.json")),
+            serde_json::to_string_pretty(&result).expect("result json"),
+        )
+        .expect("write result sidecar");
+        return;
+    }
+}
+
 #[test]
-fn create_agent_matrix_launch_writes_session_request() {
+fn create_agent_matrix_launch_reports_launched_when_app_confirms() {
     let tmp = Tmp::new("cli-create-agent-matrix-launch");
     let bin = copy_binary_into(tmp.path());
     let config_dir = config_dir_for_bin(&bin);
@@ -768,6 +819,12 @@ fn create_agent_matrix_launch_writes_session_request() {
         }),
     );
 
+    // #1163: a watcher stands in for the running app and confirms the launch.
+    let watcher_config_dir = config_dir.clone();
+    let watcher = std::thread::spawn(move || {
+        watch_and_answer_session_request(&watcher_config_dir, "created", Some("sess-1"), None);
+    });
+
     let out = Command::new(&bin)
         .args([
             "create-agent-matrix",
@@ -782,6 +839,7 @@ fn create_agent_matrix_launch_writes_session_request() {
         ])
         .output()
         .expect("spawn binary");
+    watcher.join().expect("watcher answered");
 
     assert!(
         out.status.success(),
@@ -794,10 +852,26 @@ fn create_agent_matrix_launch_writes_session_request() {
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
     assert_eq!(json["launched"], true);
+    assert_eq!(json["launchStatus"], "launched");
     assert_eq!(json["launchAgent"], "codex");
+    assert!(json["launchError"].is_null());
 
+    // The request is still on disk: the CLI consumes only the result sidecar
+    // (which it deletes), never the request.
     let requests = session_request_paths(&config_dir);
     assert_eq!(requests.len(), 1, "expected exactly one session request");
+    assert!(
+        !config_dir
+            .join("session-requests")
+            .join("sess-1.result.json")
+            .exists()
+            && !requests.iter().any(|p| {
+                p.file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.ends_with(".result.json"))
+            }),
+        "the CLI must consume (delete) the result sidecar"
+    );
 
     let request: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&requests[0]).expect("read request"))
@@ -808,6 +882,85 @@ fn create_agent_matrix_launch_writes_session_request() {
     assert_eq!(request["agentId"], "codex");
 
     assert_single_project_refresh_request(&config_dir, &project);
+}
+
+#[test]
+fn create_agent_matrix_launch_rejection_is_reported() {
+    let tmp = Tmp::new("cli-create-agent-matrix-launch-rejected");
+    let bin = copy_binary_into(tmp.path());
+    let config_dir = config_dir_for_bin(&bin);
+    let project = project_with_workspace(tmp.path());
+    write_settings(
+        &config_dir,
+        serde_json::json!({
+            "defaultShell": "powershell.exe",
+            "defaultShellArgs": [],
+            "agents": [{
+                "id": "codex",
+                "label": "Codex",
+                "command": "codex --ask-for-approval never",
+                "color": "#000000"
+            }],
+            "projectPaths": [tmp.path().to_string_lossy().to_string()]
+        }),
+    );
+
+    // #1163: the app answers with a rejection (e.g. the sessionRace gate).
+    let watcher_config_dir = config_dir.clone();
+    let watcher = std::thread::spawn(move || {
+        watch_and_answer_session_request(
+            &watcher_config_dir,
+            "rejected",
+            None,
+            Some("sessionRace"),
+        );
+    });
+
+    let out = Command::new(&bin)
+        .args([
+            "create-agent-matrix",
+            "--project",
+            "ProjectAlpha",
+            "--name",
+            "Architect",
+            "--description",
+            "Build plans",
+            "--launch",
+            "codex",
+        ])
+        .output()
+        .expect("spawn binary");
+    watcher.join().expect("watcher answered");
+
+    // Matrix creation stays independent of the launch result: exit 0 and all
+    // matrix fields present.
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout should be JSON");
+    let agent_dir = project.join(".ac").join("_agent_architect");
+    assert_same_path(json["agentPath"].as_str().expect("agentPath"), &agent_dir);
+    assert_eq!(json["agentName"], "ProjectAlpha/architect");
+    assert_same_path(
+        json["rolePath"].as_str().expect("rolePath"),
+        &agent_dir.join("Role.md"),
+    );
+    assert_eq!(json["launched"], false);
+    assert_eq!(json["launchStatus"], "rejected");
+    assert_eq!(json["launchAgent"], "codex");
+    let launch_error = json["launchError"].as_str().expect("launchError");
+    assert!(launch_error.contains("sessionRace"), "{launch_error}");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("session launch rejected"),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1535 and #1163 in one delivery.

### 1. sessionRace false positive for projects nested inside a replica (#1535)

`strict_wg_replica_anchor_from_cwd` walked ALL ancestors of the cwd and took the first `__agent_*` directory with a valid `wg-*` layout. For a project nested inside another agent's replica (e.g. a test project under `__agent_ac-cli-tester-v3/issue-1532-phase0/...`), the anchor resolved to the PARENT agent's replica, so the create-gate saw the parent agent's own live session as a "duplicate" and refused legitimate fresh launches with `sessionRace`.

Fix: the anchor is only accepted if its `wg_replica_layout.ac_root` is the closest `.ac` to the cwd (the project that owns the cwd). Ancestor-project anchors are skipped. The same confinement applies transitively to the create-gate key, sender identity, and PTY-input gate key (the only three direct callers).

### 2. Truthful CLI launch contract (#1163)

`create-agent --launch` / `create-agent-matrix --launch` reported `launched: true` and exit 0 even when the GUI later refused the session request (sessionRace, resource-monitor cap, any create error), with the failure only visible in the app log.

Fix: the session-requests poller now writes a per-request result sidecar (`session-requests/<id>.result.json`, `status: created|rejected`, `sessionId`/`error`), written on every terminal path (success, rejection, malformed request, spawn-rebuild failure) before deleting the request; stale sidecars are swept after 5 min and excluded from the request scan. The CLI waits up to 30 s (poll 250 ms) and reports `launchStatus: skipped|launched|rejected|pending` + `launchError`; `launched` is now truthful (session confirmed). Matrix creation remains independent of launch outcome (exit 0, matrix fields always present).

## Verification

- Plan: `plans/1535-sessionrace-nested-anchor-launch-contract.md` (frozen, three-party consensus, Plan-SHA256 `DE97093F...F4B9D`, user-approved)
- Grinch review PASS (Step 9, non-visual) + focused PASS on merge resolution `7035e9c..4c55c6a`
- Tests: lib 3591 passed / 20 ignored; `cli_create_agent_matrix` 18 passed; `cli_behavior_contract` 17 passed; layering guards green
- Dependency gate: `moduleCycles` 1 = 1 pre/post; 85-member SCC set identical; 0 new module from→to pairs; `module-arcs.txt` regenerated byte-identical

Closes #1535
Closes #1163