### PR TITLE
ci: enable OIDC Trusted Publishing for npm, keeping the token as fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,30 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # OIDC Trusted Publishing needs npm >= 11.5.1; node 22 ships 10.9.8.
+      # Same pin as version-sync-check.yml.
+      - name: Pin npm version
+        run: npm install -g npm@11.6.2
+
+      - name: Show OIDC preconditions
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "npm  $(npm --version)   (OIDC trusted publishing needs >= 11.5.1)"
+          echo "node $(node --version)  (OIDC trusted publishing needs >= 22.14.0)"
+
+      # Auth is mid-migration to OIDC Trusted Publishing (issue #1563), and both
+      # credentials are deliberately present at once. npm detects the OIDC
+      # environment and uses it "before falling back to traditional tokens", so
+      # this publishes via OIDC when the trusted publisher matches and via
+      # NODE_AUTH_TOKEN when it does not. Either way the release ships.
+      #
+      # --provenance is redundant under OIDC (trusted publishing generates
+      # attestations on its own) but required on the token path, and it is not
+      # an error to pass it, so it stays until the token is gone.
+      #
+      # Once a release has demonstrably published via OIDC, drop the env block
+      # and the flag, then delete the NPM_AGENTSCOMMANDER secret.
       - name: Publish @mblua/agentscommander
         working-directory: npm
         env:


### PR DESCRIPTION
Closes #1563.

## Context

The trusted publisher is now configured on npmjs.com and verified on screen:

| Field | Value |
|---|---|
| Publisher | GitHub Actions |
| Organization or user | `mblua` |
| Repository | `AgentsCommander` |
| Workflow filename | `release.yml` (bare name, no path) |
| Environment name | *(empty)* |
| Allowed actions | `npm publish` only |

But OIDC still could not engage, because **it requires npm >= 11.5.1 and the
runner is on 10.9.8.** Verified in run `33004871334`:

```
node: v22.23.2
npm:  10.9.8
```

Node 22 ships npm 10.9.8. That is the entire blocker.

## The change

Pin npm to `11.6.2` in `publish-npm` (the same pin `version-sync-check.yml`
already uses) and change nothing else. **+24 lines, all additive.**

## Why the token stays, for now

Both credentials are deliberately present at once. Per npm's docs:

> The npm CLI automatically detects OIDC environments and uses them for
> authentication before falling back to traditional tokens.

So after this merges:

- If the trusted publisher matches, the next release publishes **via OIDC**.
- If anything about it is off, the release falls back to `NODE_AUTH_TOKEN` and
  ships exactly as it does today.

Either way the release succeeds. There is no flag day, and no release can fail
on the migration itself. The publish log states which path was taken, and that
is the verification.

`--provenance` also stays. It is redundant under trusted publishing, which
generates attestations on its own, but it is required on the token path and
passing it is [not an error](https://docs.npmjs.com/generating-provenance-statements).

## Step two, after this proves out

Once a release has demonstrably published via OIDC:

1. Drop the `NODE_AUTH_TOKEN` env block and the `--provenance` flag.
2. Delete the `NPM_AGENTSCOMMANDER` repository secret.

Doing that now would trade a credential that demonstrably works for one that
has never run. That is the wrong order, so it is not this PR.

https://claude.ai/code/session_01RjvS5aJo8tt7h2jCX7QJCk
