### PR TITLE
chore: bump to 0.30.3 and reconcile the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file follows a lightweight [Keep a Changelog](https://keepachangelog.com/en
 
 ## Unreleased
 
+## 0.30.3
+
+### Changed
+
+- **Releases now publish to npm via OIDC Trusted Publishing.** `publish-npm` pins npm to 11.6.2, because OIDC trusted publishing requires npm >= 11.5.1 and the Node 22 runner ships 10.9.8. The `NPM_AGENTSCOMMANDER` token is retained as a fallback for this release only; npm prefers OIDC and falls back to a token, so the migration carries no risk to the release itself. No application change: this version is functionally identical to 0.30.2. ([#1563](https://github.com/mblua/AgentsCommander/issues/1563))
+
+## 0.30.2
+
 ### Added
 
 - **Web server: the bind address is now editable from the titlebar popover.** The PORT row grew into a BIND section (ADDR + PORT). The address chooser offers `Localhost only (127.0.0.1)`, `All interfaces (0.0.0.0)` (which discloses that any device on your network can reach the server), every detected IPv4 with its adapter name (virtual and tunnel adapters grouped and collapsed), and a validated manual entry. A stored address that is no longer on the machine stays visible as a disabled `Unavailable` row. Applying an address restarts a running server, starts a stopped-but-enabled one, and only saves otherwise. ([#1453](https://github.com/mblua/AgentsCommander/issues/1453))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentscommander-new"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,7 @@ const crypto = require('crypto');
 const os = require('os');
 const { execSync } = require('child_process');
 
-const VERSION = "0.30.2"; // Must match package.json
+const VERSION = "0.30.3"; // Must match package.json
 const OWNER = 'mblua';
 const REPO = 'AgentsCommander';
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mblua/agentscommander",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Install and run AgentsCommander, the local terminal session manager for AI coding agent teams with Claude Code, Codex, Hermes, Cursor CLI, OpenCode, and more to come.",
   "license": "MIT",
   "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentscommander",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentscommander",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentscommander",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentscommander-new"
-version = "0.30.2"
+version = "0.30.3"
 edition = "2021"
 authors = ["AgentsCommander Contributors"]
 description = "AgentsCommander: Run multiple teams of AI coding agents"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicedoc/tauri/dev/packages/tauri-utils/schema.json",
   "productName": "Agents Commander",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "identifier": "dev.agentscommander.app",
   "mainBinaryName": "agentscommander",
   "build": {


### PR DESCRIPTION
Closes #1565.

Cuts **0.30.3**.

## No application change

`origin/main` was byte-identical to `v0.30.2` before #1564, so the only delta
in this release is the npm 11.6.2 pin that lets OIDC Trusted Publishing engage.
The binaries are functionally identical to 0.30.2.

The purpose of the release is to **prove the OIDC path works end to end** on a
real publish, before the `NPM_AGENTSCOMMANDER` token is removed.

## Changelog correction

Everything under `## Unreleased` was already in the tree at `v0.30.2` and
therefore shipped in those binaries. Leaving it under "Unreleased" claimed
those features had not been released yet, which was wrong in a
user-facing file.

Moved that block to a `## 0.30.2` section, added `## 0.30.3` above it, and left
`## Unreleased` empty for the next cycle.

## Acceptance for the release that follows

- Release run green through `publish-npm`.
- GitHub Release published, `draft: false`, 16 assets.
- `@mblua/agentscommander@0.30.3` is `latest`, with provenance.
- Clean-install smoke passes.
- **The publish authenticated via OIDC, not via `NODE_AUTH_TOKEN`.**

If it falls back to the token the release still succeeds by design, and the
trusted-publisher configuration is what needs investigating, not the pipeline.

https://claude.ai/code/session_01RjvS5aJo8tt7h2jCX7QJCk
