### PR TITLE
style: format oldest Rust files (#1385)

### DIFF
--- a/src-tauri/src/cli/create_agent.rs
+++ b/src-tauri/src/cli/create_agent.rs
@@ -497,7 +497,8 @@ mod tests {
         };
         write_session_request_result(&result).expect("write result");
 
-        let outcome = wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
+        let outcome =
+            wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
         assert_eq!(
             outcome,
             LaunchOutcome::Launched {
@@ -520,7 +521,8 @@ mod tests {
         };
         write_session_request_result(&result).expect("write result");
 
-        let outcome = wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
+        let outcome =
+            wait_for_session_request_result(&result.id, std::time::Duration::from_secs(1));
         assert_eq!(
             outcome,
             LaunchOutcome::Rejected {

--- a/src-tauri/src/cli/create_agent_matrix.rs
+++ b/src-tauri/src/cli/create_agent_matrix.rs
@@ -198,10 +198,7 @@ pub(crate) fn execute_matrix_project_create(
                                 create_agent::LaunchOutcome::Rejected { error } => {
                                     launch_status = LaunchStatus::Rejected;
                                     launch_error = Some(error.clone());
-                                    eprintln!(
-                                        "Warning: session launch rejected: {}",
-                                        error
-                                    );
+                                    eprintln!("Warning: session launch rejected: {}", error);
                                 }
                                 create_agent::LaunchOutcome::Pending => {
                                     launch_status = LaunchStatus::Pending;

--- a/src-tauri/src/cli/list_peers.rs
+++ b/src-tauri/src/cli/list_peers.rs
@@ -3,9 +3,9 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::config::ac_root::existing_ac_root;
 use crate::config::agent_config::{AgentLocalConfig, CodingAgentEntry};
 use crate::config::sessions_persistence::{load_sessions_raw, PersistedSession};
-use crate::config::ac_root::existing_ac_root;
 use crate::session::session::{SessionStatus, TEMP_SESSION_PREFIX};
 
 #[derive(Args)]
@@ -708,8 +708,7 @@ fn discover_wg_peers(wg: WgReplicaInfo) -> Vec<PeerInfo> {
                     _ => continue,
                 };
 
-                if let Some(other_coord) = resolve_wg_coordinator(&wg.ac_root, &other_wg_dir)
-                {
+                if let Some(other_coord) = resolve_wg_coordinator(&wg.ac_root, &other_wg_dir) {
                     let coord_dir = other_wg_dir.join(format!("__agent_{}", other_coord));
                     if !coord_dir.is_dir() {
                         continue;

--- a/src-tauri/src/cli/loop_cmd.rs
+++ b/src-tauri/src/cli/loop_cmd.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use clap::{Args, Subcommand, ValueEnum};
 use serde::Serialize;
 
-use crate::cli::workgroup::{resolve_cli_project, resolve_cli_ac_root, write_refresh};
+use crate::cli::workgroup::{resolve_cli_ac_root, resolve_cli_project, write_refresh};
 use crate::config::loops::{
     apply_loop_update_patch, baseline_loop_state, details_from_parts, discover_loops_in_project,
     loop_dir, read_loop_config, read_loop_state, sanitize_loop_id, validate_loop_config,

--- a/src-tauri/src/cli/role_experiment.rs
+++ b/src-tauri/src/cli/role_experiment.rs
@@ -1739,8 +1739,7 @@ fn collect_experiment_validation(loaded: &LoadedExperiment) -> ExperimentValidat
     errors.extend(source_metadata_errors);
 
     if source_metadata_valid {
-        let source_matrix =
-            source_matrix_path(&loaded.ac_root, &loaded.experiment.source_agent);
+        let source_matrix = source_matrix_path(&loaded.ac_root, &loaded.experiment.source_agent);
         let source_role = source_matrix.join("Role.md");
         if !source_matrix.is_dir() {
             errors.push(err(
@@ -1789,9 +1788,7 @@ fn collect_experiment_validation(loaded: &LoadedExperiment) -> ExperimentValidat
             Ok(meta) => {
                 errors.extend(validate_variant_metadata_paths(loaded, variant, &meta));
                 validate_variant_files(loaded, &meta, &mut errors);
-                for blocker in
-                    find_live_sessions_for_variant(&loaded.ac_root, &meta.agent_name)
-                {
+                for blocker in find_live_sessions_for_variant(&loaded.ac_root, &meta.agent_name) {
                     errors.push(err(
                         "active_variant_session",
                         format!(
@@ -2257,8 +2254,8 @@ fn create_run_workgroup_dirs(
                 )]
             })?;
         }
-        let role_path = variant_matrix_path(ac_root, &variant.source_agent, &variant.name)
-            .join("Role.md");
+        let role_path =
+            variant_matrix_path(ac_root, &variant.source_agent, &variant.name).join("Role.md");
         let role_text = fs::read_to_string(&role_path).map_err(|e| {
             vec![err_at_path(
                 "variant_role_missing",
@@ -2527,8 +2524,7 @@ fn load_and_validate_resume_artifacts(
             None,
         ));
     }
-    if let Err(mut workgroup_errors) =
-        validate_workgroup_under_ac_root(&loaded.ac_root, &workgroup)
+    if let Err(mut workgroup_errors) = validate_workgroup_under_ac_root(&loaded.ac_root, &workgroup)
     {
         errors.append(&mut workgroup_errors);
     }
@@ -3179,8 +3175,7 @@ fn find_live_sessions_for_variant(
     ac_root: &Path,
     variant_agent_name: &str,
 ) -> Vec<LiveSessionBlocker> {
-    let mut out =
-        find_live_sessions_under(&ac_root.join(format!("_agent_{}", variant_agent_name)));
+    let mut out = find_live_sessions_under(&ac_root.join(format!("_agent_{}", variant_agent_name)));
     if let Ok(entries) = std::fs::read_dir(ac_root) {
         for entry in entries.flatten() {
             let path = entry.path();

--- a/src-tauri/src/cli/team.rs
+++ b/src-tauri/src/cli/team.rs
@@ -2,8 +2,8 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::cli::workgroup::{
-    build_new_team_config, clone_missing_for_config, push_unique, resolve_cli_project,
-    resolve_cli_ac_root, write_refresh,
+    build_new_team_config, clone_missing_for_config, push_unique, resolve_cli_ac_root,
+    resolve_cli_project, write_refresh,
 };
 use crate::commands::entity_creation::{
     acquire_lifecycle_project_gate, agent_ref_bare_name, create_new_team_config_on_disk,
@@ -265,10 +265,7 @@ fn add_member(args: TeamAddMemberArgs) -> Result<(), String> {
         return Err(format!("Workgroup '{}' not found", args.workgroup));
     }
     let team = parse_team_from_workgroup_name(&args.workgroup)?;
-    let config = normalize_team_config_for_project(
-        &ac_root,
-        &read_team_config(&ac_root, &team)?,
-    )?;
+    let config = normalize_team_config_for_project(&ac_root, &read_team_config(&ac_root, &team)?)?;
     let agent_ref = resolve_agent_ref(&ac_root, &args.agent)?;
     let (config, added) = add_member_to_team_config(config, &agent_ref, args.coordinator)?;
     write_team_config_guarded(&ac_root, &team, &config, &guard)?;
@@ -346,10 +343,7 @@ fn remove_member_hooked(
 
     // Re-read and revalidate the current team config under both guards, then
     // recompute the mutation from that current value.
-    let config = normalize_team_config_for_project(
-        &ac_root,
-        &read_team_config(&ac_root, &team)?,
-    )?;
+    let config = normalize_team_config_for_project(&ac_root, &read_team_config(&ac_root, &team)?)?;
     let (config, removed) = remove_member_from_team_config(config, &agent_ref)?;
     write_team_config_guarded(&ac_root, &team, &config, &guard)?;
 

--- a/src-tauri/src/cli/workgroup.rs
+++ b/src-tauri/src/cli/workgroup.rs
@@ -12,8 +12,8 @@ use crate::commands::entity_creation::{
     validate_existing_name, RepoAssignment, TeamConfigResult, WgDeleteOutcome,
     WorkgroupDiskCreateArgs,
 };
-use crate::config::projects::resolve_project_reference;
 use crate::config::ac_root::existing_ac_root;
+use crate::config::projects::resolve_project_reference;
 
 #[derive(Args)]
 pub struct WorkgroupArgs {
@@ -372,13 +372,8 @@ pub(crate) fn build_new_team_config(
     for agent in agents {
         push_unique(&mut roster, resolve_agent_ref(ac_root, agent)?);
     }
-    let repo_config = build_repo_assignments(
-        ac_root,
-        &roster,
-        repos,
-        repo_agents,
-        repo_exclude_agents,
-    )?;
+    let repo_config =
+        build_repo_assignments(ac_root, &roster, repos, repo_agents, repo_exclude_agents)?;
     Ok(TeamConfigResult {
         agents: roster,
         coordinator,

--- a/src-tauri/src/commands/entity_creation.rs
+++ b/src-tauri/src/commands/entity_creation.rs
@@ -10,6 +10,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::cli::task_ops;
 use crate::commands::ac_discovery::DiscoveryBranchWatcher;
+use crate::config::ac_root::existing_ac_root;
 use crate::config::replica_identity::{
     expected_wg_replica_identity, normalize_wg_replica_context_entries,
     repair_wg_replica_config_value, ROLE_MD_FILENAME, WG_REPLICA_REQUIRED_CONTEXT,
@@ -18,7 +19,6 @@ use crate::config::seed_manifest::{
     ManifestActivationToken, ManifestLifecycleFilter, ProjectSeedManifestGuard, SeedManifestError,
 };
 use crate::config::settings::{AppSettings, SettingsState};
-use crate::config::ac_root::existing_ac_root;
 use crate::pty::git_watcher::{CoordinatorChangedPayload, GitWatcher};
 use crate::session::manager::SessionManager;
 use crate::session::session::{SessionRepo, SessionStatus};
@@ -513,9 +513,7 @@ pub(crate) fn create_agent_matrix_from_role(
         ));
     }
     validate_existing_name(args.safe_name, "Agent")?;
-    let agent_dir = args
-        .ac_root
-        .join(format!("_agent_{}", args.safe_name));
+    let agent_dir = args.ac_root.join(format!("_agent_{}", args.safe_name));
     if agent_dir.exists() {
         return Err(format!("Agent '{}' already exists", args.safe_name));
     }
@@ -600,10 +598,7 @@ impl TeamConfigMutationGuard {
         Self::acquire_with_timing(ac_root, TeamConfigLockTiming::PRODUCTION)
     }
 
-    fn acquire_with_timing(
-        ac_root: &Path,
-        timing: TeamConfigLockTiming,
-    ) -> Result<Self, String> {
+    fn acquire_with_timing(ac_root: &Path, timing: TeamConfigLockTiming) -> Result<Self, String> {
         let requested_lock_path = ac_root.join(TEAM_CONFIG_MUTATION_LOCK_NAME);
         let canonical_ac_root = std::fs::canonicalize(ac_root)
             .map(|path| crate::path_utils::normalize_windows_verbatim_path_buf(&path))
@@ -4805,9 +4800,8 @@ mod tests {
         assert_eq!(normalized.context_alert_percentages, vec![50, 75, 90]);
 
         write_team_config(&ac_root, "dev-team", &config).expect("write config");
-        let written =
-            std::fs::read_to_string(ac_root.join("_team_dev-team").join("config.json"))
-                .expect("read config");
+        let written = std::fs::read_to_string(ac_root.join("_team_dev-team").join("config.json"))
+            .expect("read config");
         assert!(
             !written.contains(&tmp.path().to_string_lossy().to_string()),
             "team config must not persist absolute project paths: {}",
@@ -5831,8 +5825,7 @@ mod tests {
         let outside = tmp.path().join("outside.lock");
         std::fs::create_dir_all(&ac_root).expect("workspace");
         std::fs::write(&outside, b"").expect("outside lock");
-        symlink(&outside, ac_root.join(TEAM_CONFIG_MUTATION_LOCK_NAME))
-            .expect("symlink sentinel");
+        symlink(&outside, ac_root.join(TEAM_CONFIG_MUTATION_LOCK_NAME)).expect("symlink sentinel");
 
         let err = TeamConfigMutationGuard::acquire(&ac_root).expect_err("symlink escape");
         assert!(err.contains("regular non-link file"));
@@ -7476,8 +7469,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let project = tmp.path().join("ProjectAlpha");
         let ac_root = project.join(".ac");
-        std::fs::create_dir_all(ac_root.join("_agent_tech-lead-control"))
-            .expect("existing target");
+        std::fs::create_dir_all(ac_root.join("_agent_tech-lead-control")).expect("existing target");
 
         let err = create_agent_matrix_from_role(CreateAgentMatrixFromRoleArgs {
             ac_root: &ac_root,

--- a/src-tauri/src/phone/wake_lanes.rs
+++ b/src-tauri/src/phone/wake_lanes.rs
@@ -39,10 +39,7 @@ impl WakeLanes {
     /// test) and the global cap. Release is RAII via the reservation's `Drop`.
     /// Lock poisoning is absorbed so a panic holding the lock cannot wedge the
     /// set.
-    pub(crate) fn try_reserve(
-        self: &Arc<Self>,
-        target: &str,
-    ) -> Option<WakeLaneReservation> {
+    pub(crate) fn try_reserve(self: &Arc<Self>, target: &str) -> Option<WakeLaneReservation> {
         let mut active = self
             .active
             .lock()

--- a/src-tauri/tests/cli_create_agent_matrix.rs
+++ b/src-tauri/tests/cli_create_agent_matrix.rs
@@ -764,15 +764,13 @@ fn watch_and_answer_session_request(
             panic!("watcher timed out waiting for a session request");
         }
         let request_path = std::fs::read_dir(&requests_dir).ok().and_then(|rd| {
-            rd.filter_map(|e| e.ok())
-                .map(|e| e.path())
-                .find(|p| {
-                    p.extension().and_then(|s| s.to_str()) == Some("json")
-                        && !p
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .is_some_and(|s| s.ends_with(".result"))
-                })
+            rd.filter_map(|e| e.ok()).map(|e| e.path()).find(|p| {
+                p.extension().and_then(|s| s.to_str()) == Some("json")
+                    && !p
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|s| s.ends_with(".result"))
+            })
         });
         let Some(request_path) = request_path else {
             std::thread::sleep(std::time::Duration::from_millis(50));


### PR DESCRIPTION
## Summary

- apply standard `rustfmt` output to the 10 oldest non-compliant Rust files selected from the frozen 40-file baseline
- reduce the repository-wide formatting debt from 40 paths to 30 without changing behavior
- leave manifests, lockfiles, workflows, generated files, fixtures, dependencies, and the other 30 Rust files untouched

## Verification

- frozen plan SHA-256: `AAA0CC77EB13A7F797A2A3514B7C99A2CB307D1786858CCE3B4E261E3E6D68AF`
- exact scope: 10 modified files, 36 insertions, 67 deletions; no added or deleted files
- independent reviewer reproduced the 40 → 30 diagnostic and matched every committed blob byte-for-byte to stable rustfmt output
- `git diff --check`
- branch-name validation
- `cargo check --locked --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- Rust workspace and portable package tests
- implementation run also passed npm/frontend, production build, Windows release CLI smoke, and lockfile/debt gates

Adversarial review: PASS, no findings.

This is non-functional formatting-only work; no interactive/manual GUI validation applies. GitHub CI on the exact PR head remains the merge authority.

Closes #1385