### PR TITLE
style: apply cargo fmt to the 30 non-conforming src-tauri files (refs #1602)

### DIFF
--- a/src-tauri/src/agent_update.rs
+++ b/src-tauri/src/agent_update.rs
@@ -206,10 +206,7 @@ impl AgentUpdateGate {
     }
 
     pub fn mark_started(&self) {
-        self.state
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .started = true;
+        self.state.lock().unwrap_or_else(|e| e.into_inner()).started = true;
     }
 
     /// Register the prompt for `command` and return the answer channel. The
@@ -221,7 +218,10 @@ impl AgentUpdateGate {
         label: &str,
     ) -> tokio::sync::oneshot::Receiver<bool> {
         let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-        debug_assert!(!state.pending.contains_key(command), "duplicate prompt for {command}");
+        debug_assert!(
+            !state.pending.contains_key(command),
+            "duplicate prompt for {command}"
+        );
         state.prompted.insert(command.to_string());
         let (tx, rx) = tokio::sync::oneshot::channel();
         state.pending.insert(
@@ -447,7 +447,12 @@ impl AgentUpdateGate {
     pub async fn wait_until_done(&self) {
         loop {
             let notified = self.release.notified();
-            if self.state.lock().unwrap_or_else(|e| e.into_inner()).finished {
+            if self
+                .state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .finished
+            {
                 return;
             }
             notified.await;
@@ -901,15 +906,15 @@ async fn run_update_sequence(target: &UpdateTarget, step_timeout: Duration) -> A
             Ok(Ok(status)) => {
                 // The parent exited. Join the readers bounded; a descendant
                 // (npm -> node) can hold the pipe open past the parent exit.
-                let joined =
-                    tokio::time::timeout(READER_JOIN_TIMEOUT, collect(&mut stdout_rx, &mut stderr_rx))
-                        .await;
+                let joined = tokio::time::timeout(
+                    READER_JOIN_TIMEOUT,
+                    collect(&mut stdout_rx, &mut stderr_rx),
+                )
+                .await;
                 let (stdout, stderr) = match joined {
                     Ok((out, err)) => (out, err),
                     Err(_) => {
-                        log::warn!(
-                            "[agent-update] output truncated: descendant holds the pipe"
-                        );
+                        log::warn!("[agent-update] output truncated: descendant holds the pipe");
                         // Kill the tree BEFORE joining again so the readers EOF:
                         // Windows KILL_ON_JOB_CLOSE reaps the lingering tree
                         // member, Unix the process-group kill. The detached
@@ -942,9 +947,7 @@ async fn run_update_sequence(target: &UpdateTarget, step_timeout: Duration) -> A
                         {
                             Ok((out, err)) => (out, err),
                             Err(_) => {
-                                log::warn!(
-                                    "[agent-update] output still truncated after tree kill"
-                                );
+                                log::warn!("[agent-update] output still truncated after tree kill");
                                 (Vec::new(), Vec::new())
                             }
                         }
@@ -997,12 +1000,13 @@ async fn run_update_sequence(target: &UpdateTarget, step_timeout: Duration) -> A
                 unsafe {
                     libc::kill(-(pid as i32), libc::SIGKILL);
                 }
-                let _ =
-                    tokio::time::timeout(READER_JOIN_TIMEOUT, child.wait()).await;
-                let (stdout, stderr) =
-                    tokio::time::timeout(READER_JOIN_TIMEOUT, collect(&mut stdout_rx, &mut stderr_rx))
-                        .await
-                        .unwrap_or_default();
+                let _ = tokio::time::timeout(READER_JOIN_TIMEOUT, child.wait()).await;
+                let (stdout, stderr) = tokio::time::timeout(
+                    READER_JOIN_TIMEOUT,
+                    collect(&mut stdout_rx, &mut stderr_rx),
+                )
+                .await
+                .unwrap_or_default();
                 let reason = format!("timed out after {}s (killed)", step_timeout.as_secs());
                 log::warn!(
                     "[agent-update] step TIMED OUT for {} ({}): {reason}\n{}",
@@ -1395,7 +1399,11 @@ mod tests {
     fn build_plan_dedupes_by_command_first_entry_wins() {
         let catalog = vec![
             entry("claude", "Claude (primary)", vec!["claude --update"]),
-            entry("claude", "Claude (secondary)", vec!["claude --update --beta"]),
+            entry(
+                "claude",
+                "Claude (secondary)",
+                vec!["claude --update --beta"],
+            ),
             entry("codex", "Codex", vec!["codex update"]),
         ];
         let answers = BTreeMap::new();
@@ -1545,10 +1553,16 @@ mod tests {
         assert!(gate.was_prompted("claude"));
         let snap = gate.snapshot();
         assert!(snap.in_progress);
-        assert_eq!(snap.prompt.as_ref().map(|p| p.command.as_str()), Some("claude"));
+        assert_eq!(
+            snap.prompt.as_ref().map(|p| p.command.as_str()),
+            Some("claude")
+        );
 
         assert!(gate.resolve_answer("claude", true));
-        assert!(!gate.resolve_answer("claude", true), "second resolve must fail");
+        assert!(
+            !gate.resolve_answer("claude", true),
+            "second resolve must fail"
+        );
         assert!(rx.await.expect("answer delivered"));
         assert!(gate.snapshot().prompt.is_none(), "resolved prompt cleared");
 
@@ -1631,10 +1645,7 @@ mod tests {
                 label: "Test".to_string(),
                 commands: vec![
                     "exit 3".to_string(),
-                    format!(
-                        "echo x > {}",
-                        marker.to_string_lossy().replace('\\', "/")
-                    ),
+                    format!("echo x > {}", marker.to_string_lossy().replace('\\', "/")),
                 ],
                 cwd: dir.path().to_path_buf(),
             },
@@ -1792,7 +1803,10 @@ mod tests {
             let gate = Arc::clone(&gate);
             async move {
                 tokio::time::sleep(Duration::from_millis(25)).await;
-                assert!(gate.resolve_answer("claude", false), "prompt must still be pending");
+                assert!(
+                    gate.resolve_answer("claude", false),
+                    "prompt must still be pending"
+                );
                 gate.mark_finished(vec![]);
             }
         });

--- a/src-tauri/src/cli/send.rs
+++ b/src-tauri/src/cli/send.rs
@@ -1174,7 +1174,10 @@ mod tests {
             .get_subcommands()
             .find(|c| c.get_name() == "send")
             .expect("send subcommand");
-        let after = send.get_after_help().expect("after_help present").to_string();
+        let after = send
+            .get_after_help()
+            .expect("after_help present")
+            .to_string();
         assert!(
             after.contains("On enqueue, the CLI prints `Queued: <message-id>` to stdout"),
             "after_help missing enqueue-receipt sentence"

--- a/src-tauri/src/commands/ac_discovery.rs
+++ b/src-tauri/src/commands/ac_discovery.rs
@@ -7,11 +7,11 @@ use std::time::{Duration, SystemTime};
 use tauri::{AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
 
-use crate::config::settings::SettingsState;
 use crate::config::ac_root::{
-    canonical_ac_root_label, existing_ac_root, find_ac_root_segment,
-    has_ac_root, ac_root_for_project,
+    ac_root_for_project, canonical_ac_root_label, existing_ac_root, find_ac_root_segment,
+    has_ac_root,
 };
+use crate::config::settings::SettingsState;
 use crate::pty::manager::{PendingSpawn, PtyManager};
 use crate::session::manager::SessionManager;
 use crate::session::session::{SessionInfo, SessionRepo, SessionStatus};
@@ -1269,8 +1269,7 @@ pub async fn discover_ac_agents(
                                 // teams::tests::is_any_coordinator_requires_qualified_fqn.
                                 let is_coordinator =
                                     crate::config::teams::resolve_wg_coordinator_replica(
-                                        &ac_root,
-                                        &path,
+                                        &ac_root, &path,
                                     )
                                     .map(|resolved| resolved.agent_name == replica_name)
                                     .unwrap_or(false);
@@ -1628,16 +1627,12 @@ pub async fn create_ac_project(path: String) -> Result<(), String> {
         let activation = Some(crate::config::seed_manifest::ManifestActivationToken::production());
         #[cfg(test)]
         let activation: Option<crate::config::seed_manifest::ManifestActivationToken> = None;
-        create_ac_project_impl(
-            &path,
-            activation.as_ref(),
-            |ac_root, on_publication| {
-                crate::config::session_context::create_default_context_templates_with_publications(
-                    ac_root,
-                    on_publication,
-                )
-            },
-        )?;
+        create_ac_project_impl(&path, activation.as_ref(), |ac_root, on_publication| {
+            crate::config::session_context::create_default_context_templates_with_publications(
+                ac_root,
+                on_publication,
+            )
+        })?;
         // #1318 - a fresh `.ac` root seeds the catalog + masters immediately
         // (no restart needed). INSIDE this blocking closure, so the gate acquire
         // runs on the blocking thread. Fail-soft: any error is logged and the
@@ -1724,8 +1719,8 @@ where
                 error
             )
         })?;
-    let pinned_ac_root = crate::config::seed_manifest::PinnedDirectory::open(&ac_root)
-        .map_err(|error| {
+    let pinned_ac_root =
+        crate::config::seed_manifest::PinnedDirectory::open(&ac_root).map_err(|error| {
             format!(
                 "Failed to pin {} directory {}: {}",
                 canonical_ac_root_label(),
@@ -4152,8 +4147,7 @@ mod tests {
 
         let first_result = create_ac_project_impl(&path, None, |ac_root, _on_publication| {
             std::fs::write(
-                ac_root
-                    .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+                ac_root.join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
                 crate::config::session_context::get_default_agent_template(),
             )
             .expect("write partial agent context");
@@ -4424,8 +4418,7 @@ mod tests {
             std::sync::Arc::new(tokio::sync::RwLock::new(AppSettings::default()));
         let hooks = NewProjectTransactionHooks {
             before_final_revalidation: Some(std::sync::Arc::new(|ac_root| {
-                let lock =
-                    ac_root.join(crate::config::seed_manifest::SEED_MANIFEST_LOCK_FILENAME);
+                let lock = ac_root.join(crate::config::seed_manifest::SEED_MANIFEST_LOCK_FILENAME);
                 let detached = ac_root.join(".seed-manifest.lock-detached-after-save");
                 std::fs::rename(&lock, &detached).expect("detach held lock identity");
                 std::fs::write(&lock, b"").expect("install replacement lock identity");
@@ -4526,8 +4519,7 @@ mod tests {
 
         ensure_ac_root_gitignore(&ac_root).expect("ensure workspace .gitignore");
 
-        let content =
-            std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
+        let content = std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
         assert!(
             content.lines().any(|line| line.trim() == ".deleting-*/"),
             "workspace .gitignore must ignore workgroup delete sentinel directories"
@@ -4568,8 +4560,7 @@ mod tests {
 
         ensure_ac_root_gitignore(&ac_root).expect("ensure workspace .gitignore");
 
-        let content =
-            std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
+        let content = std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
         let block =
             "# AgentsCommander: exclude team-config coordination files.\n/.team-config-write.lock";
         assert_eq!(
@@ -4596,8 +4587,7 @@ mod tests {
 
         ensure_ac_root_gitignore(&ac_root).expect("ensure workspace .gitignore");
 
-        let content =
-            std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
+        let content = std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
         let count = content
             .lines()
             .filter(|line| line.trim() == ".deleting-*/")
@@ -5072,8 +5062,8 @@ mod tests {
     }
 
     #[test]
-    fn ensure_ac_root_gitignore_appends_team_config_lock_block_preserving_bytes_and_is_idempotent(
-    ) {
+    fn ensure_ac_root_gitignore_appends_team_config_lock_block_preserving_bytes_and_is_idempotent()
+    {
         let tmp = tempfile::tempdir().expect("tempdir");
         let ac_root = tmp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create .ac");
@@ -5617,14 +5607,20 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let ac_root = tmp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create .ac");
-        std::fs::write(ac_root.join(".gitignore"), "wg-*/
-").expect("write .gitignore");
+        std::fs::write(
+            ac_root.join(".gitignore"),
+            "wg-*/
+",
+        )
+        .expect("write .gitignore");
         ensure_ac_root_gitignore(&ac_root).expect("ensure workspace .gitignore");
 
-        let content =
-            std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
+        let content = std::fs::read_to_string(ac_root.join(".gitignore")).expect("read .gitignore");
         assert_eq!(
-            content.lines().filter(|line| line.trim() == "wg-*/").count(),
+            content
+                .lines()
+                .filter(|line| line.trim() == "wg-*/")
+                .count(),
             1,
             "the pre-existing wg-*/ line must survive exactly once"
         );
@@ -5638,7 +5634,10 @@ mod tests {
             "_agent_*/**/*.pyc",
         ] {
             assert_eq!(
-                content.lines().filter(|line| line.trim() == pattern).count(),
+                content
+                    .lines()
+                    .filter(|line| line.trim() == pattern)
+                    .count(),
                 1,
                 "pattern {pattern} must be appended exactly once"
             );
@@ -5660,11 +5659,8 @@ mod tests {
             "_agent_*/**/__pycache__/",
             "_agent_*/**/*.pyc",
         ];
-        std::fs::write(
-            ac_root.join(".gitignore"),
-            seven_patterns.join("\n") + "\n",
-        )
-        .expect("write .gitignore");
+        std::fs::write(ac_root.join(".gitignore"), seven_patterns.join("\n") + "\n")
+            .expect("write .gitignore");
         let replica = ".ac/wg-1/__agent_replica/rtk_ignored_tools.md";
         let path = project.join(replica);
         std::fs::create_dir_all(path.parent().expect("fixture has a parent"))
@@ -5687,6 +5683,9 @@ mod tests {
             .status()
             .expect("git check-ignore")
             .success();
-        assert!(!ignored, "{replica} must not be ignored by the 7 patterns alone");
+        assert!(
+            !ignored,
+            "{replica} must not be ignored by the 7 patterns alone"
+        );
     }
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1419,9 +1419,7 @@ fn enumerate_profile_assignment_targets(
             collect_replica_dirs_in_workgroup(wg_dir, &mut candidate_dirs)?;
         }
         ProfileAssignmentScope::Kind => {
-            for ac_root in
-                crate::config::coding_agent_profiles::configured_ac_roots(settings)
-            {
+            for ac_root in crate::config::coding_agent_profiles::configured_ac_roots(settings) {
                 collect_kind_replica_dirs(&ac_root, &mut candidate_dirs)?;
             }
         }

--- a/src-tauri/src/commands/loops.rs
+++ b/src-tauri/src/commands/loops.rs
@@ -5,6 +5,7 @@ use chrono::{Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
 
+use crate::config::ac_root::existing_ac_root;
 use crate::config::loops::{
     apply_loop_update_patch, baseline_loop_state, details_from_parts, loop_dir, next_due_after,
     read_loop_config, read_loop_state, sanitize_loop_id, validate_cron_expr, validate_loop_config,
@@ -12,7 +13,6 @@ use crate::config::loops::{
     LoopConfigDetails, LoopConfigToml, LoopDef, LoopPolicy, LoopPrompt, LoopTarget, LoopTargetKind,
     LoopTrigger, LoopTriggerKind, LoopUpdatePatch, LOOP_TIMEZONE_LOCAL,
 };
-use crate::config::ac_root::existing_ac_root;
 // #1252: keep private. A `pub use` here would re-expose the emitter and kill the E0603 backstop.
 use crate::loops::events::emit_loop_change;
 use crate::loops::scheduler::LoopScheduler;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -307,7 +307,9 @@ fn codex_tokens_have_resume(tokens: &[&str], start: usize) -> bool {
 fn antigravity_tokens_have_resume(tokens: &[&str], start: usize) -> bool {
     tokens[start..].iter().any(|t| {
         let lower = t.to_lowercase();
-        lower == "--continue" || lower == "-c" || lower == "--conversation"
+        lower == "--continue"
+            || lower == "-c"
+            || lower == "--conversation"
             || lower.starts_with("--conversation=")
     })
 }
@@ -317,7 +319,10 @@ fn inject_antigravity_resume(shell: &str, shell_args: &mut Vec<String>) -> bool 
     // source of truth). G6: slice-pattern destructure, never index — a future
     // <1-element slice degrades gracefully instead of panicking in release.
     let &[resume_token] = CodingAgentKind::Antigravity.profile().resume_tokens else {
-        debug_assert!(false, "Antigravity resume_tokens must have exactly 1 element");
+        debug_assert!(
+            false,
+            "Antigravity resume_tokens must have exactly 1 element"
+        );
         return false;
     };
     match executable_basename(shell).as_str() {
@@ -333,10 +338,12 @@ fn inject_antigravity_resume(shell: &str, shell_args: &mut Vec<String>) -> bool 
             // Tokenized and embedded forms, structurally mirroring the deleted
             // inject_gemini_resume cmd arm, but searching for a token whose
             // executable basename is exactly "agy" | "antigravity".
-            let is_antigravity_executable = |arg: &str| {
-                matches!(executable_basename(arg).as_str(), "agy" | "antigravity")
-            };
-            if let Some(idx) = shell_args.iter().position(|arg| is_antigravity_executable(arg)) {
+            let is_antigravity_executable =
+                |arg: &str| matches!(executable_basename(arg).as_str(), "agy" | "antigravity");
+            if let Some(idx) = shell_args
+                .iter()
+                .position(|arg| is_antigravity_executable(arg))
+            {
                 let tokens: Vec<&str> = shell_args.iter().map(|arg| arg.as_str()).collect();
                 if antigravity_tokens_have_resume(&tokens, idx + 1) {
                     return false;
@@ -350,7 +357,9 @@ fn inject_antigravity_resume(shell: &str, shell_args: &mut Vec<String>) -> bool 
                     .split_whitespace()
                     .map(|token| token.to_string())
                     .collect();
-                if let Some(idx) = tokens.iter().position(|token| is_antigravity_executable(token))
+                if let Some(idx) = tokens
+                    .iter()
+                    .position(|token| is_antigravity_executable(token))
                 {
                     let token_refs: Vec<&str> = tokens.iter().map(|token| token.as_str()).collect();
                     if antigravity_tokens_have_resume(&token_refs, idx + 1) {
@@ -6745,7 +6754,8 @@ mod tests {
         let rows = session_mgr.read().await.list_sessions().await;
         assert_eq!(rows.len(), 2, "ancestor + nested sessions both exist");
         assert!(
-            rows.iter().any(|row| row.working_directory == nested_origin),
+            rows.iter()
+                .any(|row| row.working_directory == nested_origin),
             "the nested-project session row must exist"
         );
         let _ = temp;
@@ -6789,9 +6799,7 @@ mod tests {
         )
         .await
         .unwrap_or_else(|e| {
-            panic!(
-                "nested replica create must not race the ancestor session; got Err({e})"
-            )
+            panic!("nested replica create must not race the ancestor session; got Err({e})")
         });
 
         // (b) A live session on the nested replica itself + another Background
@@ -10481,14 +10489,10 @@ mod tests {
         // Drive the resolved-agent path exactly as `create_session` does: the
         // resolved agent stays the command-to-run, and the configured host shell
         // (copied from the same config snapshot) travels separately.
-        let spawn = super::build_configured_agent_spawn_for_cwd(
-            &test_settings(),
-            "claude",
-            &cwd,
-            None,
-        )
-        .expect("resolve claude")
-        .expect("claude is configured in test_settings");
+        let spawn =
+            super::build_configured_agent_spawn_for_cwd(&test_settings(), "claude", &cwd, None)
+                .expect("resolve claude")
+                .expect("claude is configured in test_settings");
         let host_shell = crate::pty::backend::ResolvedAgentHostShell {
             program: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe".to_string(),
             args: vec!["-NoProfile".to_string()],
@@ -10555,14 +10559,10 @@ mod tests {
         )));
         let app = session_test_app(settings, Arc::clone(&session_mgr), Arc::clone(&pty_mgr));
 
-        let spawn = super::build_configured_agent_spawn_for_cwd(
-            &test_settings(),
-            "claude",
-            &cwd,
-            None,
-        )
-        .expect("resolve claude")
-        .expect("claude is configured in test_settings");
+        let spawn =
+            super::build_configured_agent_spawn_for_cwd(&test_settings(), "claude", &cwd, None)
+                .expect("resolve claude")
+                .expect("claude is configured in test_settings");
         let host_shell = crate::pty::backend::ResolvedAgentHostShell {
             program: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe".to_string(),
             args: vec!["-NoProfile".to_string()],
@@ -10621,7 +10621,10 @@ mod tests {
         {
             let specs = backend.specs.lock().unwrap();
             let spec = specs.last().expect("create reached the backend");
-            assert_eq!(spec.args, effective, "backend args stay the logical agent argv");
+            assert_eq!(
+                spec.args, effective,
+                "backend args stay the logical agent argv"
+            );
             assert_eq!(
                 spec.resolved_agent_host_shell
                     .as_ref()
@@ -10701,7 +10704,10 @@ mod tests {
         .await
         .expect_err("invalid configured host must fail the create");
         assert!(error.contains("conflicting/terminal"), "{error}");
-        assert!(error.contains("agent adapter owns command execution"), "{error}");
+        assert!(
+            error.contains("agent adapter owns command execution"),
+            "{error}"
+        );
 
         assert!(
             session_mgr.read().await.list_sessions().await.is_empty(),
@@ -10750,5 +10756,4 @@ mod tests {
         }
         close_test_coordinator(&app).await;
     }
-
 }

--- a/src-tauri/src/commands/task.rs
+++ b/src-tauri/src/commands/task.rs
@@ -14,8 +14,8 @@ use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
 use crate::cli::task_ops::{self, TaskOp};
-use crate::config::settings::SettingsState;
 use crate::config::ac_root::is_ac_root_name; // gate 5 (path-based clean, #545)
+use crate::config::settings::SettingsState;
 use crate::session::manager::SessionManager;
 use crate::session::session::find_workgroup_task_path_for_cwd;
 
@@ -351,7 +351,11 @@ pub async fn task_set_title_at(
 
     let outcome =
         task_ops::perform(&wg_root, TaskOp::SetUserTitle(title)).map_err(|e| e.to_string())?;
-    log::info!("[task] set_title_at for {} -> {:?}", workgroup_root, outcome);
+    log::info!(
+        "[task] set_title_at for {} -> {:?}",
+        workgroup_root,
+        outcome
+    );
 
     let (content, task_title) = match &outcome {
         task_ops::EditOutcome::Wrote { content, title, .. } => (content.clone(), title.clone()),

--- a/src-tauri/src/config/agent_command.rs
+++ b/src-tauri/src/config/agent_command.rs
@@ -1031,8 +1031,8 @@ mod tests {
         find_opencode_config_dir, is_bare_program_token, is_safe_instructions_filename,
         managed_instructions_filenames, normalize_legacy_agent_command,
         prepare_agent_spawn_command, profile_content_hash, resolve_agent_spawn_command,
-        resolve_instructions_filename, resolve_program, resolve_target_filename,
-        AgentSpawnCommand, OpencodeConfigDirOutcome,
+        resolve_instructions_filename, resolve_program, resolve_target_filename, AgentSpawnCommand,
+        OpencodeConfigDirOutcome,
     };
     use crate::config::coding_agent_profiles::ProfileResolution;
     use crate::config::settings::{
@@ -1735,10 +1735,7 @@ mod tests {
         };
         let mut got = managed_instructions_filenames(&settings);
         got.sort();
-        assert_eq!(
-            got,
-            vec!["AGENTS.md".to_string(), "CLAUDE.md".to_string()]
-        );
+        assert_eq!(got, vec!["AGENTS.md".to_string(), "CLAUDE.md".to_string()]);
     }
 
     #[test]
@@ -2273,10 +2270,7 @@ mod tests {
         ];
         expected.push((
             ConfigSeedTier::CatalogDefault,
-            ac_root
-                .join("coding-agents")
-                .join("_seed")
-                .join(".claude"),
+            ac_root.join("coding-agents").join("_seed").join(".claude"),
         ));
         assert_eq!(seed.candidates, expected);
         assert_eq!(seed.dest, expected_replica.join(".claude"));

--- a/src-tauri/src/config/coding_agent_profiles.rs
+++ b/src-tauri/src/config/coding_agent_profiles.rs
@@ -2,11 +2,11 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use crate::config::settings::{
-    empty_profile_cell, normalize_profile_letter, AppSettings, ProfileCellConfig,
-};
 use crate::config::ac_root::{
     ensure_authoritative_ac_root, is_ac_root_name, CANONICAL_AC_ROOT_DIR,
+};
+use crate::config::settings::{
+    empty_profile_cell, normalize_profile_letter, AppSettings, ProfileCellConfig,
 };
 
 #[derive(Debug, Clone)]
@@ -165,20 +165,14 @@ pub(crate) fn configured_ac_roots(settings: &AppSettings) -> Vec<PathBuf> {
                 continue;
             };
             if file_type.is_dir() {
-                collect_ac_root_candidate(
-                    &mut ac_roots,
-                    &entry.path().join(CANONICAL_AC_ROOT_DIR),
-                );
+                collect_ac_root_candidate(&mut ac_roots, &entry.path().join(CANONICAL_AC_ROOT_DIR));
             }
         }
     }
     ac_roots
 }
 
-fn ensure_ac_root_is_configured(
-    settings: &AppSettings,
-    ac_root: &Path,
-) -> Result<(), String> {
+fn ensure_ac_root_is_configured(settings: &AppSettings, ac_root: &Path) -> Result<(), String> {
     let ac_root = canonical_existing_dir(ac_root, "Project AC Root")?;
     let configured = configured_ac_roots(settings);
     if configured

--- a/src-tauri/src/config/coding_agents_catalog.rs
+++ b/src-tauri/src/config/coding_agents_catalog.rs
@@ -1100,7 +1100,13 @@ mod tests {
         assert_eq!(
             keys,
             [
-                "claude", "codex", "hermes", "cursor", "pi", "opencode", "antigravity"
+                "claude",
+                "codex",
+                "hermes",
+                "cursor",
+                "pi",
+                "opencode",
+                "antigravity"
             ]
         );
         // Antigravity is last, after OpenCode.
@@ -1907,14 +1913,8 @@ mod tests {
 
         let loaded = load_catalog(dir.path());
         assert_eq!(loaded.len(), 2);
-        assert_eq!(
-            loaded[0].update_commands,
-            vec!["pi update".to_string()]
-        );
-        assert_eq!(
-            loaded[1].update_commands,
-            vec!["pi update".to_string()]
-        );
+        assert_eq!(loaded[0].update_commands, vec!["pi update".to_string()]);
+        assert_eq!(loaded[1].update_commands, vec!["pi update".to_string()]);
     }
 
     #[test]
@@ -1936,14 +1936,8 @@ mod tests {
 
         let loaded = load_catalog(dir.path());
         assert_eq!(loaded.len(), 2);
-        assert_eq!(
-            loaded[0].update_commands,
-            vec!["pi update".to_string()]
-        );
-        assert_eq!(
-            loaded[1].update_commands,
-            vec!["pi --custom".to_string()]
-        );
+        assert_eq!(loaded[0].update_commands, vec!["pi update".to_string()]);
+        assert_eq!(loaded[1].update_commands, vec!["pi --custom".to_string()]);
     }
 
     #[test]
@@ -1963,10 +1957,9 @@ mod tests {
                 "claude" => assert_eq!(def.update_commands, vec!["claude --update".to_string()]),
                 "pi" => assert_eq!(def.update_commands, vec!["pi update".to_string()]),
                 "codex" => assert_eq!(def.update_commands, vec!["codex update".to_string()]),
-                "hermes" => assert_eq!(
-                    def.update_commands,
-                    vec!["hermes update --yes".to_string()]
-                ),
+                "hermes" => {
+                    assert_eq!(def.update_commands, vec!["hermes update --yes".to_string()])
+                }
                 "opencode" => assert_eq!(def.update_commands, vec!["opencode upgrade".to_string()]),
                 "antigravity" => assert_eq!(def.update_commands, vec!["agy update".to_string()]),
                 "cursor" => assert!(

--- a/src-tauri/src/config/config_seed.rs
+++ b/src-tauri/src/config/config_seed.rs
@@ -1921,10 +1921,7 @@ mod tests {
         let ac_root = temp.path().join("ws");
         let replica = ac_root.join("wg-1-team").join("__agent_x");
         std::fs::create_dir_all(&replica).unwrap();
-        write_file(
-            &ac_root.join("default.claude").join("f.txt"),
-            b"WORKSPACE",
-        );
+        write_file(&ac_root.join("default.claude").join("f.txt"), b"WORKSPACE");
         let master = temp.path().join("master");
         write_file(&master.join("f.txt"), b"CATALOG");
 

--- a/src-tauri/src/config/projects.rs
+++ b/src-tauri/src/config/projects.rs
@@ -10,8 +10,8 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use super::ac_root::{ac_root_for_project, existing_ac_root, has_ac_root};
 use super::settings::AppSettings;
-use super::ac_root::{existing_ac_root, has_ac_root, ac_root_for_project};
 
 /// Outcome of a register call. Callers translate this into the verb-specific
 /// stdout / IPC payload (CLI prints the lines from §2; Tauri command returns
@@ -198,13 +198,12 @@ fn register_new_project_with_store(
     store: NewProjectSettingsStore,
     activation: Option<&crate::config::seed_manifest::ManifestActivationToken>,
 ) -> Result<ProjectRegistration, ProjectError> {
-    let prepared =
-        prepare_new_project_impl(raw_path, activation, |ac_root, on_publication| {
-            crate::config::session_context::create_default_context_templates_with_publications(
-                ac_root,
-                on_publication,
-            )
-        })?;
+    let prepared = prepare_new_project_impl(raw_path, activation, |ac_root, on_publication| {
+        crate::config::session_context::create_default_context_templates_with_publications(
+            ac_root,
+            on_publication,
+        )
+    })?;
     store.refresh(settings)?;
     let before_settings = settings.clone();
     let result = commit_prepared_new_project(settings, &prepared);
@@ -284,16 +283,12 @@ pub(crate) fn prepare_new_project(raw_path: &str) -> Result<PreparedNewProject, 
     let activation = Some(crate::config::seed_manifest::ManifestActivationToken::production());
     #[cfg(test)]
     let activation: Option<crate::config::seed_manifest::ManifestActivationToken> = None;
-    prepare_new_project_impl(
-        raw_path,
-        activation.as_ref(),
-        |ac_root, on_publication| {
-            crate::config::session_context::create_default_context_templates_with_publications(
-                ac_root,
-                on_publication,
-            )
-        },
-    )
+    prepare_new_project_impl(raw_path, activation.as_ref(), |ac_root, on_publication| {
+        crate::config::session_context::create_default_context_templates_with_publications(
+            ac_root,
+            on_publication,
+        )
+    })
 }
 
 fn prepare_new_project_impl<F>(
@@ -333,8 +328,7 @@ where
     // `create_dir` below can race-detect properly. `create_dir_all` is
     // idempotent on an already-existing dir, so this costs nothing extra
     // when PATH is already there.
-    std::fs::create_dir_all(&abs)
-        .map_err(|e| ProjectError::AcRootCreateFailed(abs.clone(), e))?;
+    std::fs::create_dir_all(&abs).map_err(|e| ProjectError::AcRootCreateFailed(abs.clone(), e))?;
 
     let ac_root = ac_root_for_project(&abs);
     // The create syscall is the sole creation-intent authority. An earlier
@@ -342,12 +336,7 @@ where
     let created = match std::fs::create_dir(&ac_root) {
         Ok(()) => true,
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => false,
-        Err(e) => {
-            return Err(ProjectError::AcRootCreateFailed(
-                ac_root.clone(),
-                e,
-            ))
-        }
+        Err(e) => return Err(ProjectError::AcRootCreateFailed(ac_root.clone(), e)),
     };
     let pinned_project = crate::config::seed_manifest::PinnedDirectory::open(&abs)
         .map_err(|error| ProjectError::ProjectSetupChanged(abs.clone(), error.to_string()))?;
@@ -374,10 +363,7 @@ where
         .map_err(|error| ProjectError::ProjectSetupChanged(abs.clone(), error.to_string()))?;
     if created {
         if let Err(e) = crate::commands::ac_discovery::ensure_ac_root_gitignore(&ac_root) {
-            return Err(ProjectError::AcRootGitignoreFailed(
-                ac_root.clone(),
-                e,
-            ));
+            return Err(ProjectError::AcRootGitignoreFailed(ac_root.clone(), e));
         }
     } else {
         // Gitignore sweep (Round-1 G15): best-effort when `.ac` pre-existed
@@ -2045,10 +2031,7 @@ mod tests {
         let mut s = AppSettings::default();
         let r = register_existing_project(&mut s, fix.path().to_str().unwrap()).unwrap();
         assert!(r.registered);
-        assert_eq!(
-            existing_ac_root(fix.path()),
-            Some(fix.path().join(".ac"))
-        );
+        assert_eq!(existing_ac_root(fix.path()), Some(fix.path().join(".ac")));
     }
 
     #[test]
@@ -2167,8 +2150,7 @@ mod tests {
             None,
             |ac_root, _on_publication| {
                 std::fs::write(
-                    ac_root
-                        .join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+                    ac_root.join(crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME),
                     crate::config::session_context::get_default_agent_template(),
                 )
                 .expect("write partial agent context");
@@ -2277,9 +2259,7 @@ mod tests {
             match prepare_new_project_impl_with_hook(
                 &creator_path,
                 None,
-                |_ac_root, _on_publication| {
-                    Err("injected creator failure after gate".to_string())
-                },
+                |_ac_root, _on_publication| Err("injected creator failure after gate".to_string()),
                 move |_, created| {
                     assert!(created, "creator must own the create_dir win");
                     ready_tx.send(()).expect("signal visible root");

--- a/src-tauri/src/config/replica_identity.rs
+++ b/src-tauri/src/config/replica_identity.rs
@@ -178,15 +178,13 @@ fn validate_local_matrix(
         ));
     }
 
-    let ac_root_abs = std::fs::canonicalize(ac_root)
-        .map(strip_unc)
-        .map_err(|e| {
-            format!(
-                "Failed to canonicalize Project AC Root '{}': {}",
-                display_path(ac_root),
-                e
-            )
-        })?;
+    let ac_root_abs = std::fs::canonicalize(ac_root).map(strip_unc).map_err(|e| {
+        format!(
+            "Failed to canonicalize Project AC Root '{}': {}",
+            display_path(ac_root),
+            e
+        )
+    })?;
     let matrix_abs = std::fs::canonicalize(matrix_dir)
         .map(strip_unc)
         .map_err(|e| {

--- a/src-tauri/src/config/seed_manifest.rs
+++ b/src-tauri/src/config/seed_manifest.rs
@@ -2214,8 +2214,7 @@ impl ProjectSeedManifestGuard {
             });
         }
 
-        let ac_path =
-            canonical_project_path.join(crate::config::ac_root::CANONICAL_AC_ROOT_DIR);
+        let ac_path = canonical_project_path.join(crate::config::ac_root::CANONICAL_AC_ROOT_DIR);
         let ac_root = PinnedDirectory::open(&ac_path)?;
         let lock_path = ac_path.join(SEED_MANIFEST_LOCK_FILENAME);
         let started = Instant::now();

--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -1264,10 +1264,7 @@ fn validate_project_ac_root(ac_root: &Path) -> Result<PathBuf, String> {
         .ok_or_else(|| format!("Project AC Root {} has no parent", ac_root.display()))
 }
 
-fn validate_project_ac_root_for_scan(
-    project_dir: &Path,
-    ac_root: &Path,
-) -> Result<(), String> {
+fn validate_project_ac_root_for_scan(project_dir: &Path, ac_root: &Path) -> Result<(), String> {
     validate_existing_dir(ac_root, "Project AC Root")?;
     let expected = crate::config::ac_root::ac_root_for_project(project_dir);
     if ac_root != expected {
@@ -1326,8 +1323,7 @@ fn ensure_project_context_templates_with_clock(
     validate_existing_dir(ac_root, "Context template directory")?;
     let mut loaded = load_state(ac_root, false)?;
     for spec in project_specs() {
-        let execution =
-            sync_one_template(None, ac_root, spec, &mut loaded, true, false, clock);
+        let execution = sync_one_template(None, ac_root, spec, &mut loaded, true, false, clock);
         let _ = consume_template_execution(spec, execution, on_publication)?;
     }
     persist_state_best_effort(ac_root, &loaded);
@@ -2147,12 +2143,8 @@ mod tests {
                     publication.published_at,
                 );
             };
-            ensure_project_context_templates_with_clock(
-                &ac_root,
-                &mut clock,
-                &mut on_publication,
-            )
-            .expect("ensure project context templates");
+            ensure_project_context_templates_with_clock(&ac_root, &mut clock, &mut on_publication)
+                .expect("ensure project context templates");
         }
         guard.release();
 
@@ -2342,9 +2334,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(content, get_default_coordinator_template());
     }
 
@@ -2388,9 +2379,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(content, get_default_coordinator_template());
 
         assert!(is_known_generated_coordinator_template(
@@ -2984,9 +2974,7 @@ mod tests {
 
         assert!(updates.is_empty());
         assert!(!ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME).exists());
-        assert!(!ac_root
-            .join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME)
-            .exists());
+        assert!(!ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME).exists());
     }
 
     #[test]
@@ -3190,9 +3178,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(content, get_default_coordinator_template());
     }
 
@@ -3219,9 +3206,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(content, get_default_coordinator_template());
     }
 
@@ -3265,9 +3251,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(content, get_default_coordinator_template());
     }
 
@@ -3344,9 +3329,8 @@ mod tests {
             published_at,
         );
 
-        let content =
-            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
-                .expect("read coordinator");
+        let content = std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read coordinator");
         assert_eq!(
             content,
             get_default_coordinator_template(),
@@ -3375,11 +3359,8 @@ mod tests {
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
         let custom = "custom coordinator guidance";
-        std::fs::write(
-            ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            custom,
-        )
-        .expect("write custom coordinator");
+        std::fs::write(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME), custom)
+            .expect("write custom coordinator");
 
         let mut clock = || fixed_publication_time();
         let mut publications = Vec::new();
@@ -3427,11 +3408,8 @@ mod tests {
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
         let custom = "custom coordinator with forged seeded hash";
-        std::fs::write(
-            ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            custom,
-        )
-        .expect("write custom coordinator");
+        std::fs::write(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME), custom)
+            .expect("write custom coordinator");
         let mut state = SeededContextTemplateState::default();
         state.templates.insert(
             "coordinator".to_string(),
@@ -3463,11 +3441,8 @@ mod tests {
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
         let custom = "custom coordinator guidance";
-        std::fs::write(
-            ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            custom,
-        )
-        .expect("write custom coordinator");
+        std::fs::write(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME), custom)
+            .expect("write custom coordinator");
         let update = scan_project_context_template_updates(temp.path(), &ac_root)
             .expect("scan updates")
             .pop()
@@ -3656,11 +3631,8 @@ mod tests {
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
         let custom = "custom coordinator guidance";
-        std::fs::write(
-            ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            custom,
-        )
-        .expect("write custom coordinator");
+        std::fs::write(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME), custom)
+            .expect("write custom coordinator");
         std::fs::write(
             ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME),
             "not json",
@@ -3689,11 +3661,8 @@ mod tests {
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
         let custom = "custom coordinator guidance";
-        std::fs::write(
-            ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME),
-            custom,
-        )
-        .expect("write custom coordinator");
+        std::fs::write(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME), custom)
+            .expect("write custom coordinator");
         let update = scan_project_context_template_updates(temp.path(), &ac_root)
             .expect("scan updates")
             .pop()

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -5696,9 +5696,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             None,
             &no_skill_section(),
         );
-        assert!(out.contains(
-            "list the containing workspace root only to discover `repo-*` folder names"
-        ));
+        assert!(out
+            .contains("list the containing workspace root only to discover `repo-*` folder names"));
         assert!(out.contains("that grants no access to other contents there"));
     }
 
@@ -6073,9 +6072,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         std::fs::write(
@@ -6144,9 +6141,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
 
@@ -6259,9 +6254,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
 
@@ -6468,9 +6461,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         std::fs::create_dir_all(&ac_root).expect("create workspace dir");
         std::fs::write(
@@ -6591,9 +6582,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
 
@@ -6604,11 +6593,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&matrix_root),
             &no_skill_section(),
         );
-        std::fs::write(
-            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            &legacy,
-        )
-        .expect("write legacy rendered template");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), &legacy)
+            .expect("write legacy rendered template");
 
         let rendered = resolve_agent_context(
             &agent_root,
@@ -6630,12 +6616,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6653,11 +6635,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&path_string(&old_matrix)),
             &old_skills_section,
         );
-        std::fs::write(
-            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            &legacy,
-        )
-        .expect("write stale generated default");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), &legacy)
+            .expect("write stale generated default");
 
         let materialized = materialize_agent_context_file(
             &path_string(&new_replica),
@@ -6682,12 +6661,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6710,11 +6685,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             Some(&path_string(&old_matrix)),
             &old_skills_section,
         );
-        std::fs::write(
-            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            &legacy,
-        )
-        .expect("write stale generated default");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), &legacy)
+            .expect("write stale generated default");
 
         let materialized = materialize_agent_context_file(
             &path_string(&new_replica),
@@ -6741,12 +6713,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6798,12 +6766,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6861,12 +6825,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6913,12 +6873,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -6980,11 +6936,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             None,
             &old_skills_section,
         );
-        std::fs::write(
-            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            &legacy,
-        )
-        .expect("write stale generated default");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), &legacy)
+            .expect("write stale generated default");
 
         let materialized = materialize_agent_context_file(
             &path_string(&target_matrix),
@@ -7022,12 +6975,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -7108,12 +7057,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix_root = ac_root.join("_agent_dev-rust");
         let new_matrix_root = ac_root.join("_agent_tech-lead");
-        let old_replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica_root = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix_root).expect("create old matrix root");
         std::fs::create_dir_all(&new_matrix_root).expect("create new matrix root");
         std::fs::create_dir_all(&old_replica_root).expect("create old replica root");
@@ -7160,12 +7105,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let old_matrix_root = ac_root.join("_agent_dev-rust");
-        let old_replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica_root = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix_root).expect("create old matrix root");
         std::fs::create_dir_all(&old_replica_root).expect("create old replica root");
         std::fs::create_dir_all(&new_replica_root).expect("create new replica root");
@@ -7204,9 +7145,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
 
@@ -7492,12 +7431,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -7628,12 +7563,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
@@ -7651,9 +7582,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
 
         // Make the context dir read-only so the atomic temp-create fails and the
         // heal cannot publish.
-        let mut perms = std::fs::metadata(&ac_root)
-            .expect("metadata")
-            .permissions();
+        let mut perms = std::fs::metadata(&ac_root).expect("metadata").permissions();
         perms.set_mode(0o555);
         std::fs::set_permissions(&ac_root, perms).expect("set read-only");
 
@@ -7667,9 +7596,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         );
 
         // Restore write perms before any assertion so tempdir cleanup works.
-        let mut perms = std::fs::metadata(&ac_root)
-            .expect("metadata")
-            .permissions();
+        let mut perms = std::fs::metadata(&ac_root).expect("metadata").permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&ac_root, perms).expect("restore perms");
 
@@ -7688,9 +7615,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         let repo_dir = ac_root.join("wg-19-dev-team").join("repo-Example");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
@@ -7730,9 +7655,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         let repo_dir = ac_root.join("wg-19-dev-team").join("repo-Example");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
@@ -7775,9 +7698,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         let repo_dir = ac_root.join("wg-19-dev-team").join("repo-Example");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
@@ -7824,9 +7745,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         let repo_dir = ac_root.join("wg-19-dev-team").join("repo-Example");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
@@ -7902,9 +7821,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         let skills_section =
@@ -7936,9 +7853,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         std::fs::write(
@@ -8730,11 +8645,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
         std::fs::create_dir_all(&matrix_root).expect("create matrix root");
-        std::fs::write(
-            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
-            [0xff, 0xfe],
-        )
-        .expect("write invalid utf8 template");
+        std::fs::write(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME), [0xff, 0xfe])
+            .expect("write invalid utf8 template");
 
         let err = materialize_agent_context_file(
             &path_string(&matrix_root),
@@ -9325,9 +9237,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let matrix_root = ac_root.join("_agent_dev-rust");
-        let replica_root = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let replica_root = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&replica_root).expect("create replica root");
         write_skill(
             &matrix_root,
@@ -10068,12 +9978,8 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
         let new_matrix = ac_root.join("_agent_tech-lead");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
-        let new_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_tech-lead");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
+        let new_replica = ac_root.join("wg-19-dev-team").join("__agent_tech-lead");
         std::fs::create_dir_all(&new_matrix).expect("create new matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
         std::fs::create_dir_all(&new_replica).expect("create new replica");
@@ -10151,9 +10057,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         let old_matrix = ac_root.join("_agent_dev-rust");
-        let old_replica = ac_root
-            .join("wg-19-dev-team")
-            .join("__agent_dev-rust");
+        let old_replica = ac_root.join("wg-19-dev-team").join("__agent_dev-rust");
         std::fs::create_dir_all(&old_matrix).expect("create old matrix");
         std::fs::create_dir_all(&old_replica).expect("create old replica");
 

--- a/src-tauri/src/config/sessions_persistence.rs
+++ b/src-tauri/src/config/sessions_persistence.rs
@@ -4036,7 +4036,10 @@ mod tests {
         // `-c` and `--conversation <ID>` / `--conversation=<ID>` are
         // user-authored resume forms: they must survive stripping verbatim.
         for (shell, args) in [
-            ("agy", vec!["-c".to_string(), "-m".to_string(), "gpt-5".to_string()]),
+            (
+                "agy",
+                vec!["-c".to_string(), "-m".to_string(), "gpt-5".to_string()],
+            ),
             (
                 "agy",
                 vec![

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -1737,8 +1737,8 @@ pub(crate) fn validate_agent_command_text(context: &str, command: &str) -> Resul
         }
     }
 
-    if let Some(antigravity_idx) = find_provider_token(&tokens, "agy")
-        .or_else(|| find_provider_token(&tokens, "antigravity"))
+    if let Some(antigravity_idx) =
+        find_provider_token(&tokens, "agy").or_else(|| find_provider_token(&tokens, "antigravity"))
     {
         if antigravity_has_manual_resume(&tokens, antigravity_idx) {
             return Err(format!(

--- a/src-tauri/src/config/teams.rs
+++ b/src-tauri/src/config/teams.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+use crate::config::ac_root::{existing_ac_root, find_ac_root_segment, has_ac_root};
 use crate::config::replica_identity::{
     agent_bare_name_from_ref, read_and_repair_wg_replica_config, WG_REPLICA_REQUIRED_CONTEXT,
 };
-use crate::config::ac_root::{existing_ac_root, find_ac_root_segment, has_ac_root};
 
 /// #280 §3.4 — record whether the missing-config one-shot INFO has already
 /// fired for a given `(project, team_dir)` pair this process. Returns
@@ -952,8 +952,7 @@ pub(crate) fn strict_wg_replica_anchor_from_cwd(cwd: &Path) -> Result<Option<Pat
             // still hold a valid anchor above the current path.
             continue;
         }
-        let Some(layout) = crate::config::ac_root::wg_replica_layout_from_agent_dir(path)?
-        else {
+        let Some(layout) = crate::config::ac_root::wg_replica_layout_from_agent_dir(path)? else {
             continue;
         };
         if layout.ac_root != owning_ac_root {
@@ -2570,8 +2569,7 @@ mod tests {
         let ac_root = tmp.path().join("proj-a").join(".ac");
         let wg_dir = ac_root.join("wg-1-dev-team");
 
-        let resolved =
-            resolve_wg_coordinator_replica(&ac_root, &wg_dir).expect("coordinator");
+        let resolved = resolve_wg_coordinator_replica(&ac_root, &wg_dir).expect("coordinator");
 
         assert_eq!(resolved.project, "proj-a");
         assert_eq!(resolved.team, "dev-team");
@@ -3178,8 +3176,8 @@ mod tests {
             .join("_agent_phase0");
         std::fs::create_dir_all(&nested_origin).unwrap();
 
-        let anchor = strict_wg_replica_anchor_from_cwd(&nested_origin)
-            .expect("walk must not error");
+        let anchor =
+            strict_wg_replica_anchor_from_cwd(&nested_origin).expect("walk must not error");
         assert_eq!(
             anchor, None,
             "the ancestor project's replica must never anchor a nested-project cwd"
@@ -3231,8 +3229,7 @@ mod tests {
             .join("__agent_alice");
         std::fs::create_dir_all(&alice).unwrap();
 
-        let anchor =
-            strict_wg_replica_anchor_from_cwd(&alice).expect("walk must not error");
+        let anchor = strict_wg_replica_anchor_from_cwd(&alice).expect("walk must not error");
         assert_eq!(
             std::fs::canonicalize(anchor.expect("own replica must bind")).unwrap(),
             std::fs::canonicalize(&alice).unwrap()
@@ -3257,8 +3254,7 @@ mod tests {
 
         let anchor = strict_wg_replica_anchor_from_cwd(&deep).expect("walk must not error");
         assert_eq!(
-            std::fs::canonicalize(anchor.expect("deeper cwd must bind the own replica"))
-            .unwrap(),
+            std::fs::canonicalize(anchor.expect("deeper cwd must bind the own replica")).unwrap(),
             std::fs::canonicalize(
                 temp.path()
                     .join("proj")
@@ -3359,7 +3355,8 @@ mod tests {
     #[test]
     fn verify_pty_input_replica_cwd_nested_origin_cwd_is_invalid() {
         let (_temp, _nested_inner2, nested_origin) = nested_strict_target_fixture();
-        let err = verify_pty_input_replica_cwd(&nested_origin).expect_err("origin dir must not resolve");
+        let err =
+            verify_pty_input_replica_cwd(&nested_origin).expect_err("origin dir must not resolve");
         assert_eq!(err, "sender_identity_invalid");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod agent_update;
+pub mod agent_version;
 pub mod api;
 pub mod cli;
 pub mod commands;
@@ -17,8 +19,6 @@ pub mod shutdown;
 pub mod telegram;
 pub mod test_support;
 pub mod testability;
-pub mod agent_update;
-pub mod agent_version;
 pub mod update_check;
 pub mod voice;
 pub mod web;
@@ -1086,9 +1086,7 @@ pub(crate) fn spawn_restore_startup(
         struct RestoreGuard(Arc<RestoreInProgress>);
         impl Drop for RestoreGuard {
             fn drop(&mut self) {
-                self.0
-                     .0
-                    .store(false, std::sync::atomic::Ordering::SeqCst);
+                self.0 .0.store(false, std::sync::atomic::Ordering::SeqCst);
             }
         }
         let _restore_guard = RestoreGuard(restore_flag);
@@ -1108,10 +1106,8 @@ pub(crate) fn spawn_restore_startup(
 
         // #1341 - the selection barrier must never wedge behind a failed
         // restore (the webview's session commands queue on it).
-        let mut completion = RestoreCompletionGuard::new(
-            restore_barrier,
-            Arc::clone(&restore_observer_barrier),
-        );
+        let mut completion =
+            RestoreCompletionGuard::new(restore_barrier, Arc::clone(&restore_observer_barrier));
 
         // #1341 - a panic inside the restore body degrades (logged + partial
         // restore, retried next boot) instead of aborting the task and
@@ -1128,7 +1124,10 @@ pub(crate) fn spawn_restore_startup(
             let root_agent_path = match crate::config::root_agent::ensure_root_agent_dir() {
                 Ok(path) => Some(path),
                 Err(e) => {
-                    log::error!("[root-agent] Failed to provision root agent during restore: {}", e);
+                    log::error!(
+                        "[root-agent] Failed to provision root agent during restore: {}",
+                        e
+                    );
                     None
                 }
             };
@@ -1136,9 +1135,7 @@ pub(crate) fn spawn_restore_startup(
                 .iter()
                 .find(|ps| {
                     ps.is_root_agent
-                        || crate::config::root_agent::is_root_agent_path(
-                            &ps.working_directory,
-                        )
+                        || crate::config::root_agent::is_root_agent_path(&ps.working_directory)
                 })
                 .cloned();
 
@@ -1163,7 +1160,7 @@ pub(crate) fn spawn_restore_startup(
                                     last_coding_agent.as_deref(),
                                 )
                             };
-    
+
                             if should_auto_create {
                                 match commands::session::execute_root_transaction(
                                     &restore_transaction_for_task,
@@ -1188,9 +1185,7 @@ pub(crate) fn spawn_restore_startup(
                                 );
                             }
                         }
-                        Some(ps)
-                            if should_wake_root_agent_on_restore(ps.status.as_ref()) =>
-                        {
+                        Some(ps) if should_wake_root_agent_on_restore(ps.status.as_ref()) => {
                             let existing_root = {
                                 let mgr = session_mgr_clone.read().await;
                                 mgr.list_sessions().await.into_iter().find(|s| {
@@ -1287,78 +1282,78 @@ pub(crate) fn spawn_restore_startup(
                                     None
                                 };
                                 if !rebuild_failed {
-                                let (shell, shell_args, agent_label) =
-                                    if let Some(spawn) = resolved_spawn.as_ref() {
-                                        (
-                                            spawn.shell.clone(),
-                                            spawn.shell_args.clone(),
-                                            Some(spawn.trusted_agent_label.clone()),
-                                        )
-                                    } else {
-                                        (
-                                            ps.shell.clone(),
-                                            ps.shell_args.clone(),
-                                            ps.agent_label.clone(),
-                                        )
-                                    };
-                                match commands::session::create_session_inner_for_restore(
-                                    &restore_transaction_for_task,
-                                    &session_mgr_clone,
-                                    &pty_mgr_clone,
-                                    shell,
-                                    shell_args,
-                                    root_path.clone(),
-                                    Some(ps.name.clone()),
-                                    ps.agent_id.clone(),
-                                    agent_label,
-                                    false,
-                                    ps.git_repos.clone(),
-                                    false,
-                                    resolved_spawn,
-                                    resolved_agent_host_shell,
-                                    // #973 - headless caller: no terminal to measure, keep 120x30.
-                                    None,
-                                    Some(ps.start_fresh_on_restore),
-                                    None,
-                                )
-                                .await
-                                {
-                                    Ok(info) => {
-                                        if ps.was_active {
-                                            active_id = Some(info.id.clone());
-                                        }
-                                        n_woken += 1;
-                                        if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
-                                            commands::session::attach_persisted_telegram_if_configured(
+                                    let (shell, shell_args, agent_label) =
+                                        if let Some(spawn) = resolved_spawn.as_ref() {
+                                            (
+                                                spawn.shell.clone(),
+                                                spawn.shell_args.clone(),
+                                                Some(spawn.trusted_agent_label.clone()),
+                                            )
+                                        } else {
+                                            (
+                                                ps.shell.clone(),
+                                                ps.shell_args.clone(),
+                                                ps.agent_label.clone(),
+                                            )
+                                        };
+                                    match commands::session::create_session_inner_for_restore(
+                                        &restore_transaction_for_task,
+                                        &session_mgr_clone,
+                                        &pty_mgr_clone,
+                                        shell,
+                                        shell_args,
+                                        root_path.clone(),
+                                        Some(ps.name.clone()),
+                                        ps.agent_id.clone(),
+                                        agent_label,
+                                        false,
+                                        ps.git_repos.clone(),
+                                        false,
+                                        resolved_spawn,
+                                        resolved_agent_host_shell,
+                                        // #973 - headless caller: no terminal to measure, keep 120x30.
+                                        None,
+                                        Some(ps.start_fresh_on_restore),
+                                        None,
+                                    )
+                                    .await
+                                    {
+                                        Ok(info) => {
+                                            if ps.was_active {
+                                                active_id = Some(info.id.clone());
+                                            }
+                                            n_woken += 1;
+                                            if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                                commands::session::attach_persisted_telegram_if_configured(
                                                 &app_handle,
                                                 uuid,
                                                 ps.telegram_bot_id.as_deref(),
                                             )
                                             .await;
-                                        }
-    
-                                        if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
-                                            if let Some(ref prompt) = ps.last_prompt {
-                                                let mgr = session_mgr_clone.read().await;
-                                                mgr.set_last_prompt(uuid, prompt.clone()).await;
                                             }
-                                        }
-    
-                                        if ps.was_detached {
+
                                             if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
-                                                {
+                                                if let Some(ref prompt) = ps.last_prompt {
                                                     let mgr = session_mgr_clone.read().await;
-                                                    if let Some(ref geo) = ps.detached_geometry
-                                                    {
-                                                        mgr.set_detached_geometry(
-                                                            uuid,
-                                                            geo.clone(),
-                                                        )
-                                                        .await;
-                                                    }
+                                                    mgr.set_last_prompt(uuid, prompt.clone()).await;
                                                 }
-    
-                                                let detached_result =
+                                            }
+
+                                            if ps.was_detached {
+                                                if let Ok(uuid) = uuid::Uuid::parse_str(&info.id) {
+                                                    {
+                                                        let mgr = session_mgr_clone.read().await;
+                                                        if let Some(ref geo) = ps.detached_geometry
+                                                        {
+                                                            mgr.set_detached_geometry(
+                                                                uuid,
+                                                                geo.clone(),
+                                                            )
+                                                            .await;
+                                                        }
+                                                    }
+
+                                                    let detached_result =
                                                     commands::window::execute_detach_transaction(
                                                         &restore_transaction_for_task,
                                                         uuid,
@@ -1366,25 +1361,25 @@ pub(crate) fn spawn_restore_startup(
                                                         true,
                                                     )
                                                     .await;
-                                                if let Err(e) = detached_result {
-                                                    log::warn!(
+                                                    if let Err(e) = detached_result {
+                                                        log::warn!(
                                                         "[restore] detach_terminal_inner failed for root agent '{}': {} — session stays live (attached)",
                                                         ps.name,
                                                         e
                                                     );
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
-                                    Err(e) => {
-                                        log::error!(
+                                        Err(e) => {
+                                            log::error!(
                                             "[root-agent] Failed to restore root session '{}': {}",
                                             ps.name,
                                             e
                                         );
-                                        failed_recoverable.push(ps.clone());
+                                            failed_recoverable.push(ps.clone());
+                                        }
                                     }
-                                }
                                 }
                             }
                         }
@@ -1447,7 +1442,7 @@ pub(crate) fn spawn_restore_startup(
                             }
                         }
                     }
-                    }
+                }
             } else if let Some(ps) = root_ps.as_ref() {
                 failed_recoverable.push(ps.clone());
             }
@@ -1458,9 +1453,7 @@ pub(crate) fn spawn_restore_startup(
 
             for ps in &persisted {
                 if ps.is_root_agent
-                    || crate::config::root_agent::is_root_agent_path(
-                        &ps.working_directory,
-                    )
+                    || crate::config::root_agent::is_root_agent_path(&ps.working_directory)
                 {
                     continue;
                 }
@@ -1476,7 +1469,11 @@ pub(crate) fn spawn_restore_startup(
 
                 // Skip sessions whose CWD no longer exists (permanent failure)
                 if !std::path::Path::new(&ps.working_directory).exists() {
-                    log::warn!("Skipping restore of '{}': CWD '{}' no longer exists", ps.name, ps.working_directory);
+                    log::warn!(
+                        "Skipping restore of '{}': CWD '{}' no longer exists",
+                        ps.name,
+                        ps.working_directory
+                    );
                     // §1295 site C (restore-skip): append ONE archive
                     // record BEFORE the `continue`. The restore task is
                     // async and holds no `sessions_save_lock` here, so we
@@ -1511,11 +1508,10 @@ pub(crate) fn spawn_restore_startup(
                     teams.is_empty(),
                     ps.is_coordinator,
                 );
-                let archived_session =
-                    sessions_persistence::is_under_normalized_archived_roots(
-                        &ps.working_directory,
-                        &archived_roots,
-                    );
+                let archived_session = sessions_persistence::is_under_normalized_archived_roots(
+                    &ps.working_directory,
+                    &archived_roots,
+                );
                 let wake = restore_session_should_wake(
                     archived_session,
                     setting_on,
@@ -1526,14 +1522,12 @@ pub(crate) fn spawn_restore_startup(
                 if !wake {
                     // Defer: create a dormant Session record (no PTY, status = Exited(0)).
                     match restore_transaction_for_task
-                        .restore_dormant_inline(
-                            crate::session::selection::DormantRestoreRequest {
-                                persisted: ps.clone(),
-                                working_directory: ps.working_directory.clone(),
-                                is_coordinator: is_coord,
-                                is_root_agent: false,
-                            },
-                        )
+                        .restore_dormant_inline(crate::session::selection::DormantRestoreRequest {
+                            persisted: ps.clone(),
+                            working_directory: ps.working_directory.clone(),
+                            is_coordinator: is_coord,
+                            is_root_agent: false,
+                        })
                         .await
                     {
                         Ok(info) => {
@@ -1552,10 +1546,8 @@ pub(crate) fn spawn_restore_startup(
                             // The post-loop branching (Fix A) ensures `set_active_only`
                             // is used (not `switch_session`), so the dormant status
                             // survives selection.
-                            if restore_session_should_become_active(
-                                ps.was_active,
-                                archived_session,
-                            ) {
+                            if restore_session_should_become_active(ps.was_active, archived_session)
+                            {
                                 active_id = Some(info.id);
                             }
                         }
@@ -1601,20 +1593,20 @@ pub(crate) fn spawn_restore_startup(
                 } else {
                     None
                 };
-                let (shell, shell_args, agent_label) =
-                    if let Some(spawn) = resolved_spawn.as_ref() {
-                        (
-                            spawn.shell.clone(),
-                            spawn.shell_args.clone(),
-                            Some(spawn.trusted_agent_label.clone()),
-                        )
-                    } else {
-                        (
-                            ps.shell.clone(),
-                            ps.shell_args.clone(),
-                            ps.agent_label.clone(),
-                        )
-                    };
+                let (shell, shell_args, agent_label) = if let Some(spawn) = resolved_spawn.as_ref()
+                {
+                    (
+                        spawn.shell.clone(),
+                        spawn.shell_args.clone(),
+                        Some(spawn.trusted_agent_label.clone()),
+                    )
+                } else {
+                    (
+                        ps.shell.clone(),
+                        ps.shell_args.clone(),
+                        ps.agent_label.clone(),
+                    )
+                };
 
                 // Wake: full PTY restore inside the restore transaction.
                 match commands::session::create_session_inner_for_restore(
@@ -1635,13 +1627,17 @@ pub(crate) fn spawn_restore_startup(
                     // #973 - headless caller: no terminal to measure, keep 120x30.
                     None,
                     Some(ps.start_fresh_on_restore),
-                    is_coord.then(|| {
-                        crate::commands::session::carry_communication_for_restart(
-                            ps.communication.clone(),
-                            ps.start_fresh_on_restore,
-                        )
-                    }).flatten(),
-                ).await {
+                    is_coord
+                        .then(|| {
+                            crate::commands::session::carry_communication_for_restart(
+                                ps.communication.clone(),
+                                ps.start_fresh_on_restore,
+                            )
+                        })
+                        .flatten(),
+                )
+                .await
+                {
                     Ok(info) => {
                         if ps.was_active {
                             active_id = Some(info.id.clone());
@@ -1715,7 +1711,10 @@ pub(crate) fn spawn_restore_startup(
             // the restore log in chronological order, not interleaved with switch events.
             log::info!(
                 "[restore] complete — {} woken, {} deferred (setting_on={}, total_evaluated={})",
-                n_woken, n_deferred, setting_on, persisted.len()
+                n_woken,
+                n_deferred,
+                setting_on,
+                persisted.len()
             );
 
             let persisted_target = active_id
@@ -1733,14 +1732,18 @@ pub(crate) fn spawn_restore_startup(
             }
 
             // Persist restored sessions + failed-but-recoverable entries
-            let mgr: tokio::sync::RwLockReadGuard<'_, SessionManager> = session_mgr_clone.read().await;
+            let mgr: tokio::sync::RwLockReadGuard<'_, SessionManager> =
+                session_mgr_clone.read().await;
             sessions_persistence::persist_merging_failed(&mgr, &failed_recoverable).await;
 
             if !failed_recoverable.is_empty() {
                 log::warn!(
                     "Session restore: {} sessions failed (preserved for next attempt): {:?}",
                     failed_recoverable.len(),
-                    failed_recoverable.iter().map(|s| &s.name).collect::<Vec<_>>()
+                    failed_recoverable
+                        .iter()
+                        .map(|s| &s.name)
+                        .collect::<Vec<_>>()
                 );
             }
         });

--- a/src-tauri/src/loops/scheduler.rs
+++ b/src-tauri/src/loops/scheduler.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use tauri::{AppHandle, Manager};
 use uuid::Uuid;
 
+use crate::config::ac_root::existing_ac_root;
 use crate::config::loops::{
     append_loop_audit_once, baseline_loop_state, details_from_parts, latest_due_between, loop_dir,
     next_due_after, read_loop_config, read_loop_state, revalidate_loop_current,
@@ -15,7 +16,6 @@ use crate::config::loops::{
 use crate::config::projects::{enumerate_registered_project_candidates, ProjectResolution};
 use crate::config::sessions_persistence;
 use crate::config::settings::SettingsState;
-use crate::config::ac_root::existing_ac_root;
 use crate::loops::delivery::{deliver_loop_prompt, LoopDeliveryReport};
 use crate::loops::events::emit_loop_change;
 use crate::shutdown::ShutdownSignal;
@@ -441,8 +441,8 @@ impl Default for LoopScheduler {
 }
 
 fn loop_dirs(ac_root: &Path) -> Result<Vec<PathBuf>, String> {
-    let entries = std::fs::read_dir(ac_root)
-        .map_err(|e| format!("Failed to read Project AC Root: {}", e))?;
+    let entries =
+        std::fs::read_dir(ac_root).map_err(|e| format!("Failed to read Project AC Root: {}", e))?;
     let mut dirs = Vec::new();
     for entry in entries.flatten() {
         let path = entry.path();

--- a/src-tauri/src/phone/mailbox.rs
+++ b/src-tauri/src/phone/mailbox.rs
@@ -3164,7 +3164,10 @@ impl MailboxPoller {
                     error
                 );
             } else {
-                log::warn!("[mailbox] #1399 returned unowned claim {} to the outbox", id);
+                log::warn!(
+                    "[mailbox] #1399 returned unowned claim {} to the outbox",
+                    id
+                );
             }
         }
     }
@@ -3734,10 +3737,7 @@ impl MailboxPoller {
                     if rejected {
                         self.retry_tracker.remove(&path);
                     } else {
-                        log::error!(
-                            "Failed to reject outbox message {:?}; will retry",
-                            path
-                        );
+                        log::error!("Failed to reject outbox message {:?}; will retry", path);
                     }
                 }
             }
@@ -9444,12 +9444,13 @@ impl MailboxPoller {
             }
             paths
         };
-        let wg =
-            match crate::config::teams::verified_wg_coordinator_target(&msg.from, &effective_paths)
-            {
-                Some(wg) => wg,
-                None => {
-                    return self
+        let wg = match crate::config::teams::verified_wg_coordinator_target(
+            &msg.from,
+            &effective_paths,
+        ) {
+            Some(wg) => wg,
+            None => {
+                return self
                         .reject_message(
                             path,
                             msg,
@@ -9459,8 +9460,8 @@ impl MailboxPoller {
                         ),
                         )
                         .await;
-                }
-            };
+            }
+        };
 
         // 3. --wg assertion (§3.6: interlock, not selector).
         if let Some(ref t) = msg.target {
@@ -11242,9 +11243,7 @@ impl MailboxPoller {
                     }
 
                     for dir in dirs_to_check {
-                        let Some(ac_root) =
-                            crate::config::ac_root::existing_ac_root(&dir)
-                        else {
+                        let Some(ac_root) = crate::config::ac_root::existing_ac_root(&dir) else {
                             continue;
                         };
                         let candidate = ac_root.join(wg_name).join(&replica_dir);
@@ -21752,7 +21751,10 @@ mod tests {
         let origin = Path::new("outbox-dir/abc.json");
         let claim = wake_claim_path(origin);
         assert_eq!(claim, PathBuf::from("outbox-dir/abc.json.in-flight"));
-        assert_eq!(claim.extension().and_then(|s| s.to_str()), Some("in-flight"));
+        assert_eq!(
+            claim.extension().and_then(|s| s.to_str()),
+            Some("in-flight")
+        );
         assert_eq!(claim.parent(), origin.parent());
         assert_eq!(wake_claim_origin(&claim), Some(origin.to_path_buf()));
         // An id containing a dot survives the round trip (with_extension would
@@ -22015,11 +22017,8 @@ mod tests {
             ));
         }
 
-        let capped_handoff = capped_poller.claim_and_spawn_wake(
-            &app,
-            &capped_source,
-            wake_message_to_target(),
-        );
+        let capped_handoff =
+            capped_poller.claim_and_spawn_wake(&app, &capped_source, wake_message_to_target());
 
         assert!(matches!(capped_handoff, WakeHandoff::LaneBusy));
         assert_eq!(capped_poller.wake_workers.len(), 0);
@@ -22360,13 +22359,8 @@ mod tests {
         // by default, so the uppercased final component resolves to the same
         // physical directory on every standard Windows host, while the raw
         // `OsStr` is guaranteed distinct from the canonical spelling.
-        let escaped_alias = outbox.with_file_name(
-            outbox
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .to_uppercase(),
-        );
+        let escaped_alias =
+            outbox.with_file_name(outbox.file_name().unwrap().to_string_lossy().to_uppercase());
         assert_ne!(escaped_alias.as_os_str(), canonical_outbox.as_os_str());
         assert_eq!(
             crate::path_identity::verify_directory(&escaped_alias)
@@ -22430,7 +22424,10 @@ mod tests {
         let mut next_cycle_candidates = vec![canonical_outbox.clone(), escaped_alias.clone()];
         dedup_outbox_dirs_by_object_id(&mut next_cycle_candidates);
         assert_eq!(next_cycle_candidates.len(), 1);
-        assert_eq!(next_cycle_candidates[0].as_os_str(), canonical_outbox.as_os_str());
+        assert_eq!(
+            next_cycle_candidates[0].as_os_str(),
+            canonical_outbox.as_os_str()
+        );
         let claims: Vec<PathBuf> = std::fs::read_dir(&next_cycle_candidates[0])
             .unwrap()
             .filter_map(|e| e.ok())
@@ -22449,11 +22446,8 @@ mod tests {
     #[tokio::test]
     async fn ten_guard_drops_reach_terminal_rejection() {
         let temp = tempfile::TempDir::new().unwrap();
-        let origin = write_wake_message(
-            temp.path(),
-            "ten-guard-drops",
-            "2026-07-15T00:00:03+00:00",
-        );
+        let origin =
+            write_wake_message(temp.path(), "ten-guard-drops", "2026-07-15T00:00:03+00:00");
         let expected: OutboxMessage = serde_json::from_str(
             &std::fs::read_to_string(&origin).expect("read token-bearing source"),
         )
@@ -22479,8 +22473,7 @@ mod tests {
             assert!(!origin.exists());
             assert!(claim.exists());
 
-            let report =
-                WakeOutcomeReport::new(poller.wake_outcomes_tx.clone(), origin.clone());
+            let report = WakeOutcomeReport::new(poller.wake_outcomes_tx.clone(), origin.clone());
             drop(report);
             poller.drain_wake_outcomes().await;
 
@@ -22509,10 +22502,9 @@ mod tests {
                 assert!(rejected_payload.exists());
                 assert!(rejected_reason.exists());
 
-                let rejected: OutboxMessage = serde_json::from_str(
-                    &std::fs::read_to_string(&rejected_payload).unwrap(),
-                )
-                .unwrap();
+                let rejected: OutboxMessage =
+                    serde_json::from_str(&std::fs::read_to_string(&rejected_payload).unwrap())
+                        .unwrap();
                 assert_eq!(rejected.id, expected.id);
                 assert_eq!(rejected.from, expected.from);
                 assert_eq!(rejected.to, expected.to);
@@ -22709,11 +22701,10 @@ mod tests {
             shutdown.token().clone(),
         );
         let output_senders = Arc::new(Mutex::new(HashMap::new()));
-        let telegram: crate::telegram::manager::TelegramBridgeState = Arc::new(
-            tokio::sync::Mutex::new(
+        let telegram: crate::telegram::manager::TelegramBridgeState =
+            Arc::new(tokio::sync::Mutex::new(
                 crate::telegram::manager::TelegramBridgeManager::new(output_senders),
-            ),
-        );
+            ));
         let store_dir = tempfile::TempDir::new().expect("create target-gate store");
         let message_store = Arc::new(
             crate::api::message_store::MessageStore::open(
@@ -22745,7 +22736,9 @@ mod tests {
             .manage(std::sync::Arc::new(
                 crate::session::purge_guard::PurgeGuard::default(),
             ))
-            .manage(Arc::new(crate::resource_monitor::ResourceMonitorState::new()))
+            .manage(Arc::new(
+                crate::resource_monitor::ResourceMonitorState::new(),
+            ))
             .manage(coordinator.clone())
             .manage(target_gate_state.clone())
             .manage(shutdown)
@@ -22846,15 +22839,8 @@ mod tests {
         MailboxPoller::new().poll_session_requests(&app).await;
 
         let result = read_session_request_result_json(&request.id);
-        assert_eq!(
-            result["status"], "created",
-            "unexpected result: {}",
-            result
-        );
-        let session_id = result["sessionId"]
-            .as_str()
-            .expect("sessionId")
-            .to_string();
+        assert_eq!(result["status"], "created", "unexpected result: {}", result);
+        let session_id = result["sessionId"].as_str().expect("sessionId").to_string();
         assert!(!session_id.is_empty());
         assert!(
             !session_request_file_for(&request.id).exists(),

--- a/src-tauri/src/pty/local_backend.rs
+++ b/src-tauri/src/pty/local_backend.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
 use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -805,7 +805,10 @@ fn validate_common_adapter_input(
         ));
     }
     for (value, label) in [
-        (host_shell.program.as_str(), "configured default-shell program"),
+        (
+            host_shell.program.as_str(),
+            "configured default-shell program",
+        ),
         (command, "logical agent program"),
     ] {
         if value.contains('\0') || value.contains('\r') || value.contains('\n') {
@@ -838,7 +841,11 @@ fn mark_seen(
     token: &str,
 ) -> Result<(), AppError> {
     if seen.iter().any(|s| s.eq_ignore_ascii_case(option)) {
-        return Err(adapter_error(host_program, token, "a duplicate configured option"));
+        return Err(adapter_error(
+            host_program,
+            token,
+            "a duplicate configured option",
+        ));
     }
     seen.push(option.to_string());
     Ok(())
@@ -846,8 +853,7 @@ fn mark_seen(
 
 // --- Section 4.3.2 - PowerShell products -----------------------------------
 
-const POWERSHELL_FLAG_OPTIONS: &[&str] =
-    &["NoLogo", "NoProfile", "NonInteractive", "Sta", "Mta"];
+const POWERSHELL_FLAG_OPTIONS: &[&str] = &["NoLogo", "NoProfile", "NonInteractive", "Sta", "Mta"];
 const POWERSHELL_VALUE_OPTIONS: &[&str] = &[
     "ExecutionPolicy",
     "WindowStyle",
@@ -868,9 +874,27 @@ const PWSH_VALUE_OPTIONS: &[&str] = &[
 /// terminators, rejected conservatively for BOTH PowerShell classes. Each
 /// spelling may appear with `-` or `/`; `--` and `--%` are literal tokens.
 const POWERSHELL_CONFLICTING_OPTIONS: &[&str] = &[
-    "Command", "c", "CommandWithArgs", "cwa", "File", "f", "EncodedCommand", "enc",
-    "e", "NoExit", "noe", "Version", "v", "Help", "h", "?", "SSHServerMode",
-    "ServerMode", "WindowsPowerShell", "Login", "Interactive",
+    "Command",
+    "c",
+    "CommandWithArgs",
+    "cwa",
+    "File",
+    "f",
+    "EncodedCommand",
+    "enc",
+    "e",
+    "NoExit",
+    "noe",
+    "Version",
+    "v",
+    "Help",
+    "h",
+    "?",
+    "SSHServerMode",
+    "ServerMode",
+    "WindowsPowerShell",
+    "Login",
+    "Interactive",
 ];
 /// powershell.exe-only spellings that pwsh does not define; rejected for pwsh
 /// with the unknown/ambiguous category.
@@ -917,7 +941,11 @@ fn validate_powershell_arguments(
             ));
         }
         if !token.starts_with('-') && !token.starts_with('/') {
-            return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+            return Err(adapter_error(
+                host_program,
+                token,
+                "an unknown or ambiguous token",
+            ));
         }
         let body = &token[1..];
         // Conflicting/terminal spellings are matched against the FULL body before
@@ -937,14 +965,24 @@ fn validate_powershell_arguments(
             Some(idx) => (&body[..idx], Some(&body[idx + 1..])),
             None => (body, None),
         };
-        if let Some(flag) = flags.iter().find(|option| option.eq_ignore_ascii_case(name)) {
+        if let Some(flag) = flags
+            .iter()
+            .find(|option| option.eq_ignore_ascii_case(name))
+        {
             if attached.is_some() {
-                return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+                return Err(adapter_error(
+                    host_program,
+                    token,
+                    "an unknown or ambiguous token",
+                ));
             }
             mark_seen(&mut seen, flag, host_program, token)?;
             continue;
         }
-        if let Some(option) = values.iter().find(|option| option.eq_ignore_ascii_case(name)) {
+        if let Some(option) = values
+            .iter()
+            .find(|option| option.eq_ignore_ascii_case(name))
+        {
             match attached {
                 Some(value) if !value.is_empty() => {
                     mark_seen(&mut seen, option, host_program, token)?;
@@ -967,9 +1005,17 @@ fn validate_powershell_arguments(
                 .iter()
                 .any(|option| option.eq_ignore_ascii_case(name))
         {
-            return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+            return Err(adapter_error(
+                host_program,
+                token,
+                "an unknown or ambiguous token",
+            ));
         }
-        return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+        return Err(adapter_error(
+            host_program,
+            token,
+            "an unknown or ambiguous token",
+        ));
     }
     if let Some(option) = pending_operand {
         return Err(adapter_error(
@@ -992,7 +1038,11 @@ fn validate_cmd_arguments(host_program: &str, args: &[String]) -> Result<(), App
     let mut seen: Vec<String> = Vec::new();
     for token in args {
         if !token.starts_with('/') {
-            return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+            return Err(adapter_error(
+                host_program,
+                token,
+                "an unknown or ambiguous token",
+            ));
         }
         let body = &token[1..];
         if body.eq_ignore_ascii_case("C")
@@ -1038,7 +1088,11 @@ fn validate_cmd_arguments(host_program: &str, args: &[String]) -> Result<(), App
             mark_seen(&mut seen, canonical, host_program, token)?;
             continue;
         }
-        return Err(adapter_error(host_program, token, "an unknown or ambiguous token"));
+        return Err(adapter_error(
+            host_program,
+            token,
+            "an unknown or ambiguous token",
+        ));
     }
     Ok(())
 }
@@ -1197,7 +1251,9 @@ fn posix_literal(value: &str) -> String {
 /// literal invocation only for an `ExternalScript`. Contains no `--%` token and
 /// never ends with a backslash (the trailing-run invariant).
 fn powershell_script(command: &str, args: &[String]) -> String {
-    let batch_unsupported = args.iter().any(|arg| arg.contains('%') || arg.contains('"'));
+    let batch_unsupported = args
+        .iter()
+        .any(|arg| arg.contains('%') || arg.contains('"'));
     let mut script = String::new();
     script.push_str("$global:LASTEXITCODE = $null;\n");
     script.push_str("$ac_batch_unsupported_logical_arg = $");
@@ -3185,7 +3241,11 @@ mod adapter_tests {
         );
         assert_eq!(
             launch.args[..3],
-            ["-NoProfile".to_string(), "-ExecutionPolicy".to_string(), "Bypass".to_string()]
+            [
+                "-NoProfile".to_string(),
+                "-ExecutionPolicy".to_string(),
+                "Bypass".to_string()
+            ]
         );
         assert_eq!(launch.args[3], "-Command");
         let script = &launch.args[4];
@@ -3237,9 +3297,7 @@ mod adapter_tests {
         assert!(script.contains("'claude'"), "bare lookup name: {script}");
         // The native Arguments value is the standard Windows encoding of the
         // logical argv through a PowerShell literal.
-        assert!(script.contains(
-            "$ac_start.Arguments = '\"agent''s tool\" \"a b\"';"
-        ));
+        assert!(script.contains("$ac_start.Arguments = '\"agent''s tool\" \"a b\"';"));
         assert!(!script.contains("--%"));
         // The only cmd.exe mention is the documented nested system-cmd child
         // for a resolved .cmd/.bat target, never the top-level host.
@@ -3263,9 +3321,7 @@ mod adapter_tests {
         let script = &launch.args[1];
         assert!(script.contains("$ac_batch_unsupported_logical_arg = $true;"));
         // Batch sub-branch with the system-cmd child.
-        assert!(script.contains(
-            "([System.IO.Path]::GetExtension($ac_command.Path) -ieq '.cmd')"
-        ));
+        assert!(script.contains("([System.IO.Path]::GetExtension($ac_command.Path) -ieq '.cmd')"));
         assert!(script.contains(
             "[System.IO.Path]::Combine([System.Environment]::SystemDirectory, 'cmd.exe')"
         ));
@@ -3306,13 +3362,23 @@ mod adapter_tests {
             &["a%b".to_string()],
             &shell,
         ));
-        assert_error_shape(&err, "powershell.exe", "(batch target)", "unsupported explicit-batch");
+        assert_error_shape(
+            &err,
+            "powershell.exe",
+            "(batch target)",
+            "unsupported explicit-batch",
+        );
         let err = launch_error(prepare_windows_resolved_agent_launch(
             r"C:\tools\claude.bat",
             &["a\"b".to_string()],
             &shell,
         ));
-        assert_error_shape(&err, "powershell.exe", "(batch target)", "unsupported explicit-batch");
+        assert_error_shape(
+            &err,
+            "powershell.exe",
+            "(batch target)",
+            "unsupported explicit-batch",
+        );
         // Clean explicit batch argv is accepted (nested system-cmd path).
         let launch = prepare_windows_resolved_agent_launch(
             r"C:\tools\claude.cmd",
@@ -3328,14 +3394,15 @@ mod adapter_tests {
     #[test]
     fn configured_default_shell_cmd_uses_unquoted_single_payload() {
         let shell = host(r"C:\Windows\System32\cmd.exe", &["/D", "/Q"]);
-        let args = vec!["--flag".to_string(), "bang!".to_string(), r"a\b".to_string()];
+        let args = vec![
+            "--flag".to_string(),
+            "bang!".to_string(),
+            r"a\b".to_string(),
+        ];
         let launch = prepare_windows_resolved_agent_launch("claude", &args, &shell)
             .expect("valid configured cmd host");
         assert_eq!(launch.program, r"C:\Windows\System32\cmd.exe");
-        assert_eq!(
-            launch.args[..2],
-            ["/D".to_string(), "/Q".to_string()]
-        );
+        assert_eq!(launch.args[..2], ["/D".to_string(), "/Q".to_string()]);
         assert_eq!(
             launch.args[2..5],
             ["/V:OFF".to_string(), "/S".to_string(), "/C".to_string()]
@@ -3362,8 +3429,21 @@ mod adapter_tests {
     fn configured_default_shell_cmd_payload_rejects_out_of_domain_tokens() {
         let shell = host("cmd.exe", &[]);
         let rejected: &[&str] = &[
-            "with space", "a\"b", "a&b", "a|b", "a^b", "a<b", "a>b", "a(b", "a)b",
-            "a%b", "a=b", "a,b", "a;b", "", "a\\",
+            "with space",
+            "a\"b",
+            "a&b",
+            "a|b",
+            "a^b",
+            "a<b",
+            "a>b",
+            "a(b",
+            "a)b",
+            "a%b",
+            "a=b",
+            "a,b",
+            "a;b",
+            "",
+            "a\\",
         ];
         for token in rejected {
             let err = launch_error(prepare_windows_resolved_agent_launch(
@@ -3373,7 +3453,12 @@ mod adapter_tests {
             ));
             if token.ends_with('\\') {
                 // The payload-final backslash rule reports the payload itself.
-                assert_error_shape(&err, "cmd.exe", "(payload)", "unsupported cmd payload character");
+                assert_error_shape(
+                    &err,
+                    "cmd.exe",
+                    "(payload)",
+                    "unsupported cmd payload character",
+                );
             } else {
                 assert_error_shape(&err, "cmd.exe", token, "unsupported cmd payload character");
             }
@@ -3384,7 +3469,12 @@ mod adapter_tests {
             &[],
             &shell,
         ));
-        assert_error_shape(&err, "cmd.exe", "@claude", "unsupported cmd payload character");
+        assert_error_shape(
+            &err,
+            "cmd.exe",
+            "@claude",
+            "unsupported cmd payload character",
+        );
         // NUL/CR/LF remain forbidden (common rule).
         for bad in ["a\0b", "a\rb", "a\nb"] {
             let err = launch_error(prepare_windows_resolved_agent_launch(
@@ -3424,10 +3514,7 @@ mod adapter_tests {
             .expect("custom posix host with empty args");
         assert_eq!(launch.program, r"C:\tools\bash.exe");
         assert_eq!(launch.args[0], "-c");
-        assert_eq!(
-            launch.args[1],
-            "exec 'claude' 'it'\"'\"'s' 'a b'"
-        );
+        assert_eq!(launch.args[1], "exec 'claude' 'it'\"'\"'s' 'a b'");
         assert_eq!(launch.args.len(), 2);
     }
 
@@ -3545,15 +3632,17 @@ mod adapter_tests {
             "mintty.exe",
         ] {
             let shell = host(program, &["--login", "-i"]);
-            let err =
-                launch_error(prepare_windows_resolved_agent_launch("claude", &[], &shell));
+            let err = launch_error(prepare_windows_resolved_agent_launch("claude", &[], &shell));
             assert!(err.contains("detached launcher"), "{err}");
             assert!(err.contains(r"bin\bash.exe"), "{err}");
         }
         let shell = host("bash.exe", &["--login", "-i"]);
         let launch = prepare_windows_resolved_agent_launch("claude", &[], &shell)
             .expect("bash host with terminal-only args");
-        assert_eq!(launch.args, vec!["-c".to_string(), "exec 'claude'".to_string()]);
+        assert_eq!(
+            launch.args,
+            vec!["-c".to_string(), "exec 'claude'".to_string()]
+        );
     }
 
     #[cfg(windows)]
@@ -3573,9 +3662,13 @@ mod adapter_tests {
             .to_string();
         assert!(error.contains("detached launcher"), "{error}");
 
-        let error = prepare_launch("git-bash.exe", &["--x".to_string()], Some(&host("bash.exe", &[])))
-            .expect_err("direct launcher agent must be rejected on Windows")
-            .to_string();
+        let error = prepare_launch(
+            "git-bash.exe",
+            &["--x".to_string()],
+            Some(&host("bash.exe", &[])),
+        )
+        .expect_err("direct launcher agent must be rejected on Windows")
+        .to_string();
         assert!(error.contains("detached launcher"), "{error}");
 
         let launch = prepare_launch(
@@ -3606,14 +3699,26 @@ mod adapter_tests {
         for (program, expected) in [
             ("powershell", WindowsHostShellKind::PowerShell),
             ("powershell.exe", WindowsHostShellKind::PowerShell),
-            (r"C:\Program Files\WindowsPowerShell\v1.0\powershell.exe", WindowsHostShellKind::PowerShell),
-            (r"\\server\share\POWERSHELL.EXE", WindowsHostShellKind::PowerShell),
+            (
+                r"C:\Program Files\WindowsPowerShell\v1.0\powershell.exe",
+                WindowsHostShellKind::PowerShell,
+            ),
+            (
+                r"\\server\share\POWERSHELL.EXE",
+                WindowsHostShellKind::PowerShell,
+            ),
             (r"\\?\C:\tools\pwsh.exe", WindowsHostShellKind::Pwsh),
             ("pwsh", WindowsHostShellKind::Pwsh),
             ("cmd", WindowsHostShellKind::Cmd),
-            (r"C:\Program Files (x86)\thing\cmd.exe", WindowsHostShellKind::Cmd),
+            (
+                r"C:\Program Files (x86)\thing\cmd.exe",
+                WindowsHostShellKind::Cmd,
+            ),
             ("cmd.exe", WindowsHostShellKind::Cmd),
-            (r"C:\Program Files\Git\bin\bash.exe", WindowsHostShellKind::Posix),
+            (
+                r"C:\Program Files\Git\bin\bash.exe",
+                WindowsHostShellKind::Posix,
+            ),
             ("/usr/bin/sh", WindowsHostShellKind::Posix),
         ] {
             assert_eq!(
@@ -3679,9 +3784,27 @@ mod adapter_tests {
         // Every conflicting/terminal spelling, in both - and / prefix spellings.
         for prefix in ["-", "/"] {
             for spelling in [
-                "Command", "c", "CommandWithArgs", "cwa", "File", "f", "EncodedCommand",
-                "enc", "e", "NoExit", "noe", "Version", "v", "Help", "h", "?",
-                "SSHServerMode", "ServerMode", "WindowsPowerShell", "Login", "Interactive",
+                "Command",
+                "c",
+                "CommandWithArgs",
+                "cwa",
+                "File",
+                "f",
+                "EncodedCommand",
+                "enc",
+                "e",
+                "NoExit",
+                "noe",
+                "Version",
+                "v",
+                "Help",
+                "h",
+                "?",
+                "SSHServerMode",
+                "ServerMode",
+                "WindowsPowerShell",
+                "Login",
+                "Interactive",
             ] {
                 for is_pwsh in [false, true] {
                     let token = format!("{prefix}{spelling}");
@@ -3689,13 +3812,21 @@ mod adapter_tests {
                         "claude",
                         &[],
                         &host(
-                            if is_pwsh { "pwsh.exe" } else { "powershell.exe" },
+                            if is_pwsh {
+                                "pwsh.exe"
+                            } else {
+                                "powershell.exe"
+                            },
                             &[token.as_str()],
                         ),
                     ));
                     assert_error_shape(
                         &err,
-                        if is_pwsh { "pwsh.exe" } else { "powershell.exe" },
+                        if is_pwsh {
+                            "pwsh.exe"
+                        } else {
+                            "powershell.exe"
+                        },
                         &token,
                         "conflicting/terminal configured option",
                     );
@@ -3738,7 +3869,9 @@ mod adapter_tests {
 
     #[test]
     fn powershell_grammar_rejects_bare_unknown_and_abbreviated_tokens() {
-        for token in ["foo", "echo", "-NoPro", "/NoPro", "-Bogus", "/Bogus", "-noex", "/E:O"] {
+        for token in [
+            "foo", "echo", "-NoPro", "/NoPro", "-Bogus", "/Bogus", "-noex", "/E:O",
+        ] {
             let err = launch_error(prepare_windows_resolved_agent_launch(
                 "claude",
                 &[],
@@ -3755,7 +3888,12 @@ mod adapter_tests {
             &[],
             &host("powershell.exe", &["-ExecutionPolicy"]),
         ));
-        assert_error_shape(&err, "powershell.exe", "ExecutionPolicy", "missing or option-shaped");
+        assert_error_shape(
+            &err,
+            "powershell.exe",
+            "ExecutionPolicy",
+            "missing or option-shaped",
+        );
         let err = launch_error(prepare_windows_resolved_agent_launch(
             "claude",
             &[],
@@ -3772,7 +3910,12 @@ mod adapter_tests {
             &[],
             &host("powershell.exe", &["-ExecutionPolicy:"]),
         ));
-        assert_error_shape(&err, "powershell.exe", "-ExecutionPolicy:", "missing or option-shaped");
+        assert_error_shape(
+            &err,
+            "powershell.exe",
+            "-ExecutionPolicy:",
+            "missing or option-shaped",
+        );
     }
 
     #[test]
@@ -3780,26 +3923,41 @@ mod adapter_tests {
         for (args, offending) in [
             (vec!["-NoProfile", "-NoProfile"], "-NoProfile"),
             (vec!["-NoProfile", "/NoProfile"], "/NoProfile"),
-            (vec!["-ExecutionPolicy:Bypass", "-ExecutionPolicy", "RemoteSigned"], "RemoteSigned"),
+            (
+                vec![
+                    "-ExecutionPolicy:Bypass",
+                    "-ExecutionPolicy",
+                    "RemoteSigned",
+                ],
+                "RemoteSigned",
+            ),
         ] {
             let err = launch_error(prepare_windows_resolved_agent_launch(
                 "claude",
                 &[],
                 &host("powershell.exe", &args),
             ));
-            assert_error_shape(&err, "powershell.exe", offending, "duplicate configured option");
+            assert_error_shape(
+                &err,
+                "powershell.exe",
+                offending,
+                "duplicate configured option",
+            );
         }
     }
 
     #[test]
     fn cmd_grammar_rejects_ownership_terminals_and_unknowns() {
-        for token in ["/C", "/K", "/S", "/V:ON", "/V:", "/V:ZZ", "/?", "-D", "foo", "/help", "/E:O"] {
+        for token in [
+            "/C", "/K", "/S", "/V:ON", "/V:", "/V:ZZ", "/?", "-D", "foo", "/help", "/E:O",
+        ] {
             let err = launch_error(prepare_windows_resolved_agent_launch(
                 "claude",
                 &[],
                 &host("cmd.exe", &[token]),
             ));
-            let category = if matches!(token, "/C" | "/K" | "/S" | "/V:ON" | "/V:" | "/V:ZZ" | "/?") {
+            let category = if matches!(token, "/C" | "/K" | "/S" | "/V:ON" | "/V:" | "/V:ZZ" | "/?")
+            {
                 "conflicting/terminal"
             } else {
                 "unknown or ambiguous"
@@ -3878,7 +4036,12 @@ mod adapter_tests {
             &[],
             &host(
                 "pwsh.exe",
-                &["-WorkingDirectory", r"C:\Program Files", "-SettingsFile", "x.json"],
+                &[
+                    "-WorkingDirectory",
+                    r"C:\Program Files",
+                    "-SettingsFile",
+                    "x.json",
+                ],
             ),
         )
         .expect("accepted pwsh spellings");
@@ -3899,7 +4062,10 @@ mod adapter_tests {
         let launch = prepare_windows_resolved_agent_launch(
             "claude",
             &[],
-            &host("cmd.exe", &["/D", "/Q", "/E:ON", "/T:1F", "/V:OFF", "/A", "/F:OFF"]),
+            &host(
+                "cmd.exe",
+                &["/D", "/Q", "/E:ON", "/T:1F", "/V:OFF", "/A", "/F:OFF"],
+            ),
         )
         .expect("accepted cmd spellings");
         assert_eq!(
@@ -3928,7 +4094,10 @@ mod adapter_tests {
             &[],
             &host("   ", &[]),
         ));
-        assert!(err.contains("blank configured default-shell program"), "{err}");
+        assert!(
+            err.contains("blank configured default-shell program"),
+            "{err}"
+        );
 
         for bad in ["pow\0er", "pow\rer", "pow\ner"] {
             let err = launch_error(prepare_windows_resolved_agent_launch(
@@ -3957,16 +4126,15 @@ mod adapter_tests {
     #[test]
     fn prepare_launch_keeps_cmd_exe_fallback_without_host_shell_and_direct_otherwise() {
         // No host shell + non-direct command: historical cmd.exe /C wrapper.
-        let launch = prepare_launch("claude", &["--x".to_string()], None)
-            .expect("fallback launch");
+        let launch = prepare_launch("claude", &["--x".to_string()], None).expect("fallback launch");
         assert_eq!(launch.program, "cmd.exe");
         assert_eq!(
             launch.args,
             vec!["/C".to_string(), "claude".to_string(), "--x".to_string()]
         );
         // Direct exe: unchanged program + argv.
-        let launch = prepare_launch("claude.exe", &["--x".to_string()], None)
-            .expect("direct launch");
+        let launch =
+            prepare_launch("claude.exe", &["--x".to_string()], None).expect("direct launch");
         assert_eq!(launch.program, "claude.exe");
         assert_eq!(launch.args, vec!["--x".to_string()]);
     }
@@ -3983,7 +4151,10 @@ mod adapter_tests {
             let launch = prepare_windows_resolved_agent_launch("claude", &args, &shell)
                 .expect("accepted native values");
             let script = launch.args.last().unwrap();
-            assert!(!script.ends_with('\\'), "trailing-run invariant for {args:?}");
+            assert!(
+                !script.ends_with('\\'),
+                "trailing-run invariant for {args:?}"
+            );
         }
     }
 
@@ -4076,9 +4247,14 @@ mod adapter_spawn_sync_tests {
         );
         let id = spec.id;
 
-        let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
+        let error = backend
+            .spawn_sync(spec)
+            .expect_err("must reject before PTY");
         assert!(error.to_string().contains("-Command"), "{error}");
-        assert!(error.to_string().contains("conflicting/terminal"), "{error}");
+        assert!(
+            error.to_string().contains("conflicting/terminal"),
+            "{error}"
+        );
         assert_eq!(
             backend.pre_pty_attempts.load(Ordering::SeqCst),
             0,
@@ -4108,8 +4284,15 @@ mod adapter_spawn_sync_tests {
         );
         let id = spec.id;
 
-        let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
-        assert!(error.to_string().contains("unsupported cmd payload character"), "{error}");
+        let error = backend
+            .spawn_sync(spec)
+            .expect_err("must reject before PTY");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported cmd payload character"),
+            "{error}"
+        );
         assert_eq!(backend.pre_pty_attempts.load(Ordering::SeqCst), 0);
         assert!(backend.ptys.lock().unwrap().is_empty());
         assert!(crate::pty::spawn_diagnostics::record_for(id).is_none());
@@ -4125,8 +4308,13 @@ mod adapter_spawn_sync_tests {
         );
         let id = spec.id;
 
-        let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
-        assert!(error.to_string().contains("unsupported explicit-batch"), "{error}");
+        let error = backend
+            .spawn_sync(spec)
+            .expect_err("must reject before PTY");
+        assert!(
+            error.to_string().contains("unsupported explicit-batch"),
+            "{error}"
+        );
         assert_eq!(backend.pre_pty_attempts.load(Ordering::SeqCst), 0);
         assert!(backend.ptys.lock().unwrap().is_empty());
         assert!(crate::pty::spawn_diagnostics::record_for(id).is_none());
@@ -4138,8 +4326,15 @@ mod adapter_spawn_sync_tests {
         let spec = spawn_spec("claude", &[], Some(host("   ", &[])));
         let id = spec.id;
 
-        let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
-        assert!(error.to_string().contains("blank configured default-shell program"), "{error}");
+        let error = backend
+            .spawn_sync(spec)
+            .expect_err("must reject before PTY");
+        assert!(
+            error
+                .to_string()
+                .contains("blank configured default-shell program"),
+            "{error}"
+        );
         assert_eq!(backend.pre_pty_attempts.load(Ordering::SeqCst), 0);
         assert!(backend.ptys.lock().unwrap().is_empty());
         assert!(crate::pty::spawn_diagnostics::record_for(id).is_none());
@@ -4151,8 +4346,13 @@ mod adapter_spawn_sync_tests {
         let spec = spawn_spec("claude", &[], Some(host("bash.exe", &["--norc"])));
         let id = spec.id;
 
-        let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
-        assert!(error.to_string().contains("conflicting/terminal"), "{error}");
+        let error = backend
+            .spawn_sync(spec)
+            .expect_err("must reject before PTY");
+        assert!(
+            error.to_string().contains("conflicting/terminal"),
+            "{error}"
+        );
         assert_eq!(backend.pre_pty_attempts.load(Ordering::SeqCst), 0);
         assert!(backend.ptys.lock().unwrap().is_empty());
         assert!(crate::pty::spawn_diagnostics::record_for(id).is_none());
@@ -4163,11 +4363,17 @@ mod adapter_spawn_sync_tests {
         let (backend, _app) = test_backend();
         let specs = [
             spawn_spec("git-bash.exe", &["--login", "-i"], None),
-            spawn_spec("claude", &[], Some(host("git-bash.exe", &["--login", "-i"]))),
+            spawn_spec(
+                "claude",
+                &[],
+                Some(host("git-bash.exe", &["--login", "-i"])),
+            ),
         ];
         for spec in specs {
             let id = spec.id;
-            let error = backend.spawn_sync(spec).expect_err("must reject before PTY");
+            let error = backend
+                .spawn_sync(spec)
+                .expect_err("must reject before PTY");
             assert!(error.to_string().contains("detached launcher"), "{error}");
             assert_eq!(
                 backend.pre_pty_attempts.load(Ordering::SeqCst),

--- a/src-tauri/src/pty/output.rs
+++ b/src-tauri/src/pty/output.rs
@@ -832,14 +832,12 @@ impl TerminalOutputAttachments {
             if labels.is_empty() {
                 return Accumulated::Unattached;
             }
-            let accumulator = Arc::clone(
-                state
-                    .accumulators
-                    .entry(session_id)
-                    .or_insert_with(|| {
-                        Arc::new(Mutex::new(SessionAccumulator::new(Arc::clone(registration))))
-                    }),
-            );
+            let accumulator =
+                Arc::clone(state.accumulators.entry(session_id).or_insert_with(|| {
+                    Arc::new(Mutex::new(SessionAccumulator::new(Arc::clone(
+                        registration,
+                    ))))
+                }));
             (accumulator, labels)
         };
 
@@ -2515,7 +2513,10 @@ mod tests {
             fanout.activate_terminal_output(id, WINDOW, true),
             Ok(None)
         ));
-        assert_eq!(fanout.attached_labels_for_test(id), vec![WINDOW.to_string()]);
+        assert_eq!(
+            fanout.attached_labels_for_test(id),
+            vec![WINDOW.to_string()]
+        );
 
         fanout.handle_output(&token, &id.to_string(), b"after the fault".to_vec());
         flush(&fanout, id);
@@ -2629,7 +2630,11 @@ mod tests {
         assert!(String::from_utf8_lossy(&snapshot.data).contains("before"));
         assert_eq!(fanout.pending_output_bytes_for_test(id), Some(0));
         let seeded = events(&sink);
-        assert_eq!(seeded.len(), 1, "the window already watching keeps its bytes");
+        assert_eq!(
+            seeded.len(),
+            1,
+            "the window already watching keeps its bytes"
+        );
         assert_eq!(seeded[0].1, b"before\r\n");
         assert_eq!(seeded[0].2, Some(1));
 
@@ -2674,7 +2679,11 @@ mod tests {
         fanout.handle_output(&token, &id.to_string(), b"after divergence".to_vec());
         flush(&fanout, id);
         let emitted = events(&sink);
-        assert_eq!(emitted.len(), 1, "the attached window keeps receiving its bytes");
+        assert_eq!(
+            emitted.len(),
+            1,
+            "the attached window keeps receiving its bytes"
+        );
         assert_eq!(emitted[0].1, b"after divergence");
         assert_eq!(emitted[0].2, Some(2));
 
@@ -2745,7 +2754,11 @@ mod tests {
         }
 
         let emitted = events(&sink);
-        assert_eq!(emitted.len(), 1, "no timer, no explicit flush: the ceiling did it");
+        assert_eq!(
+            emitted.len(),
+            1,
+            "no timer, no explicit flush: the ceiling did it"
+        );
         assert_eq!(emitted[0].1.len(), UI_BATCH_LIMIT_BYTES);
         assert_eq!(fanout.pending_output_bytes_for_test(id), Some(0));
     }
@@ -2810,12 +2823,22 @@ mod tests {
             .expect("register app-handle session");
 
         attach(&fanout, id, WINDOW);
-        fanout.handle_output(&token, &id.to_string(), b"only the attached window".to_vec());
+        fanout.handle_output(
+            &token,
+            &id.to_string(),
+            b"only the attached window".to_vec(),
+        );
         flush(&fanout, id);
 
         assert_eq!(attached_events.load(std::sync::atomic::Ordering::SeqCst), 1);
-        assert_eq!(unattached_events.load(std::sync::atomic::Ordering::SeqCst), 0);
-        assert_eq!(any_target_events.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(
+            unattached_events.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            any_target_events.load(std::sync::atomic::Ordering::SeqCst),
+            1
+        );
     }
 
     /// 3.4.1's no-zombie invariant, at the one interleaving that broke it: an attach that

--- a/src-tauri/src/session/context_alerts.rs
+++ b/src-tauri/src/session/context_alerts.rs
@@ -1507,11 +1507,10 @@ fn resolve_member_policy_blocking(session: &Session) -> MemberPolicyResolution {
             Ok(result) => result,
             Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
         };
-    let identity_ac_root =
-        match canonical_real_directory(&identity.ac_root, "Identity workspace") {
-            Ok(path) => path,
-            Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
-        };
+    let identity_ac_root = match canonical_real_directory(&identity.ac_root, "Identity workspace") {
+        Ok(path) => path,
+        Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
+    };
     let matrix_dir = match canonical_real_directory(&identity.matrix_dir, "Agent Matrix") {
         Ok(path) => path,
         Err(error) => return MemberPolicyResolution::PermanentIneligible(error),
@@ -1690,8 +1689,7 @@ fn validate_attempt_guard<R: tauri::Runtime>(
     }
     let (_, identity) =
         crate::config::replica_identity::read_wg_replica_config_read_only(&replica)?;
-    let identity_ac_root =
-        canonical_real_directory(&identity.ac_root, "Identity workspace")?;
+    let identity_ac_root = canonical_real_directory(&identity.ac_root, "Identity workspace")?;
     let identity_matrix = canonical_real_directory(&identity.matrix_dir, "Agent Matrix")?;
     if identity.agent_name != fingerprint.member
         || identity_ac_root != fingerprint.ac_root

--- a/src-tauri/src/session/profile.rs
+++ b/src-tauri/src/session/profile.rs
@@ -799,7 +799,10 @@ impl CodingAgentKind {
             Some(CodingAgentKind::Claude)
         } else if basenames.iter().any(|b| b.starts_with("codex")) {
             Some(CodingAgentKind::Codex)
-        } else if basenames.iter().any(|b| matches!(b.as_str(), "agy" | "antigravity")) {
+        } else if basenames
+            .iter()
+            .any(|b| matches!(b.as_str(), "agy" | "antigravity"))
+        {
             Some(CodingAgentKind::Antigravity)
         } else {
             None
@@ -1038,7 +1041,13 @@ mod tests {
 
     #[test]
     fn detect_antigravity_stems_and_wrapper_exclusions() {
-        for shell in ["agy", "agy.exe", "agy.cmd", "antigravity", r"C:\tools\agy.exe"] {
+        for shell in [
+            "agy",
+            "agy.exe",
+            "agy.cmd",
+            "antigravity",
+            r"C:\tools\agy.exe",
+        ] {
             assert_eq!(
                 CodingAgentKind::detect(shell, &[]),
                 Some(CodingAgentKind::Antigravity),
@@ -1047,19 +1056,18 @@ mod tests {
         }
         // Tokenized cmd form.
         assert_eq!(
-            CodingAgentKind::detect(
-                "cmd.exe",
-                &strings(&["/C", "agy", "--effort", "high"])
-            ),
+            CodingAgentKind::detect("cmd.exe", &strings(&["/C", "agy", "--effort", "high"])),
             Some(CodingAgentKind::Antigravity)
         );
         // Exact-stem only: prefix wrappers are NOT inferred.
-        for shell in ["agy-proxy", "my-agy", "antigravity-pro", "agyctl", "antigravityctl"] {
-            assert_eq!(
-                CodingAgentKind::detect(shell, &[]),
-                None,
-                "shell={shell:?}"
-            );
+        for shell in [
+            "agy-proxy",
+            "my-agy",
+            "antigravity-pro",
+            "agyctl",
+            "antigravityctl",
+        ] {
+            assert_eq!(CodingAgentKind::detect(shell, &[]), None, "shell={shell:?}");
         }
         // `--model antigravity` as a VALUE for claude still detects Claude
         // (prefix precedence wins); a gemini* executable is no longer a kind.
@@ -1887,11 +1895,7 @@ mod tests {
             Some(PtySubmissionAgent::Antigravity)
         );
         assert_eq!(
-            detect_pty_submission_agent(
-                "antigravity.exe",
-                &[],
-                Some(CodingAgentKind::Antigravity)
-            ),
+            detect_pty_submission_agent("antigravity.exe", &[], Some(CodingAgentKind::Antigravity)),
             Some(PtySubmissionAgent::Antigravity)
         );
         assert_eq!(

--- a/src-tauri/src/telegram/bridge.rs
+++ b/src-tauri/src/telegram/bridge.rs
@@ -1375,7 +1375,10 @@ mod tests {
             "   ▄▀▀    ▀▀▄     D:/0_repos/AgentsCommander_iac/.ac/wg-21-ac-dev-team-v3/__agent_ac-cli-tester-v3",
         ];
         for line in horizontal {
-            assert!(!filter.keep_line(line), "logo row should be dropped: {line:?}");
+            assert!(
+                !filter.keep_line(line),
+                "logo row should be dropped: {line:?}"
+            );
         }
 
         // Vertical logo text rows, frame 03:15:27.898 (Blocker C: no block
@@ -1386,7 +1389,10 @@ mod tests {
             "  Gemini 3.7 Flash (High)",
         ];
         for line in vertical {
-            assert!(!filter.keep_line(line), "vertical logo row should be dropped: {line:?}");
+            assert!(
+                !filter.keep_line(line),
+                "vertical logo row should be dropped: {line:?}"
+            );
         }
     }
 
@@ -1396,9 +1402,7 @@ mod tests {
 
         // The 4 exact rows of the vertical-logo response frame (L19-33),
         // with explicit outcomes.
-        assert!(!filter.keep_line(
-            "  mariano.blua@gmail.com (Google AI Pro)"
-        )); // DROPPED: account row by `Google AI Pro` pattern
+        assert!(!filter.keep_line("  mariano.blua@gmail.com (Google AI Pro)")); // DROPPED: account row by `Google AI Pro` pattern
         assert!(!filter.keep_line("  Gemini 3.7 Flash (High)")); // DROPPED: model row by ` (High)` pattern
         assert!(filter.keep_line(
             "  D:/0_repos/AgentsCommander_iac/.ac/wg-21-ac-dev-team-v3/__agent_ac-cli-tester-v3"
@@ -1432,9 +1436,8 @@ mod tests {
         // Blocker A: counter variant, bare and fused (frame 03:23:42.495, L208
         // — exact content, 15 spaces).
         assert!(!filter.keep_line("Gemini 3.7 Flash · high · 1 task(s) · /tasks"));
-        assert!(!filter.keep_line(
-            "esc to cancel               Gemini 3.7 Flash · high · 1 task(s) · /tasks"
-        ));
+        assert!(!filter
+            .keep_line("esc to cancel               Gemini 3.7 Flash · high · 1 task(s) · /tasks"));
     }
 
     #[test]
@@ -1445,9 +1448,7 @@ mod tests {
         assert!(!filter.keep_line("▸ Thought for 2s, 236 tokens"));
         assert!(!filter.keep_line("▸ Thought for 14s, 2.8k tokens"));
         assert!(!filter.keep_line("▸ Thought for 4s, 1.8k tokens"));
-        assert!(!filter.keep_line(
-            "▸ ThougUse /feedback to share your experience with the team."
-        ));
+        assert!(!filter.keep_line("▸ ThougUse /feedback to share your experience with the team."));
     }
 
     #[test]
@@ -1484,9 +1485,9 @@ mod tests {
         assert!(filter.keep_line(
             "  ¡Hola! Soy ac-cli-tester-v3. Estoy listo para ayudarte con la validación"
         ));
-        assert!(filter.keep_line(
-            "He ejecutado la validación en vivo de las 5 filas PENDING asignadas"
-        ));
+        assert!(
+            filter.keep_line("He ejecutado la validación en vivo de las 5 filas PENDING asignadas")
+        );
         // A normal code/tool line.
         assert!(filter.keep_line("  let info = BridgeInfo { bot_id: bot.id.clone() };"));
         // Tool-call activity rows pass intentionally (informative, not chrome).
@@ -1507,7 +1508,10 @@ mod tests {
             "  Investigating System Behavior",
             "  Observing System Activity",
         ] {
-            assert!(filter.keep_line(line), "step label should be kept: {line:?}");
+            assert!(
+                filter.keep_line(line),
+                "step label should be kept: {line:?}"
+            );
         }
     }
 
@@ -1541,7 +1545,10 @@ mod tests {
             filter_for_agent(Some(CodingAgentKind::Codex)).name(),
             "claude-code"
         );
-        assert_eq!(filter_for_agent(Some(CodingAgentKind::Pi)).name(), "claude-code");
+        assert_eq!(
+            filter_for_agent(Some(CodingAgentKind::Pi)).name(),
+            "claude-code"
+        );
         assert_eq!(filter_for_agent(None).name(), "claude-code");
     }
 
@@ -1553,8 +1560,8 @@ mod tests {
 
         for line in [
             "────────────────────", // box-drawing separator (U+2500)
-            "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", // braille spinner row (U+2800..U+28FF)
-            "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪", // low-alnum decorative line
+            "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏",           // braille spinner row (U+2800..U+28FF)
+            "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪",     // low-alnum decorative line
         ] {
             assert!(!agy.keep_line(line), "agy should drop: {line:?}");
             assert!(!claude.keep_line(line), "claude should drop: {line:?}");

--- a/src-tauri/src/web/commands.rs
+++ b/src-tauri/src/web/commands.rs
@@ -1550,7 +1550,9 @@ mod tests {
             .manage(Arc::clone(&session_mgr))
             .manage(Arc::clone(&pty_mgr))
             .manage(coordinator.clone())
-            .manage(Arc::new(crate::resource_monitor::ResourceMonitorState::new()))
+            .manage(Arc::new(
+                crate::resource_monitor::ResourceMonitorState::new(),
+            ))
             .manage(Arc::new(crate::RestoreInProgress(
                 std::sync::atomic::AtomicBool::new(false),
             )))
@@ -1636,12 +1638,21 @@ mod tests {
             .as_str()
             .expect("invalid configured host must fail the create");
         assert!(error.contains("conflicting/terminal"), "{error}");
-        assert!(error.contains("agent adapter owns command execution"), "{error}");
+        assert!(
+            error.contains("agent adapter owns command execution"),
+            "{error}"
+        );
 
         // Full no-side-effect postcondition through the web creation path: no
         // session row and no pending/metadata record survive the rejection.
         assert!(
-            state.session_mgr.read().await.list_sessions().await.is_empty(),
+            state
+                .session_mgr
+                .read()
+                .await
+                .list_sessions()
+                .await
+                .is_empty(),
             "no session may appear in the session manager"
         );
         // The adapter rejection happens at the TOP of spawn_sync, before any
@@ -1720,8 +1731,17 @@ mod tests {
         let error = response["error"]
             .as_str()
             .expect("invalid cmd payload must fail the create");
-        assert!(error.contains("unsupported cmd payload character"), "{error}");
-        assert!(state.session_mgr.read().await.list_sessions().await.is_empty());
+        assert!(
+            error.contains("unsupported cmd payload character"),
+            "{error}"
+        );
+        assert!(state
+            .session_mgr
+            .read()
+            .await
+            .list_sessions()
+            .await
+            .is_empty());
         let pending_ids = state
             .session_mgr
             .read()

--- a/src-tauri/tests/cli_project_registration.rs
+++ b/src-tauri/tests/cli_project_registration.rs
@@ -578,9 +578,8 @@ fn ac_discovery_rs_threads_production_tokens_for_context_boundaries() {
         "the per-repo discovery context-update (ContextUpdate) must thread the activation token"
     );
     assert!(
-        production.contains(
-            "scan_project_context_templates_recorded(&base,&ac_root,activation.as_ref()"
-        ),
+        production
+            .contains("scan_project_context_templates_recorded(&base,&ac_root,activation.as_ref()"),
         "the workgroup discovery context-update (ContextUpdate) must thread the activation token"
     );
     assert!(

--- a/src-tauri/tests/pty_lifecycle_regression.rs
+++ b/src-tauri/tests/pty_lifecycle_regression.rs
@@ -587,18 +587,24 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
         fixture
             .cleanup
             .record_session(&fixture.pty_mgr, restart_old_id);
-        wait_for_snapshot_contains(&fixture, &fixture.app, &restart_old_id, "AC_READY", "Phase F")
-            .await
-            .unwrap_or_else(|e| {
-                panic!(
-                    "{e}\n{}",
-                    fixture.dump(
-                        "Phase F",
-                        &[restart_old_id],
-                        std::slice::from_ref(&pid_restart)
-                    )
+        wait_for_snapshot_contains(
+            &fixture,
+            &fixture.app,
+            &restart_old_id,
+            "AC_READY",
+            "Phase F",
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "{e}\n{}",
+                fixture.dump(
+                    "Phase F",
+                    &[restart_old_id],
+                    std::slice::from_ref(&pid_restart)
                 )
-            });
+            )
+        });
         let restart_old_pid = wait_for_pid_file(&pid_restart, PID_TIMEOUT)
             .await
             .unwrap_or_else(|e| {
@@ -665,18 +671,24 @@ fn real_pty_session_lifecycle_create_io_resize_restart_persist_restore_cleanup()
             });
         fixture.cleanup.record_pid(restart_new_pid);
         assert!(process_exists(restart_new_pid));
-        wait_for_snapshot_contains(&fixture, &fixture.app, &restart_new_id, "AC_READY", "Phase F")
-            .await
-            .unwrap_or_else(|e| {
-                panic!(
-                    "{e}\n{}",
-                    fixture.dump(
-                        "Phase F",
-                        &[restart_old_id, restart_new_id],
-                        std::slice::from_ref(&pid_restart)
-                    )
+        wait_for_snapshot_contains(
+            &fixture,
+            &fixture.app,
+            &restart_new_id,
+            "AC_READY",
+            "Phase F",
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "{e}\n{}",
+                fixture.dump(
+                    "Phase F",
+                    &[restart_old_id, restart_new_id],
+                    std::slice::from_ref(&pid_restart)
                 )
-            });
+            )
+        });
         {
             let last_event_sequence =
                 last_strictly_increasing_sequence(&fixture, &restarted.id, "Phase F");
@@ -942,9 +954,15 @@ fn claude_launch_materializes_context_without_prompt_file_arg() {
 
         let session_id = parse_session_id(&info);
         fixture.cleanup.record_session(&fixture.pty_mgr, session_id);
-        wait_for_snapshot_contains(&fixture, &fixture.app, &session_id, "AC_READY", "Claude materialization")
-            .await
-            .unwrap_or_else(|e| panic!("{e}"));
+        wait_for_snapshot_contains(
+            &fixture,
+            &fixture.app,
+            &session_id,
+            "AC_READY",
+            "Claude materialization",
+        )
+        .await
+        .unwrap_or_else(|e| panic!("{e}"));
 
         assert_eq!(
             info.agent_kind,
@@ -1140,9 +1158,8 @@ async fn wait_for_snapshot_contains(
         )
         .map_err(|e| format!("{phase}: get_screen_snapshot failed for {session_id}: {e}"))?;
         if let Some(snapshot) = snapshot {
-            last_snapshot = Some(
-                serde_json::to_value(&snapshot).expect("serialize legacy snapshot payload"),
-            );
+            last_snapshot =
+                Some(serde_json::to_value(&snapshot).expect("serialize legacy snapshot payload"));
             let text = String::from_utf8_lossy(&snapshot.data);
             if text.contains(expected_bytes) {
                 let deliveries = fixture

--- a/src-tauri/tests/pty_powershell_managed_native.rs
+++ b/src-tauri/tests/pty_powershell_managed_native.rs
@@ -211,7 +211,8 @@ fn make_fixture() -> Fixture {
     })
     .expect("seed isolated settings");
 
-    let captured_deliveries: Arc<Mutex<HashMap<String, usize>>> = Arc::new(Mutex::new(HashMap::new()));
+    let captured_deliveries: Arc<Mutex<HashMap<String, usize>>> =
+        Arc::new(Mutex::new(HashMap::new()));
     let listener_errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
     let session_mgr = Arc::new(tokio::sync::RwLock::new(SessionManager::new()));
@@ -254,12 +255,11 @@ fn make_fixture() -> Fixture {
     let deliveries = Arc::clone(&captured_deliveries);
     let error_capture = Arc::clone(&listener_errors);
     let app = agentscommander_lib::test_support::test_builder()
-        .manage(MasterToken::new("pty-powershell-native-master-token".into()))
+        .manage(MasterToken::new(
+            "pty-powershell-native-master-token".into(),
+        ))
         .manage(AppOutbox::new(
-            repo_root
-                .join(".app-outbox")
-                .to_string_lossy()
-                .to_string(),
+            repo_root.join(".app-outbox").to_string_lossy().to_string(),
         ))
         .manage(settings)
         .manage(Arc::clone(&session_mgr))
@@ -269,7 +269,9 @@ fn make_fixture() -> Fixture {
         .manage(voice_tracking)
         .manage(Arc::new(RestoreInProgress(AtomicBool::new(false))))
         .manage(shutdown_signal)
-        .manage(Arc::new(WebAccessToken::new("pty-powershell-native-web-token".into())))
+        .manage(Arc::new(WebAccessToken::new(
+            "pty-powershell-native-web-token".into(),
+        )))
         .manage(WsBroadcaster::new())
         .manage(WebServerHandle::default())
         .manage(spec_board_state)
@@ -400,8 +402,9 @@ async fn create_resolved_session(
     cwd: &str,
     name: &str,
 ) -> SessionInfo {
-    let spawn = build_agent_spawn_command(settings, agent_id, Some(std::path::Path::new(cwd)), None)
-        .unwrap_or_else(|e| panic!("resolve agent spawn for {agent_id}: {e}"));
+    let spawn =
+        build_agent_spawn_command(settings, agent_id, Some(std::path::Path::new(cwd)), None)
+            .unwrap_or_else(|e| panic!("resolve agent spawn for {agent_id}: {e}"));
     let host_shell = ResolvedAgentHostShell {
         program: settings.default_shell.clone(),
         args: settings.default_shell_args.clone(),
@@ -480,9 +483,8 @@ async fn wait_for_snapshot_contains(
         )
         .map_err(|e| format!("{phase}: get_screen_snapshot failed for {session_id}: {e}"))?;
         if let Some(snapshot) = snapshot {
-            last_snapshot = Some(
-                serde_json::to_value(&snapshot).expect("serialize legacy snapshot payload"),
-            );
+            last_snapshot =
+                Some(serde_json::to_value(&snapshot).expect("serialize legacy snapshot payload"));
             let text = String::from_utf8_lossy(&snapshot.data);
             if text.contains(expected_bytes) {
                 let deliveries = fixture
@@ -539,7 +541,11 @@ async fn wait_for_session_gone(
 ) -> Result<(), String> {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if fixture.pty_mgr.lock().unwrap().context_session_liveness(session_id)
+        if fixture
+            .pty_mgr
+            .lock()
+            .unwrap()
+            .context_session_liveness(session_id)
             == agentscommander_lib::pty::context_scrape::ContextSessionLiveness::SessionOver
         {
             return Ok(());
@@ -825,9 +831,7 @@ fn configured_powershell_managed_native_reporter_argv_and_pty_io() {
         for line in &expected_lines {
             wait_for_snapshot_contains(&fixture, &id, line, "reporter-argv")
                 .await
-                .unwrap_or_else(|e| {
-                    panic!("{e}\nargv line missing: {line:?}")
-                });
+                .unwrap_or_else(|e| panic!("{e}\nargv line missing: {line:?}"));
         }
 
         // PTY input path: a distinct marker through PtyManager::write must be
@@ -898,27 +902,37 @@ fn configured_powershell_batch_regression() {
     // --session-id pair lands after the known values and is not echoed), then
     // exits with a deterministic code. `%~N` strips the command-line quotes;
     // cmd batch can only expand %0-%9, so `shift` brings args 10+ into %1.
-    let mut shim_body = String::from("echo AC_BATCH_MARKER
-");
+    let mut shim_body = String::from(
+        "echo AC_BATCH_MARKER
+",
+    );
     let mut shifted = 0usize;
     for i in 1..=cmd_safe_args.len() {
         if i <= 9 {
-            shim_body.push_str(&format!("echo \"V{i}=[%~{i}]\"
-"));
+            shim_body.push_str(&format!(
+                "echo \"V{i}=[%~{i}]\"
+"
+            ));
         } else {
             // `shift` moves every parameter one position left; before reading
             // arg i (i > 9), shift it down to %1.
             while shifted < i - 1 {
-                shim_body.push_str("shift
-");
+                shim_body.push_str(
+                    "shift
+",
+                );
                 shifted += 1;
             }
-            shim_body.push_str(&format!("echo \"V{i}=[%~1]\"
-"));
+            shim_body.push_str(&format!(
+                "echo \"V{i}=[%~1]\"
+"
+            ));
         }
     }
-    shim_body.push_str("exit /b 17
-");
+    shim_body.push_str(
+        "exit /b 17
+",
+    );
     write_cmd_shim(&shim_dir.join("claude.cmd"), &shim_body);
 
     let Some(powershell) = powershell_required_host() else {
@@ -980,16 +994,15 @@ fn configured_powershell_batch_regression() {
         for line in &expected_lines {
             wait_for_snapshot_contains(&fixture, &id, line, "batch-argument")
                 .await
-                .unwrap_or_else(|e| {
-                    panic!(
-                        "{e}\nargument line missing: {line:?}"
-                    )
-                });
+                .unwrap_or_else(|e| panic!("{e}\nargument line missing: {line:?}"));
         }
         let code = wait_for_exit_code(&fixture, id, EXIT_TIMEOUT)
             .await
             .expect("batch shim exit code must propagate");
-        assert_eq!(code, 17, "nested batch shim exit code must propagate exactly");
+        assert_eq!(
+            code, 17,
+            "nested batch shim exit code must propagate exactly"
+        );
 
         // Pre-PTY rejection: explicit .cmd program with '%' in an argument.
         let explicit = shim_dir.join("explicit.cmd");
@@ -1017,7 +1030,13 @@ fn configured_powershell_batch_regression() {
             "pre-PTY rejection must name the explicit-batch rule: {err}"
         );
         assert!(
-            fixture.session_mgr.read().await.list_sessions().await.is_empty()
+            fixture
+                .session_mgr
+                .read()
+                .await
+                .list_sessions()
+                .await
+                .is_empty()
                 || !fixture
                     .session_mgr
                     .read()
@@ -1076,9 +1095,13 @@ fn configured_cmd_host_shim_argv_and_pre_pty_rejections() {
     let shim_dir = temp.join("shim-cmd");
     std::fs::create_dir_all(&shim_dir).expect("create shim dir");
     let shim_path = shim_dir.join("cmdprobe.cmd");
-    write_cmd_shim(&shim_path, "echo CMD_PROBE_MARKER\r\necho [%*]\r\nexit /b 7");
+    write_cmd_shim(
+        &shim_path,
+        "echo CMD_PROBE_MARKER\r\necho [%*]\r\nexit /b 7",
+    );
 
-    let cmd_host = std::env::var("ComSpec").unwrap_or_else(|_| "C:\\Windows\\System32\\cmd.exe".to_string());
+    let cmd_host =
+        std::env::var("ComSpec").unwrap_or_else(|_| "C:\\Windows\\System32\\cmd.exe".to_string());
     let host_shell = ResolvedAgentHostShell {
         program: cmd_host.clone(),
         args: vec!["/D".to_string()],
@@ -1121,9 +1144,16 @@ fn configured_cmd_host_shim_argv_and_pre_pty_rejections() {
             .await
             .expect("cmd shim marker must arrive through PTY output");
         // One literal argument each: the shim echoes [%*].
-        wait_for_snapshot_contains(&fixture, &id, "[--flag !bang! a\\b]", "cmd-literal-argument")
-            .await
-            .expect("flag-style, bang, and internal-backslash values must be one literal argument each");
+        wait_for_snapshot_contains(
+            &fixture,
+            &id,
+            "[--flag !bang! a\\b]",
+            "cmd-literal-argument",
+        )
+        .await
+        .expect(
+            "flag-style, bang, and internal-backslash values must be one literal argument each",
+        );
         let code = wait_for_exit_code(&fixture, id, EXIT_TIMEOUT)
             .await
             .expect("cmd shim exit code must propagate");
@@ -1224,7 +1254,10 @@ fn configured_powershell_host_shutdown_reaps_agent() {
     let shim_dir = temp.join("shim-long");
     std::fs::create_dir_all(&shim_dir).expect("create shim dir");
     let shim_path = shim_dir.join("claude.cmd");
-    write_cmd_shim(&shim_path, "echo AC_LONG_MARKER\r\nping -n 60 127.0.0.1 > nul");
+    write_cmd_shim(
+        &shim_path,
+        "echo AC_LONG_MARKER\r\nping -n 60 127.0.0.1 > nul",
+    );
 
     let Some(powershell) = powershell_required_host() else {
         eprintln!(
@@ -1263,9 +1296,7 @@ fn configured_powershell_host_shutdown_reaps_agent() {
             .expect("long-running shim must start");
 
         let record = spawn_diagnostics::record_for(id).expect("spawn record exists");
-        let host_pid = record
-            .pid()
-            .expect("the tracked host pid is available");
+        let host_pid = record.pid().expect("the tracked host pid is available");
         assert!(process_exists(host_pid), "PowerShell host must be running");
 
         destroy_session_inner(fixture.app.handle(), id)


### PR DESCRIPTION
Closes #1602

## What

Applies the canonical formatter over the crate, clearing the accumulated `rustfmt` backlog in a single behavior-free commit:

```
rustup run stable cargo fmt --all --manifest-path src-tauri/Cargo.toml
```

## Scope

`30 files changed, 971 insertions(+), 829 deletions(-)` — exactly the 30 files that `cargo fmt --check --files-with-diff` reported as non-conforming at `main` (`1eee2cd`). No file outside that list is touched: 27 under `src-tauri/src/`, 3 under `src-tauri/tests/`.

No `rustfmt.toml` was added (none exists in the repo, so this is stock rustfmt default behavior), and no `#[rustfmt::skip]` was introduced. No code was edited by hand.

## Verification

- `rustup run stable cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` exits `0` on this branch (it exited `1` on `main`).
- `git diff --name-only main...HEAD` matches the 30-file list exactly, 30/30.
- The residual `git diff --ignore-all-space` is non-empty (`796 insertions(+), 654 deletions(-)`) and was classified hunk by hunk. All of it is standard, semantically inert rustfmt normalization:
  - trailing commas added/removed per multi-line vs single-line layout;
  - redundant braces removed from closures and match arms (`|e| { panic!(..) }` → `|e| panic!(..)`);
  - `use` / `pub mod` reordering (default `reorder_imports = true`);
  - one match arm wrapped into a block in `config/coding_agents_catalog.rs`.
- No identifier, string literal, or control-flow change. No test expectation was modified.

## Notes

No CI job enforces `cargo fmt` today, so this only clears the current backlog; it does not prevent future drift. Adding a fmt gate to CI is a separate follow-up.
