### PR TITLE
docs: name the portable Windows asset and describe the second-instance message

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ agentscommander new-project /path/to/project
 
 The npm package is `@mblua/agentscommander`. The installed command is still `agentscommander`.
 
-Prefer a desktop installer or a manual download? Get the Windows installer, Linux AppImage, macOS dmg, or portable assets from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
+Prefer a desktop installer or a manual download? Get the Windows installer, the Windows portable zip (`agentscommander-X.Y.Z-windows-x86_64-portable.zip`), the Linux AppImage, or the macOS dmg from [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
 
 ## The 30-second pitch
 
@@ -88,7 +88,7 @@ You bring the coding agents. AgentsCommander coordinates them.
    agentscommander
    ```
 
-   Prefer a desktop installer or portable binary? Use [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
+   Prefer a desktop installer, or a portable copy you unzip and run? Use [GitHub Releases](https://github.com/mblua/AgentsCommander/releases/latest).
 2. **Open a project**: click `New Project` in the sidebar and point it at an empty folder. AC creates a Project AC Root (`.ac/`) there.
 3. **Create a Team**: add an orchestrator and one worker agent, each with a role prompt. [Teams and workgroups](docs/agents/teams-and-workgroups.md) walks through this.
 4. **Launch the orchestrator**: pick Claude Code, Codex, Antigravity, Pi, or OpenCode from the dropdown. Ask it to send the worker a hello message. The worker terminal receives a file notification and responds in real time.

--- a/docs/features/portable-instances.md
+++ b/docs/features/portable-instances.md
@@ -43,6 +43,8 @@ Unknown suffixes get a deterministic port in the 9880–9899 range based on a ha
 
 That's it. The instance creates its own config directory on first launch, gets a unique mutex (so it does not conflict with other instances), and shows **[MYTEAM]** in the titlebar.
 
+The rename is what makes the copy independent, not the folder you put it in. Two copies that still share a file name share one instance identity, so starting the second one shows a message explaining the collision and pointing at the rename, then exits without disturbing the first. Before #1592 it exited silently, which looked like nothing happening at all.
+
 ## Why you might want this
 
 - **Stage / prod parity.** Run `agentscommander_stage.exe` against your test repos while the canonical `agentscommander.exe` stays focused on shipping work.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,7 @@ If you prefer a desktop installer or manual download, get the latest asset for y
 
 | Platform | Asset |
 |---|---|
-| Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe` or the portable `agentscommander.exe` |
+| Windows 10 1809+ | `Agents Commander_X.Y.Z_x64-setup.exe`, or `agentscommander-X.Y.Z-windows-x86_64-portable.zip` for a no-install copy |
 | Linux | `agentscommander_*_amd64.AppImage` |
 | macOS | `Agents Commander_*.dmg` (Apple Silicon + Intel) |
 
@@ -43,7 +43,7 @@ Windows code signing is planned through SignPath and pending setup. Current Wind
 Get-AuthenticodeSignature "Agents Commander_X.Y.Z_x64-setup.exe"
 ```
 
-Run the installer, or drop the portable `.exe` into any folder and double-click. On first launch AC creates its config directory next to the binary (e.g. `.agentscommander/` on Windows). See [Portable instances](features/portable-instances.md) for the rules.
+Run the installer, or unzip the portable download into any folder and double-click `agentscommander.exe`. On first launch AC creates its config directory next to the binary (e.g. `.agentscommander/` on Windows). The zip also carries a `PORTABLE.txt` covering updates, second instances, and the WebView2 requirement. See [Portable instances](features/portable-instances.md) for the rules.
 
 ## 2. Open or create an AC project
 

--- a/packaging/windows/PORTABLE.txt
+++ b/packaging/windows/PORTABLE.txt
@@ -35,9 +35,10 @@ RUNNING MORE THAN ONE INSTANCE
   sessions, its own ports, and its own single-instance lock. The suffix shows
   as a badge in the title bar.
 
-  Two copies with the SAME file name are the same instance identity even in
-  different folders, so the second one will not open a second window. Rename
-  it if you want both running at once.
+  Two copies with the SAME file name are the same instance identity, even in
+  different folders. Starting the second one shows a message saying so and
+  then closes it, leaving the first instance untouched. Rename it if you want
+  both running at once.
 
 
 REQUIREMENTS


### PR DESCRIPTION
Closes #1606.

Documentation catch-up for two changes that landed today. No behavior, workflow, or script change.

## What was wrong

**The portable download had no name.** #1589 shipped `agentscommander-X.Y.Z-windows-x86_64-portable.zip`, gated so a release without it stays a draft. But `docs/quickstart.md` still offered "the portable `agentscommander.exe`", which has never been a published asset. A reader following that instruction downloads the raw `agentscommander-windows-x86_64.exe` instead, and that name parses as instance suffix `64`, silently giving them `.agentscommander-windows-x86_64\`, an `AC [64]` badge, a non-default mutex, and ports 9886/9906 instead of 9877/9887. Naming the real asset is what prevents that.

**The second-instance behavior changed.** #1592 replaced the silent `exit(0)` with a message explaining the collision and pointing at the rename. `packaging/windows/PORTABLE.txt` ships inside the zip specifically to explain that scenario and still described the old behavior.

## Deliberately not fixed here

Two claims in these same files are inaccurate today. Both are fixed by work in flight, so correcting them now would mean writing the text twice:

| Claim | Why it waits |
|---|---|
| `README.md:63` "copy the `.exe` to any drive and it carries its own config" | True only where the destination is writable. #1577 adds the probe and the fallback. |
| `docs/features/portable-instances.md:85` "AC keeps no global state outside that directory" | The WebView2 user-data folder defaults to `%LOCALAPPDATA%\dev.agentscommander.app\` because no builder sets `data_directory`. #1590 confines it. |

macOS and Linux portability wording is untouched for the same reason: each needs #1577 **plus** a platform-specific bundle-aware resolver branch (#1594 for macOS; the AppImage case is not filed yet). Until those land, an AppImage or a `.app` is a per-user install rather than a portable one, and the docs should not claim otherwise in either direction.

## Verification

- Four files changed, 10 insertions, 7 deletions.
- The two deferred claims are confirmed present and unmodified.
- No page anywhere in `README.md` or `docs/` still offers a portable download by a name that is not a published release asset.
- `bundle-validation` runs on this PR because it touches `packaging/windows/**`, so the reworded `PORTABLE.txt` is re-packed and re-smoked against a real built binary.

https://claude.ai/code/session_01HydthWuftnNBoYzqHZTNm8
