### PR TITLE
ci: add rust-fmt gate to PR regression gates (refs #1608)

### DIFF
--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -180,6 +180,23 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --all-targets -- -D warnings
 
+  rust-fmt:
+    name: rust-fmt
+    # Skip branch-deletion push events while still requiring pull request validation.
+    if: github.event_name != 'push' || (github.event.deleted != true && github.event.after != '0000000000000000000000000000000000000000')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust stable with rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --check
+        working-directory: src-tauri
+        run: cargo fmt --all -- --check
+
   terminal-snapshot-portable:
     name: terminal-snapshot-portable (${{ matrix.os }})
     # Skip branch-deletion push events while still requiring pull request validation.

--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -189,7 +189,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust stable with rustfmt
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
 


### PR DESCRIPTION
Closes #1608

## What

Adds a dedicated `rust-fmt` job to `.github/workflows/pr-regression-gates.yml` running `cargo fmt --all -- --check` in `src-tauri`.

`main` was made fmt-clean by #1602 / #1603 (merge `25a258d6`), which cleared 30 non-conforming files. Nothing prevented that drift from reaccumulating, because no CI job enforced formatting. This is that gate.

## Scope

`1 file changed, 17 insertions(+)` — only the workflow. No `rustfmt.toml` was added (the repo has none, so stock rustfmt defaults apply, which is exactly what #1602 normalized to), and no source file was reformatted.

## Design

The job is deliberately minimal: `actions/checkout` plus `dtolnay/rust-toolchain@stable` with the `rustfmt` component, and nothing else. `cargo fmt --check` parses source and compiles nothing, so it needs no Node.js, no `npm ci`, no frontend build, no Tauri system dependencies, and no `swatinem/rust-cache`. It carries the same branch-deletion `if:` guard as its sibling jobs and is placed with the other `rust-*` jobs.

A separate job rather than a step inside an existing leg: it fails in seconds instead of waiting behind a full `cargo check`, and a dedicated red check names the problem directly in the PR UI.

## Verification

- YAML validated three ways: `yaml.safe_load`, `yaml-lint`, and `actionlint v1.7.12` (exit 0, no findings across the whole workflow).
- Positive control: `cargo fmt --all -- --check` exits `0` on this branch.
- **Negative control**, performed rather than assumed: a formatting violation was deliberately injected into `src-tauri/src/errors.rs` (`use  thiserror::Error;`, double space — valid syntax, non-conforming format). The check exited `1` and named the file with a diff. The violation was then reverted and the check returned to exit `0`.

The negative control matters because a workflow with broken YAML does not fail, it simply never runs. A gate never observed failing is not a proven gate.

## Follow-up

This check reports but does not block until it is added to the `main` ruleset as a required status check. That is a repository-settings change requiring owner action and is not done in this PR.
