### PR TITLE
ci(pr-gates): correct the IS #1577 guard comment, refs #1619

### DIFF
--- a/.github/workflows/pr-regression-gates.yml
+++ b/.github/workflows/pr-regression-gates.yml
@@ -170,15 +170,32 @@ jobs:
           #   3. The "1 passed" grep catches the filter matching nothing or
           #      matching something else instead.
           #
-          # Do NOT drop `pipefail` and rely on the greps. The test re-executes
-          # its own harness as a child with --nocapture, so the child's output
-          # interleaves and BOTH the identifier and a "1 passed" line appear
-          # TWICE. If the parent fails, the child's "ok" line is still in the
-          # log and both greps would still succeed. Only the exit code
-          # distinguishes those cases.
+          # The test re-executes itself as a child process, but the child's
+          # stdout and stderr are Stdio::piped() and collected into a String.
+          # On the success path that output is NEVER printed, so the identifier
+          # and the result line each appear EXACTLY ONCE in this log.
+          #
+          # On a FAILURE path the parent embeds the child's captured stdout
+          # into its panic message via {:?}, which debug-escapes the newlines
+          # onto a single line. That embedded text contains a literal
+          # "test result: ok. 1 passed" from a child that succeeded before the
+          # parent's own assertions failed. Two consequences:
+          #
+          #   - Guard 3 is anchored with `^` for exactly this reason. Embedded
+          #     mid-line, the child's "ok" cannot satisfy an anchored match.
+          #     Do NOT remove the `^`.
+          #   - Guard 2 is unanchored and CAN be satisfied by that embedded
+          #     text, so guard 2 alone cannot tell a real pass from a parent
+          #     failure that dumped a successful child's output.
+          #
+          # Keep `pipefail`. It is the only guard that does not depend on
+          # parsing text at all, so it is the only one no output shape can
+          # fool.
           #
           # Do NOT tighten these into count-based assertions (`grep -c ... 1`).
-          # Two occurrences are expected and correct.
+          # The success path yields one occurrence and the failure paths yield
+          # a different number depending on which assertion failed, so a fixed
+          # count would be wrong for some real failure it is meant to catch.
           grep -qF "$TEST" test-1577.log || {
             echo "::error::$TEST never ran. It was renamed, moved, or gated out, and this step was silently testing nothing."
             exit 1


### PR DESCRIPTION
Closes #1619.

Comment-only change to the `cargo test (IS #1577 primary case)` step in `.github/workflows/pr-regression-gates.yml`. **No behaviour change.** The step, all three guards, `set -euo pipefail`, both greps and the `^` anchor are untouched.

## Why

The comment claimed the test's child harness interleaves its output, so the identifier and the `1 passed` line each appear **twice**, and that "two occurrences are expected and correct."

They appear **once**. The child is spawned with `stdout`/`stderr` as `Stdio::piped()` and collected into a `String` the success path never prints.

Verified two ways:

- **Log.** `rust-regression-linux`, run `33165515901`, job `98829865390`, attempt 1, head `884ae62e` (the second parent of merge commit `ce946500`) shows one occurrence of each.
- **Source.** `src-tauri/src/lib.rs`, the test's parent branch: `.stdout(Stdio::piped()).stderr(Stdio::piped())`, then `wait_with_output()` into a `String` that only reaches a log inside a `format!` panic message on failure paths.

The comment exists to stop a future maintainer weakening the guards for a wrong reason, so a wrong reason inside it is worth correcting.

## What replaces it

The mechanism that is actually load-bearing:

- On a **failure** path the parent embeds the child's captured stdout via `{:?}`, debug-escaped onto a single line. A failing log can therefore contain a literal `test result: ok. 1 passed` from a child that succeeded before the parent's own assertions failed.
- That is precisely why guard 3 is anchored with `^`. Embedded mid-line, the child's "ok" cannot satisfy an anchored match. **Do not remove the `^`.**
- Guard 2 is unanchored and **can** be satisfied by that embedded text, so it alone cannot distinguish a real pass from a parent failure that dumped a successful child's output.

The "none is redundant" claim is also dropped. The guards overlap: a renamed test trips guards 2 **and** 3; a failing test trips `pipefail` **and** guard 3. The defensible statement is that they have **different blind spots**, and `pipefail`'s is the smallest because it is the only one that does not parse text at all. "None is redundant" would not survive the first person who tests it, and when it failed they might strip guards.

## Verification that this is comment-only

Both files parsed with PyYAML and compared structurally:

| Property | Result |
|---|---|
| YAML parses | yes, 8 jobs, same keys and order |
| All jobs other than `rust-regression-linux` | byte-identical |
| Step names in `rust-regression-linux` | identical |
| All non-`run` keys of the changed step | identical |
| **Executable `run` lines, comments stripped** | **identical** |
| Line endings | LF, `CR=0` |

Block digest, blob-read over a fixed-width window: `b27c2ba8...` (2670 B, 49 lines) -> `758e2a9d...` (3713 B, 66 lines). Any frozen artifact carrying the old digest should note the supersession rather than mismatch on a future audit.

## Provenance

Found while independently pulling the #1577 proof line for release reporting: the occurrence count in the real log did not match what the comment predicted. Original block author: `git-npm-expert`, who is also the author of the error.
