### PR TITLE
feat(context): add per-platform {{HOST_PLATFORM_RULES}} block to the global context seed (refs #1605)

### DIFF
--- a/docs/agents/host-platform-rules.md
+++ b/docs/agents/host-platform-rules.md
@@ -1,0 +1,56 @@
+# Host platform rules (`{{HOST_PLATFORM_RULES}}`)
+
+For operators running AgentsCommander. What the per-platform `{{HOST_PLATFORM_RULES}}` block is, where it renders, and how to customize it by editing a plain file — without code changes or a release.
+
+## What it is
+
+`{{HOST_PLATFORM_RULES}}` is the 8th mandatory placeholder of the global default agent template (template version 5), rendered immediately after `{{CLI_CONTEXT}}` in every materialized agent context. Its content is selected by the session's **execution platform**:
+
+| Host OS | Rendered block |
+|---|---|
+| Windows | The Git Bash CLI-routing rule (single source of truth; the `{{INTER_AGENT_MESSAGING}}` section only carries a pointer to it) |
+| Linux / macOS | A minimal note that no platform-specific shell routing rules apply |
+| Container (transport api) session | Nothing — no block, no file read |
+
+The block is mandatory: a preserved personalized template that lacks the token receives the current block through the append fallback, exactly like `{{AGENT_REPOS}}`.
+
+## Where it renders
+
+- **Global template** (`Context.AgentsCommander.md` / `AGENTS.md` / `CLAUDE.md` materializations): between `## CLI executable` and `## Session credentials`.
+- **Root Agent runtime prologue**: as its 10th code-owned block, between the CLI context and session credentials blocks. The root role template (`Context.root-agent.md`) is never rendered through the placeholder machinery; the root gets the block from the prologue.
+- **Coordinator sessions**: through the global render — no coordinator-template change is needed and none exists (the block must not be added to `Context.coordinator.md`, or it would duplicate).
+- **Container sessions**: never.
+
+## The platform files
+
+Each platform's block content is configurable by editing a per-platform file in the **project** `.ac` root:
+
+| File | Platform |
+|---|---|
+| `.ac/Context.platform.windows.md` | Windows host sessions |
+| `.ac/Context.platform.linux.md` | Linux host sessions |
+| `.ac/Context.platform.macos.md` | macOS host sessions |
+
+The file content **is** the rendered block, including its `## Host Platform Rules` heading — whatever you write in the file replaces the whole section verbatim.
+
+The files are **project-level**: they are seeded absent-only into project `.ac` roots (never into the app-config directory), so they can be committed to an infrastructure-as-code repository and reviewed like any other file.
+
+## How the lifecycle works
+
+- **Seeding**: on project open/create/scan, a missing platform file is created byte-equal to the embedded default for that platform (absent-only: a pre-existing file is never overwritten, and an unowned pre-existing file is preserved silently).
+- **Editing**: edits are preserved. The seeded-template state (`.agentscommander-context-templates.json`) records the file in the observed posture (`lastObservedSha256`), and if a future app default differs, the file is offered a pending update instead of being silently overwritten.
+- **Deleting or emptying** a platform file: the render falls back to the embedded default for that platform with a `WARN` line in `app.log`; the next project open re-seeds a deleted file (absent-only).
+- **Versioning**: platform files are versioned in the seeded-template state like the global/coordinator templates (`platform.windows`, `platform.linux`, `platform.macos`, version 1). When a future release changes a platform default, the previous default is frozen as a snapshot and recognized, so seeded files auto-update while edited files stay preserved with the pending-update offer.
+
+## Applying a change
+
+1. Edit `.ac/Context.platform.windows.md` (or `.linux.md` / `.macos.md`) in the project.
+2. Respawn the session — the new text is rendered on the next materialization. **No rebuild, no release.**
+
+The render reads the file on every materialization; there is no cache.
+
+## Notes
+
+- The byte budget that binds the default template applies to the **embedded defaults**; an owner-authored longer file is a deliberate choice and is read without a size cap.
+- Deleting the file between project opens renders the embedded default (identical content to a freshly seeded file) until the next open re-seeds.
+- The Windows block is the single source of truth for the Git Bash routing rule; do not re-add that recipe to the messaging section or any other template.

--- a/plans/1605-host-platform-rules.md
+++ b/plans/1605-host-platform-rules.md
@@ -1,0 +1,363 @@
+# Plan #1605: `{{HOST_PLATFORM_RULES}}` global context block — file-configurable per-platform shell-routing rules, versioned seeding, fallback self-heal
+
+Author: ac-architect-v3, workgroup wg-19-ac-dev-team-v3. Sole editor of this plan per round-1 consensus dispatch (`20260828-004800-wg19-ac-tech-lead-v3-to-wg19-ac-architect-v3-issue1605-round1-plan.md`) as amended by the mandatory owner amendment (`20260828-005300-wg19-ac-tech-lead-v3-to-wg19-ac-architect-v3-issue1605-enmienda-archivo.md`), which elevates spec point 6 (file-configurable platform rules) from "propose as PHASE 2" to a HARD acceptance requirement: the rendered `{{HOST_PLATFORM_RULES}}` content must be changeable by editing a file, without code changes or a release.
+
+Status: READY_FOR_IMPLEMENTATION
+
+Revision: round 2 (2026-08-28 UTC) — amendment of the round-1 plan per `20260828-043000-wg19-ac-tech-lead-v3-to-wg19-ac-architect-v3-issue1605-round2-enmienda.md`, documenting what the implementation actually executed: S4 (`src-tauri/src/config/seed_manifest.rs` scope literals, §6.4), the measured budget values (8262 / 6504 / 8042, §3.7), and the bounded base drift (§1). No D1–D11 decision changes; the round-1 certified digest is invalidated by this amendment. Plan-SHA256 of the certified bytes is reported to the tech-lead in the reply message, never embedded here (a file cannot contain its own hash; see `plans/1446-...` §Certification conventions).
+
+Issue: [mblua/AgentsCommander#1605](https://github.com/mblua/AgentsCommander/issues/1605) (OPEN) — "{{HOST_PLATFORM_RULES}} en seed de contexto global" — owner directive via WG17.
+
+Objective: add an 8th mandatory placeholder `{{HOST_PLATFORM_RULES}}` to the global default agent template (version 4 → 5) immediately after `{{CLI_CONTEXT}}`, rendered per the session's EXECUTION platform (host for backend=local; nothing for container/transport-api sessions). On Windows host sessions the block carries the Git Bash CLI-routing rule (single source of truth; the #1596 paragraph in `{{INTER_AGENT_MESSAGING}}` shrinks to a pointer to it). The block content is configurable per platform through `.ac/Context.platform.<os>.md` files (seeded absent-only, versioned in the seeded-template state, edits preserved, embedded-default fallback with WARN when missing/empty). Coordinator sessions receive the block through the global template render (no coordinator-template change needed). Byte budget `full_wg <= 8_313` and `touched_owners <= 6_810` are preserved with specified wording trims; the 3 manual gates stay green.
+
+---
+
+## 1. Frozen authority and entry gate
+
+Working tree: `repo-AgentsCommander`, branch `feat/1605-host-platform-rules` (created by the tech-lead from `main`). At authoring time (2026-08-28 UTC):
+
+- `git status --porcelain` is empty; local `HEAD` == `origin/main` == `047248bc568d7d5470ed504c6ccf9d572d5cd60a` (verified by `git log origin/main -1`).
+- Codebase Memory gate: `ready` (project `D-0_repos-AgentsCommander_iac-.ac-wg-19-ac-dev-team-v3-repo-AgentsCommander`, 25291 nodes / 136245 edges, index at head `047248bc568d7d5470ed504c6ccf9d572d5cd60a`). Evidence gathered by direct reads of the anchor files below (the budget profile was re-measured by running `token_accounting_report` against the debug build of this exact tree; see §3.7).
+- The plan file is the ONLY file this plan may create; `.gitignore` line 11 ignores `/plans/`, so the implementer MUST force-add it: `git add -f plans/1605-host-platform-rules.md`. Do not remove or weaken the ignore rule.
+
+The implementers must repeat the authority ritual: fetch `origin/main` and stop for current-base review if `origin/main`, the local committed branch head, or their merge base no longer equals the frozen SHA above. If a quoted line number no longer matches the quoted text, re-anchor on the text, never on the number. Target-branch drift after this round that does not touch the selected files (§6) does not reopen the design; it is recorded at the next bounded gate (skill: delivery-nonfunctional-invariants §Bounded target-branch drift).
+
+**Round-2 amendment (2026-08-28 UTC) — bounded base drift registered:** between round 1 and the implementation, `origin/main` advanced `047248bc568d7d5470ed504c6ccf9d572d5cd60a` → `d7008b34` (6 commits, all CI/fmt: the `#1608` rust-fmt gate, the `#1610` dtolnay/rust-toolchain full-SHA pin, the `#1602` cargo-fmt sweep). Registered as a bounded gate per the delivery-nonfunctional-invariants §Bounded target-branch drift rule: the implementer's word/token-diff of the merge is empty (streams identical modulo whitespace/pins), the v4 freeze operand is intact at the merged tree (`get_default_agent_template()` len 539, sha256 `f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a`), and the round-1 certified digest (reported out-of-band, never embedded here) was verified unchanged at implementation start until this amendment. The implementation base is therefore `d7008b34`; §9.1's workflow source-of-truth reference is updated to it. The drift does not reopen the design.
+
+## 2. Task class and threat model
+
+Routine application change: one new context placeholder + renderer branch, three new seeded content files with one state extension (additive map entries, no schema bump), wording trims in four existing context blocks, one doc, and unit tests. No release, no signing, no packaging, no security-boundary change, no migration of stored data, no new binary. Baseline gates apply; **no enhanced controls are applicable** (no hostile-host threat model is claimed; host executables are trusted per the repository contract — GitHub CI is the authoritative host-dependent evidence, §9.1).
+
+## 3. Verified evidence (re-verified at `047248bc`, not predicted)
+
+### 3.1 The v4 global template and render chain (`src-tauri/src/config/session_context.rs`)
+
+1. `get_default_agent_template()` (~:2469) is the v4 template: 7 mandatory placeholders in order `WRITE_RESTRICTIONS`, `DELEGATED_TASK_REPORTING`, `SKILLS_SECTION`, `AGENT_REPOS`, `CLI_CONTEXT`, `SESSION_CREDENTIALS`, `INTER_AGENT_MESSAGING`. Measured from the accessor bytes at this head: **len 539, sha256 `f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a`** (no CRLF; Rust raw literals normalize `\r\n` → `\n`). This is the v4 operand to freeze for the bump (§5.4).
+2. `render_agent_context_template_inner` (~:2555) runs the mandatory-placeholder loop (append-fallback for missing tokens, `MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS` ~:3037) and then the replace chain (~:2647-2657) which fills each placeholder. The new `.replace("{{HOST_PLATFORM_RULES}}", ...)` goes between the `{{CLI_CONTEXT}}` and `{{SESSION_CREDENTIALS}}` replaces. The platform block value must be computed BEFORE the chain (like `agent_repos` at :2612).
+3. The append-fallback machinery: `mandatory_section_heading` (~:3049) maps each placeholder to its unique heading; `mandatory_placeholder_aliases` (~:3085); `mandatory_section_present_inline` (~:3098, line-anchored); `coarse_section_dedup_safe` (~:3138). Test `mandatory_section_heading_map_is_complete_and_collision_free` (~:4989) auto-checks completeness/collisions for whatever the list contains.
+4. `get_default_coordinator_template()` (~:2508) is plain text (no placeholders); the coordinator body is appended AFTER the combined replica context in `resolve_session_context_content_with_activation` (~:2105-2170, `---\n\n# Orchestrator Context\n\n`). Coordinator sessions render the global template through the same `ensure_session_context_with_config` → `resolve_agent_context_with_activation` → `render_agent_context_template` path (replica `config.json` requires `$AGENTSCOMMANDER_CONTEXT`, `replica_identity.rs:8`), so the new block reaches coordinator sessions automatically via the global render. **No coordinator-template change** (§5.2).
+
+### 3.2 Platform discriminator (precedent #935) and the #1596 rule
+
+1. `repo_mounts: Option<&RepoMountResolution>` threads through `render_agent_context_template_inner` and `render_root_runtime_prologue_inner`; `Some` = containerized session (transport api), `None` = host local session (`render_agent_repos_string` ~:1581, #935). The host OS is decided with `cfg!(windows)`/`target_os`, exactly like `WINDOWS_SHELL_ROUTING` (~:3472, empty on non-Windows).
+2. `WINDOWS_SHELL_ROUTING` is injected into `render_inter_agent_messaging_block` (~:3436-3467) as `{windows_shell_routing}`; current bytes (measured): **201 chars** — `"\n\n**Windows:** the release binary is GUI-subsystem; PowerShell direct capture is empty. Run AC CLI invocations via Git Bash (`C:\Program Files\Git\bin\bash.exe`); never `& $bin ... | ConvertFrom-Json`."`. Requirement 5: this becomes a pointer to the platform block (no duplication).
+
+### 3.3 Root prologue (#979 G4) and the preserved root template
+
+1. `render_root_runtime_prologue_inner` (~:3225-3270) assembles **9 direct blocks** (`ROOT_RUNTIME_PROLOGUE_HEADER`, `CORE_CONCEPTS_SECTION`, write_restrictions, `DEFAULT_DELEGATED_TASK_REPORTING`, skills, agent_repos, `DEFAULT_CLI_CONTEXT`, `DEFAULT_SESSION_CREDENTIALS`, inter_agent_messaging). It never passes the placeholder machinery, so a missing platform block cannot be suppressed by an editable file. The platform block becomes the **10th block, between `DEFAULT_CLI_CONTEXT` and `DEFAULT_SESSION_CREDENTIALS`** (mirroring the template order), computed by the same `render_host_platform_rules_block` (§5.5).
+2. `Context.root-agent.md` (`ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME`, `root_spec` v7, `project_actionable: false`) is the root ROLE template — preserved by the daemon, never rendered through the placeholder machinery, and NOT part of the runtime prologue. It is untouched by this plan; the acceptance "probar con `Context.root-agent.md`" is realized as a self-heal unit test using a personalized-template fixture with root-agent-shaped content (§8.1, T-6).
+
+### 3.4 Seeded-template state and specs (`src-tauri/src/config/seeded_context_templates.rs`)
+
+1. `SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME` = `.agentscommander-context-templates.json`; `STATE_SCHEMA_VERSION = 1`; `SeededContextTemplateState { schema_version, templates: BTreeMap<String, SeededContextTemplateEntry> }`; `SeededContextTemplateEntry { template_id, current_version, last_seeded_sha256, last_observed_sha256, ignored_default_sha256, ignored_observed_sha256 }` (~:147-175). `SeededContextTemplateSpec` (~:177) drives everything: id, filename, label, current_version, current_content: fn() -> &'static str, is_known_generated, project_actionable, suppress_unknown_without_state.
+2. `project_specs()` (~:477) currently returns `[global(v4), coordinator(v5)]`; `root_spec()` (~:505) is the separate non-actionable root template. `is_known_generated_global_template` (~:535) recognizes current + frozen v1/v2/v3; `is_known_generated_standalone_global_template` (~:553) additionally recognizes the 307-byte #979 standalone snapshot; `is_known_generated_coordinator_template` (~:561) recognizes current + 4 frozen coordinator generations.
+3. `sync_one_template` (~:1000-1170) implements the full lifecycle reused here: create-missing absent-only (`write_template_if_missing`, hard-link publish); byte-equal-default → `mark_seeded`; seeded + known-generated + default-changed → `auto_update_generated_template`; customized → preserved + `mark_observed` (+ pending update in scan mode, or the WARN "a newer default is available"); stateless unknown → `suppress_unknown_without_state` (AmbiguousWithoutState) or preserved.
+4. Seed call sites: `ensure_project_context_templates_with_clock` (~:1314, project open/create/scan, `allow_create_missing: true`) and `scan_project_context_template_updates_with_clock` (~:1363, read-only). `sync_project_context_template_for_read` (~:1419) is per-filename; `read_or_create_context_template_with_sync` (`session_context.rs` ~:1199) invokes it only for the two `is_managed_project_template` filenames (global, coordinator). **Platform files are deliberately NOT read-time-synced** (§5.6) — the render reads them directly.
+5. Seed-manifest scope mapping: `manifest_scope_for_project_context_filename` (`session_context.rs` ~:29) maps global→`context:agentscommander`, coordinator→`context:coordinator`, else `None` (no row). Platform publications need a scope (§5.7).
+6. Standalone retirement (`retire_standalone_global_context`, ~:1478) and `remove_global_state_entry` (~:1709) operate ONLY on the app-config directory and the standalone global name; platform files live only in project `.ac` roots and are never retired or clobbered by it (§5.8).
+
+### 3.5 Version-pin and assumption tests that the bump must update
+
+- `project_specs_bump_only_the_global_template_to_v4` (~:2059) destructures `let [global, coordinator] = project_specs();` — **will not compile** with 5 specs; must be rewritten.
+- Six tests assert `templates["global"]["currentVersion"] == 4` (~:2471, :2569, :2628, :2847, :2905, :2973) → 5.
+- Byte-exact pins: `global_pre_token_minimization_snapshot_is_byte_exact` (:2406), `global_pre_agent_repos_snapshot_is_byte_exact` (:2481), `global_before_summarization_snapshot_is_byte_exact` (:2495) model the new v4 pin.
+- `read_sync_updates_pre_token_minimization_global_template` (:2414) is the failing-first template for the v4→v5 upgrade proof (auto-upgrade a pristine v4 on disk + state currentVersion + both recognizers).
+- `context_create_records_both_project_templates_under_the_gate` (~:2140) asserts manifest scopes (`context:agentscommander`, `context:coordinator`) — platform files add `context:platform` rows; the test's `contains` asserts still pass, but the name/comment must be updated.
+- `create_default_context_templates_does_not_create_root_template` (`root_agent.rs` ~:2963) asserts global + coordinator exist and no root template — passes with platform files present.
+- Legacy classification (`classify_legacy_rendered_default_context` ~:4033): the LEGACY compat renderer is frozen and untouched; baked v4 renders already classify as NotLegacy (they contain `# Agent Repos`), so the bump needs no legacy-renderer change. The append-fallback covers baked templates (they lack the new heading).
+
+### 3.6 Byte budget — measured on this tree (Windows debug build, `token_accounting_report`, `--ignored --nocapture`)
+
+Measured at `047248bc` (same machine shape as the CI windows `rust-regression` job):
+
+| item | chars |
+|---|---|
+| write restrictions (A2, replica) | 3475 |
+| inter-agent messaging (A3, replica, incl. 201-byte Windows paragraph) | 2103 |
+| CLI context (A4a) | 726 |
+| session credentials (A4b) | 257 |
+| delegated task reporting (A4c) | 205 |
+| **profile: WG replica (`full_wg`)** | **8245** |
+| profile: Root Agent | 14074 |
+
+Budget constants in `summarized_default_context_meets_size_budget` (~:10346): `MAX_FULL_WG_PROFILE_BYTES = 8_313`, `V3_FULL_WG_PROFILE_BYTES = 9_070`, `REQUIRED_REDUCTION_BYTES = 757`, `MAX_TOUCHED_OWNERS_BYTES = 6_810` (5 "touched owner" blocks), `V3_TOUCHED_OWNERS_BYTES = 7_567`. Current slack: full_wg 68, touched_owners 44 (6766). The fixture is deterministic per CI OS: `default_context(FAKE_REPLICA_ROOT, ...)` renders with `repo_mounts=None` and a fake root with no `.ac` ancestor → the platform block comes from the embedded default for the build's OS (§5.9). The budget test itself reads NO platform file.
+
+### 3.7 Budget arithmetic for the final texts (§5.10) — exact, script-counted
+
+- Current Windows paragraph (removed from messaging): 201 chars.
+- New pointer in messaging: `"\n\n**Windows:** see **Host Platform Rules** above."` = 49 chars (Windows builds only).
+- Windows platform default: **277 chars** (exact text §5.10, sha256 `5fd5dd5f7d3d097f90e58cee6e6a210e2b2a6070c24e4164a7ac06d3854286a7`).
+- Linux/macOS platform defaults: **106 chars** each (sha256 `848e6bd25a001b091dd419fb665d2114abc5e5c2a19429fc820144aaa6190790` / `a305af4fce8148ac80d8e197b02142738a6056959e9b72bee43689b3d01cdc4d`).
+- Compensating wording trims (exact before/after in §5.10): total **110 chars** (wait 15, help 7, invoke 12, auth 19, peer-format 13, recipient 44).
+- Round-1 expectation (superseded by the measured values below): Windows `full_wg` = 8245 − 201 + 49 + 277 − 110 = 8260; Linux/macOS `full_wg` = 8245 − 201 + 106 = 8150; `touched_owners` = 6766 − 110 = 6656. The round-1 arithmetic omitted (a) the `\n\n` blank-line separators around the new block (+2) on every OS, (b) the −110 trims on Linux/macOS (they apply on every OS), and (c) the −201 + 49 Windows-paragraph swap in the touched-owners sum.
+- **Measured (round 2 — implementation executed, protocol §5.10 verbatim; re-verified first-party by running `token_accounting_report` + the budget test at the amended head, Windows debug build, same fixture as §3.6)**: Windows `full_wg` = 8245 − 201 + 49 + 277 + 2 − 110 = **8262** (slack 51 ≤ 8313; reduction 9070−8262 = 808 ≥ 757). Linux/macOS `full_wg` = 8245 − 201 + 106 + 2 − 110 = **8042** (slack 271). `touched_owners` = 6766 − 201 + 49 − 110 = **6504** ≤ 6810 (slack 306; reduction 7567−6504 = 1063 ≥ 757).
+- The fixture is deterministic: the budget test's fake roots resolve no `.ac`, so the render falls back to the embedded default (per-OS const); Windows is the binding case on the CI windows job, and the linux/macos jobs are strictly smaller. No budget constant changes.
+
+## 4. Root cause / requirement statement
+
+Today the Windows Git Bash routing rule exists only as a 201-byte paragraph inside `{{INTER_AGENT_MESSAGING}}` (#1596), hardcoded and not present on non-Windows messaging (where it is correctly absent). The owner requires: (a) a dedicated, mandatory, per-EXECUTION-platform block `{{HOST_PLATFORM_RULES}}` right after `{{CLI_CONTEXT}}` in the global template (v4→v5) — Windows host sessions get the Git Bash rule (bash.exe for shell work and every AC CLI invocation; PowerShell wrap `& 'C:\Program Files\Git\bin\bash.exe' -lc '...'`; never capture CLI output without `2>&1 | Out-String`), Linux/macOS host sessions get a minimal note, container sessions get nothing; (b) mandatory self-heal for preserved personalized templates lacking the token (append fallback, same as `{{AGENT_REPOS}}`); (c) NO duplication with the #1596 rule — the messaging section points at the platform block; (d) the byte budget measured and respected; (e) the block's content configurable by editing `.ac/Context.platform.<os>.md` (seeded absent-only, versioned in the seeded-template state, edited content preserved, missing/empty → embedded default + WARN, never an empty section on Windows); (f) docs in `docs/agents/`. The file lives in `.ac/` so the IaC repo can track it.
+
+## 5. Design decisions (decision-complete; no TBD)
+
+### 5.1 D1 — The placeholder, version bump, and freeze
+
+- Add `{{HOST_PLATFORM_RULES}}` to `get_default_agent_template()` between `{{CLI_CONTEXT}}` and `{{SESSION_CREDENTIALS}}` (blank-line separated, exactly like the other tokens): v4 → **v5**. v5 draft bytes (informative): len 564.
+- Freeze the CURRENT v4 accessor bytes as `GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES` with provenance doc (len 539, sha256 `f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a` at 047248bc) and a new byte-exact pin test (`global_before_host_platform_rules_snapshot_is_byte_exact`), mirroring the v3 pin. Never edit the frozen const.
+- Add the v4 snapshot to BOTH `is_known_generated_global_template` and `is_known_generated_standalone_global_template` (a pristine v4 project template must auto-upgrade; a pristine v4 standalone template must stay recognizable for retirement).
+- `project_specs()` global `current_version` 4 → 5. Coordinator stays 5, unchanged.
+
+### 5.2 D2 — Coordinator: no template change
+
+The coordinator body (`Context.coordinator.md`, plain text) is appended after the rendered global, and coordinator sessions render the global template (evidence §3.1.4). The block therefore reaches coordinator sessions through the global render. Adding the block to the coordinator body too would duplicate it. **No `get_default_coordinator_template()` change, no coordinator snapshot, no coordinator version bump.** The plan's test T-9 asserts a coordinator-shaped session profile contains the block exactly once.
+
+### 5.3 D3 — Platform-file mechanism (owner amendment, hard requirement)
+
+- Three new managed project templates, reusing `SeededContextTemplateSpec` and the whole `sync_one_template` lifecycle (absent-only seed, seeded/observed state, edit preservation, pending-update offer, auto-update of seeded files when a future default ships):
+
+| id | filename | label | current_version | current_content | is_known_generated |
+|---|---|---|---|---|---|
+| `platform.windows` | `Context.platform.windows.md` | Windows host platform rules | 1 | `DEFAULT_HOST_PLATFORM_RULES_WINDOWS` | equality with the current default |
+| `platform.linux` | `Context.platform.linux.md` | Linux host platform rules | 1 | `DEFAULT_HOST_PLATFORM_RULES_LINUX` | equality with the current default |
+| `platform.macos` | `Context.platform.macos.md` | macOS host platform rules | 1 | `DEFAULT_HOST_PLATFORM_RULES_MACOS` | equality with the current default |
+
+  All three specs: `project_actionable: true`, `suppress_unknown_without_state: true` (a pre-existing unowned file is preserved silently, never prompted — same posture as the global template). `project_specs()` returns the 5-element array (order: global, coordinator, then the three platform specs). `current_content` uses non-capturing closures (`|| DEFAULT_HOST_PLATFORM_RULES_WINDOWS`), which coerce to `fn() -> &'static str`.
+- Defaults live as `pub(crate) const` in `session_context.rs` (single source for seed + render fallback), plus filename consts `HOST_PLATFORM_RULES_FILENAME_WINDOWS/LINUX/MACOS = "Context.platform.windows.md" / "Context.platform.linux.md" / "Context.platform.macos.md"` next to `COORDINATOR_CONTEXT_TEMPLATE_FILENAME`.
+- When a future release changes a platform default, freeze the previous default as a snapshot const and extend its recognizer (exact same pattern as the global template generations), so seeded files auto-update and edited files are preserved with the pending-update offer. Documented in `docs/agents/host-platform-rules.md` (§6.8) and in the const provenance doc. Version 1 needs no snapshot.
+
+### 5.4 D4 — State: reuse, no schema bump
+
+The three platform entries are additive keys in the existing `templates` map of `.agentscommander-context-templates.json` (`STATE_SCHEMA_VERSION` stays 1; `SeededContextTemplateEntry` is unchanged). Forward/backward compatibility: an older build parses the new state file losslessly (same entry struct; map round-trips), a newer build reading an older state creates the entries on first `entry_mut`. No migration, no new state file, no new mechanism.
+
+### 5.5 D5 — Render: read per materialization, no cache
+
+New helper in `session_context.rs`:
+
+```rust
+fn render_host_platform_rules_block(agent_root: &str,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>) -> String
+```
+
+- `repo_mounts.is_some()` → return `String::new()` (container session: no host platform rules, no file read — the file is never mounted or injected for containers; the discriminator IS the execution platform).
+- Host session: pick the filename by `cfg!(target_os)` (windows/linux/macos); resolve the project `.ac` via `resolve_ac_root_context_dir(Path::new(agent_root))` and read through `read_context_template` (regular-file + UTF-8 validated, symlink/reparse rejected, **no size cap** — the file is owner-authored content in their own repo; a cap would silently drop their bytes, worse than a large context; the byte budget binds the DEFAULTS, and an oversized custom file is the owner's deliberate choice).
+- `Ok(Some(content))` and `!content.trim().is_empty()` → the file content verbatim (no cache: every materialization re-reads, so edit → respawn → new text without rebuild).
+- Missing, empty, invalid UTF-8, non-regular file, or unresolvable `.ac` → `log::warn!` + embedded default for the build's OS; never an empty section on Windows.
+- Called from `render_agent_context_template_inner` (value computed before the replace chain; `.replace("{{HOST_PLATFORM_RULES}}", &platform_rules)` after the `{{CLI_CONTEXT}}` replace) and from `render_root_runtime_prologue_inner` as the 10th block between `DEFAULT_CLI_CONTEXT` and `DEFAULT_SESSION_CREDENTIALS` (the existing `if block.is_empty() { continue; }` naturally drops it for container roots). Update the "Nine blocks (#979 G4)" comment to ten blocks.
+- `MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS`: insert `"{{HOST_PLATFORM_RULES}}"` after `"{{CLI_CONTEXT}}"`. `mandatory_section_heading("{{HOST_PLATFORM_RULES}}") = "## Host Platform Rules"` (the file content includes the heading — the file IS the block, per the owner's "su contenido es lo que se rinde"). `mandatory_placeholder_aliases`: none. `coarse_section_dedup_safe("{{HOST_PLATFORM_RULES}}") = false` — never dedup an inline copy: the block is platform- and file-dependent, so an inline baked copy can be stale or platform-wrong; appending the current block is the safe side (mirrors `SKILLS_SECTION`/`AGENT_REPOS`). No existing template generation carries the heading, so no real-world duplication can occur.
+
+### 5.6 D6 — Seed timing: project open/create/scan only, never read-time
+
+Platform files are seeded by the existing `ensure_project_context_templates_with_clock` (project registration/create and project open) and scanned by `scan_project_context_template_updates_with_clock` (UI "newer default available" flow) — automatically, because they join `project_specs()`. They are deliberately NOT in the `is_managed_project_template` read-time-sync set and NOT synced by `sync_project_context_template_for_read`: the acceptance criterion "delete the file and respawn → embedded default + WARN" requires the render to observe the deletion, not to silently re-seed before reading. The next project open re-seeds a deleted file (absent-only). Standalone (app-config) seeding does NOT include platform files — they are project-level by design.
+
+### 5.7 D7 — Seed-manifest scope
+
+`manifest_scope_for_project_context_filename` gains a branch: the three platform filenames → `"context:platform"`. Platform seed publications are recorded under the held project gate like the other templates (fail-soft no-op on degraded permit, unchanged).
+
+### 5.8 D8 — Retirement/auto-update interaction
+
+`retire_standalone_global_context` and `remove_global_state_entry` touch only the standalone app-config global; platform files (project `.ac` only) are never retired, backed up, or clobbered by it. `is_known_generated_standalone_global_template` grows ONLY the v4 global snapshot (§5.1), never platform content. Platform recognizers are per-file equality with their current default (+ frozen snapshots added on future default changes, §5.3).
+
+### 5.9 D9 — Budget fixture determinism
+
+The budget test computes `full_wg` from `default_context(FAKE_REPLICA_ROOT, ...)` with `repo_mounts=None` and fake roots that have no `.ac` ancestor → the platform block comes from the embedded default of the build OS (Windows: 277; Linux/macOS: 106). The test needs NO fixture file and stays platform-deterministic per CI job; Windows is the binding case. The test adds one assertion: `full_wg.contains("## Host Platform Rules")` (all OSes — linux/macos render their minimal block too). `token_accounting_report` gains two rows ("block: host platform rules (Windows default)" / "(linux/macos default)"). Budget constants are untouched.
+
+### 5.10 D10 — Exact texts and trims (byte-counted; apply verbatim)
+
+**Platform defaults (embedded consts AND seeded file contents):**
+
+Windows (277 bytes):
+```
+## Host Platform Rules
+
+Windows host session: use `C:\Program Files\Git\bin\bash.exe` for all shell work and every AgentsCommander CLI invocation; from PowerShell wrap with `& 'C:\Program Files\Git\bin\bash.exe' -lc '...'`; never capture CLI output without `2>&1 | Out-String`.
+```
+
+Linux (106 bytes): `## Host Platform Rules` + blank line + `This session runs on a Linux host; no platform-specific shell routing rules apply.`
+macOS (106 bytes): same with `macOS`.
+
+**Messaging pointer (replaces `WINDOWS_SHELL_ROUTING`, cfg(windows), 49 bytes):** `\n\n**Windows:** see **Host Platform Rules** above.` — non-Windows stays `""`. Update the const's doc comment from #1596 to #1605 (single source of truth moved to the platform block). The pointer is the only Windows text left in messaging.
+
+**Compensating trims (exact before → after, savings in parentheses):**
+
+1. Messaging: `After sending, wait for the reply.` → `Wait for the reply.` (15)
+2. `DEFAULT_CLI_CONTEXT`: `Use `--help` only for commands or flags not documented here:` → `Use `--help` only for undocumented commands or flags:` (7)
+3. `DEFAULT_CLI_CONTEXT`: `Invoke only `AGENTSCOMMANDER_BINARY_PATH`; never hardcode or guess another executable.` → `Invoke only `AGENTSCOMMANDER_BINARY_PATH`; never guess another executable.` (12)
+4. `DEFAULT_CLI_CONTEXT`: `The Inter-Agent Messaging section is authoritative for sending and peer discovery.` → `The Inter-Agent Messaging section is authoritative for sending.` (19)
+5. Messaging peer-name-format line: `**Peer name format** (canonical FQN, the `list-peers-lean` `name` field):` → `**Peer name format** (canonical FQN from `list-peers-lean`):` (13)
+6. Messaging: `The recipient reads the notified file path. ` → `` (44; the following `Do NOT use `--get-output` ...` sentence remains)
+
+All six are wording-level; no instruction is deleted (the `--get-output` prohibition, the receipt rule, the FQN guidance, and the `--help`/invocation rules all stay). Verified: no unit test asserts any trimmed string (the asserted strings in `default_context_documents_env_only_credentials`, `default_context_documents_delegated_task_reporting`, `default_context_embeds_send_receipt_rule`, `default_context_embeds_filename_only_warning`, `default_context_documents_incoming_inter_agent_processing`, `default_context_embeds_fqn_format_and_filesystem_warning`, and the budget test's `for required in [...]` list are all untouched).
+
+Round-1 expectation (superseded): `full_wg` = 8260 (slack 53), `touched_owners` = 6656 (slack 154, reduction 911), Linux/macOS `full_wg` = 8150 — the round-1 arithmetic omitted the `\n\n` separators and the touched-owners Windows swap (§3.7). **Measured post-change values (round 2, Windows debug build, same fixture as §3.6): `full_wg` = 8262 (slack 51), `touched_owners` = 6504 (slack 306, reduction 1063), Linux/macOS `full_wg` = 8042 (slack 271).** Protocol executed: the six trims applied verbatim, budget constants untouched, ceilings respected. If any future re-measurement differs by more than a couple of bytes, apply only the trims above verbatim, re-measure, and report the measured value with the discrepancy — do NOT change the budget constants; if the ceiling is still exceeded after the verbatim trims, stop and report to the tech-lead.
+
+### 5.11 D11 — Doc and out-of-repo split
+
+| Change | Location | Owner |
+|---|---|---|
+| Template, renderer, platform defaults/filenames, trims | `src-tauri/src/config/session_context.rs` | implementer (this PR) |
+| Platform specs, state, recognizers, v4 freeze, sync coverage | `src-tauri/src/config/seeded_context_templates.rs` | implementer (this PR) |
+| Manifest scope | `src-tauri/src/config/session_context.rs` | implementer (this PR) |
+| Seed-manifest scope literals (round-2 S4) | `src-tauri/src/config/seed_manifest.rs` | implementer (this PR) |
+| Operator doc | `docs/agents/host-platform-rules.md` (new) | implementer (this PR) |
+| Seed/reseed platform files into existing projects, optional IaC commit of `.ac/Context.platform.*.md` | harness (outside repo) | tech-lead (harness operator), after release, per §7 |
+
+## 6. In-repo change plan (file-by-file)
+
+### 6.1 S1 — `src-tauri/src/config/session_context.rs`
+
+(a) `get_default_agent_template()`: insert `{{HOST_PLATFORM_RULES}}` between `{{CLI_CONTEXT}}` and `{{SESSION_CREDENTIALS}}` (blank lines around it, like the other tokens).
+(b) New pub(crate) consts: `HOST_PLATFORM_RULES_FILENAME_WINDOWS/LINUX/MACOS`, `DEFAULT_HOST_PLATFORM_RULES_WINDOWS/LINUX/MACOS` (§5.10 texts), `WINDOWS_SHELL_ROUTING` → the §5.10 pointer (cfg(windows); `""` otherwise) with an updated #1605 doc comment.
+(c) New `fn render_host_platform_rules_block(agent_root, repo_mounts) -> String` (§5.5) + `fn host_platform_rules_filename()` / `host_platform_rules_default()` helpers (cfg-selected).
+(d) `render_agent_context_template_inner`: add the platform block to the mandatory loop set via `MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS` (after `{{CLI_CONTEXT}}`), `mandatory_section_heading` (`"## Host Platform Rules"`), `coarse_section_dedup_safe` (false); compute `let host_platform_rules = render_host_platform_rules_block(agent_root, repo_mounts);` before the chain and add `.replace("{{HOST_PLATFORM_RULES}}", &host_platform_rules)` after the CLI_CONTEXT replace.
+(e) `render_root_runtime_prologue_inner`: compute the block and add it as the 10th element between `DEFAULT_CLI_CONTEXT` and `DEFAULT_SESSION_CREDENTIALS`; update the "Nine blocks" comment to ten.
+(f) Apply the six §5.10 trims to `render_inter_agent_messaging_block`, `default_context_dynamic_values` (peer-name-format line), and `DEFAULT_CLI_CONTEXT`.
+(g) `manifest_scope_for_project_context_filename`: add the three platform filenames → `"context:platform"`.
+(h) Tests (with the module): T-1..T-10, updates listed in §8.1.
+
+### 6.2 S2 — `src-tauri/src/config/seeded_context_templates.rs`
+
+(a) New `GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES` (exact v4 accessor bytes) with provenance doc (len 539, sha256 `f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a` at 047248bc); extend `is_known_generated_global_template` and `is_known_generated_standalone_global_template` with it.
+(b) New `platform_specs()` returning the three `SeededContextTemplateSpec`s (§5.3); `project_specs()` returns 5 (global v5, coordinator v5, platform v1 each) — order: global, coordinator, windows, linux, macos.
+(c) New recognizers `is_known_generated_platform_windows/linux/macos` (equality with the corresponding current default const).
+(d) Tests: T-11..T-15 + the updates in §8.1 (version-pin tests 4→5, destructure test rewrite, v4 pin test, recognizer asserts, manifest scope assert).
+
+### 6.3 S3 — `docs/agents/host-platform-rules.md` (new)
+
+Content: what `{{HOST_PLATFORM_RULES}}` is and where it renders (global template after `{{CLI_CONTEXT}}`, root prologue, coordinator sessions via the global render; never in container sessions); the three files `.ac/Context.platform.windows.md` / `.linux.md` / `.macos.md` (path, format — the file content IS the rendered block including its `## Host Platform Rules` heading; absent-only seeding; edits preserved; deleting or emptying a file falls back to the embedded default with a WARN in app.log; how a new app default interacts with seeded vs edited files via `.agentscommander-context-templates.json`); how to apply a change (edit the file, respawn the session — no rebuild); and the note that the files are project-level and can be committed to the IaC repo.
+
+### 6.4 S4 — `src-tauri/src/config/seed_manifest.rs` (round-2 amendment; executed in commit B, +7 lines, 0 deletions)
+
+`validate_row` (~:1268) holds a CLOSED path→scope map — only `.ac/Context.AgentsCommander.md` and `.ac/Context.coordinator.md` — so the `context:platform` rows that D7 (§5.7) requires were rejected and the platform seed publications were dropped fail-soft; the test this plan itself mandates to update (§8.1, assert `scope = "context:platform"`) would fail without the change. The change: in the `ProjectContextTemplate` branch of `validate_row`, the three literals `.ac/Context.platform.windows.md` / `.ac/Context.platform.linux.md` / `.ac/Context.platform.macos.md` → `"context:platform"`, with a comment mirroring `manifest_scope_for_project_context_filename` (session_context.rs); the literals are deliberate — referencing `session_context` from `seed_manifest` would create a new module arc. Verified: 7 insertions, 0 deletions; Gate 1 re-run green at the implemented head (`cyclicSccs` identical set-to-set, `module-arcs.txt` byte-identical; §10).
+
+### 6.5 No changes to
+
+`cli/*`, `config_seed.rs`, `docs/agents/inter-agent-messaging.md`, workflows, `Cargo.*`, `package.json`, smoke scripts, the standalone retirement machinery, or any budget constant.
+
+## 7. Out-of-repo handoff checklist (owner: ac-tech-lead-v3 as harness operator; NOT implementable in this PR)
+
+1. After the release binary ships, existing projects re-seed `.ac/Context.platform.{windows,linux,macos}.md` absent-only at the next project open (automatic). For the IaC-tracked project (e.g. `D:\0_repos\AgentsCommander_iac`), optionally commit the three seeded files so the owner can edit them in-repo from day one.
+2. Verify on this machine: edit `.ac/Context.platform.windows.md` in the IaC project, respawn a Windows replica, confirm the materialized `CLAUDE.md`/`AGENTS.md` carries the edited text; delete the file, respawn, confirm the embedded default appears and app.log records the WARN; container sessions (transport api) confirm no `Host Platform Rules` section.
+3. No role-template or seed-template changes are needed (the block is rendered by the app, not by harness templates).
+
+## 8. Tests and acceptance evidence
+
+### 8.1 Unit/CI tests (implementer-run; exact-head CI is authoritative per §9.1)
+
+New (session_context.rs):
+- T-1 `default_context_embeds_host_platform_rules_block` (`#[cfg(windows)]`): `default_context("C:/fake/wg-7-dev-team/__agent_architect", None, &no_skill_section())` contains `## Host Platform Rules`, `bash.exe`, `2>&1 | Out-String`, and the `**Windows:** see **Host Platform Rules**` pointer.
+- T-2 `default_context_non_windows_embeds_minimal_platform_block` (`#[cfg(not(windows))]`): contains `## Host Platform Rules` and NOT `bash.exe`/`2>&1 | Out-String`.
+- T-3 `container_session_omits_host_platform_rules_block`: `render_agent_context_template_inner(v5 template, fake root, ..., Some(&RepoMountResolution::default()), false)` → `!out.contains("Host Platform Rules")` and no raw `{{` (uses the `RepoMountResolution::default()` empty-resolution fixture; `render_agent_repos_containerized` already handles empty entries).
+- T-4 `root_prologue_embeds_host_platform_rules_block` (`#[cfg(windows)]`): `render_root_runtime_prologue_inner(FAKE_ROOT_AGENT, ..., None, None, true)` contains the Windows default text; T-5 container-root variant omits it.
+- T-6 `personalized_template_without_host_platform_rules_token_appends_fallback`: a personalized template fixture WITHOUT the token (including a root-agent-shaped fixture per the owner's `Context.root-agent.md` probe) renders with exactly one `## Host Platform Rules` section (assert count 1 + no `{{`), mirroring the `{{AGENT_REPOS}}` fallback tests; also `custom_agent_template_is_used_for_wg_replica`-shaped coverage for the both-tokens pathological case (token present → single block).
+- T-7 `host_platform_rules_reads_project_file_each_materialization` (all OSes): temp `Proj/.ac/wg-1-team/__agent_dev` layout; write `Context.platform.<os>.md` with custom text → render contains it; rewrite with different text → render again → new text (proves per-materialization read, no rebuild, no cache).
+- T-8 `host_platform_rules_missing_or_empty_file_falls_back_to_embedded_default`: same layout, file absent → embedded default; file present but empty → embedded default.
+- T-9 `coordinator_session_profile_embeds_host_platform_rules_once`: coordinator-shaped profile (replica + `# Orchestrator Context` + coordinator body) contains exactly one `## Host Platform Rules`.
+- T-10 `assert_mandatory_sections_once` + `assert_no_raw_template_placeholders`-based fixtures: extend `assert_mandatory_sections_once` with `## Host Platform Rules` count 1; the existing "no unexpanded placeholders" and heading-count tests now cover the 8-token render automatically.
+- `default_context_embeds_windows_shell_routing_paragraph` (existing, Windows): update assertions to the pointer + platform block (`**Windows:**`, `Host Platform Rules`, `bash.exe`, `2>&1 | Out-String` — drop the obsolete `ConvertFrom-Json` assert).
+- `token_accounting_report` (`#[ignore]`): add the two platform-block rows.
+
+New (seeded_context_templates.rs):
+- T-11 `global_before_host_platform_rules_snapshot_is_byte_exact`: len 539 + sha256 `f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a`; and `assert_ne!` vs the v5 accessor; both recognizers accept the frozen v4 bytes; the project recognizer rejects a platform default (no widening).
+- T-12 `read_sync_updates_pre_host_platform_rules_global_template` (failing-first, modeled on `read_sync_updates_pre_token_minimization_global_template`): pristine v4 template on disk → read-sync auto-upgrades to v5; state `currentVersion == 5`; one publication.
+- T-13 `ensure_project_context_templates_seeds_platform_files_absent_only`: fresh `.ac` → three platform files byte-equal to their defaults; state entries `platform.windows/linux/macos` with `lastSeededSha256 == default sha`; a pre-existing custom platform file is NOT overwritten (absent-only) and lands in the observed/ignored posture.
+- T-14 `platform_file_edit_is_preserved_and_observed`: seed → edit the file → `sync_one_template`/read-sync → content unchanged, state `lastObservedSha256` updated; a later default change would produce a pending update (scan path), never a silent overwrite.
+- T-15 `project_specs_bump_global_to_v5_and_add_platform_specs` (rewrite of `project_specs_bump_only_the_global_template_to_v4`, which cannot compile with 5 specs): global v5, coordinator v5, three platform specs v1 with correct filenames/labels/recognizers.
+- Update the six `currentVersion == 4` assertions to 5; update `context_create_records_both_project_templates_under_the_gate` name/comment + assert `scope = "context:platform"` (executed: renamed `context_create_records_project_templates_under_the_gate`, scope assert present and green; the S4 literal in `seed_manifest.rs` is what makes that assert pass, §6.4).
+
+### 8.2 Acceptance criteria (owner + spec; objective)
+
+1. Windows-rendered `CLAUDE.md`/`AGENTS.md` contains the platform block for claude, codex, and pi sessions; container sessions (transport api) do NOT contain it (T-3, T-1, T-2).
+2. Personalized preserved templates without the placeholder receive the fallback block (T-6, incl. the `Context.root-agent.md`-shaped probe).
+3. Editing `.ac/Context.platform.windows.md` and respawning a replica renders the edited text WITHOUT rebuild (T-7); deleting the file and respawning renders the embedded default with a WARN in app.log (T-8).
+4. Seeded absent-only + edit preservation + versioned state (T-13, T-14); no duplication with the `{{INTER_AGENT_MESSAGING}}` rule (pointer only).
+5. Byte budget measured (round 2): Windows `full_wg` = 8262 ≤ 8313 (slack 51), `touched_owners` = 6504 ≤ 6810 (slack 306), Linux/macOS `full_wg` = 8042 ≤ 8313 (slack 271) — budget test green, constants untouched, reductions 808/1063 ≥ 757 (§3.7).
+6. The 3 manual gates, run by dev/grinch and reported in implementation/review:
+   - rust levelization: no new SCC (arc record byte-identical, criterion §10);
+   - layering guards (e.g. `loops_layering`, `instance_gitignore_layering`) green;
+   - `check:frontend-dependencies` = 0.
+
+### 8.3 Manual behavioral verification (implementer, on this machine, release binary)
+
+1. Edit the IaC project's `.ac/Context.platform.windows.md` (e.g. append a line), respawn a replica, inspect the materialized `AGENTS.md`/`CLAUDE.md` → edited text present, no rebuild.
+2. Delete the file, respawn → embedded default present; `app.log` contains the WARN line.
+3. Container session (transport api): spawned context contains no `## Host Platform Rules` section.
+
+### 8.4 Final Git/diff evidence (implementer, before PR) — round-2 amended path set
+
+- `git status --porcelain` shows ONLY: the plan file (staged with `-f`), `src-tauri/src/config/session_context.rs`, `src-tauri/src/config/seeded_context_templates.rs`, `src-tauri/src/config/seed_manifest.rs` (round-2 addition, §6.4), `docs/agents/host-platform-rules.md`. Real state at round-2 verification (`d7008b34..HEAD`): `A plans/1605-host-platform-rules.md` staged + the three `.rs` modified + the new doc — nothing else.
+- `git diff` is limited to the anchors in §6 (no budget constants, no state schema version, no `Cargo.*`, no workflow changes).
+- Plan file force-added: `git add -f plans/1605-host-platform-rules.md`.
+
+## 9. Delivery gates (baseline; evidence owner per gate)
+
+Task class: routine (§2). No enhanced controls apply — recorded per the delivery-nonfunctional-invariants skill; host-tool provenance, signed-release, and hostile-host attestations are out of the accepted threat model and are NOT gates.
+
+### 9.1 CI-to-plan parity
+
+Source of truth: `.github/workflows/pr-regression-gates.yml` at `d7008b34` (the drifted base, §1; jobs: `test-debt`, `rust-regression` (windows: cargo check/clippy/`cargo test --lib --bins --tests`), `rust-regression-linux`, `rust-regression-macos`, `rust-fmt` (`cargo fmt --all -- --check`, added by #1608 in the drift), `terminal-snapshot-portable`, `windows-release-cli-smoke`, `frontend-regression`). The diff touches Rust (all three OS jobs exercise the platform-conditional render) + docs. Every triggered and configured-required check must pass on the exact PR-head SHA; evidence from another SHA, an unexplained skip, or a waiver does not satisfy the gate. `rust-regression` windows is the authoritative run for the binding budget case (full_wg 8262) and the `#[cfg(windows)]` tests; linux/macos jobs verify `full_wg` 8042 and the non-Windows defaults; `rust-fmt` verifies `cargo fmt --all -- --check` (exit 0 locally). Failure behavior: any red required check blocks delivery.
+
+### 9.2 Deterministic toolchain and build
+
+Repository contract: `Cargo.lock` committed; `npm ci` pinned (`npm@11.6.2`); stable toolchain via `dtolnay/rust-toolchain@stable`. Local: `--locked` for all cargo commands; record `rustc --version`/`cargo --version` in the PR. Expected: resolution from the lockfile; the platform blocks are compile-time consts, so builds are byte-deterministic per OS. Failure behavior: resolution/build errors block.
+
+### 9.3 Authorized, traceable Git
+
+Issue #1605 OPEN; branch `feat/1605-host-platform-rules` created from `main` @ `047248bc` (verified §1). State-changing Git runs only inside `repo-AgentsCommander`; delivery via PR, never direct push to `main`. Plan file force-added (§1). Preconditions: clean tree + pinned base before the first product mutation, re-fetched before PR creation (§1 ritual). Failure behavior: unknown/dirty base, missing issue linkage, or scope drift blocks readiness.
+
+### 9.4 Process state, configuration, working directory
+
+No inherited env/config materially changes the commands (cargo/npm standard). All mutating and cwd-sensitive commands run from the repo root with explicit paths. Expected: reproducible output. Failure behavior: cwd drift or ambient config interference is recorded and fixed before acceptance.
+
+### 9.5 Validation and scope before acceptance
+
+Frozen path set (§8.4). Postcondition: `git status --porcelain` matches §8.4; the budget fixture needs no platform file (deterministic per OS, §5.9). Failure behavior: any file outside the set, or any change to budget constants / state schema version / workflows / Cargo files, is scope drift → stop and report.
+
+### 9.6 Mutation ownership and no-clobber recovery
+
+The implementer is the only writer on this branch during implementation. Before writes: recheck frozen base + clean status. On failure: restore only paths this run changed, and only when their current state is demonstrably that run's output (`git diff`/`git restore -- <file>` on the specific file); never broad `git reset`/`git restore` of the tree; preserve and report any externally changed bytes. The plan file is added with `-f` only. Success: prove the §8.4 path set, index state (plan file staged), and ordinary-untracked state (nothing else).
+
+### 9.7 Bounded execution and durable diagnostics
+
+`cargo test`/`cargo clippy` run with a runner timeout (≥30 min cold, ≥15 min warm) and non-interactive stdin; retain stdout/stderr + exit/timing context. A timed-out or cancelled run is never reported as success. Failure behavior: timeout/cancel → rerun with the recorded diagnostics; cleanup defects must not erase the primary failure.
+
+### 9.8 Evidence discipline
+
+Zero and absence are valid typed states: "no platform file" → embedded default + WARN (asserted, T-8); "empty platform file" → embedded default (T-8); "container session" → no block (T-3); "personalized template without token" → fallback append (T-6); "platform file present" → verbatim content (T-7). Each gate states its expected result and failure behavior; remote-only evidence is owned by the exact-head CI checks (§9.1).
+
+## 10. Dependency-cycle and layering statement (planning rule 8)
+
+Enumerated arcs introduced by this plan:
+
+- `config/session_context.rs`: new private helpers (`render_host_platform_rules_block`, `host_platform_rules_filename/default`) using only existing same-module functions (`resolve_ac_root_context_dir`, `read_context_template`) and new `pub(crate)` consts in the SAME module; a new branch in `manifest_scope_for_project_context_filename` (same module). **NO new module arc.**
+- `config/seeded_context_templates.rs`: three new `SeededContextTemplateSpec`s whose `current_content`/`is_known_generated` reference `crate::config::session_context::{DEFAULT_HOST_PLATFORM_RULES_*, HOST_PLATFORM_RULES_FILENAME_*}` — the module arc `seeded_context_templates → session_context` ALREADY exists (`current_content: crate::config::session_context::get_default_agent_template` and `get_default_coordinator_template` in `project_specs()` at :477-505); the render path does NOT call into `seeded_context_templates` for platform files (direct read), so no new arc in either direction. **Zero new module-to-module arcs**; `cyclicSccs` and every SCC member set cannot change; there is no cross-boundary arc to classify.
+- Role/layering hygiene: the file read and text consts stay in the config layer (file seeding and context rendering are already its job); no lower layer gains a UI-transport/`AppHandle`/tauri dependency; no `cli/*` or `pty/*` changes.
+- `config/seed_manifest.rs` (round-2 S4, §6.4): the three `.ac/Context.platform.*.md → "context:platform"` entries are string literals in the existing closed map — no module reference, hence no new arc (a `session_context` import was deliberately avoided). Gate 1 re-verified at the implemented head: `cyclicSccs` identical set-to-set, regenerated `module-arcs.txt` byte-identical (1037 arcs, empty `git status` on it).
+
+Acceptance criterion for the implementer (base `047248bc` vs final branch head, clean tree for both):
+
+```
+node "<VAULT>/rust/01-rust_module-dependency-cycles.mjs" src-tauri --emit-graph pre.json --quiet
+node "<VAULT>/rust/01-rust_module-dependency-cycles.mjs" src-tauri --emit-graph post.json --quiet
+node scripts/02-module-arc-record.mjs --graph post.json --out src-tauri/module-arcs.txt
+```
+
+Green iff: (1) `cyclicSccs` equal pre/post; (2) cyclic SCC member sets identical set-to-set; (3) zero new `from -> to` pairs cross a previously-clean SCC boundary; (4) regenerated `module-arcs.txt` byte-identical (empty `git status` on it); (5) structural layering guards (e.g. `loops_layering`, `instance_gitignore_layering`) stay green. Exit code 1 from the detector is the normal gating outcome; only exit 3 means no graph.
+
+## 11. Implementation order
+
+1. Commit A — S2 seed layer first (v4 freeze const + recognizers + platform specs + state/sync tests): establishes the frozen operand and the file lifecycle the renderer will read.
+2. Commit B — S1 render layer (template v5, placeholder machinery, `render_host_platform_rules_block`, root 10th block, pointer + trims, manifest scope) + S4 `seed_manifest.rs` scope literals (§6.4) + its tests.
+3. Commit C — S3 docs.
+4. Force-add this plan file and run the full §8 battery: `cargo test --locked --lib --bins --tests` (Windows — binding budget case), clippy, check, `cargo fmt --all -- --check`, budget test (measured 8262/6504/8042, §3.7), manual §8.3 checks, §10 dependency-cycle gate.
+5. Open/refresh the PR with the §9.3 evidence; report exact-head CI results (windows/linux/macos budget rows).
+
+## 12. Residual risks and accepted tradeoffs (decision-complete)
+
+- **Byte budget tightness**: slack drops from 68 to 51 bytes on Windows `full_wg` (round-2 measured 8262; the +2 `\n\n` separators around the new block, omitted in round-1 arithmetic, cost the last 2 bytes — cosmetic, within ceiling: slack 51/306/271, §3.7). The fixture is deterministic and the trims are exact; if re-measurement deviates, the verbatim-trim re-measure protocol (§5.10) applies — constants never change.
+- **A customized platform file can exceed the budget**: the ceiling binds the DEFAULTS; an owner-authored longer file is their deliberate choice (no size cap, §5.5). Accepted and documented.
+- **Deleted platform file between project opens**: renders the embedded default + WARN until the next project open re-seeds (absent-only). This is the required behavior (§5.6).
+- **First upgrade on an existing project**: platform files appear only after the next project open/ensure; until then the render falls back to the embedded default (identical content). No gap.
+- **Future default change on platform files**: seeded files auto-update only after the previous default is frozen into the recognizer (documented extension rule, §5.3); until then they are preserved with a pending-update offer rather than silently overwritten — the safe side of the owner requirement.
+- **`Context.root-agent.md` (root role template)**: untouched; the root gets the block from the code-owned prologue (10th block), never from the editable template. Root sessions in the installed layout (no `.ac` ancestor) use the embedded default; in a `.ac`-nested layout they read the project file. Deterministic per install.
+- **Coordinator**: block arrives via the global render; the coordinator template is unchanged (no duplication).
+- **Non-Windows**: Linux/macOS host sessions render the minimal block (106 bytes); messaging pointer and Windows default are `#[cfg]`-gated, so no behavior change on non-Windows beyond the new minimal section.
+- **GUI behavior**: untouched — no `main.rs`, no Tauri surface, no binary, no packaging changes.

--- a/src-tauri/src/config/seed_manifest.rs
+++ b/src-tauri/src/config/seed_manifest.rs
@@ -1268,6 +1268,13 @@ fn validate_row(row: &PublishedManifestRow) -> Result<(), SeedManifestError> {
             let expected_scope = match row.path.serialized.as_str() {
                 ".ac/Context.AgentsCommander.md" => "context:agentscommander",
                 ".ac/Context.coordinator.md" => "context:coordinator",
+                // #1605: the per-platform `{{HOST_PLATFORM_RULES}}` files join the
+                // project-context scope set (mirrors
+                // `manifest_scope_for_project_context_filename` in session_context.rs;
+                // literals kept here to avoid a new module arc).
+                ".ac/Context.platform.windows.md" => "context:platform",
+                ".ac/Context.platform.linux.md" => "context:platform",
+                ".ac/Context.platform.macos.md" => "context:platform",
                 _ => {
                     return Err(SeedManifestError::Validation(format!(
                         "unsupported project context path {}",

--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -2270,7 +2270,7 @@ mod tests {
     // fail them (plan acceptance item 22).
 
     #[test]
-    fn context_create_records_both_project_templates_under_the_gate() {
+    fn context_create_records_project_templates_under_the_gate() {
         let temp = tempfile::tempdir().expect("tempdir");
         let project = temp.path();
         let ac_root = project.join(".ac");
@@ -2304,6 +2304,10 @@ mod tests {
         assert!(
             manifest.contains("scope = \"context:coordinator\""),
             "manifest: {manifest}"
+        );
+        assert!(
+            manifest.contains("scope = \"context:platform\""),
+            "platform seed publications must record the context:platform scope: {manifest}"
         );
         assert!(
             manifest.contains("kind = \"project_context_template\""),
@@ -2680,6 +2684,11 @@ mod tests {
             ),
             "the project recognizer must not widen to a platform default"
         );
+        assert_ne!(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES,
+            crate::config::session_context::get_default_agent_template(),
+            "the v5 placeholder insertion must differ from its frozen v4 operand"
+        );
     }
 
     #[test]
@@ -2965,6 +2974,62 @@ mod tests {
                 FINE_TEMPLATE
             );
         }
+    }
+
+    /// #1605 failing-first proof for ALL of: the v5 placeholder insertion
+    /// (assert_ne), BOTH recognizers (project auto-update and standalone root
+    /// retirement), the version bump, and the pristine-v4-on-disk auto-upgrade
+    /// through the seeded-state SHA flow.
+    #[test]
+    fn read_sync_updates_pre_host_platform_rules_global_template() {
+        assert_ne!(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES,
+            crate::config::session_context::get_default_agent_template(),
+            "the v5 rewrite must actually change the template or the freeze is pointless"
+        );
+        assert!(
+            is_known_generated_global_template(GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES),
+            "project recognizer must accept the frozen v4 bytes"
+        );
+        assert!(
+            is_known_generated_standalone_global_template(
+                GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
+            ),
+            "standalone (retirement) recognizer must accept the frozen v4 bytes"
+        );
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+        std::fs::write(
+            ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME),
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES,
+        )
+        .expect("write pristine v4 global");
+
+        let published_at = fixed_publication_time();
+        let publications =
+            sync_for_read_at(&ac_root, GLOBAL_CONTEXT_TEMPLATE_FILENAME, published_at);
+        assert_one_publication(
+            &publications,
+            GLOBAL_CONTEXT_TEMPLATE_FILENAME,
+            published_at,
+        );
+
+        let content = std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+            .expect("read global");
+        assert_eq!(
+            content,
+            crate::config::session_context::get_default_agent_template(),
+            "pristine v4 Context.AgentsCommander.md must auto-upgrade to v5"
+        );
+        let state = std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+            .expect("read seeded state");
+        let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
+        assert_eq!(
+            parsed["templates"]["global"]["currentVersion"], 5,
+            "recognized v4 global content must land on the current v5 default"
+        );
     }
 
     /// #1369 (C4) AC-4.5-C: population C, the edge case - a pristine v2 on disk

--- a/src-tauri/src/config/seeded_context_templates.rs
+++ b/src-tauri/src/config/seeded_context_templates.rs
@@ -201,6 +201,39 @@ You are running inside an AgentsCommander session - a terminal session manager c
 {{INTER_AGENT_MESSAGING}}
 "#;
 
+/// #1605: `get_default_agent_template()` exactly as it shipped through base
+/// commit 047248bc (the v4 summarization), frozen so a pristine v4
+/// `Context.AgentsCommander.md` on disk keeps being recognized (project
+/// auto-update AND standalone root retirement) after the v5
+/// `{{HOST_PLATFORM_RULES}}` insertion. Never edit. Provenance: the accessor at
+/// 047248bc is len 539, sha256
+/// f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a; pinned by
+/// `global_before_host_platform_rules_snapshot_is_byte_exact` against those
+/// externally captured values, never against this const itself.
+const GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES: &str = r#"# AgentsCommander Context
+
+You are in AgentsCommander, a terminal session manager coordinating multiple AI agents.
+
+## Core Concepts
+
+- **Team**: the logical capability and organization. It defines membership, who coordinates, and which repos are available.
+- **Workgroup**: a runtime replica of a team for a specific task. It contains replica agents and `repo-*` working repos.
+
+{{WRITE_RESTRICTIONS}}
+
+{{DELEGATED_TASK_REPORTING}}
+
+{{SKILLS_SECTION}}
+
+{{AGENT_REPOS}}
+
+{{CLI_CONTEXT}}
+
+{{SESSION_CREDENTIALS}}
+
+{{INTER_AGENT_MESSAGING}}
+"#;
+
 /// #1005 S4: `get_default_coordinator_template()` exactly as it shipped from
 /// #684 (raise-hand) through base commit 1dd0b58, frozen as the second legacy
 /// snapshot so a pristine v2 `Context.coordinator.md` on disk keeps being
@@ -474,13 +507,14 @@ impl LoadedState {
     }
 }
 
-fn project_specs() -> [SeededContextTemplateSpec; 2] {
+fn project_specs() -> [SeededContextTemplateSpec; 5] {
+    let [windows, linux, macos] = platform_specs();
     [
         SeededContextTemplateSpec {
             id: "global",
             filename: crate::config::session_context::GLOBAL_CONTEXT_TEMPLATE_FILENAME,
             label: "AgentsCommander shared context",
-            current_version: 4,
+            current_version: 5,
             current_content: crate::config::session_context::get_default_agent_template,
             is_known_generated: is_known_generated_global_template,
             project_actionable: true,
@@ -495,6 +529,50 @@ fn project_specs() -> [SeededContextTemplateSpec; 2] {
             is_known_generated: is_known_generated_coordinator_template,
             project_actionable: true,
             suppress_unknown_without_state: false,
+        },
+        windows,
+        linux,
+        macos,
+    ]
+}
+
+/// #1605: the three per-EXECUTION-platform `{{HOST_PLATFORM_RULES}}` files
+/// (`Context.platform.<os>.md`), seeded absent-only in project `.ac` roots by
+/// the same `sync_one_template` lifecycle as the global/coordinator templates
+/// (seeded/observed state, edit preservation, pending-update offer).
+/// `suppress_unknown_without_state: true` keeps a pre-existing unowned file
+/// preserved silently, never prompted — same posture as the global template.
+fn platform_specs() -> [SeededContextTemplateSpec; 3] {
+    [
+        SeededContextTemplateSpec {
+            id: "platform.windows",
+            filename: crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_WINDOWS,
+            label: "Windows host platform rules",
+            current_version: 1,
+            current_content: || crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS,
+            is_known_generated: is_known_generated_platform_windows,
+            project_actionable: true,
+            suppress_unknown_without_state: true,
+        },
+        SeededContextTemplateSpec {
+            id: "platform.linux",
+            filename: crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_LINUX,
+            label: "Linux host platform rules",
+            current_version: 1,
+            current_content: || crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX,
+            is_known_generated: is_known_generated_platform_linux,
+            project_actionable: true,
+            suppress_unknown_without_state: true,
+        },
+        SeededContextTemplateSpec {
+            id: "platform.macos",
+            filename: crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_MACOS,
+            label: "macOS host platform rules",
+            current_version: 1,
+            current_content: || crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_MACOS,
+            is_known_generated: is_known_generated_platform_macos,
+            project_actionable: true,
+            suppress_unknown_without_state: true,
         },
     ]
 }
@@ -537,6 +615,7 @@ fn is_known_generated_global_template(content: &str) -> bool {
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION
+        || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
 }
 
 /// #979: exact recognition of a STANDALONE (app-config) generated global context.
@@ -555,7 +634,25 @@ fn is_known_generated_standalone_global_template(content: &str) -> bool {
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_TOKEN_MINIMIZATION
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_AGENT_REPOS
         || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION
+        || content == GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
         || content == STANDALONE_GLOBAL_CONTEXT_BEFORE_CORE_CONCEPTS
+}
+
+/// #1605: per-platform generated recognizers — equality with the current
+/// platform default const only. A future default change MUST first freeze the
+/// previous default as a snapshot const and extend the recognizer (same pattern
+/// as the global template generations), so seeded files auto-update and edited
+/// files are preserved with the pending-update offer.
+fn is_known_generated_platform_windows(content: &str) -> bool {
+    content == crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS
+}
+
+fn is_known_generated_platform_linux(content: &str) -> bool {
+    content == crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX
+}
+
+fn is_known_generated_platform_macos(content: &str) -> bool {
+    content == crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_MACOS
 }
 
 fn is_known_generated_coordinator_template(content: &str) -> bool {
@@ -2043,23 +2140,38 @@ mod tests {
         assert!(is_known_generated_standalone_global_template(
             GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION
         ));
+        assert!(is_known_generated_global_template(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
+        ));
+        assert!(is_known_generated_standalone_global_template(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
+        ));
         assert!(
             !is_known_generated_global_template(
                 COORDINATOR_CONTEXT_TEMPLATE_BEFORE_CROSS_WORKGROUP_RULE
             ),
             "the global recognizer must not widen to a coordinator snapshot"
         );
+        assert!(
+            !is_known_generated_global_template(
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS
+            ),
+            "the global recognizer must not widen to a platform default"
+        );
     }
 
     #[test]
-    fn project_specs_bump_only_the_global_template_to_v4() {
-        let [global, coordinator] = project_specs();
+    fn project_specs_bump_global_to_v5_and_add_platform_specs() {
+        let [global, coordinator, windows, linux, macos] = project_specs();
         assert_eq!(global.id, "global");
-        assert_eq!(global.current_version, 4);
+        assert_eq!(global.current_version, 5);
         assert_eq!(
             (global.current_content)(),
             crate::config::session_context::get_default_agent_template()
         );
+        assert!((global.is_known_generated)(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
+        ));
         assert!((global.is_known_generated)(
             GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION
         ));
@@ -2075,6 +2187,41 @@ mod tests {
         ));
         assert!(!(coordinator.is_known_generated)(
             GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION
+        ));
+
+        for (spec, id, filename, default) in [
+            (
+                windows,
+                "platform.windows",
+                crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_WINDOWS,
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS,
+            ),
+            (
+                linux,
+                "platform.linux",
+                crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_LINUX,
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX,
+            ),
+            (
+                macos,
+                "platform.macos",
+                crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_MACOS,
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_MACOS,
+            ),
+        ] {
+            assert_eq!(spec.id, id);
+            assert_eq!(spec.filename, filename);
+            assert_eq!(spec.current_version, 1);
+            assert_eq!((spec.current_content)(), default);
+            assert!((spec.is_known_generated)(default));
+            assert!(spec.project_actionable);
+            assert!(spec.suppress_unknown_without_state);
+        }
+        assert!(!(windows.is_known_generated)(
+            crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX
+        ));
+        assert!(!(global.is_known_generated)(
+            crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS
         ));
     }
 
@@ -2458,7 +2605,7 @@ mod tests {
             .expect("read seeded state");
         let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
         assert_eq!(
-            parsed["templates"]["global"]["currentVersion"], 4,
+            parsed["templates"]["global"]["currentVersion"], 5,
             "recognized v1 global content must land on the current v4 default"
         );
     }
@@ -2497,6 +2644,41 @@ mod tests {
             GLOBAL_CONTEXT_TEMPLATE_BEFORE_SUMMARIZATION,
             crate::config::session_context::get_default_agent_template(),
             "the v4 summarization must differ from its frozen v3 operand"
+        );
+    }
+
+    /// #1605: the frozen v4 global snapshot must stay byte-identical to what
+    /// shipped at base commit 047248bc. Expected values captured by a one-off
+    /// run of the shipped accessor AT 047248bc (len 539, sha256
+    /// f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a),
+    /// never from this const.
+    #[test]
+    fn global_before_host_platform_rules_snapshot_is_byte_exact() {
+        assert_eq!(
+            GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES.len(),
+            539,
+            "frozen v4 global snapshot must be the 047248bc bytes"
+        );
+        assert_eq!(
+            hash_text(GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES),
+            "f44065965f3c53c8b8d2c2e6b3d38c68b998f848ae893eddb7e64085a3c5316a",
+            "frozen v4 global snapshot changed; it must stay byte-identical to what shipped"
+        );
+        assert!(
+            is_known_generated_global_template(GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES),
+            "the project recognizer must accept the frozen v4 bytes"
+        );
+        assert!(
+            is_known_generated_standalone_global_template(
+                GLOBAL_CONTEXT_TEMPLATE_BEFORE_HOST_PLATFORM_RULES
+            ),
+            "the standalone (retirement) recognizer must accept the frozen v4 bytes"
+        );
+        assert!(
+            !is_known_generated_global_template(
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS
+            ),
+            "the project recognizer must not widen to a platform default"
         );
     }
 
@@ -2556,7 +2738,7 @@ mod tests {
                 .expect("read seeded state"),
         )
         .expect("parse seeded state");
-        assert_eq!(state["templates"]["global"]["currentVersion"], 4);
+        assert_eq!(state["templates"]["global"]["currentVersion"], 5);
         assert_eq!(
             state["templates"]["global"]["lastSeededSha256"],
             current_hash
@@ -2615,7 +2797,7 @@ mod tests {
                 .expect("read seeded state"),
         )
         .expect("parse seeded state");
-        assert_eq!(state["templates"]["global"]["currentVersion"], 4);
+        assert_eq!(state["templates"]["global"]["currentVersion"], 5);
         assert_eq!(
             state["templates"]["global"]["lastSeededSha256"],
             current_hash
@@ -2695,7 +2877,7 @@ mod tests {
                 assert!(scan_publications.is_empty(), "{label}/{trusted_state}");
                 if trusted_state {
                     assert_eq!(updates.len(), 1, "{label}: trusted state must be pending");
-                    assert_eq!(updates[0].current_default_version, 4);
+                    assert_eq!(updates[0].current_default_version, 5);
                     assert_eq!(
                         updates[0].current_default_sha256,
                         hash_text(crate::config::session_context::get_default_agent_template())
@@ -2775,7 +2957,7 @@ mod tests {
                 .expect("scan fine custom global");
             assert_eq!(updates.len(), usize::from(trusted_state));
             if trusted_state {
-                assert_eq!(updates[0].current_default_version, 4);
+                assert_eq!(updates[0].current_default_version, 5);
             }
             assert_eq!(
                 std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
@@ -2834,7 +3016,7 @@ mod tests {
         let state = std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
             .expect("read seeded state");
         let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
-        assert_eq!(parsed["templates"]["global"]["currentVersion"], 4);
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 5);
         assert!(
             scan_project_context_template_updates(temp.path(), &ac_root)
                 .expect("scan updates")
@@ -2892,7 +3074,7 @@ mod tests {
                 .expect("read seeded state"),
         )
         .expect("parse seeded state");
-        assert_eq!(parsed["templates"]["global"]["currentVersion"], 4);
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 5);
         assert!(
             scan_project_context_template_updates(temp.path(), &ac_root)
                 .expect("scan updates")
@@ -2935,7 +3117,7 @@ mod tests {
         let v4_sha = hash_text(crate::config::session_context::get_default_agent_template());
         assert_eq!(update.filename, GLOBAL_CONTEXT_TEMPLATE_FILENAME);
         assert_eq!(update.current_default_sha256, v4_sha);
-        assert_eq!(update.current_default_version, 4);
+        assert_eq!(update.current_default_version, 5);
 
         let result = overwrite_context_template_with_default(
             &ac_root,
@@ -2960,7 +3142,7 @@ mod tests {
         )
         .expect("parse seeded state");
         assert_eq!(parsed["templates"]["global"]["lastSeededSha256"], v4_sha);
-        assert_eq!(parsed["templates"]["global"]["currentVersion"], 4);
+        assert_eq!(parsed["templates"]["global"]["currentVersion"], 5);
     }
 
     #[test]
@@ -3157,6 +3339,158 @@ mod tests {
             std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
                 .expect("read first published target"),
             crate::config::session_context::get_default_agent_template()
+        );
+    }
+
+    /// #1605: a fresh `.ac` root seeds the three platform files byte-equal to
+    /// their embedded defaults with `platform.*` state entries carrying the
+    /// default sha; a pre-existing custom platform file is never overwritten
+    /// (absent-only) and is preserved silently.
+    #[test]
+    fn ensure_project_context_templates_seeds_platform_files_absent_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+
+        let custom_windows = "## Host Platform Rules\n\nMY OWN WINDOWS RULES\n";
+        std::fs::write(
+            ac_root.join(crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_WINDOWS),
+            custom_windows,
+        )
+        .expect("write pre-existing custom windows platform file");
+
+        let published_at = fixed_publication_time();
+        let mut clock = || published_at;
+        let mut publications = Vec::new();
+        ensure_project_context_templates_with_clock(
+            &ac_root,
+            &mut clock,
+            &mut |filename, publication| publications.push((filename, publication)),
+        )
+        .expect("ensure project context templates");
+
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read global"),
+            crate::config::session_context::get_default_agent_template()
+        );
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(COORDINATOR_CONTEXT_TEMPLATE_FILENAME))
+                .expect("read coordinator"),
+            get_default_coordinator_template()
+        );
+        for (filename, default) in [
+            (
+                crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_LINUX,
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX,
+            ),
+            (
+                crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_MACOS,
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_MACOS,
+            ),
+        ] {
+            assert_eq!(
+                std::fs::read_to_string(ac_root.join(filename)).expect("read seeded platform file"),
+                default,
+                "{filename} must be seeded byte-equal to its embedded default"
+            );
+        }
+        assert_eq!(
+            std::fs::read_to_string(
+                ac_root.join(crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_WINDOWS)
+            )
+            .expect("read preserved windows platform file"),
+            custom_windows,
+            "a pre-existing custom platform file must be preserved, never overwritten"
+        );
+
+        let state = std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+            .expect("read seeded state");
+        let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
+        for (id, default) in [
+            (
+                "platform.linux",
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_LINUX,
+            ),
+            (
+                "platform.macos",
+                crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_MACOS,
+            ),
+        ] {
+            assert_eq!(
+                parsed["templates"][id]["currentVersion"], 1,
+                "{id} state entry must be v1"
+            );
+            assert_eq!(
+                parsed["templates"][id]["lastSeededSha256"],
+                hash_text(default),
+                "{id} state entry must carry the default sha"
+            );
+        }
+        assert_eq!(
+            parsed["templates"]["platform.windows"],
+            serde_json::Value::Null,
+            "a stateless pre-existing custom platform file must stay unowned (same posture as the global template)"
+        );
+    }
+
+    /// #1605: after seeding, an edit to a platform file is preserved by the
+    /// sync path (content unchanged) and lands in the observed posture
+    /// (`lastObservedSha256` updated); a scan against the same default yields no
+    /// pending update, and the file is never silently overwritten.
+    #[test]
+    fn platform_file_edit_is_preserved_and_observed() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac_root = temp.path().join(".ac");
+        std::fs::create_dir(&ac_root).expect("create workspace");
+        ensure_project_context_templates(&ac_root).expect("seed platform files");
+
+        let filename = crate::config::session_context::HOST_PLATFORM_RULES_FILENAME_WINDOWS;
+        let edited = format!(
+            "{}\n\nMY OWN WINDOWS RULES\n",
+            crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS
+        );
+        std::fs::write(ac_root.join(filename), &edited).expect("edit windows platform file");
+
+        let published_at = fixed_publication_time();
+        let publications = sync_for_read_at(&ac_root, filename, published_at);
+        assert!(
+            publications.is_empty(),
+            "an edited platform file must not publish"
+        );
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(filename)).expect("read edited platform file"),
+            edited,
+            "the edit must be preserved, never overwritten"
+        );
+
+        let state = std::fs::read_to_string(ac_root.join(SEEDED_CONTEXT_TEMPLATE_STATE_FILENAME))
+            .expect("read seeded state");
+        let parsed: serde_json::Value = serde_json::from_str(&state).expect("parse seeded state");
+        assert_eq!(
+            parsed["templates"]["platform.windows"]["lastObservedSha256"],
+            hash_text(&edited),
+            "the edit must land in the observed posture"
+        );
+
+        let updates =
+            scan_project_context_template_updates(temp.path(), &ac_root).expect("scan updates");
+        assert_eq!(
+            updates.len(),
+            1,
+            "a customized platform file must be offered as a pending update"
+        );
+        assert_eq!(updates[0].filename, filename);
+        assert_eq!(updates[0].current_file_sha256, hash_text(&edited));
+        assert_eq!(
+            updates[0].current_default_sha256,
+            hash_text(crate::config::session_context::DEFAULT_HOST_PLATFORM_RULES_WINDOWS)
+        );
+        assert_eq!(updates[0].current_default_version, 1);
+        assert_eq!(
+            std::fs::read_to_string(ac_root.join(filename)).expect("re-read edited platform file"),
+            edited,
+            "the scan must never silently overwrite the edit"
         );
     }
 
@@ -3510,7 +3844,7 @@ mod tests {
         assert_eq!(updates.len(), 1);
         assert_eq!(updates[0].current_file_sha256, custom_hash);
         assert_eq!(updates[0].current_default_sha256, v4_hash);
-        assert_eq!(updates[0].current_default_version, 4);
+        assert_eq!(updates[0].current_default_version, 5);
         assert_eq!(
             std::fs::read_to_string(ac_root.join(GLOBAL_CONTEXT_TEMPLATE_FILENAME))
                 .expect("read preserved custom global"),
@@ -3566,7 +3900,7 @@ mod tests {
     }
 
     #[test]
-    fn ignored_current_v4_pair_remains_suppressed() {
+    fn ignored_current_v5_pair_remains_suppressed() {
         let temp = tempfile::tempdir().expect("tempdir");
         let ac_root = temp.path().join(".ac");
         std::fs::create_dir(&ac_root).expect("create workspace");
@@ -3580,7 +3914,7 @@ mod tests {
             "global".to_string(),
             SeededContextTemplateEntry {
                 template_id: "global".to_string(),
-                current_version: 4,
+                current_version: 5,
                 last_seeded_sha256: Some(v4_hash.clone()),
                 last_observed_sha256: Some(custom_hash.clone()),
                 ignored_default_sha256: Some(v4_hash),

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -13,6 +13,40 @@ const LEGACY_AGENT_CONTEXT_TEMPLATE_FILENAME: &str = "Context.agent.md";
 pub const COORDINATOR_CONTEXT_TEMPLATE_FILENAME: &str = "Context.coordinator.md";
 pub const ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME: &str =
     crate::config::instance_artifacts::ROOT_AGENT_CONTEXT_TEMPLATE_FILENAME;
+
+/// #1605: per-platform project `.ac` files whose content IS the rendered
+/// `{{HOST_PLATFORM_RULES}}` block (including its `## Host Platform Rules`
+/// heading). Project-level only; never seeded in the app-config directory.
+pub const HOST_PLATFORM_RULES_FILENAME_WINDOWS: &str = "Context.platform.windows.md";
+pub const HOST_PLATFORM_RULES_FILENAME_LINUX: &str = "Context.platform.linux.md";
+pub const HOST_PLATFORM_RULES_FILENAME_MACOS: &str = "Context.platform.macos.md";
+
+/// #1605: embedded default content for the `{{HOST_PLATFORM_RULES}}` block on
+/// Windows host sessions (277 bytes; sha256
+/// 5fd5dd5f7d3d097f90e58cee6e6a210e2b2a6070c24e4164a7ac06d3854286a7 at
+/// 047248bc). Single source for both the `.ac/Context.platform.windows.md` seed
+/// and the render fallback.
+pub(crate) const DEFAULT_HOST_PLATFORM_RULES_WINDOWS: &str = r#"## Host Platform Rules
+
+Windows host session: use `C:\Program Files\Git\bin\bash.exe` for all shell work and every AgentsCommander CLI invocation; from PowerShell wrap with `& 'C:\Program Files\Git\bin\bash.exe' -lc '...'`; never capture CLI output without `2>&1 | Out-String`."#;
+
+/// #1605: embedded default content for the `{{HOST_PLATFORM_RULES}}` block on
+/// Linux host sessions (106 bytes; sha256
+/// 848e6bd25a001b091dd419fb665d2114abc5e5c2a19429fc820144aaa6190790 at
+/// 047248bc). Single source for both the `.ac/Context.platform.linux.md` seed
+/// and the render fallback.
+pub(crate) const DEFAULT_HOST_PLATFORM_RULES_LINUX: &str = r#"## Host Platform Rules
+
+This session runs on a Linux host; no platform-specific shell routing rules apply."#;
+
+/// #1605: embedded default content for the `{{HOST_PLATFORM_RULES}}` block on
+/// macOS host sessions (106 bytes; sha256
+/// a305af4fce8148ac80d8e197b02142738a6056959e9b72bee43689b3d01cdc4d at
+/// 047248bc). Single source for both the `.ac/Context.platform.macos.md` seed
+/// and the render fallback.
+pub(crate) const DEFAULT_HOST_PLATFORM_RULES_MACOS: &str = r#"## Host Platform Rules
+
+This session runs on a macOS host; no platform-specific shell routing rules apply."#;
 static CONTEXT_TEMPLATE_TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/config/session_context.rs
+++ b/src-tauri/src/config/session_context.rs
@@ -59,12 +59,21 @@ pub(crate) enum CreateOnlyPublication {
 
 /// Map a managed project context-template filename to its canonical v1 seed-manifest
 /// scope, or `None` for a non-project template (the Root agent context) that carries
-/// no manifest row. The two project scopes are the closed enum in plan section 4.2.
+/// no manifest row. The project scopes are the closed enum in plan section 4.2
+/// (#1605 adds the per-platform `context:platform` scope for the three
+/// `Context.platform.<os>.md` files).
 pub(crate) fn manifest_scope_for_project_context_filename(filename: &str) -> Option<&'static str> {
     if filename == GLOBAL_CONTEXT_TEMPLATE_FILENAME {
         Some("context:agentscommander")
     } else if filename == COORDINATOR_CONTEXT_TEMPLATE_FILENAME {
         Some("context:coordinator")
+    } else if matches!(
+        filename,
+        HOST_PLATFORM_RULES_FILENAME_WINDOWS
+            | HOST_PLATFORM_RULES_FILENAME_LINUX
+            | HOST_PLATFORM_RULES_FILENAME_MACOS
+    ) {
+        Some("context:platform")
     } else {
         None
     }
@@ -2520,6 +2529,8 @@ You are in AgentsCommander, a terminal session manager coordinating multiple AI 
 
 {{CLI_CONTEXT}}
 
+{{HOST_PLATFORM_RULES}}
+
 {{SESSION_CREDENTIALS}}
 
 {{INTER_AGENT_MESSAGING}}
@@ -2638,6 +2649,11 @@ fn render_agent_context_template_inner(
     }
 
     let agent_repos = render_agent_repos_string(cwd_path, config, repo_mounts, is_root_agent);
+    // #1605: computed BEFORE the replace chain (like `agent_repos`): the value
+    // feeds the `{{HOST_PLATFORM_RULES}}` replace between `{{CLI_CONTEXT}}` and
+    // `{{SESSION_CREDENTIALS}}`. Container sessions (repo_mounts.is_some())
+    // render nothing.
+    let host_platform_rules = render_host_platform_rules_block(agent_root, repo_mounts);
     // #1369 (C4): a template may carry the current token, the frozen legacy
     // alias, or - pathologically, if a user pasted both - the two of them.
     // Exactly one block must be emitted, so the alias renders the block only
@@ -2679,6 +2695,7 @@ fn render_agent_context_template_inner(
             &render_write_restrictions_block(agent_root, &rendered),
         )
         .replace("{{CLI_CONTEXT}}", DEFAULT_CLI_CONTEXT)
+        .replace("{{HOST_PLATFORM_RULES}}", &host_platform_rules)
         .replace("{{SESSION_CREDENTIALS}}", DEFAULT_SESSION_CREDENTIALS)
         .replace(
             "{{INTER_AGENT_MESSAGING}}",
@@ -3073,6 +3090,7 @@ const MANDATORY_GLOBAL_CONTEXT_PLACEHOLDERS: &[&str] = &[
     "{{INTER_AGENT_MESSAGING}}",
     "{{SESSION_CREDENTIALS}}",
     "{{CLI_CONTEXT}}",
+    "{{HOST_PLATFORM_RULES}}",
     "{{SKILLS_SECTION}}",
     "{{AGENT_REPOS}}",
     "{{DELEGATED_TASK_REPORTING}}",
@@ -3090,6 +3108,7 @@ fn mandatory_section_heading(placeholder: &str) -> Option<&'static str> {
         "{{INTER_AGENT_MESSAGING}}" => "## Inter-Agent Messaging",
         "{{SESSION_CREDENTIALS}}" => "## Session credentials",
         "{{CLI_CONTEXT}}" => "## CLI executable",
+        "{{HOST_PLATFORM_RULES}}" => "## Host Platform Rules",
         "{{SKILLS_SECTION}}" => "## Skills",
         "{{AGENT_REPOS}}" => "# Agent Repos",
         "{{DELEGATED_TASK_REPORTING}}" => "## Delegated Task Reporting",
@@ -3195,6 +3214,12 @@ fn coarse_section_dedup_safe(
         // is absent, so any inline copy is a baked/stale list -> never dedup,
         // always append the current block.
         "{{SKILLS_SECTION}}" | "{{AGENT_REPOS}}" => false,
+        // #1605: never dedup an inline `## Host Platform Rules` copy: the block is
+        // platform- and file-dependent, so an inline baked copy can be stale or
+        // platform-wrong; appending the current block is the safe side (mirrors
+        // SKILLS_SECTION/AGENT_REPOS). No existing template generation carries the
+        // heading, so no real-world duplication can occur.
+        "{{HOST_PLATFORM_RULES}}" => false,
         _ => false,
     }
 }
@@ -3273,14 +3298,18 @@ fn render_root_runtime_prologue_inner(
     let rendered = default_context_dynamic_values(agent_root, None, skills_section, is_root_agent);
     let write_restrictions = render_write_restrictions_block(agent_root, &rendered);
     let agent_repos = render_agent_repos_string(cwd_path, config, repo_mounts, is_root_agent);
+    // #1605: the 10th block, mirroring the template order between CLI context and
+    // session credentials; the `if block.is_empty() { continue; }` below drops it
+    // naturally for container roots.
+    let host_platform_rules = render_host_platform_rules_block(agent_root, repo_mounts);
     let inter_agent_messaging = render_inter_agent_messaging_block(&rendered);
 
-    // Nine blocks (#979 G4): the heading and Core Concepts reproduce the built-in
-    // template's preamble, then the seven mandatory blocks in the order
+    // Ten blocks (#979 G4): the heading and Core Concepts reproduce the built-in
+    // template's preamble, then the eight mandatory blocks in the order
     // `get_default_agent_template()` renders them today. ROOT_AUTHORITY_SECTION is
     // already emitted INSIDE the write-restrictions block and must not be appended
-    // separately. Do not "simplify" this back to seven blocks.
-    let blocks: [&str; 9] = [
+    // separately. Do not "simplify" this back to eight blocks.
+    let blocks: [&str; 10] = [
         ROOT_RUNTIME_PROLOGUE_HEADER,
         CORE_CONCEPTS_SECTION,
         &write_restrictions,
@@ -3288,6 +3317,7 @@ fn render_root_runtime_prologue_inner(
         skills_section,
         &agent_repos,
         DEFAULT_CLI_CONTEXT,
+        &host_platform_rules,
         DEFAULT_SESSION_CREDENTIALS,
         &inter_agent_messaging,
     ];
@@ -3323,11 +3353,11 @@ Credentials use these environment variables:
 - `AGENTSCOMMANDER_BINARY_PATH`: full CLI path to invoke
 - `AGENTSCOMMANDER_LOCAL_DIR`: config directory name for this instance
 
-Invoke only `AGENTSCOMMANDER_BINARY_PATH`; never hardcode or guess another executable.
+Invoke only `AGENTSCOMMANDER_BINARY_PATH`; never guess another executable.
 
 ## Self-discovery via --help
 
-Use `--help` only for commands or flags not documented here:
+Use `--help` only for undocumented commands or flags:
 
 ```
 "<AGENTSCOMMANDER_BINARY_PATH>" --help
@@ -3335,7 +3365,7 @@ Use `--help` only for commands or flags not documented here:
 "<AGENTSCOMMANDER_BINARY_PATH>" list-peers-lean --help
 ```
 
-The Inter-Agent Messaging section is authoritative for sending and peer discovery."#;
+The Inter-Agent Messaging section is authoritative for sending."#;
 
 const DEFAULT_SESSION_CREDENTIALS: &str = r#"## Session credentials
 
@@ -3479,13 +3509,13 @@ fn render_inter_agent_messaging_block(rendered: &DefaultContextDynamicValues) ->
 
 Before every send, run `list-peers-lean` and use its exact JSON `name`. A filesystem directory name is NEVER a valid `--to` value; `__agent_*` replicas and `_agent_*` matrices are on-disk paths only. If it returns an empty array, stop and report it.
 
-**Peer name format** (canonical FQN, the `list-peers-lean` `name` field):
+**Peer name format** (canonical FQN from `list-peers-lean`):
 
 {peer_name_format}
 
 {send_message_instructions}
 
-The recipient reads the notified file path. Do NOT use `--get-output` (blocks; non-interactive only). **Receipt required:** never report a message as sent without a captured `Queued: <message-id>` line; a missing receipt means NOT enqueued. After sending, wait for the reply.
+Do NOT use `--get-output` (blocks; non-interactive only). **Receipt required:** never report a message as sent without a captured `Queued: <message-id>` line; a missing receipt means NOT enqueued. Wait for the reply.
 
 ### List available peers
 
@@ -3498,15 +3528,79 @@ The recipient reads the notified file path. Do NOT use `--get-output` (blocks; n
     )
 }
 
-/// #1596: Windows-only paragraph appended to the inter-agent messaging block.
-/// The release binary is GUI-subsystem, so PowerShell direct capture of its
-/// stdout is empty; the recipe routes AC CLI invocations through Git Bash.
-/// The whole paragraph is the constant (empty string on non-Windows builds).
+/// #1605: Windows-only pointer to the `{{HOST_PLATFORM_RULES}}` block, which is
+/// now the SINGLE source of truth for the Git Bash CLI-routing rule (the #1596
+/// paragraph moved there; this pointer is the only Windows text left in
+/// messaging). Empty string on non-Windows builds.
 #[cfg(target_os = "windows")]
-const WINDOWS_SHELL_ROUTING: &str = "\n\n**Windows:** the release binary is GUI-subsystem; PowerShell direct capture is empty. Run AC CLI invocations via Git Bash (`C:\\Program Files\\Git\\bin\\bash.exe`); never `& $bin ... | ConvertFrom-Json`.";
+const WINDOWS_SHELL_ROUTING: &str = "\n\n**Windows:** see **Host Platform Rules** above.";
 
 #[cfg(not(target_os = "windows"))]
 const WINDOWS_SHELL_ROUTING: &str = "";
+
+/// #1605: the `{{HOST_PLATFORM_RULES}}` block content for THIS materialization.
+///
+/// - Container session (`repo_mounts.is_some()`): empty string — the execution
+///   platform is the container/transport-api session, so no host rules render
+///   and no platform file is ever read or mounted.
+/// - Host session: read `.ac/Context.platform.<os>.md` (per-OS filename) fresh
+///   on EVERY materialization (no cache): edit → respawn → new text, no rebuild.
+///   Missing/empty/unreadable file or unresolvable `.ac` → embedded default for
+///   the build's OS with a WARN; never an empty section on Windows.
+fn render_host_platform_rules_block(
+    agent_root: &str,
+    repo_mounts: Option<&crate::pty::container_repos::RepoMountResolution>,
+) -> String {
+    if repo_mounts.is_some() {
+        return String::new();
+    }
+    let filename = host_platform_rules_filename();
+    let fallback = host_platform_rules_default();
+    match read_context_template(agent_root, filename) {
+        Ok(Some(content)) if !content.trim().is_empty() => content,
+        Ok(Some(_)) => {
+            log::warn!(
+                "[session_context] platform rules file {} is empty; using the embedded default",
+                filename
+            );
+            fallback.to_string()
+        }
+        Ok(None) => {
+            log::warn!(
+                "[session_context] platform rules file {} is missing; using the embedded default",
+                filename
+            );
+            fallback.to_string()
+        }
+        Err(error) => {
+            log::warn!(
+                "[session_context] platform rules file {} is not readable ({error}); using the embedded default",
+                filename
+            );
+            fallback.to_string()
+        }
+    }
+}
+
+fn host_platform_rules_filename() -> &'static str {
+    if cfg!(target_os = "windows") {
+        HOST_PLATFORM_RULES_FILENAME_WINDOWS
+    } else if cfg!(target_os = "macos") {
+        HOST_PLATFORM_RULES_FILENAME_MACOS
+    } else {
+        HOST_PLATFORM_RULES_FILENAME_LINUX
+    }
+}
+
+fn host_platform_rules_default() -> &'static str {
+    if cfg!(target_os = "windows") {
+        DEFAULT_HOST_PLATFORM_RULES_WINDOWS
+    } else if cfg!(target_os = "macos") {
+        DEFAULT_HOST_PLATFORM_RULES_MACOS
+    } else {
+        DEFAULT_HOST_PLATFORM_RULES_LINUX
+    }
+}
 
 fn default_context_dynamic_values(
     agent_root: &str,
@@ -4355,6 +4449,7 @@ mod tests {
         assert_eq!(count_context_occurrences(out, "## Skills"), 1);
         assert_eq!(count_context_occurrences(out, "# Agent Repos"), 1);
         assert_eq!(count_context_occurrences(out, "## CLI executable"), 1);
+        assert_eq!(count_context_occurrences(out, "## Host Platform Rules"), 1);
         assert_eq!(count_context_occurrences(out, "## Session credentials"), 1);
         assert_eq!(
             count_context_occurrences(out, "## Inter-Agent Messaging"),
@@ -4731,6 +4826,7 @@ For peer discovery, the sections below (`## Inter-Agent Messaging` and `### List
                 "{{SKILLS_SECTION}}",
                 "{{AGENT_REPOS}}",
                 "{{CLI_CONTEXT}}",
+                "{{HOST_PLATFORM_RULES}}",
                 "{{SESSION_CREDENTIALS}}",
                 "{{INTER_AGENT_MESSAGING}}",
             ]
@@ -5332,17 +5428,264 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn default_context_embeds_windows_shell_routing_paragraph() {
-        // #1596: the release binary is GUI-subsystem; PowerShell direct capture
-        // is empty, so the context routes AC CLI invocations through Git Bash.
+    fn default_context_embeds_windows_shell_routing_pointer() {
+        // #1605: the #1596 Git Bash paragraph moved to the
+        // `{{HOST_PLATFORM_RULES}}` block (single source of truth); messaging now
+        // carries only a pointer to it.
         let out = default_context(
             "C:/fake/wg-7-dev-team/__agent_architect",
             None,
             &no_skill_section(),
         );
-        assert!(out.contains("**Windows:**"));
+        assert!(out.contains("**Windows:** see **Host Platform Rules** above."));
+        assert!(out.contains("## Host Platform Rules"));
         assert!(out.contains("bash.exe"));
-        assert!(out.contains("ConvertFrom-Json"));
+        assert!(out.contains("2>&1 | Out-String"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn default_context_embeds_host_platform_rules_block() {
+        // #1605 T-1: a Windows host session carries the Git Bash routing rule in
+        // the platform block plus the messaging pointer.
+        let out = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+        );
+        assert!(out.contains("## Host Platform Rules"));
+        assert!(out.contains("bash.exe"));
+        assert!(out.contains("2>&1 | Out-String"));
+        assert!(out.contains("**Windows:** see **Host Platform Rules** above."));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn default_context_non_windows_embeds_minimal_platform_block() {
+        // #1605 T-2: Linux/macOS host sessions render only the minimal block.
+        let out = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+        );
+        assert!(out.contains("## Host Platform Rules"));
+        assert!(!out.contains("bash.exe"));
+        assert!(!out.contains("2>&1 | Out-String"));
+    }
+
+    #[test]
+    fn container_session_omits_host_platform_rules_block() {
+        // #1605 T-3: a container (transport-api) session renders no host platform
+        // rules block (the Windows messaging pointer may still name the block,
+        // so assert on the heading) and no raw placeholder.
+        let out = render_agent_context_template_inner(
+            get_default_agent_template(),
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+            Path::new("C:/fake/wg-7-dev-team/__agent_architect"),
+            None,
+            Some(&crate::pty::container_repos::RepoMountResolution::default()),
+            false,
+        );
+        assert!(!out.contains("## Host Platform Rules"));
+        assert!(!out.contains("bash.exe"));
+        assert_no_raw_template_placeholders(&out);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn root_prologue_embeds_host_platform_rules_block() {
+        // #1605 T-4: the Root runtime prologue renders the platform block as its
+        // 10th block between CLI context and session credentials.
+        let out = render_root_runtime_prologue_inner(
+            "C:/fake/ac-root-agent",
+            &no_skill_section(),
+            Path::new("C:/fake/ac-root-agent"),
+            None,
+            None,
+            true,
+        );
+        assert!(out.contains("## Host Platform Rules"));
+        assert!(out.contains("bash.exe"));
+        assert!(out.contains("2>&1 | Out-String"));
+        let cli_pos = out.find("## CLI executable").expect("CLI block");
+        let platform_pos = out.find("## Host Platform Rules").expect("platform block");
+        let credentials_pos = out
+            .find("## Session credentials")
+            .expect("credentials block");
+        assert!(
+            cli_pos < platform_pos && platform_pos < credentials_pos,
+            "the platform block must sit between CLI context and session credentials"
+        );
+    }
+
+    #[test]
+    fn container_root_prologue_omits_host_platform_rules_block() {
+        // #1605 T-5: a container root renders no host platform rules block.
+        let out = render_root_runtime_prologue_inner(
+            "C:/fake/ac-root-agent",
+            &no_skill_section(),
+            Path::new("C:/fake/ac-root-agent"),
+            None,
+            Some(&crate::pty::container_repos::RepoMountResolution::default()),
+            true,
+        );
+        assert!(!out.contains("## Host Platform Rules"));
+        assert!(!out.contains("bash.exe"));
+        assert_no_raw_template_placeholders(&out);
+    }
+
+    #[test]
+    fn personalized_template_without_host_platform_rules_token_appends_fallback() {
+        // #1605 T-6: a preserved personalized template lacking the token (and a
+        // root-agent-shaped fixture, per the owner's `Context.root-agent.md`
+        // probe) receives exactly one `## Host Platform Rules` section via the
+        // append fallback.
+        let no_token = get_default_agent_template().replace("{{HOST_PLATFORM_RULES}}", "");
+        let root_shaped = "# Root Agent\n\nCustom prose without the platform token.\n".to_string();
+        for template in [no_token, root_shaped] {
+            let out = render_agent_context_template_inner(
+                &template,
+                "C:/fake/wg-7-dev-team/__agent_architect",
+                None,
+                &no_skill_section(),
+                Path::new("C:/fake/wg-7-dev-team/__agent_architect"),
+                None,
+                None,
+                false,
+            );
+            assert_eq!(
+                count_context_occurrences(&out, "## Host Platform Rules"),
+                1,
+                "the fallback must append exactly one platform block"
+            );
+            assert_no_raw_template_placeholders(&out);
+        }
+
+        // Token present (both-tokens pathological shape): exactly one block.
+        let with_token = get_default_agent_template();
+        let out = render_agent_context_template_inner(
+            with_token,
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+            Path::new("C:/fake/wg-7-dev-team/__agent_architect"),
+            None,
+            None,
+            false,
+        );
+        assert_eq!(count_context_occurrences(&out, "## Host Platform Rules"), 1);
+        assert_no_raw_template_placeholders(&out);
+    }
+
+    #[test]
+    fn host_platform_rules_reads_project_file_each_materialization() {
+        // #1605 T-7: every materialization re-reads `.ac/Context.platform.<os>.md`
+        // (no cache, no rebuild): edit the file, render again, get the new text.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac = temp.path().join(".ac");
+        let replica = ac.join("wg-1-team").join("__agent_dev");
+        std::fs::create_dir_all(&replica).expect("create replica layout");
+        let filename = host_platform_rules_filename();
+
+        let first = format!("## Host Platform Rules\n\nFIRST CUSTOM TEXT {filename}\n");
+        std::fs::write(ac.join(filename), &first).expect("write first custom platform file");
+        let out1 = render_agent_context_template_inner(
+            get_default_agent_template(),
+            &path_string(&replica),
+            None,
+            &no_skill_section(),
+            &replica,
+            None,
+            None,
+            false,
+        );
+        assert!(out1.contains("FIRST CUSTOM TEXT"));
+
+        let second = "## Host Platform Rules\n\nSECOND CUSTOM TEXT\n";
+        std::fs::write(ac.join(filename), second).expect("rewrite platform file");
+        let out2 = render_agent_context_template_inner(
+            get_default_agent_template(),
+            &path_string(&replica),
+            None,
+            &no_skill_section(),
+            &replica,
+            None,
+            None,
+            false,
+        );
+        assert!(out2.contains("SECOND CUSTOM TEXT"));
+        assert!(!out2.contains("FIRST CUSTOM TEXT"));
+        assert_eq!(
+            count_context_occurrences(&out2, "## Host Platform Rules"),
+            1
+        );
+        assert_no_raw_template_placeholders(&out2);
+    }
+
+    #[test]
+    fn host_platform_rules_missing_or_empty_file_falls_back_to_embedded_default() {
+        // #1605 T-8: absent or empty platform file -> embedded default for the
+        // build's OS (with a WARN in app.log), never an empty section.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let ac = temp.path().join(".ac");
+        let replica = ac.join("wg-1-team").join("__agent_dev");
+        std::fs::create_dir_all(&replica).expect("create replica layout");
+        let filename = host_platform_rules_filename();
+        let default = host_platform_rules_default();
+
+        let missing = render_agent_context_template_inner(
+            get_default_agent_template(),
+            &path_string(&replica),
+            None,
+            &no_skill_section(),
+            &replica,
+            None,
+            None,
+            false,
+        );
+        assert!(missing.contains("## Host Platform Rules"));
+        assert!(missing.contains(default));
+
+        std::fs::write(ac.join(filename), "").expect("write empty platform file");
+        let empty = render_agent_context_template_inner(
+            get_default_agent_template(),
+            &path_string(&replica),
+            None,
+            &no_skill_section(),
+            &replica,
+            None,
+            None,
+            false,
+        );
+        assert!(empty.contains("## Host Platform Rules"));
+        assert!(empty.contains(default));
+        assert_eq!(
+            count_context_occurrences(&empty, "## Host Platform Rules"),
+            1
+        );
+    }
+
+    #[test]
+    fn coordinator_session_profile_embeds_host_platform_rules_once() {
+        // #1605 T-9: the block reaches coordinator sessions through the global
+        // render exactly once; the coordinator body adds no duplicate.
+        let replica = default_context(
+            "C:/fake/wg-7-dev-team/__agent_architect",
+            None,
+            &no_skill_section(),
+        );
+        let coordinator = format!(
+            "{}\n\n---\n\n# Orchestrator Context\n\n{}",
+            replica,
+            get_default_coordinator_template()
+        );
+        assert_eq!(
+            count_context_occurrences(&coordinator, "## Host Platform Rules"),
+            1
+        );
+        assert!(!get_default_coordinator_template().contains("Host Platform Rules"));
     }
 
     #[test]
@@ -5968,6 +6311,7 @@ You may ONLY modify files in your own replica root:\n   C:/OLD/__agent_other\n\n
             "## Skills",
             "# Agent Repos",
             "## CLI executable",
+            "## Host Platform Rules",
             "## Session credentials",
             "## Inter-Agent Messaging",
             "## Privileged PTY Input to Workgroup Orchestrators",
@@ -10305,6 +10649,12 @@ mod token_accounting {
         assert_eq!(full_wg.matches("# Agent Repos").count(), 1);
         assert!(!full_wg.contains("{{"));
         assert!(!full_wg.contains("}}"));
+        // #1605: the platform block renders in the WG profile on every OS (linux/
+        // macos render their minimal block too).
+        assert!(
+            full_wg.contains("## Host Platform Rules"),
+            "the platform block must render in the WG profile"
+        );
 
         assert!(
             touched_owners <= MAX_TOUCHED_OWNERS_BYTES,
@@ -10365,6 +10715,14 @@ mod token_accounting {
         print_row(
             "block: delegated task reporting (A4c)",
             super::DEFAULT_DELEGATED_TASK_REPORTING.len(),
+        );
+        print_row(
+            "block: host platform rules (Windows default)",
+            super::DEFAULT_HOST_PLATFORM_RULES_WINDOWS.len(),
+        );
+        print_row(
+            "block: host platform rules (linux/macos default)",
+            super::DEFAULT_HOST_PLATFORM_RULES_LINUX.len(),
         );
         print_row(
             "block: agent repos header (A6, replica variant)",


### PR DESCRIPTION
Closes #1605

## What
Adds the 8th mandatory placeholder `{{HOST_PLATFORM_RULES}}` to the global default agent template (v4→v5) right after `{{CLI_CONTEXT}}`, rendered per the session's EXECUTION platform:
- Windows host sessions: Git Bash CLI-routing rule (single source of truth; the #1596 paragraph in `{{INTER_AGENT_MESSAGING}}` shrinks to a 49-byte pointer).
- Linux/macOS host sessions: minimal note (106 B each).
- Container (transport-api) sessions: nothing.
- Content configurable per platform via `.ac/Context.platform.<os>.md` (seeded absent-only, versioned in `.agentscommander-context-templates.json`, edits preserved, missing/empty → embedded default + WARN).
- Root prologue gains the block as its 10th section; coordinator sessions get it via the global render (no coordinator change).
- Operator doc: `docs/agents/host-platform-rules.md`.

## Files (frozen set per plan §8.4)
- `plans/1605-host-platform-rules.md` (force-added; Plan-SHA256 `F1DFB4C967BE104DB31286B09A429246BDA91F13B6975A9693315AB92BC15723`, approved by owner via WG17 gate 7.5 round 2)
- `src-tauri/src/config/session_context.rs` (template v5, renderer, defaults, pointer, 6 trims −110 B, manifest scope)
- `src-tauri/src/config/seeded_context_templates.rs` (v4 freeze + recognizers, 3 platform specs, project_specs 2→5)
- `src-tauri/src/config/seed_manifest.rs` (+7 lines: 3 `context:platform` literals)
- `docs/agents/host-platform-rules.md` (new)

## Evidence
- Plan gate 7.5 round 2: owner APPROVED (digest bound), via wg-17 ac-healer.
- Architect: READY / dev: PLAN_APPROVED / grinch: PLAN_APPROVED (round 2, same digest).
- Grinch Step-9 diff review: **PASS** on `d7008b34..a964bc42`; re-verification on the merged head (main drift `d7008b34→7dba5049`, #1577/#1612/#1619, no selected-file overlap) in progress.
- Manual gates (run by grinch on Windows): levelization green (SCC identical, `module-arcs.txt` byte-identical, 0 new arcs), layering guards 33 passed/0 failed (4 suites), `check:frontend-dependencies` = 0.
- Budget (Windows debug build): `full_wg` 8262 ≤ 8313 (slack 51), `touched_owners` 6504 ≤ 6810 (slack 306), linux/macos `full_wg` 8042; constants untouched.
- Battery: `cargo test --locked` 3966 passed / 0 failed (pre-merge); clippy/check/fmt clean.
- Toolchain: rustc/cargo 1.97.1, `--locked`.

Post-merge: Windows release build to `0_AC`, post-release re-seed of `.ac/Context.platform.*.md` (absent-only) + optional IaC commit, closing report to WG17.